### PR TITLE
Improve FAQ instructions for vendoring golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,14 +362,24 @@ By doing this you won't create new issues in code and can smoothly fix existing 
 
 A: You have 2 choices:
 1. Use [GolangCI](https://golangci.com): this service is highly integrated with GitHub (issues are commented in the pull request) and uses a `golangci-lint` tool. For configuration use `.golangci.yml` (or toml/json).
-2. Use custom CI: just run `golangci-lint` in CI and check exit code. If it's non-zero - fail the build. The main disadvantage is that you can't see found issues in pull request code and should view build log, then open needed source file to see a context.
-If you'd like to vendor `golangci-lint` to fix it's version run:
+2. Use custom CI: just run `golangci-lint` in CI and check the exit code. If it's non-zero - fail the build. The main disadvantage is that you can't see found issues in pull request code and should view build log, then open needed source file to see a context.
+If you'd like to vendor `golangci-lint` in your repo, run:
 ```bash
 go get -u github.com/golang/dep/cmd/dep
 dep init
 dep ensure -v -add github.com/golangci/golangci-lint/cmd/golangci-lint
 ```
-And in CI run next command to install vendored `golangci-lint`: `go install ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint/`.
+Then add these lines to your `Gopkg.toml` file, so `dep ensure -update` won't delete the vendored `golangci-lint` code.
+```toml
+required = [
+  "github.com/golangci/golangci-lint/cmd/golangci-lint",
+]
+```
+In your CI scripts, install the vendored `golangci-lint` like this:
+```bash
+go install ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint/`
+```
+Vendoring `golangci-lint` saves a network request, potentially making your CI system a little more reliable.
 
 **Q: `golangci-lint` doesn't work**
 1. Update it: `go get -u github.com/golangci/golangci-lint/cmd/golangci-lint`


### PR DESCRIPTION
```toml
required = [
  "github.com/golangci/golangci-lint/cmd/golangci-lint",
]
```
[The section on vendoring `golangci-lint`](https://github.com/golangci/golangci-lint/tree/61463e305fc23e1246e17b54db2b8daec3220ad4#faq) fails to mention that it needs to be added to the `required` section in `Gopkg.toml`. Without `required`, the vendored `golangci-lint` would be deleted on the next `dep ensure -update`. Also, some of the wording was a bit hard to understand.