### PR TITLE
Allocate memory for known size slices

### DIFF
--- a/pkg/golinters/deadcode.go
+++ b/pkg/golinters/deadcode.go
@@ -24,7 +24,11 @@ func (d Deadcode) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, er
 		return nil, err
 	}
 
-	var res []result.Issue
+	if len(issues) == 0 {
+		return nil, nil
+	}
+
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		res = append(res, result.Issue{
 			Pos:        i.Pos,

--- a/pkg/golinters/dupl.go
+++ b/pkg/golinters/dupl.go
@@ -25,7 +25,11 @@ func (d Dupl) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error)
 		return nil, err
 	}
 
-	var res []result.Issue
+	if len(issues) == 0 {
+		return nil, nil
+	}
+
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		dupl := fmt.Sprintf("%s:%d-%d", i.To.Filename(), i.To.LineStart(), i.To.LineEnd())
 		text := fmt.Sprintf("%d-%d lines are duplicate of %s",

--- a/pkg/golinters/errcheck.go
+++ b/pkg/golinters/errcheck.go
@@ -25,7 +25,11 @@ func (e Errcheck) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, er
 		return nil, err
 	}
 
-	var res []result.Issue
+	if len(issues) == 0 {
+		return nil, nil
+	}
+
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		var text string
 		if i.FuncName != "" {

--- a/pkg/golinters/gas.go
+++ b/pkg/golinters/gas.go
@@ -33,8 +33,11 @@ func (lint Gas) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, erro
 
 	analyzer.ProcessProgram(lintCtx.Program)
 	issues, _ := analyzer.Report()
+	if len(issues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		text := fmt.Sprintf("%s: %s", i.RuleID, i.What) // TODO: use severity and confidence
 		var r result.Range

--- a/pkg/golinters/goconst.go
+++ b/pkg/golinters/goconst.go
@@ -32,8 +32,11 @@ func (lint Goconst) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, 
 
 		goconstIssues = append(goconstIssues, issues...)
 	}
+	if len(goconstIssues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(goconstIssues))
 	for _, i := range goconstIssues {
 		textBegin := fmt.Sprintf("string %s has %d occurrences", formatCode(i.Str, lintCtx.Cfg), i.OccurencesCount)
 		var textEnd string

--- a/pkg/golinters/gocyclo.go
+++ b/pkg/golinters/gocyclo.go
@@ -22,7 +22,7 @@ func (Gocyclo) Desc() string {
 func (g Gocyclo) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	var stats []gocycloAPI.Stat
 	for _, f := range lintCtx.ASTCache.GetAllValidFiles() {
-		stats = append(stats, gocycloAPI.BuildStats(f.F, f.Fset, stats)...)
+		stats = gocycloAPI.BuildStats(f.F, f.Fset, stats)
 	}
 	if len(stats) == 0 {
 		return nil, nil

--- a/pkg/golinters/gocyclo.go
+++ b/pkg/golinters/gocyclo.go
@@ -22,17 +22,20 @@ func (Gocyclo) Desc() string {
 func (g Gocyclo) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	var stats []gocycloAPI.Stat
 	for _, f := range lintCtx.ASTCache.GetAllValidFiles() {
-		stats = gocycloAPI.BuildStats(f.F, f.Fset, stats)
+		stats = append(stats, gocycloAPI.BuildStats(f.F, f.Fset, stats)...)
+	}
+	if len(stats) == 0 {
+		return nil, nil
 	}
 
 	sort.Slice(stats, func(i, j int) bool {
 		return stats[i].Complexity > stats[j].Complexity
 	})
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(stats))
 	for _, s := range stats {
 		if s.Complexity <= lintCtx.Settings().Gocyclo.MinComplexity {
-			continue
+			break //Break as the stats is already sorted from greatest to least
 		}
 
 		res = append(res, result.Issue{

--- a/pkg/golinters/golint.go
+++ b/pkg/golinters/golint.go
@@ -53,8 +53,11 @@ func (g Golint) lintFiles(minConfidence float64, filenames ...string) ([]result.
 	if err != nil {
 		return nil, fmt.Errorf("can't lint files %s: %s", filenames, err)
 	}
+	if len(ps) == 0 {
+		return nil, nil
+	}
 
-	var issues []result.Issue
+	issues := make([]result.Issue, 0, len(ps)) //This is worst case
 	for _, p := range ps {
 		if p.Confidence >= minConfidence {
 			issues = append(issues, result.Issue{

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -27,8 +27,11 @@ func (g Govet) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error
 		}
 		govetIssues = append(govetIssues, issues...)
 	}
+	if len(govetIssues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(govetIssues))
 	for _, i := range govetIssues {
 		res = append(res, result.Issue{
 			Pos:        i.Pos,

--- a/pkg/golinters/ineffassign.go
+++ b/pkg/golinters/ineffassign.go
@@ -20,8 +20,11 @@ func (Ineffassign) Desc() string {
 
 func (lint Ineffassign) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	issues := ineffassignAPI.Run(lintCtx.Paths.Files)
+	if len(issues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		res = append(res, result.Issue{
 			Pos:        i.Pos,

--- a/pkg/golinters/interfacer.go
+++ b/pkg/golinters/interfacer.go
@@ -27,8 +27,11 @@ func (lint Interfacer) Run(ctx context.Context, lintCtx *Context) ([]result.Issu
 	if err != nil {
 		return nil, err
 	}
+	if len(issues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		pos := lintCtx.SSAProgram.Fset.Position(i.Pos())
 		res = append(res, result.Issue{

--- a/pkg/golinters/maligned.go
+++ b/pkg/golinters/maligned.go
@@ -20,8 +20,11 @@ func (Maligned) Desc() string {
 
 func (m Maligned) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	issues := malignedAPI.Run(lintCtx.Program)
+	if len(issues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		text := fmt.Sprintf("struct of size %d bytes could be of size %d bytes", i.OldSize, i.NewSize)
 		if lintCtx.Settings().Maligned.SuggestNewOrder {

--- a/pkg/golinters/megacheck.go
+++ b/pkg/golinters/megacheck.go
@@ -41,8 +41,11 @@ func (m Megacheck) Desc() string {
 func (m Megacheck) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	issues := megacheckAPI.Run(lintCtx.Program, lintCtx.LoaderConfig, lintCtx.SSAProgram,
 		m.StaticcheckEnabled, m.GosimpleEnabled, m.UnusedEnabled)
+	if len(issues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		res = append(res, result.Issue{
 			Pos:        i.Position,

--- a/pkg/golinters/structcheck.go
+++ b/pkg/golinters/structcheck.go
@@ -20,8 +20,11 @@ func (Structcheck) Desc() string {
 
 func (s Structcheck) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	issues := structcheckAPI.Run(lintCtx.Program, lintCtx.Settings().Structcheck.CheckExportedFields)
+	if len(issues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		res = append(res, result.Issue{
 			Pos:        i.Pos,

--- a/pkg/golinters/unconvert.go
+++ b/pkg/golinters/unconvert.go
@@ -19,7 +19,11 @@ func (Unconvert) Desc() string {
 
 func (lint Unconvert) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	positions := unconvertAPI.Run(lintCtx.Program)
-	var res []result.Issue
+	if len(positions) == 0 {
+		return nil, nil
+	}
+
+	res := make([]result.Issue, 0, len(positions))
 	for _, pos := range positions {
 		res = append(res, result.Issue{
 			Pos:        pos,

--- a/pkg/golinters/varcheck.go
+++ b/pkg/golinters/varcheck.go
@@ -20,8 +20,11 @@ func (Varcheck) Desc() string {
 
 func (v Varcheck) Run(ctx context.Context, lintCtx *Context) ([]result.Issue, error) {
 	issues := varcheckAPI.Run(lintCtx.Program, lintCtx.Settings().Varcheck.CheckExportedFields)
+	if len(issues) == 0 {
+		return nil, nil
+	}
 
-	var res []result.Issue
+	res := make([]result.Issue, 0, len(issues))
 	for _, i := range issues {
 		res = append(res, result.Issue{
 			Pos:        i.Pos,


### PR DESCRIPTION
I know this does not save that many memory allocations compared to other areas but every little bit helps in my opinion. 

Also, think I fixed a bug that was not reported in GoCyclo on line 25. It was iterating through the files but only kept the latest stats instead of appending.