### PR TITLE
skip issues of file "C"

### DIFF
--- a/pkg/printers/text.go
+++ b/pkg/printers/text.go
@@ -67,6 +67,9 @@ func (p *Text) Print(ctx context.Context, issues <-chan result.Issue) (bool, err
 
 	issuesN := 0
 	for i := range issues {
+		if i.FilePath() == "C" {
+			continue
+		}
 		issuesN++
 		p.printIssue(&i)
 


### PR DESCRIPTION
Solves

    WARN[0005] running error: can\'t print 99 issues: can\'t read file C for printing issued line: open C: no such file or directory

errors of checking projects using cgo.

You can check it on `gopkg.in/goracle.v2`