### PR TITLE
Allow --enable, --enable-all and --fast to coexist.

### DIFF
--- a/pkg/lint/lintersdb/lintersdb.go
+++ b/pkg/lint/lintersdb/lintersdb.go
@@ -256,7 +256,7 @@ func validateAllDisableEnableOptions(cfg *config.Linters) error {
 		}
 	}
 
-	if cfg.EnableAll && len(cfg.Enable) != 0 {
+	if cfg.EnableAll && len(cfg.Enable) != 0 && !cfg.Fast {
 		return fmt.Errorf("can't combine options --enable-all and --enable %s", cfg.Enable[0])
 	}
 


### PR DESCRIPTION
This is useful to first enable all linters (including fast ones), then
only enable fast linters, then add extra linters. eg.

```
golangci-lint run --no-config --enable-all --fast --print-issued-lines=false \
    --exclude-use-default=false --tests --enable typecheck .
```