### PR TITLE
Speedup program loading on 20%.

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint"
 	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
+	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/printers"
 	"github.com/golangci/golangci-lint/pkg/result"
 	"github.com/golangci/golangci-lint/pkg/result/processors"
@@ -231,12 +232,14 @@ func setOutputToDevNull() (savedStdout, savedStderr *os.File) {
 }
 
 func (e *Executor) runAndPrint(ctx context.Context, args []string) error {
-	// Don't allow linters and loader to print anything
-	log.SetOutput(ioutil.Discard)
-	savedStdout, savedStderr := setOutputToDevNull()
-	defer func() {
-		os.Stdout, os.Stderr = savedStdout, savedStderr
-	}()
+	if !logutils.HaveDebugTag("linters_output") {
+		// Don't allow linters and loader to print anything
+		log.SetOutput(ioutil.Discard)
+		savedStdout, savedStderr := setOutputToDevNull()
+		defer func() {
+			os.Stdout, os.Stderr = savedStdout, savedStderr
+		}()
+	}
 
 	issues, err := e.runAnalysis(ctx, args)
 	if err != nil {

--- a/pkg/golinters/gofmt.go
+++ b/pkg/golinters/gofmt.go
@@ -75,7 +75,6 @@ func (g Gofmt) extractIssuesFromPatch(patch string) ([]result.Issue, error) {
 		for _, hunk := range d.Hunks {
 			deletedLine, addedLine, err := getFirstDeletedAndAddedLineNumberInHunk(hunk)
 			if err != nil {
-				logrus.Infof("Can't get first deleted line number for hunk: %s", err)
 				if addedLine > 1 {
 					deletedLine = addedLine - 1 // use previous line, TODO: use both prev and next lines
 				} else {

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -51,3 +51,7 @@ func Debug(tag string) DebugFunc {
 func IsDebugEnabled() bool {
 	return len(enabledDebugs) != 0
 }
+
+func HaveDebugTag(tag string) bool {
+	return enabledDebugs[tag]
+}


### PR DESCRIPTION
Don't typecheck func bodies for non-local packages.
Works only if megacheck and interfacer are disabled: they require all
func bodies to build SSA repr.
Export GL_DEBUG=load to get logs for this feature.