### PR TITLE
Remove extra backtick in install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ required = [
 ```
 In your CI scripts, install the vendored `golangci-lint` like this:
 ```bash
-go install ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint/`
+go install ./vendor/github.com/golangci/golangci-lint/cmd/golangci-lint/
 ```
 Vendoring `golangci-lint` saves a network request, potentially making your CI system a little more reliable.
 


### PR DESCRIPTION
This just removes the extra back in the `go install` step. Helps people (like me) that just copy paste blindly into a Makefile or into the cmdline!