### PR TITLE
disable the congrats message

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Global Flags:
   -j, --concurrency int           Concurrency (default NumCPU) (default 8)
       --cpu-profile-path string   Path to CPU profile output file
       --mem-profile-path string   Path to memory profile output file
+  -s, --silent                    disables congrats outputs
   -v, --verbose                   verbose output
 
 ```

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -83,6 +83,7 @@ func (e *Executor) needVersionOption() bool {
 
 func initRootFlagSet(fs *pflag.FlagSet, cfg *config.Config, needVersionOption bool) {
 	fs.BoolVarP(&cfg.Run.IsVerbose, "verbose", "v", false, wh("verbose output"))
+	fs.BoolVarP(&cfg.Run.Silent, "silent", "s", false, wh("disables congrats outputs"))
 	fs.StringVar(&cfg.Run.CPUProfilePath, "cpu-profile-path", "", wh("Path to CPU profile output file"))
 	fs.StringVar(&cfg.Run.MemProfilePath, "mem-profile-path", "", wh("Path to memory profile output file"))
 	fs.IntVarP(&cfg.Run.Concurrency, "concurrency", "j", getDefaultConcurrency(), wh("Concurrency (default NumCPU)"))

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -258,10 +258,10 @@ func (e *Executor) runAndPrint(ctx context.Context, args []string) error {
 		p = printers.NewJSON()
 	case config.OutFormatColoredLineNumber, config.OutFormatLineNumber:
 		p = printers.NewText(e.cfg.Output.PrintIssuedLine,
-			format == config.OutFormatColoredLineNumber, e.cfg.Output.PrintLinterName,
+			format == config.OutFormatColoredLineNumber, e.cfg.Output.PrintLinterName, e.cfg.Run.Silent,
 			e.log.Child("text_printer"))
 	case config.OutFormatTab:
-		p = printers.NewTab(e.cfg.Output.PrintLinterName,
+		p = printers.NewTab(e.cfg.Output.PrintLinterName, e.cfg.Run.Silent,
 			e.log.Child("tab_printer"))
 	case config.OutFormatCheckstyle:
 		p = printers.NewCheckstyle()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,6 +92,7 @@ func GetDefaultExcludePatternsStrings() []string {
 
 type Run struct {
 	IsVerbose           bool `mapstructure:"verbose"`
+	Silent              bool
 	CPUProfilePath      string
 	MemProfilePath      string
 	Concurrency         int

--- a/pkg/printers/tab.go
+++ b/pkg/printers/tab.go
@@ -13,12 +13,14 @@ import (
 
 type Tab struct {
 	printLinterName bool
+	silent          bool
 	log             logutils.Log
 }
 
-func NewTab(printLinterName bool, log logutils.Log) *Tab {
+func NewTab(printLinterName bool, silent bool, log logutils.Log) *Tab {
 	return &Tab{
 		printLinterName: printLinterName,
+		silent:          silent,
 		log:             log,
 	}
 }
@@ -40,8 +42,10 @@ func (p *Tab) Print(ctx context.Context, issues <-chan result.Issue) (bool, erro
 	if issuesN != 0 {
 		p.log.Infof("Found %d issues", issuesN)
 	} else if ctx.Err() == nil { // don't print "congrats" if timeouted
-		outStr := p.SprintfColored(color.FgGreen, "Congrats! No issues were found.")
-		fmt.Fprintln(logutils.StdOut, outStr)
+		if !p.silent {
+			outStr := p.SprintfColored(color.FgGreen, "Congrats! No issues were found.")
+			fmt.Fprintln(logutils.StdOut, outStr)
+		}
 	}
 
 	if err := w.Flush(); err != nil {

--- a/pkg/printers/text.go
+++ b/pkg/printers/text.go
@@ -20,16 +20,18 @@ type Text struct {
 	printIssuedLine bool
 	useColors       bool
 	printLinterName bool
+	silent          bool
 
 	cache filesCache
 	log   logutils.Log
 }
 
-func NewText(printIssuedLine, useColors, printLinterName bool, log logutils.Log) *Text {
+func NewText(printIssuedLine, useColors, printLinterName bool, silent bool, log logutils.Log) *Text {
 	return &Text{
 		printIssuedLine: printIssuedLine,
 		useColors:       useColors,
 		printLinterName: printLinterName,
+		silent:          silent,
 		cache:           filesCache{},
 		log:             log,
 	}
@@ -92,8 +94,10 @@ func (p *Text) Print(ctx context.Context, issues <-chan result.Issue) (bool, err
 	if issuesN != 0 {
 		p.log.Infof("Found %d issues", issuesN)
 	} else if ctx.Err() == nil { // don't print "congrats" if timeouted
-		outStr := p.SprintfColored(color.FgGreen, "Congrats! No issues were found.")
-		fmt.Fprintln(logutils.StdOut, outStr)
+		if !p.silent {
+			outStr := p.SprintfColored(color.FgGreen, "Congrats! No issues were found.")
+			fmt.Fprintln(logutils.StdOut, outStr)
+		}
 	}
 
 	return issuesN != 0, nil

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -33,6 +33,12 @@ func checkNoIssuesRun(t *testing.T, out string, exitCode int) {
 	assert.Equal(t, "Congrats! No issues were found.\n", out)
 }
 
+func TestCongratsMessageGoneIfSilent(t *testing.T) {
+	out, exitCode := runGolangciLint(t, "../...", "-s")
+	assert.Equal(t, exitcodes.Success, exitCode)
+	assert.Equal(t, "", out)
+}
+
 func TestCongratsMessageIfNoIssues(t *testing.T) {
 	out, exitCode := runGolangciLint(t, "../...")
 	checkNoIssuesRun(t, out, exitCode)


### PR DESCRIPTION
There is now an extra switch '-s' to disable the congrats message when
there are no issues detected

Fixes: #110