### PR TITLE
Fix #94: load object files for govet for old go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -122,7 +122,7 @@
     "lib/cfg",
     "lib/whitelist"
   ]
-  revision = "18c83969a303d67eaa9d67747a930f007e3e9c89"
+  revision = "54e733a64097854cf4d8fa80ccf48012a487ae1a"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/golangci/govet/types.go
+++ b/vendor/github.com/golangci/govet/types.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"time"
 
+	"golang.org/x/tools/go/gcexportdata"
 	"golang.org/x/tools/go/loader"
 )
 
@@ -28,6 +29,10 @@ var (
 	stringerType  *types.Interface // possibly nil
 	formatterType *types.Interface // possibly nil
 )
+
+func newGCExportDataImporter(fset *token.FileSet) types.ImporterFrom {
+	return gcexportdata.NewImporter(fset, make(map[string]*types.Package))
+}
 
 func inittypes() error {
 	errorType = types.Universe.Lookup("error").Type().Underlying().(*types.Interface)
@@ -83,7 +88,7 @@ func (pkg *Package) check(fs *token.FileSet, astFiles []*ast.File, pkgInfo *load
 		if *source {
 			stdImporter = importer.For("source", nil)
 		} else {
-			stdImporter = importer.Default()
+			stdImporter = newGCExportDataImporter(fs)
 		}
 		if err := inittypes(); err != nil {
 			return []error{fmt.Errorf("can't init std types: %s", err)}


### PR DESCRIPTION
Do it in compatible with old go versions object files way:
use golang.org/x/tools/go/gcexportdata instead of importer.Default