### PR TITLE
Fixed example for 'exclude-use-default'

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -165,8 +165,8 @@ issues:
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
   # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is false.
-  exclude-use-default: true
+  # Default value for this option is true.
+  exclude-use-default: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-per-linter: 0

--- a/README.md
+++ b/README.md
@@ -578,8 +578,8 @@ issues:
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
   # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is false.
-  exclude-use-default: true
+  # Default value for this option is true.
+  exclude-use-default: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-per-linter: 0


### PR DESCRIPTION
Hi,

There is a mistake in the `README` and `.golangci.example.yml`.

Default value is actually `true`

Proof: https://github.com/golangci/golangci-lint/blob/master/pkg/commands/run.go#L141

```go
fs.BoolVar(&ic.UseDefaultExcludes, "exclude-use-default", true, getDefaultExcludeHelp())
```