### PR TITLE
Use a multi-staged Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
+FROM golang:1.10 AS builder
+
+COPY . $GOPATH/src/github.com/golangci/golangci-lint
+
+RUN make -C $GOPATH/src/github.com/golangci/golangci-lint
+
 FROM golang:1.10
 
 RUN apt-get update && apt-get install -y gcc
 
-COPY golangci-lint $GOPATH/bin/
+COPY --from=builder $GOPATH/bin $GOPATH/bin
+
 ENTRYPOINT ["golangci-lint"]


### PR DESCRIPTION
This way we have consistent docker images rather than locally build binaries dumped into an image. Ideally we'd build with 1.11 right away, but this doesn't seem to work correctly just yet sadly