### PR TITLE
Update dockerfile to use golang 1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.11
 
 RUN apt-get update && apt-get install -y gcc
 


### PR DESCRIPTION
### Description

Since golangci-lint is build with go 1.11. It is not possible to validate golangci-lint with the command:
```console
$ docker run --rm -it  -v `pwd`:/go/src/github.com/golangci/golangci-lint -w /go/src/github.com/golangci/golangci-lint golangci/golangci-lint:v1.10 run 
WARN [runner/megacheck] Can't run megacheck because of compilation errors in packages [github.com/golangci/golangci-lint/vendor/golang.org/x/tools/go/internal/gcimporter]: vendor/golang.org/x/tools/go/internal/gcimporter/newInterface11.go:12: NewInterfaceType not declared by package types 
vendor/golang.org/x/tools/go/internal/gcimporter/newInterface11.go:12:15: NewInterfaceType not declared by package types (typecheck)
	return types.NewInterfaceType(methods, embeddeds)
```

So I propose to update Dockerfile base image to `golang:1.11` and the issue should be fixed