### PR TITLE
Use CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM golang:1.11
 RUN apt-get update && apt-get install -y gcc
 
 COPY golangci-lint $GOPATH/bin/
-ENTRYPOINT ["golangci-lint"]
+CMD ["golangci-lint"]


### PR DESCRIPTION
This replaces `Dockerfile`'s `ENTRYPOINT` to `CMD` which is more convenient for debugging and playing around with the linter, when `ENTRYPOINT` is more for scripts that set the env and do `exec $@`.

It also fixes #190 