### PR TITLE
Fix compilation with go1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/mock v1.1.1
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
-	github.com/golangci/errcheck v0.0.0-20180902071612-f726ab79eeeb
+	github.com/golangci/errcheck v0.0.0-20181003203344-1765131d5be5
 	github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613
 	github.com/golangci/go-tools v0.0.0-20180902103155-93eecd106a0b
 	github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/errcheck v0.0.0-20180902071612-f726ab79eeeb h1:nIkmxOhujne45EXNG0EK88C4CgYNt90Dq5045+RYjtU=
 github.com/golangci/errcheck v0.0.0-20180902071612-f726ab79eeeb/go.mod h1:DbHgvLiFKX1Sh2T1w8Q/h4NAI8MHIpzCdnBUDTXU3I0=
+github.com/golangci/errcheck v0.0.0-20181003203344-1765131d5be5 h1:q7aCFiVt6gMxZseillOwgsyitdcxbqQz5oxA2rHIeMY=
+github.com/golangci/errcheck v0.0.0-20181003203344-1765131d5be5/go.mod h1:DbHgvLiFKX1Sh2T1w8Q/h4NAI8MHIpzCdnBUDTXU3I0=
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613 h1:WadunOE/TeHR8U7f0TXiJACHeU3cuFOXuKafw4rozqU=
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613/go.mod h1:SyvUF2NxV+sN8upjjeVYr5W7tyxaT1JVtvhKhOn2ii8=
 github.com/golangci/go-tools v0.0.0-20180902103155-93eecd106a0b h1:FSrt9JBK7JINu5UobyIF6epfpjL66H+67KZoTbE0zwk=


### PR DESCRIPTION
Needed to update `errcheck` module because I was getting:

```
% go build ./cmd/golangci-lint
go: downloading github.com/fatih/color v1.6.0
go: downloading github.com/pkg/errors v0.8.0
go: downloading github.com/mattn/go-colorable v0.0.9
go: downloading github.com/spf13/viper v1.0.2
go: downloading github.com/sirupsen/logrus v1.0.5
go: downloading github.com/spf13/cobra v0.0.2
go: downloading github.com/OpenPeeDeeP/depguard v0.0.0-20180806142446-a69c782687b2
go: downloading github.com/golangci/govet v0.0.0-20180818181408-44ddbe260190
go: downloading github.com/golangci/errcheck v0.0.0-20180902071612-f726ab79eeeb
go: downloading github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4
go: downloading github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee
go: downloading github.com/golangci/unparam v0.0.0-20180902112548-7ad9dbcccc16
go: downloading golang.org/x/tools v0.0.0-20180831211245-7ca132754999
go: downloading github.com/pelletier/go-toml v1.1.0
go: downloading gopkg.in/yaml.v2 v2.2.1
go: downloading github.com/golangci/go-tools v0.0.0-20180902103155-93eecd106a0b
go: downloading github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
go: downloading github.com/golangci/tools v0.0.0-20180902102414-98e75f53b4b9
go: downloading github.com/golangci/lint-1 v0.0.0-20180610141402-4bf9709227d1
go: downloading github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec
go: downloading github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613
go: downloading github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21
go: downloading github.com/spf13/pflag v1.0.1
go: downloading github.com/golangci/gosec v0.0.0-20180901114220-8afd9cbb6cfb
go: downloading github.com/golangci/lint v0.0.0-20180902080404-c2187e7932b5
go: downloading github.com/golangci/ineffassign v0.0.0-20180808204949-2ee8f2867dde
go: downloading github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
go: downloading github.com/golang/mock v1.1.1
go: downloading github.com/golangci/gofmt v0.0.0-20180506063654-2076e05ced53
go: downloading github.com/magiconair/properties v1.7.6
go: downloading github.com/golangci/interfacer v0.0.0-20180902080945-01958817a6ec
go: downloading github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770
go: downloading golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
go: downloading sourcegraph.com/sourcegraph/go-diff v0.0.0-20171119081133-3f415a150aec
go: downloading github.com/gobwas/glob v0.2.3
go: downloading golang.org/x/text v0.3.0
go: downloading github.com/kisielk/gotool v1.0.0
go: downloading github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
go: downloading github.com/nbutton23/zxcvbn-go v0.0.0-20171102151520-eafdab6b0663
go: downloading github.com/mattn/go-isatty v0.0.3
go: downloading github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238
go: downloading github.com/spf13/cast v1.2.0
go: downloading github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
go: downloading github.com/fsnotify/fsnotify v1.4.7
go: downloading github.com/spf13/afero v1.1.0
go: downloading github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3
go: downloading github.com/gogo/protobuf v1.0.0
go: downloading golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
go: downloading github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0
go: downloading sourcegraph.com/sqs/pbtypes v0.0.0-20160107090929-4d1b9dc7ffc3
go: downloading golang.org/x/crypto v0.0.0-20180505025534-4ec37c66abab
# github.com/golangci/golangci-lint/pkg/golinters
pkg/golinters/errcheck.go:32:17: undefined: golangci.RunWithConfig
pkg/golinters/errcheck.go:59:51: undefined: golangci.Config
pkg/golinters/errcheck.go:60:8: undefined: golangci.Config
```

BTW: what's the right way to build the binary, because building it with vendored dependencies also fails with go1.11:
```
% go build -mod=vendor ./cmd/golangci-lint
build golang.org/x/net/context: cannot find module for path golang.org/x/net/context
```

If needed I can include revendored modules that are produced by `go mod vendor` that seem to fix the compilation issue.