### PR TITLE
config: gas => gosec defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,19 +387,19 @@ Flags:
                                       # megacheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
                                       - ineffective break statement. Did you mean to break out of the outer loop
                                     
-                                      # gas: Too many false-positives on 'unsafe' usage
+                                      # gosec: Too many false-positives on 'unsafe' usage
                                       - Use of unsafe calls should be audited
                                     
-                                      # gas: Too many false-positives for parametrized shell calls
+                                      # gosec: Too many false-positives for parametrized shell calls
                                       - Subprocess launch(ed with variable|ing should be audited)
                                     
-                                      # gas: Duplicated errcheck checks
+                                      # gosec: Duplicated errcheck checks
                                       - G104
                                     
-                                      # gas: Too many issues in popular repos
+                                      # gosec: Too many issues in popular repos
                                       - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
                                     
-                                      # gas: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+                                      # gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
                                       - Potential file inclusion via variable
                                      (default true)
       --max-issues-per-linter int   Maximum issues count per one linter. Set to 0 to disable (default 50)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,27 +59,27 @@ var DefaultExcludePatterns = []ExcludePattern{
 	},
 	{
 		Pattern: "Use of unsafe calls should be audited",
-		Linter:  "gas",
+		Linter:  "gosec",
 		Why:     "Too many false-positives on 'unsafe' usage",
 	},
 	{
 		Pattern: "Subprocess launch(ed with variable|ing should be audited)",
-		Linter:  "gas",
+		Linter:  "gosec",
 		Why:     "Too many false-positives for parametrized shell calls",
 	},
 	{
 		Pattern: "G104",
-		Linter:  "gas",
+		Linter:  "gosec",
 		Why:     "Duplicated errcheck checks",
 	},
 	{
 		Pattern: "(Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)",
-		Linter:  "gas",
+		Linter:  "gosec",
 		Why:     "Too many issues in popular repos",
 	},
 	{
 		Pattern: "Potential file inclusion via variable",
-		Linter:  "gas",
+		Linter:  "gosec",
 		Why:     "False positive is triggered by 'src, err := ioutil.ReadFile(filename)'",
 	},
 }


### PR DESCRIPTION
Updates the strings to reflect the linter rename.