### PR TITLE
Improve readme with extended installation instruction when building from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GolangCI-Lint
 [![Build Status](https://travis-ci.com/golangci/golangci-lint.svg?branch=master)](https://travis-ci.com/golangci/golangci-lint)
+[![GolangCI](https://golangci.com/badges/github.com/golangci/golangci-lint.svg)](https://golangci.com)
 
 GolangCI-Lint is a linters aggregator. It's fast: on average [5 times faster](#performance) than gometalinter.
 It's [easy to integrate and use](#command-line-options), has [nice output](#quick-start) and has a minimum number of false positives.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ update if needed.
 ## Local Installation
 It's a not recommended for your CI pipeline. Only install like this for your local development environment.
 ```bash
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+go get -u github.com/golangci/golangci-lint
+cd $GOPATH/src/github.com/golangci/golangci-lint/cmd/golangci-lint
+go install -ldflags "-X 'main.version=$(git rev-parse --abbrev-ref HEAD)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
 ```
 
 You can also install it on OSX using brew:

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -1,5 +1,6 @@
 # GolangCI-Lint
 [![Build Status](https://travis-ci.com/golangci/golangci-lint.svg?branch=master)](https://travis-ci.com/golangci/golangci-lint)
+[![GolangCI](https://golangci.com/badges/github.com/golangci/golangci-lint.svg)](https://golangci.com)
 
 GolangCI-Lint is a linters aggregator. It's fast: on average [5 times faster](#performance) than gometalinter.
 It's [easy to integrate and use](#command-line-options), has [nice output](#quick-start) and has a minimum number of false positives.

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -80,7 +80,9 @@ update if needed.
 ## Local Installation
 It's a not recommended for your CI pipeline. Only install like this for your local development environment.
 ```bash
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+go get -u github.com/golangci/golangci-lint
+cd $GOPATH/src/github.com/golangci/golangci-lint/cmd/golangci-lint
+go install -ldflags "-X 'main.version=$(git rev-parse --abbrev-ref HEAD)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
 ```
 
 You can also install it on OSX using brew:

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180826000951-f6ba57429505/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20180831211245-5d4988d199e2 h1:DpCOQ3KV1qfJ60hZlyxHUgKvOehh5A/F9Fznu08v5Yw=
 golang.org/x/tools v0.0.0-20180831211245-5d4988d199e2/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180831211245-7ca132754999 h1:mf2VYfMpSMTlp0I/UXrX13w5LejDx34QeUUHH4TrUA8=
 golang.org/x/tools v0.0.0-20180831211245-7ca132754999/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Building from source gave some problems with for example `--version` see #229 . This pull request updates the documentation so that building from source includes the needed ldfags.