### PR TITLE
Add without-tests flag for errcheck

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -59,6 +59,10 @@ linters-settings:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
     check-blank: false
+
+    # report about checking of _test.go files is disabled.
+    # default is false: such cases aren't reported by default.
+    check-without-tests: false
   govet:
     # report about shadowed variables
     check-shadowing: true

--- a/README.md
+++ b/README.md
@@ -496,6 +496,10 @@ linters-settings:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
     check-blank: false
+
+    # report about checking of _test.go files is disabled.
+    # default is false: such cases aren't reported by default.
+    check-without-tests: false
   govet:
     # report about shadowed variables
     check-shadowing: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -169,6 +169,7 @@ type LintersSettings struct {
 type ErrcheckSettings struct {
 	CheckTypeAssertions bool       `mapstructure:"check-type-assertions"`
 	CheckAssignToBlank  bool       `mapstructure:"check-blank"`
+	CheckWithoutTests   bool       `mapstructure:"check-without-tests"`
 	Ignore              IgnoreFlag `mapstructure:"ignore"`
 	Exclude             string     `mapstructure:"exclude"`
 }

--- a/pkg/golinters/errcheck.go
+++ b/pkg/golinters/errcheck.go
@@ -58,9 +58,10 @@ func (e Errcheck) Run(ctx context.Context, lintCtx *linter.Context) ([]result.Is
 
 func genConfig(errCfg *config.ErrcheckSettings) (*errcheckAPI.Config, error) {
 	c := &errcheckAPI.Config{
-		Ignore:  errCfg.Ignore,
-		Blank:   errCfg.CheckAssignToBlank,
-		Asserts: errCfg.CheckTypeAssertions,
+		Ignore:       errCfg.Ignore,
+		Blank:        errCfg.CheckAssignToBlank,
+		Asserts:      errCfg.CheckTypeAssertions,
+		WithoutTests: errCfg.CheckWithoutTests,
 	}
 	if errCfg.Exclude != "" {
 		exclude, err := readExcludeFile(errCfg.Exclude)


### PR DESCRIPTION
We would be able to hand over `-ignoretests` flag to `errcheck` linter.
ref. https://github.com/kisielk/errcheck#the-deprecated-method