### PR TITLE
Tweak log entry for "not compiling" packages.

### DIFF
--- a/pkg/lint/load.go
+++ b/pkg/lint/load.go
@@ -271,7 +271,7 @@ func separateNotCompilingPackages(lintCtx *linter.Context) {
 	}
 
 	if len(lintCtx.NotCompilingPackages) != 0 {
-		lintCtx.Log.Infof("Not compiling packages: %+v", lintCtx.NotCompilingPackages)
+		lintCtx.Log.Infof("Packages that do not compile: %+v", lintCtx.NotCompilingPackages)
 	}
 }
 


### PR DESCRIPTION
Motivation: Make it clear that the message is indicating packages
*which do not compile*, rather than packages which *won't be
compiled*.
