### PR TITLE
Fix #261: build-tags fix for package loader

### DIFF
--- a/pkg/lint/load.go
+++ b/pkg/lint/load.go
@@ -196,7 +196,7 @@ func (cl ContextLoader) loadPackages(ctx context.Context, loadMode packages.Load
 	var buildFlags []string
 	if len(cl.cfg.Run.BuildTags) != 0 {
 		// go help build
-		buildFlags = []string{fmt.Sprintf("-tags '%s'", strings.Join(cl.cfg.Run.BuildTags, " "))}
+		buildFlags = []string{"-tags", strings.Join(cl.cfg.Run.BuildTags, " ")}
 	}
 	conf := &packages.Config{
 		Mode:       loadMode,


### PR DESCRIPTION
Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make readme`.