### PR TITLE
fix #264: fix Windows compatibility

### DIFF
--- a/pkg/goutil/env.go
+++ b/pkg/goutil/env.go
@@ -1,13 +1,10 @@
 package goutil
 
 import (
-	"bufio"
-	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
-	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -29,27 +26,13 @@ func NewEnv(log logutils.Log) *Env {
 }
 
 func (e *Env) Discover(ctx context.Context) error {
-	out, err := exec.CommandContext(ctx, "go", "env").Output()
+	out, err := exec.CommandContext(ctx, "go", "env", "-json").Output()
 	if err != nil {
 		return errors.Wrap(err, "failed to run 'go env'")
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		parts := strings.SplitN(scanner.Text(), "=", 2)
-		if len(parts) != 2 {
-			e.log.Warnf("Can't parse go env line %q: got %d parts", scanner.Text(), len(parts))
-			continue
-		}
-
-		v, err := strconv.Unquote(parts[1])
-		if err != nil {
-			e.log.Warnf("Invalid key %q with value %q: %s", parts[0], parts[1], err)
-			continue
-		}
-
-		e.vars[parts[0]] = v
+	if err = json.Unmarshal(out, &e.vars); err != nil {
+		return errors.Wrap(err, "failed to parse go env json")
 	}
 
 	e.debugf("Read go env: %#v", e.vars)

--- a/pkg/packages/skip.go
+++ b/pkg/packages/skip.go
@@ -3,10 +3,16 @@ package packages
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 )
 
+func pathElemReImpl(e string, sep rune) string {
+	escapedSep := regexp.QuoteMeta(string(sep)) // needed for windows sep '\\'
+	return fmt.Sprintf(`(^|%s)%s($|%s)`, escapedSep, e, escapedSep)
+}
+
 func pathElemRe(e string) string {
-	return fmt.Sprintf(`(^|%c)%s($|%c)`, filepath.Separator, e, filepath.Separator)
+	return pathElemReImpl(e, filepath.Separator)
 }
 
 var StdExcludeDirRegexps = []string{

--- a/pkg/packages/skip_test.go
+++ b/pkg/packages/skip_test.go
@@ -1,0 +1,38 @@
+package packages
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathElemRe(t *testing.T) {
+	matches := [][]string{
+		{"dir"},
+		{"root", "dir"},
+		{"root", "dir", "subdir"},
+		{"dir", "subdir"},
+	}
+	noMatches := [][]string{
+		{"nodir"},
+		{"dirno"},
+		{"root", "dirno"},
+		{"root", "nodir"},
+		{"root", "dirno", "subdir"},
+		{"root", "nodir", "subdir"},
+		{"dirno", "subdir"},
+		{"nodir", "subdir"},
+	}
+	for _, sep := range []rune{'/', '\\'} {
+		reStr := pathElemReImpl("dir", sep)
+		re := regexp.MustCompile(reStr)
+		for _, m := range matches {
+			assert.Regexp(t, re, strings.Join(m, string(sep)))
+		}
+		for _, m := range noMatches {
+			assert.NotRegexp(t, re, strings.Join(m, string(sep)))
+		}
+	}
+}


### PR DESCRIPTION
Fix skip-dirs regexps and 'go env' on Windows.

Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make readme`.