### PR TITLE
Use `git describe --tags` to get most recent tag reachable from HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ It's a not recommended for your CI pipeline. Only install like this for your loc
 ```bash
 go get -u github.com/golangci/golangci-lint
 cd $GOPATH/src/github.com/golangci/golangci-lint/cmd/golangci-lint
-go install -ldflags "-X 'main.version=$(git rev-parse --abbrev-ref HEAD)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
+go install -ldflags "-X 'main.version=$(git describe --tags)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
 ```
 
 You can also install it on OSX using brew:

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -92,7 +92,7 @@ It's a not recommended for your CI pipeline. Only install like this for your loc
 ```bash
 go get -u github.com/golangci/golangci-lint
 cd $GOPATH/src/github.com/golangci/golangci-lint/cmd/golangci-lint
-go install -ldflags "-X 'main.version=$(git rev-parse --abbrev-ref HEAD)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
+go install -ldflags "-X 'main.version=$(git describe --tags)' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date)'"
 ```
 
 You can also install it on OSX using brew:


### PR DESCRIPTION
From `git help describe`:

> The command finds the most recent tag that is reachable from a commit. If the tag points to the commit, then only the tag is shown. Otherwise, it suffixes
       the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit.

Example:
```bash
$ git checkout v1.11.3
HEAD is now at ccac35a Fix false positives with unused identifiers
$ git describe --tags
v1.11.3
$ git checkout HEAD^
Previous HEAD position was ccac35a Fix false positives with unused identifiers
HEAD is now at 3345c71 fix #264: fix Windows compatibility
$ git describe --tags
v1.11.2-6-g3345c71
$ 
```