### PR TITLE
On of cases for #260: fix crash in staticcheck

### DIFF
--- a/pkg/golinters/megacheck.go
+++ b/pkg/golinters/megacheck.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
+	libpackages "github.com/golangci/golangci-lint/pkg/packages"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
@@ -87,7 +88,7 @@ func (m Megacheck) Run(ctx context.Context, lintCtx *linter.Context) ([]result.I
 		var errors []packages.Error
 		for _, p := range lintCtx.NotCompilingPackages {
 			errPkgs = append(errPkgs, p.String())
-			errors = append(errors, p.Errors...)
+			errors = append(errors, libpackages.ExtractErrors(p)...)
 		}
 
 		warnText := fmt.Sprintf("Can't run megacheck because of compilation errors in packages %s",

--- a/pkg/golinters/typecheck.go
+++ b/pkg/golinters/typecheck.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/tools/go/packages"
 
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
+	libpackages "github.com/golangci/golangci-lint/pkg/packages"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
@@ -59,7 +60,8 @@ func (lint TypeCheck) parseError(srcErr packages.Error) (*result.Issue, error) {
 func (lint TypeCheck) Run(ctx context.Context, lintCtx *linter.Context) ([]result.Issue, error) {
 	var res []result.Issue
 	for _, pkg := range lintCtx.NotCompilingPackages {
-		for _, err := range pkg.Errors {
+		errors := libpackages.ExtractErrors(pkg)
+		for _, err := range errors {
 			i, perr := lint.parseError(err)
 			if perr != nil {
 				res = append(res, result.Issue{

--- a/pkg/packages/util.go
+++ b/pkg/packages/util.go
@@ -1,0 +1,51 @@
+package packages
+
+import (
+	"fmt"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func ExtractErrors(pkg *packages.Package) []packages.Error {
+	errors := extractErrorsImpl(pkg)
+	if len(errors) == 0 {
+		return errors
+	}
+
+	seenErrors := map[string]bool{}
+	var uniqErrors []packages.Error
+	for _, err := range errors {
+		if seenErrors[err.Msg] {
+			continue
+		}
+		seenErrors[err.Msg] = true
+		uniqErrors = append(uniqErrors, err)
+	}
+
+	if len(pkg.Errors) == 0 && len(pkg.GoFiles) != 0 {
+		// erorrs were extracted from deps and have at leat one file in package
+		for i := range uniqErrors {
+			// change pos to local file to properly process it by processors (properly read line etc)
+			uniqErrors[i].Msg = fmt.Sprintf("%s: %s", uniqErrors[i].Pos, uniqErrors[i].Msg)
+			uniqErrors[i].Pos = fmt.Sprintf("%s:1", pkg.GoFiles[0])
+		}
+	}
+
+	return uniqErrors
+}
+
+func extractErrorsImpl(pkg *packages.Package) []packages.Error {
+	if len(pkg.Errors) != 0 {
+		return pkg.Errors
+	}
+
+	var errors []packages.Error
+	for _, iPkg := range pkg.Imports {
+		iPkgErrors := extractErrorsImpl(iPkg)
+		if iPkgErrors != nil {
+			errors = append(errors, iPkgErrors...)
+		}
+	}
+
+	return errors
+}

--- a/pkg/result/processors/cgo.go
+++ b/pkg/result/processors/cgo.go
@@ -42,7 +42,7 @@ func (p Cgo) Process(issues []result.Issue) ([]result.Issue, error) {
 			issueFilePath = absPath
 		}
 
-		if strings.HasPrefix(issueFilePath, p.goCacheDir) {
+		if p.goCacheDir != "" && strings.HasPrefix(issueFilePath, p.goCacheDir) {
 			return false, nil
 		}
 

--- a/pkg/result/processors/skip_dirs.go
+++ b/pkg/result/processors/skip_dirs.go
@@ -52,7 +52,6 @@ func NewSkipDirs(patterns []string, log logutils.Log, runArgs []string) (*SkipDi
 		sortedAbsArgs = append(sortedAbsArgs, absArg)
 	}
 	sort.Sort(sortedByLenStrings(sortedAbsArgs))
-	log.Infof("sorted abs args: %s", sortedAbsArgs)
 
 	return &SkipDirs{
 		patterns:      patternsRe,


### PR DESCRIPTION
1. Fix crash if deps of analyzed packages weren't compiled.
2. Print deps typechecking errors
3. Fix all issues filtering because of empty go env GOCACHE for go < 1.10
