### PR TITLE
Fix the skip-dirs option.

### DIFF
--- a/pkg/result/processors/skip_dirs.go
+++ b/pkg/result/processors/skip_dirs.go
@@ -85,9 +85,7 @@ func (p *SkipDirs) getLongestArgRelativeIssuePath(i *result.Issue) string {
 			continue
 		}
 
-		relPath := strings.TrimPrefix(issueAbsPath, arg)
-		relPath = strings.TrimPrefix(relPath, string(filepath.Separator))
-		return relPath
+		return i.FilePath()
 	}
 
 	p.log.Infof("Issue path %q isn't relative to any of run args", i.FilePath())


### PR DESCRIPTION
Prior to this change the SkipDir runner was not skipping files such as `foo/bar/baz.go` with a `skip-dir` entry of `foo/bar` when the `run` command was invoked with an argument of `foo/...`.  This is both a surprising and problematic behavior change.

The pathology was:

1. `shouldPassIssue()` was receiving an input like `foo/bar/baz.go`
2. `shouldPassIssue()` would call `p.getLongestArgRelativeIssuePath()` which was returning `bar`, not `foo/bar` as expected.
3. The reason for this was because inside of `getLongestArgRelativeIssuePath()` it was trimming the prefix that matched the path prefix (e.g. `foo/`).

If you have the file structure:

  - foo/bar/baz.go
  - bur/bar/baz.go

There is no way to isolate `foo/bar` from `bur/baz` without strictly controlling both your `skip-dirs` configuration and the arguments to `run`.

The rest of the logic to skip files that don't match `run`'s argument is valid, however the regexp should be evaluated based on the `filepath.Dir()` of the input (e.g. `foo/bar`) and not the truncated version of the issue's filepath.

This fixed unexpected breakage resulting from a recent upgrade.

Fixes: #301 