### PR TITLE
Remove stylecheck from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ $ golangci-lint help linters
 ...
 Disabled by default linters:
 golint: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true]
-stylecheck: Stylecheck is a replacement for golint [fast: false]
 gosec (gas): Inspects source code for security problems [fast: true]
 interfacer: Linter that suggests narrower interface types [fast: false]
 unconvert: Remove unnecessary type conversions [fast: true]


### PR DESCRIPTION
stylecheck is no longer supported:

```shell
$ golangci-lint --version
golangci-lint has version 1.12.5 built from 609de32 on 2018-12-23T09:42:24Z
$ golangci-lint help linters | grep stylecheck
$
```

Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make readme`.