### PR TITLE
Add 'segmentio/terraform-docs' to list of great projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following great projects use golangci-lint:
 * [banzaicloud/pipeline](https://github.com/banzaicloud/pipeline)
 * [posener/complete](https://github.com/posener/complete)
 * [y0ssar1an/q](https://github.com/y0ssar1an/q)
+* [segmentio/terraform-docs](https://github.com/segmentio/terraform-docs)
 
 ## Quick Start
 
@@ -489,6 +490,7 @@ Global Flags:
       --cpu-profile-path string   Path to CPU profile output file
       --mem-profile-path string   Path to memory profile output file
   -v, --verbose                   verbose output
+      --version                   Print version
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -490,7 +490,6 @@ Global Flags:
       --cpu-profile-path string   Path to CPU profile output file
       --mem-profile-path string   Path to memory profile output file
   -v, --verbose                   verbose output
-      --version                   Print version
 
 ```
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -140,6 +140,7 @@ The following great projects use golangci-lint:
 * [banzaicloud/pipeline](https://github.com/banzaicloud/pipeline)
 * [posener/complete](https://github.com/posener/complete)
 * [y0ssar1an/q](https://github.com/y0ssar1an/q)
+* [segmentio/terraform-docs](https://github.com/segmentio/terraform-docs)
 
 ## Quick Start
 


### PR DESCRIPTION
Thank you for considering segmentio/terraform-docs for your list of projects using golangci-lint. `make readme` also added the `--version` option into `README.md` (seems like the README was outdated in this regard). Let me know if this is an issue and I'll resubmit. Thanks!

---

Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make readme`.

