### PR TITLE
Add code-climate output format

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -49,7 +49,7 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   format: colored-line-number
 
   # print lines of code with issue, default is true

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Usage:
   golangci-lint run [flags]
 
 Flags:
-      --out-format string           Format of output: colored-line-number|line-number|json|tab|checkstyle (default "colored-line-number")
+      --out-format string           Format of output: colored-line-number|line-number|json|tab|checkstyle|code-climate (default "colored-line-number")
       --print-issued-lines          Print lines of code with issue (default true)
       --print-linter-name           Print linter name in issue line (default true)
       --issues-exit-code int        Exit code when issues were found (default 1)
@@ -572,7 +572,7 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   format: colored-line-number
 
   # print lines of code with issue, default is true

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -363,6 +363,8 @@ func (e *Executor) createPrinter() (printers.Printer, error) {
 		p = printers.NewTab(e.cfg.Output.PrintLinterName, e.log.Child("tab_printer"))
 	case config.OutFormatCheckstyle:
 		p = printers.NewCheckstyle()
+	case config.OutFormatCodeClimate:
+		p = printers.NewCodeClimate()
 	default:
 		return nil, fmt.Errorf("unknown output format %s", format)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ const (
 	OutFormatColoredLineNumber = "colored-line-number"
 	OutFormatTab               = "tab"
 	OutFormatCheckstyle        = "checkstyle"
+	OutFormatCodeClimate       = "code-climate"
 )
 
 var OutFormats = []string{
@@ -18,6 +19,7 @@ var OutFormats = []string{
 	OutFormatJSON,
 	OutFormatTab,
 	OutFormatCheckstyle,
+	OutFormatCodeClimate,
 }
 
 type ExcludePattern struct {

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -1,0 +1,56 @@
+package printers
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+
+	"github.com/golangci/golangci-lint/pkg/logutils"
+	"github.com/golangci/golangci-lint/pkg/result"
+)
+
+// CodeClimateIssue is a subset of the Code Climate spec - https://github.com/codeclimate/spec/blob/master/SPEC.md#data-types
+// It is just enough to support GitLab CI Code Quality - https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html
+type CodeClimateIssue struct {
+	Description string `json:"description"`
+	Fingerprint string `json:"fingerprint"`
+	Location    struct {
+		Path  string `json:"path"`
+		Lines struct {
+			Begin int `json:"begin"`
+		} `json:"lines"`
+	} `json:"location"`
+}
+
+type CodeClimate struct {
+}
+
+func NewCodeClimate() *CodeClimate {
+	return &CodeClimate{}
+}
+
+func (p CodeClimate) Print(ctx context.Context, issues <-chan result.Issue) error {
+	allIssues := []CodeClimateIssue{}
+	for i := range issues {
+		var issue CodeClimateIssue
+		issue.Description = i.FromLinter + ": " + i.Text
+		issue.Location.Path = i.Pos.Filename
+		issue.Location.Lines.Begin = i.Pos.Line
+
+		// Need a checksum of the issue, so we use MD5 of the filename, text, and first line of source
+		hash := md5.New()
+		_, _ = hash.Write([]byte(i.Pos.Filename + i.Text + i.SourceLines[0]))
+		issue.Fingerprint = fmt.Sprintf("%X", hash.Sum(nil))
+
+		allIssues = append(allIssues, issue)
+	}
+
+	outputJSON, err := json.Marshal(allIssues)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(logutils.StdOut, string(outputJSON))
+	return nil
+}


### PR DESCRIPTION
Just the minimum of the format, to support GitLab CI Code Quality - https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html

You can then add it as a job to `.gitlab-ci.yml`

```yaml
lint:
  script:
    - golangci-lint run --out-format code-climate --issues-exit-code 0 > code-quality-report.json
  artifacts:
    reports:
      codequality: code-quality-report.json
```

And the new/resolved issues will be displayed in merge requests

![image](https://user-images.githubusercontent.com/622455/52309201-7cda8c00-29f3-11e9-8823-684bbf91e9d7.png)

