### PR TITLE
Add version information to built artifact when go get with go1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Local installation is not recommended for your CI pipeline. Only install the lin
 go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 ```
 
+With `go1.11` or later you can get a particular version
+```bash
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.14.1
+```
+
 #### MacOS
 
 You can also install it on MacOS using [brew](https://brew.sh/):

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -96,6 +96,11 @@ Local installation is not recommended for your CI pipeline. Only install the lin
 go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 ```
 
+With `go1.11` or later you can get a particular version
+```bash
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.14.1
+```
+
 #### MacOS
 
 You can also install it on MacOS using [brew](https://brew.sh/):

--- a/cmd/golangci-lint/mod_version.go
+++ b/cmd/golangci-lint/mod_version.go
@@ -1,0 +1,18 @@
+// +build go1.12
+
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+func init() {
+	if info, available := debug.ReadBuildInfo(); available {
+		if date == "" && info.Main.Version != "(devel)" {
+			version = info.Main.Version
+			commit = fmt.Sprintf("(unknown, mod sum: %q)", info.Main.Sum)
+			date = "(unknown)"
+		}
+	}
+}


### PR DESCRIPTION
With upcoming `go1.12` we can now embed some version information without `LDFLAGS`. This PR uses [`debug.ReadBuildInfo()`](https://godoc.org/github.com/golang/go/src/runtime/debug#ReadBuildInfo) to simplify versioning with `go get`.

Here is a working example
```
GO111MODULE=on go1.12rc1 get github.com/vearutop/go-versioning-example@v0.0.1
```

```
go-versioning-example
Build info: &{Path:github.com/vearutop/go-versioning-example Main:{Path:github.com/vearutop/go-versioning-example Version:v0.0.1 Sum:h1:RtKk8SiukO2jrjtkz+0mYQ6bQjUcom3UUqTdBpGAk5o= Replace:<nil>} Deps:[0xc0000a02c0 0xc0000a0300]}
2019-02-12T11:11:20.447+0100	INFO	go-versioning-example@v0.0.1/main.go:9	App Version: v0.0.1
```