### PR TITLE
Fix AST cache key consistency

### DIFF
--- a/pkg/lint/astcache/astcache.go
+++ b/pkg/lint/astcache/astcache.go
@@ -129,10 +129,12 @@ func (c *Cache) loadFromPackage(pkg *packages.Package) {
 			continue
 		}
 
-		c.m[pos.Filename] = &File{
+		filePath := c.normalizeFilename(pos.Filename)
+
+		c.m[filePath] = &File{
 			F:    f,
 			Fset: pkg.Fset,
-			Name: pos.Filename,
+			Name: filePath,
 		}
 	}
 }


### PR DESCRIPTION
After upgrading to v1.15.0 I started seeing some strange AST cache resolution errors.

```
Can't run linter golint: no AST for file /path/to/foo.go in cache: {...}

Can't process result by autogenerated_exclude processor: can't filter issue result.Issue{...}: can't parse file /path/to/foo.go: <nil>"

Can't process result by nolint processor: can't filter issue result.Issue{...}: can't parse file /path/to/foo.go: <nil>, astcache is [...]
```

I've narrowed it down to commit 96af9582052f62722593d4085f2357df508a6310 which changed the symlink resolution behavior. This change fixes a key consistency issue by ensuring all loads/stores accessing the AST cache use the normalized file path.