### PR TITLE
Add Exclude regexp for LLL

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -123,6 +123,8 @@ linters-settings:
     line-length: 120
     # tab width in spaces. Default to 1.
     tab-width: 1
+    #lines that are matching regexp will be excluded
+    exclude: ".*go:generate.*"
   unused:
     # treat code as a program (not a library) and report unused exported identifiers; default is false.
     # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:

--- a/README.md
+++ b/README.md
@@ -653,6 +653,8 @@ linters-settings:
     line-length: 120
     # tab width in spaces. Default to 1.
     tab-width: 1
+    #lines that are matching regexp will be excluded
+    exclude: ".*go:generate.*"
   unused:
     # treat code as a program (not a library) and report unused exported identifiers; default is false.
     # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,8 +181,9 @@ type ErrcheckSettings struct {
 }
 
 type LllSettings struct {
-	LineLength int `mapstructure:"line-length"`
-	TabWidth   int `mapstructure:"tab-width"`
+	LineLength int    `mapstructure:"line-length"`
+	TabWidth   int    `mapstructure:"tab-width"`
+	Exclude    string `mapstructure:"exclude"`
 }
 
 type UnparamSettings struct {


### PR DESCRIPTION
Add Exclude regexp for LLL to allow excluding lines that can extend max line size, for example:
```
//go:generate mockgen -source=$GOPATH/src/github.com//myVeryLongOrganizationName/myLongServiceNameThatIAmForcedToUse/pkg/api/api.pb.go -destination=mocks/api.pb.go -package=mocks
```