### PR TITLE
Include log level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,7 @@ There is the most valuable changes log:
 2. Build and test on go 1.12
 3. Support `--color` option
 4. Update x/tools to fix c++ issues
+5. Include support to log level
 
 ### February 2019
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -491,6 +491,7 @@ There is the most valuable changes log:
 2. Build and test on go 1.12
 3. Support `--color` option
 4. Update x/tools to fix c++ issues
+5. Include support to log level
 
 ### February 2019
 

--- a/pkg/logutils/stderr_log.go
+++ b/pkg/logutils/stderr_log.go
@@ -24,12 +24,22 @@ func NewStderrLog(name string) *StderrLog {
 		level:  LogLevelWarn,
 	}
 
-	// control log level in logutils, not in logrus
-	sl.logger.SetLevel(logrus.DebugLevel)
+	switch os.Getenv("LOG_LEVEL") {
+	case "error", "err":
+		sl.logger.SetLevel(logrus.ErrorLevel)
+	case "warning", "warn":
+		sl.logger.SetLevel(logrus.WarnLevel)
+	case "info":
+		sl.logger.SetLevel(logrus.InfoLevel)
+	default:
+		sl.logger.SetLevel(logrus.DebugLevel)
+	}
+
 	sl.logger.Out = StdErr
 	sl.logger.Formatter = &logrus.TextFormatter{
 		DisableTimestamp: true, // `INFO[0007] msg` -> `INFO msg`
 	}
+
 	return sl
 }
 


### PR DESCRIPTION
It provides support to user define a custom log level to avoid warnings or debug options.
The usage will be something like this:
```bash
LOG_LEVEL=error golangci-lint run
```

Close #432 