### PR TITLE
Add --color flag to force colored output on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Flags:
   -h, --help                        help for run
 
 Global Flags:
+      --color string              Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
   -j, --concurrency int           Concurrency (default NumCPU) (default 8)
       --cpu-profile-path string   Path to CPU profile output file
       --mem-profile-path string   Path to memory profile output file

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -47,6 +48,17 @@ func NewExecutor(version, commit, date string) *Executor {
 	}
 	if commandLineCfg != nil {
 		logutils.SetupVerboseLog(e.log, commandLineCfg.Run.IsVerbose)
+	}
+
+	switch commandLineCfg.Output.Color {
+	case "always":
+		color.NoColor = false
+	case "never":
+		color.NoColor = true
+	case "auto":
+		// nothing
+	default:
+		e.log.Fatalf("invalid value %q for --color; must be 'always', 'auto', or 'never'", commandLineCfg.Output.Color)
 	}
 
 	// init of commands must be done before config file reading because

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -48,17 +48,17 @@ func NewExecutor(version, commit, date string) *Executor {
 	}
 	if commandLineCfg != nil {
 		logutils.SetupVerboseLog(e.log, commandLineCfg.Run.IsVerbose)
-	}
 
-	switch commandLineCfg.Output.Color {
-	case "always":
-		color.NoColor = false
-	case "never":
-		color.NoColor = true
-	case "auto":
-		// nothing
-	default:
-		e.log.Fatalf("invalid value %q for --color; must be 'always', 'auto', or 'never'", commandLineCfg.Output.Color)
+		switch commandLineCfg.Output.Color {
+		case "always":
+			color.NoColor = false
+		case "never":
+			color.NoColor = true
+		case "auto":
+			// nothing
+		default:
+			e.log.Fatalf("invalid value %q for --color; must be 'always', 'auto', or 'never'", commandLineCfg.Output.Color)
+		}
 	}
 
 	// init of commands must be done before config file reading because

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -103,4 +103,6 @@ func initRootFlagSet(fs *pflag.FlagSet, cfg *config.Config, needVersionOption bo
 	if needVersionOption {
 		fs.BoolVar(&cfg.Run.PrintVersion, "version", false, wh("Print version"))
 	}
+
+	fs.StringVar(&cfg.Output.Color, "color", "auto", wh("Use color when printing; can be 'always', 'auto', or 'never'"))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -288,6 +288,7 @@ type Config struct { //nolint:maligned
 
 	Output struct {
 		Format              string
+		Color               string
 		PrintIssuedLine     bool `mapstructure:"print-issued-lines"`
 		PrintLinterName     bool `mapstructure:"print-linter-name"`
 		PrintWelcomeMessage bool `mapstructure:"print-welcome"`


### PR DESCRIPTION
fatih/color disables color output automatically if the output is not a tty, and expects applications to override this if required. In Jenkins the output is not a tty, but it does understand color codes.