### PR TITLE
Update go version to 1.12 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY golangci-lint /usr/bin/


### PR DESCRIPTION
Hi! I always use golangci-lint with the docker image.

I edited Dockerfile to update go version to 1.12
I would be glad if you reviewed and merged this request.

Thanks!