### PR TITLE
Makefile: Add target build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-test:
-	go build -o golangci-lint ./cmd/golangci-lint
+test: build
 	GL_TEST_RUN=1 ./golangci-lint run -v
 	GL_TEST_RUN=1 ./golangci-lint run --fast --no-config -v --skip-dirs 'test/testdata_etc,pkg/golinters/goanalysis/(checker|passes)'
 	GL_TEST_RUN=1 ./golangci-lint run --no-config -v --skip-dirs 'test/testdata_etc,pkg/golinters/goanalysis/(checker|passes)'
 	GL_TEST_RUN=1 go test -v ./...
+
+build:
+	go build -o golangci-lint ./cmd/golangci-lint
 
 test_race:
 	go build -race -o golangci-lint ./cmd/golangci-lint


### PR DESCRIPTION
kata-containers's ci will re-build and re-install golangci-lint every
time it did the staic check.
So run test of golangci-lint with build will make it slow.
Add target build to make golangci-lint just build but not test.

Fixes: #458

Signed-off-by: Hui Zhu <teawater@hyper.sh>

Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make readme`.