### PR TITLE
Lll: add regexp excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@ There is the most valuable changes log:
 5. Support `--color` option
 6. Update x/tools to fix c++ issues
 7. Include support for log level
+8. Support regexp excludes for `lll`
 
 ### February 2019
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -494,6 +494,7 @@ There is the most valuable changes log:
 5. Support `--color` option
 6. Update x/tools to fix c++ issues
 7. Include support for log level
+8. Support regexp excludes for `lll`
 
 ### February 2019
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -184,8 +184,9 @@ type ErrcheckSettings struct {
 }
 
 type LllSettings struct {
-	LineLength int `mapstructure:"line-length"`
-	TabWidth   int `mapstructure:"tab-width"`
+	LineLength int      `mapstructure:"line-length"`
+	TabWidth   int      `mapstructure:"tab-width"`
+	Excludes   []string `mapstructure:"excludes"`
 }
 
 type UnparamSettings struct {

--- a/pkg/golinters/lll.go
+++ b/pkg/golinters/lll.go
@@ -123,11 +123,12 @@ func (lint Lll) getIssuesForFile(
 func (lint Lll) Run(ctx context.Context, lintCtx *linter.Context) ([]result.Issue, error) {
 	var res []result.Issue
 	spaces := strings.Repeat(" ", lintCtx.Settings().Lll.TabWidth)
+	settings := lintCtx.Settings().Lll
 	for _, f := range getAllFileNames(lintCtx) {
 		issues, err := lint.getIssuesForFile(
 			f,
-			lintCtx.Settings().Lll.LineLength,
-			lintCtx.Settings().Lll.Excludes,
+			settings.LineLength,
+			settings.Excludes,
 			spaces,
 		)
 		if err != nil {

--- a/pkg/golinters/lll_test.go
+++ b/pkg/golinters/lll_test.go
@@ -1,0 +1,128 @@
+package golinters
+
+import (
+	"go/token"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/golangci/golangci-lint/pkg/result"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLllExcludes(t *testing.T) {
+	testCases := []struct {
+		name        string
+		excludes    []string
+		maxLineLen  int
+		tabSpaces   string
+		err         bool
+		fileContent string
+		issues      func(filename string) []result.Issue
+	}{
+		{
+			name:       "no issue no excludes",
+			maxLineLen: 100,
+			tabSpaces:  "    ",
+			fileContent: `
+hello world
+`,
+			issues: func(filename string) []result.Issue {
+				return nil
+			},
+		},
+		{
+			name:       "no issue 1 exclude line matches",
+			maxLineLen: 10,
+			tabSpaces:  "    ",
+			fileContent: `
+a
+b
+c
+d
+e
+this line is more than 10 char but matches regexp
+`,
+			excludes: []string{"regexp"},
+			issues: func(filename string) []result.Issue {
+				return nil
+			},
+		},
+		{
+			name:       "no issue 2 excludes line matches",
+			maxLineLen: 10,
+			tabSpaces:  "    ",
+			fileContent: `
+a
+b
+c
+d
+e
+this line is more than 10 char but matches regexp
+`,
+			excludes: []string{"foo", "regexp"},
+			issues: func(filename string) []result.Issue {
+				return nil
+			},
+		},
+		{
+			name:       "1 issue 2 exclude, line does not match",
+			maxLineLen: 10,
+			tabSpaces:  "    ",
+			fileContent: `
+a
+b
+c
+d
+e
+this line is more than 10 char but matches regexp
+
+`,
+			excludes: []string{"foo", "bar"},
+			issues: func(filename string) []result.Issue {
+				return []result.Issue{
+					{
+						Pos: token.Position{
+							Filename: filename,
+							Line:     7,
+						},
+						Text:       "line is 49 characters",
+						FromLinter: "lll",
+					},
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(
+			testCase.name,
+			func(t *testing.T) {
+				f, err := ioutil.TempFile(os.TempDir(), "")
+				assert.Nil(t, err)
+
+				defer os.Remove(f.Name())
+
+				_, err = f.Write([]byte(testCase.fileContent))
+				assert.Nil(t, err)
+
+				linter := Lll{}
+
+				issues, err := linter.getIssuesForFile(
+					f.Name(),
+					testCase.maxLineLen,
+					testCase.excludes,
+					testCase.tabSpaces,
+				)
+
+				if testCase.err {
+					assert.NotNil(t, err)
+					return
+				}
+				assert.Nil(t, err)
+				assert.Equal(t, testCase.issues(f.Name()), issues)
+			},
+		)
+	}
+}

--- a/pkg/golinters/lll_test.go
+++ b/pkg/golinters/lll_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/golangci/golangci-lint/pkg/result"
+
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Hi, 

I'd like to add excludes to `lll` so that if a line longer than the maxLineLen matches one of the excludes regexp, it won't be considered an issue.

Example config:
```yaml
lll:
    line-length: 80
    tab-width: 1
    excludes: 
    - "`[A-z0-9]+:\".*.\"`"
```