### PR TITLE
[#479] make use of LoadAllSyntax compatible with the latest x/tools version

### DIFF
--- a/pkg/lint/load.go
+++ b/pkg/lint/load.go
@@ -168,7 +168,9 @@ func stringifyLoadMode(mode packages.LoadMode) string {
 		return "load types"
 	case packages.LoadSyntax:
 		return "load types and syntax"
-	case packages.LoadAllSyntax:
+	}
+	// it may be an alias, and may be not
+	if mode == packages.LoadAllSyntax {
 		return "load deps types and syntax"
 	}
 	return "unknown"


### PR DESCRIPTION
LoadAllSyntax in the latest version is equal to the LoadSyntax (https://github.com/golang/tools/blob/master/go/packages/packages.go#L104) and thus can not be used in a switch with LoadSyntax because it duplicates a value.

https://github.com/golangci/golangci-lint/issues/479