### PR TITLE
Add support to ignore test files when using errcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Flags:
       --no-config                   Don't read config
       --skip-dirs strings           Regexps of directories to skip
       --skip-files strings          Regexps of files to skip
+      --errcheck.without-tests      Boolean value to include tests in errcheck or not
   -E, --enable strings              Enable specific linter
   -D, --disable strings             Disable specific linter
       --enable-all                  Enable all linters

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -103,6 +103,7 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.StringVar(&lsc.Errcheck.Ignore, "errcheck.ignore", "fmt:.*",
 		`Comma-separated list of pairs of the form pkg:regex. The regex is used to ignore names within pkg`)
 	hideFlag("errcheck.ignore")
+	fs.BoolVar(&lsc.Errcheck.WithoutTests, "errcheck.without-tests", false, "Boolean value to include tests in errcheck or not")
 
 	fs.BoolVar(&lsc.Govet.CheckShadowing, "govet.check-shadowing", false,
 		"Govet: check for shadowed variables")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,6 +181,7 @@ type ErrcheckSettings struct {
 	CheckAssignToBlank  bool   `mapstructure:"check-blank"`
 	Ignore              string `mapstructure:"ignore"`
 	Exclude             string `mapstructure:"exclude"`
+	WithoutTests        bool   `mapstructure:"without-tests"`
 }
 
 type LllSettings struct {

--- a/pkg/golinters/errcheck.go
+++ b/pkg/golinters/errcheck.go
@@ -98,9 +98,10 @@ func genConfig(errCfg *config.ErrcheckSettings) (*errcheckAPI.Config, error) {
 	}
 
 	c := &errcheckAPI.Config{
-		Ignore:  ignoreConfig,
-		Blank:   errCfg.CheckAssignToBlank,
-		Asserts: errCfg.CheckTypeAssertions,
+		Ignore:       ignoreConfig,
+		Blank:        errCfg.CheckAssignToBlank,
+		Asserts:      errCfg.CheckTypeAssertions,
+		WithoutTests: errCfg.WithoutTests,
 	}
 
 	if errCfg.Exclude != "" {


### PR DESCRIPTION
This PR solves #493  by adding `without-tests` field to `errcheck`. 

Depends on golangci/errcheck#2