### PR TITLE
Fix version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 With `go1.11` or later you can get a particular version
 ```bash
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.14.1
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.16.0
 ```
 
 #### MacOS
@@ -185,16 +185,16 @@ GolangCI-Lint can be used with zero configuration. By default the following lint
 ```bash
 $ golangci-lint help linters
 Enabled by default linters:
-deadcode: Finds unused code [fast: true, auto-fix: false]
-errcheck: Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: true, auto-fix: false]
-gosimple: Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
-govet (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
-ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
-staticcheck: Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false, auto-fix: false]
-structcheck: Finds an unused struct fields [fast: true, auto-fix: false]
-typecheck: Like the front-end of a Go compiler, parses and type-checks Go code [fast: true, auto-fix: false]
-unused: Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
-varcheck: Finds unused global variables and constants [fast: true, auto-fix: false]
+govet: Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: true]
+errcheck: Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: true]
+staticcheck: Staticcheck is a go vet on steroids, applying a ton of static analysis checks [fast: false]
+unused: Checks Go code for unused constants, variables, functions and types [fast: false]
+gosimple: Linter for Go source code that specializes in simplifying a code [fast: false]
+structcheck: Finds an unused struct fields [fast: true]
+varcheck: Finds unused global variables and constants [fast: true]
+ineffassign: Detects when assignments to existing variables are not used [fast: true]
+deadcode: Finds unused code [fast: true]
+typecheck: Like the front-end of a Go compiler, parses and type-checks Go code [fast: true]
 ```
 
 and the following linters are disabled by default:
@@ -203,27 +203,27 @@ and the following linters are disabled by default:
 $ golangci-lint help linters
 ...
 Disabled by default linters:
-depguard: Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
-dupl: Tool for code clone detection [fast: true, auto-fix: false]
-gochecknoglobals: Checks that no globals are present in Go code [fast: true, auto-fix: false]
-gochecknoinits: Checks that no init functions are present in Go code [fast: true, auto-fix: false]
-goconst: Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
-gocritic: The most opinionated Go source code linter [fast: true, auto-fix: false]
-gocyclo: Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
-gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
-goimports: Goimports does everything that gofmt does. Additionally it checks unused imports [fast: true, auto-fix: true]
-golint: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true, auto-fix: false]
-gosec (gas): Inspects source code for security problems [fast: true, auto-fix: false]
-interfacer: Linter that suggests narrower interface types [fast: false, auto-fix: false]
-lll: Reports long lines [fast: true, auto-fix: false]
-maligned: Tool to detect Go structs that would take less memory if their fields were sorted [fast: true, auto-fix: false]
-misspell: Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
-nakedret: Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
-prealloc: Finds slice declarations that could potentially be preallocated [fast: true, auto-fix: false]
-scopelint: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
-stylecheck: Stylecheck is a replacement for golint [fast: false, auto-fix: false]
-unconvert: Remove unnecessary type conversions [fast: true, auto-fix: false]
-unparam: Reports unused function parameters [fast: false, auto-fix: false]
+golint: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true]
+gosec (gas): Inspects source code for security problems [fast: true]
+interfacer: Linter that suggests narrower interface types [fast: false]
+unconvert: Remove unnecessary type conversions [fast: true]
+dupl: Tool for code clone detection [fast: true]
+goconst: Finds repeated strings that could be replaced by a constant [fast: true]
+gocyclo: Computes and checks the cyclomatic complexity of functions [fast: true]
+gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true]
+goimports: Goimports does everything that gofmt does. Additionally it checks unused imports [fast: true]
+maligned: Tool to detect Go structs that would take less memory if their fields were sorted [fast: true]
+megacheck: 3 sub-linters in one: unused, gosimple and staticcheck [fast: false]
+depguard: Go linter that checks if package imports are in a list of acceptable packages [fast: true]
+misspell: Finds commonly misspelled English words in comments [fast: true]
+lll: Reports long lines [fast: true]
+unparam: Reports unused function parameters [fast: false]
+nakedret: Finds naked returns in functions greater than a specified function length [fast: true]
+prealloc: Finds slice declarations that could potentially be preallocated [fast: true]
+scopelint: Scopelint checks for unpinned variables in go programs [fast: true]
+gocritic: The most opinionated Go source code linter [fast: true]
+gochecknoinits: Checks that no init functions are present in Go code [fast: true]
+gochecknoglobals: Checks that no globals are present in Go code [fast: true]
 ```
 
 Pass `-E/--enable` to enable linter and `-D/--disable` to disable:
@@ -457,7 +457,7 @@ Usage:
   golangci-lint run [flags]
 
 Flags:
-      --out-format string           Format of output: colored-line-number|line-number|json|tab|checkstyle|code-climate (default "colored-line-number")
+      --out-format string           Format of output: colored-line-number|line-number|json|tab|checkstyle (default "colored-line-number")
       --print-issued-lines          Print lines of code with issue (default true)
       --print-linter-name           Print linter name in issue line (default true)
       --issues-exit-code int        Exit code when issues were found (default 1)
@@ -473,7 +473,7 @@ Flags:
   -D, --disable strings             Disable specific linter
       --enable-all                  Enable all linters
       --disable-all                 Disable all linters
-  -p, --presets strings             Enable presets (bugs|complexity|format|performance|style|unused) of linters. Run 'golangci-lint linters' to see them. This option implies option --disable-all
+  -p, --presets strings             Enable presets (bugs|unused|format|style|complexity|performance) of linters. Run 'golangci-lint linters' to see them. This option implies option --disable-all
       --fast                        Run only fast linters from enabled linters set (first run won't be fast)
   -e, --exclude strings             Exclude issue by regexp
       --exclude-use-default         Use or not use default excludes:
@@ -489,7 +489,7 @@ Flags:
                                       # govet: Common false positives
                                       - (possible misuse of unsafe.Pointer|should have signature)
                                     
-                                      # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
+                                      # megacheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
                                       - ineffective break statement. Did you mean to break out of the outer loop
                                     
                                       # gosec: Too many false-positives on 'unsafe' usage
@@ -515,15 +515,14 @@ Flags:
                                     For CI setups, prefer --new-from-rev=HEAD~, as --new can skip linting the current patch if any scripts generate unstaged files before golangci-lint runs.
       --new-from-rev REV            Show only new issues created after git revision REV
       --new-from-patch PATH         Show only new issues created in git patch with file path PATH
-      --fix                         Fix found issues (if it's supported by the linter)
   -h, --help                        help for run
 
 Global Flags:
-      --color string              Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
   -j, --concurrency int           Concurrency (default NumCPU) (default 8)
       --cpu-profile-path string   Path to CPU profile output file
       --mem-profile-path string   Path to memory profile output file
   -v, --verbose                   verbose output
+      --version                   Print version
 
 ```
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -98,7 +98,7 @@ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 With `go1.11` or later you can get a particular version
 ```bash
-GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.14.1
+GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.16.0
 ```
 
 #### MacOS


### PR DESCRIPTION
v1.14.1 version not exist in github so it generate error on install.

Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make readme`.