### PR TITLE
Add strict mode for go vet shadow check

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,6 +173,7 @@ type LintersSettings struct {
 
 type GovetSettings struct {
 	CheckShadowing bool `mapstructure:"check-shadowing"`
+	ShadowStrict   bool `mapstructure:"shadow-strict"`
 	Settings       map[string]map[string]interface{}
 }
 

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -1,6 +1,8 @@
 package golinters
 
 import (
+	"log"
+
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
@@ -73,6 +75,12 @@ func NewGovet(cfg *config.GovetSettings) *goanalysis.Linter {
 	if cfg != nil {
 		if cfg.CheckShadowing {
 			analyzers = append(analyzers, shadow.Analyzer)
+			if cfg.ShadowStrict {
+				err := shadow.Analyzer.Flags.Set("strict", "true")
+				if err != nil {
+					log.Printf("failed to set strict mode for shadow analyzer: %v", err)
+				}
+			}
 		}
 		settings = cfg.Settings
 	}


### PR DESCRIPTION
Add "shadow-strict" configuration option for go vet.