### PR TITLE
Fix staticcheck panic on packages that do not compile

### DIFF
--- a/pkg/exitcodes/exitcodes.go
+++ b/pkg/exitcodes/exitcodes.go
@@ -24,4 +24,8 @@ var (
 		Message: "no go files to analyze",
 		Code:    NoGoFiles,
 	}
+	ErrFailure = &ExitError{
+		Message: "failed to analyze",
+		Code:    Failure,
+	}
 )

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -32,7 +32,7 @@ func TestEmptyDirRun(t *testing.T) {
 
 func TestNotExistingDirRun(t *testing.T) {
 	testshared.NewLintRunner(t).Run(getTestDataDir("no_such_dir")).
-		ExpectExitCode(exitcodes.WarningInTest).
+		ExpectExitCode(exitcodes.Failure).
 		ExpectOutputContains(`cannot find package \"./testdata/no_such_dir\"`)
 }
 


### PR DESCRIPTION
The bug was introduced in golangci-lint when migrating staticcheck to go/packages.
Also, thanks to pkg.IllTyped we can analyze as max as we can by
staticcheck.

Relates: #418, #369, #429, #489