### PR TITLE
fix #513: don't add gofmt "with -s" if not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
   - 1.11.x
   - 1.12.x
 
+before_script:
+  - go get github.com/valyala/quicktemplate
+
 script: make check_generated test
 
 after_success:

--- a/test/errchk.go
+++ b/test/errchk.go
@@ -52,6 +52,7 @@ func errorCheck(outStr string, wantAuto bool, fullshort ...string) (err error) {
 		}
 		matched := false
 		n := len(out)
+		var textsToMatch []string
 		for _, errmsg := range errmsgs {
 			// Assume errmsg says "file:line: foo".
 			// Cut leading "file:line: " to avoid accidental matching of file name instead of message.
@@ -63,10 +64,13 @@ func errorCheck(outStr string, wantAuto bool, fullshort ...string) (err error) {
 				matched = true
 			} else {
 				out = append(out, errmsg)
+				textsToMatch = append(textsToMatch, text)
 			}
 		}
 		if !matched {
-			errs = append(errs, fmt.Errorf("%s:%d: no match for %#q in:\n\t%s", we.file, we.lineNum, we.reStr, strings.Join(out[n:], "\n\t")))
+			err := fmt.Errorf("%s:%d: no match for %#q vs %q in:\n\t%s",
+				we.file, we.lineNum, we.reStr, textsToMatch, strings.Join(out[n:], "\n\t"))
+			errs = append(errs, err)
 			continue
 		}
 	}

--- a/test/testdata/gofmt_no_simplify.go
+++ b/test/testdata/gofmt_no_simplify.go
@@ -1,0 +1,13 @@
+//args: -Egofmt
+//config: linters-settings.gofmt.simplify=false
+package testdata
+
+import "fmt"
+
+func GofmtNotSimplifiedOk() {
+	var x []string
+	fmt.Print(x[1:len(x)])
+}
+
+func GofmtBadFormat(){  // ERROR "^File is not `gofmt`-ed$"
+}

--- a/test/testshared/testshared.go
+++ b/test/testshared/testshared.go
@@ -14,9 +14,10 @@ import (
 )
 
 type LintRunner struct {
-	t   assert.TestingT
-	log logutils.Log
-	env []string
+	t         assert.TestingT
+	log       logutils.Log
+	env       []string
+	installed bool
 }
 
 func NewLintRunner(t assert.TestingT, environ ...string) *LintRunner {
@@ -30,12 +31,13 @@ func NewLintRunner(t assert.TestingT, environ ...string) *LintRunner {
 }
 
 func (r *LintRunner) Install() {
-	if _, err := os.Stat("../golangci-lint"); err == nil {
+	if r.installed {
 		return
 	}
 
 	cmd := exec.Command("make", "-C", "..", "build")
 	assert.NoError(r.t, cmd.Run(), "Can't go install golangci-lint")
+	r.installed = true
 }
 
 type RunResult struct {
@@ -79,7 +81,7 @@ func (r *LintRunner) Run(args ...string) *RunResult {
 	r.Install()
 
 	runArgs := append([]string{"run"}, args...)
-	r.log.Infof("golangci-lint %s", strings.Join(runArgs, " "))
+	r.log.Infof("../golangci-lint %s", strings.Join(runArgs, " "))
 	cmd := exec.Command("../golangci-lint", runArgs...)
 	cmd.Env = append(os.Environ(), r.env...)
 	out, err := cmd.CombinedOutput()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -181,12 +181,12 @@ github.com/spf13/viper
 # github.com/stretchr/testify v1.2.2
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
+# github.com/timakin/bodyclose v0.0.0-20190407043127-4a873e97b2bb
+github.com/timakin/bodyclose/passes/bodyclose
 # github.com/valyala/bytebufferpool v1.0.0
 github.com/valyala/bytebufferpool
 # github.com/valyala/quicktemplate v1.1.1
 github.com/valyala/quicktemplate
-# github.com/timakin/bodyclose v0.0.0-20190407043127-4a873e97b2bb
-github.com/timakin/bodyclose/passes/bodyclose
 # golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/sys v0.0.0-20190312061237-fead79001313


### PR DESCRIPTION
Output
  File is not `gofmt`-ed
insted of
  File is not `gofmt`-ed  with `-s`
when gofmt.simplify == false