### PR TITLE
Update depguard version to 1.0.0 (Performance improvements)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/golangci/golangci-lint
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/OpenPeeDeeP/depguard v0.0.0-20180806142446-a69c782687b2
+	github.com/OpenPeeDeeP/depguard v1.0.0
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/fatih/color v1.6.0
 	github.com/go-critic/go-critic v0.0.0-20181204210945-1df300866540

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/OpenPeeDeeP/depguard v0.0.0-20180806142446-a69c782687b2 h1:HTOmFEEYrWi4MW5ZKUx6xfeyM10Sx3kQF65xiQJMPYA=
-github.com/OpenPeeDeeP/depguard v0.0.0-20180806142446-a69c782687b2/go.mod h1:7/4sitnI9YlQgTLLk734QlzXT8DuHVnAyztLplQjk+o=
+github.com/OpenPeeDeeP/depguard v1.0.0 h1:k9QF73nrHT3nPLz3lu6G5s+3Hi8Je36ODr1F5gjAXXM=
+github.com/OpenPeeDeeP/depguard v1.0.0/go.mod h1:7/4sitnI9YlQgTLLk734QlzXT8DuHVnAyztLplQjk+o=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/OpenPeeDeeP/depguard/README.md
+++ b/vendor/github.com/OpenPeeDeeP/depguard/README.md
@@ -28,6 +28,9 @@ The following is an example configuration file.
   "packages": [
     "github.com/OpenPeeDeeP/depguard"
   ],
+  "inTests": [
+    "github.com/stretchr/testify"
+  ],
   "includeGoRoot": true
 }
 ```
@@ -35,6 +38,7 @@ The following is an example configuration file.
 - `type` can be either `whitelist` or `blacklist`. This check is case insensitive.
 If not specified the default is `blacklist`.
 - `packages` is a list of packages for the list type specified.
+- `inTests` is a list of packages allowed/disallowed only in test files.
 - Set `includeGoRoot` to true if you want to check the list against standard lib.
 If not specified the default is false.
 

--- a/vendor/github.com/OpenPeeDeeP/depguard/rootchecker.go
+++ b/vendor/github.com/OpenPeeDeeP/depguard/rootchecker.go
@@ -1,0 +1,52 @@
+package depguard
+
+import (
+	"go/build"
+)
+
+// RootChecker checks if import paths point to root packages.
+type RootChecker struct {
+	buildCtx *build.Context
+	cache    map[string]bool
+}
+
+// NewRootChecker creates a new RootChecker instance using the build.Context
+// given, or build.Default.
+func NewRootChecker(buildCtx *build.Context) *RootChecker {
+	// Use the &build.Default if build.Context is not specified
+	ctx := buildCtx
+	if ctx == nil {
+		ctx = &build.Default
+	}
+	return &RootChecker{
+		buildCtx: ctx,
+		cache:    make(map[string]bool, 0),
+	}
+}
+
+// IsRoot checks if the given import path (imported from sourceDir)
+// points to a a root package. Subsequent calls with the same arguments
+// are cached. This is not thread-safe.
+func (rc *RootChecker) IsRoot(path, sourceDir string) (bool, error) {
+	key := path + ":::" + sourceDir
+	isRoot, ok := rc.cache[key]
+	if ok {
+		return isRoot, nil
+	}
+	isRoot, err := rc.calcIsRoot(path, sourceDir)
+	if err != nil {
+		return false, err
+	}
+	rc.cache[key] = isRoot
+	return isRoot, nil
+}
+
+// calcIsRoot performs the call to the build context to check if
+// the import path points to a root package.
+func (rc *RootChecker) calcIsRoot(path, sourceDir string) (bool, error) {
+	pkg, err := rc.buildCtx.Import(path, sourceDir, build.FindOnly)
+	if err != nil {
+		return false, err
+	}
+	return pkg.Goroot, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # github.com/BurntSushi/toml v0.3.1
 github.com/BurntSushi/toml
-# github.com/OpenPeeDeeP/depguard v0.0.0-20180806142446-a69c782687b2
+# github.com/OpenPeeDeeP/depguard v1.0.0
 github.com/OpenPeeDeeP/depguard
 # github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
 github.com/StackExchange/wmi


### PR DESCRIPTION
depguard was patched to improve performance on large projects, by caching checks for root packages from the import paths.

This PR merely updates depguard to version 1.0.0, and then `make vendor` was run.

/edit

`make test` was also run without issues