### PR TITLE
Update `gochecknoglobals` to support version exception

### DIFF
--- a/pkg/golinters/gochecknoglobals.go
+++ b/pkg/golinters/gochecknoglobals.go
@@ -61,7 +61,7 @@ func (lint Gochecknoglobals) checkFile(f *ast.File, fset *token.FileSet) []resul
 }
 
 func isWhitelisted(i *ast.Ident) bool {
-	return i.Name == "_" || looksLikeError(i)
+	return i.Name == "_" || i.Name == "version" || looksLikeError(i)
 }
 
 // looksLikeError returns true if the AST identifier starts


### PR DESCRIPTION
See https://github.com/leighmcculloch/gochecknoglobals/commit/7c3491d2b6ec7491e3fe40b42c6e436aea88bacd
