### PR TITLE
Build FreeBSD binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
       - darwin
       - windows
       - linux
+      - freebsd
     goarch:
       - amd64
       - 386


### PR DESCRIPTION
```
% uname -v
FreeBSD 12.0-RELEASE-p7 GENERIC
% uname -m
amd64
% ./golangci-lint-SNAPSHOT-d2b1eea2c6171a1a1141a448a745335ce2e928a1-freebsd-amd64/golangci-lint -h
Smart, fast linters runner. Run it in cloud for every GitHub pull request on https://golangci.com

Usage:
  golangci-lint [flags]
  golangci-lint [command]

Available Commands:
  config      Config
  help        Help
  linters     List current linters configuration
  run         Run this tool in cloud on every github pull request in https://golangci.com for free (public repos)

Flags:
      --color string              Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -j, --concurrency int           Concurrency (default NumCPU) (default 8)
      --cpu-profile-path string   Path to CPU profile output file
  -h, --help                      help for golangci-lint
      --mem-profile-path string   Path to memory profile output file
  -v, --verbose                   verbose output
      --version                   Print version

Use "golangci-lint [command] --help" for more information about a command.
```