### PR TITLE
Fix install script on Windows

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,8 +97,8 @@ tag_to_version() {
   VERSION=${TAG#v}
 }
 adjust_format() {
-  # change format (tar.gz or zip) based on ARCH
-  case ${ARCH} in
+  # change format (tar.gz or zip) based on OS
+  case ${OS} in
     windows) FORMAT=zip ;;
   esac
   true


### PR DESCRIPTION
`adjust_format()` should use OS and not ARCH. In Windows, `$OS` will be calculated to be `"windows"` while `$ARCH` will be `"386"` or `"amd64"` (most of the time). `$ARCH` will surely never be `"windows"`.