### PR TITLE
Add kubeedge to list of projects using golangci-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The following great projects use golangci-lint:
 * [posener/complete](https://github.com/posener/complete)
 * [y0ssar1an/q](https://github.com/y0ssar1an/q)
 * [segmentio/terraform-docs](https://github.com/segmentio/terraform-docs)
+* [kubeedge/kubeedge](https://github.com/kubeedge/kubeedge)
 
 ## Quick Start
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -158,6 +158,7 @@ The following great projects use golangci-lint:
 * [posener/complete](https://github.com/posener/complete)
 * [y0ssar1an/q](https://github.com/y0ssar1an/q)
 * [segmentio/terraform-docs](https://github.com/segmentio/terraform-docs)
+* [kubeedge/kubeedge](https://github.com/kubeedge/kubeedge)
 
 ## Quick Start
 


### PR DESCRIPTION
Thanks for the great project golangci-lint which we have used and thank you for considering CNCF project kubeedge/kubeedge to your list of projects using golangci-lint. 

I have changed the `README.tmpl.md` and running `make README.md`.
