### PR TITLE
Add support for bash completions

### DIFF
--- a/pkg/commands/completion.go
+++ b/pkg/commands/completion.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func (e *Executor) initCompletion() {
+	completionCmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generates bash completion scripts",
+		RunE:  e.executeCompletion,
+	}
+	e.rootCmd.AddCommand(completionCmd)
+}
+
+func (e *Executor) executeCompletion(cmd *cobra.Command, args []string) error {
+	err := cmd.Root().GenBashCompletion(os.Stdout)
+	if err != nil {
+		return fmt.Errorf("unable to generate bash completions: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -72,6 +72,7 @@ func NewExecutor(version, commit, date string) *Executor {
 	e.initHelp()
 	e.initLinters()
 	e.initConfig()
+	e.initCompletion()
 
 	// init e.cfg by values from config: flags parse will see these values
 	// like the default ones. It will overwrite them only if the same option


### PR DESCRIPTION
Cobra has built in support for bash completions. Expose these via a command.

These can be used with `source <(./golangci-lint completion)`