### PR TITLE
Add user supplied error messages in depguard issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,8 @@ linters-settings:
       # logging is allowed only by logutils.Log, logrus
       # is allowed to use only in logutils package
       - github.com/sirupsen/logrus
+    packages-with-error-messages:
+      github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   misspell:
     locale: US
   lll:

--- a/README.md
+++ b/README.md
@@ -837,6 +837,8 @@ linters-settings:
       # logging is allowed only by logutils.Log, logrus
       # is allowed to use only in logutils package
       - github.com/sirupsen/logrus
+    packages-with-error-messages:
+      github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   misspell:
     locale: US
   lll:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,9 +153,10 @@ type LintersSettings struct {
 		MinOccurrencesCount int `mapstructure:"min-occurrences"`
 	}
 	Depguard struct {
-		ListType      string `mapstructure:"list-type"`
-		Packages      []string
-		IncludeGoRoot bool `mapstructure:"include-go-root"`
+		ListType                 string `mapstructure:"list-type"`
+		Packages                 []string
+		IncludeGoRoot            bool              `mapstructure:"include-go-root"`
+		PackagesWithErrorMessage map[string]string `mapstructure:"packages-with-error-message"`
 	}
 	Misspell struct {
 		Locale      string

--- a/test/testdata/configs/depguard.yml
+++ b/test/testdata/configs/depguard.yml
@@ -1,0 +1,7 @@
+linters-settings:
+  depguard:
+    include-go-root: true
+    packages: 
+      - compress/*
+    packages-with-error-message:
+      log: "don't use log"

--- a/test/testdata/depguard.go
+++ b/test/testdata/depguard.go
@@ -1,11 +1,10 @@
 //args: -Edepguard
-//config: linters-settings.depguard.include-go-root=true
-//config: linters-settings.depguard.packages=compress/*,log
+//config_path: testdata/configs/depguard.yml
 package testdata
 
 import (
 	"compress/gzip" // ERROR "`compress/gzip` is in the blacklist"
-	"log"           // ERROR "`log` is in the blacklist"
+	"log"           // ERROR "`log` is in the blacklist: don't use log"
 )
 
 func SpewDebugInfo() {


### PR DESCRIPTION
This adds the ability for a user to add an error message for specific packages when encountered in depguard issues.  This is really useful to point users to use another package. 

An example of what the new output looks like when a user supplies an error message
![image](https://user-images.githubusercontent.com/11651981/64317294-1eb35e80-cf6c-11e9-88c9-4a9865c65f51.png)

I have made an upstream PR to add similar functionality to depguard in https://github.com/OpenPeeDeeP/depguard/pull/12

