### PR TITLE
all: Add GolangCI Lint action, mention it in README

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Run linters
+
+on: [push]
+
+jobs:
+  golang-ci-lint:
+    name: GolangCI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Run GolangCI-Lint
+        uses: docker://matousdz/golangci-lint-action:v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .golangci.yml

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ go install -ldflags "-X 'main.version=$(git describe --tags)' -X 'main.commit=$(
 
 On Windows, you can run the above commands with Git Bash, which comes with [Git for Windows](https://git-scm.com/download/win).
 
+### GitHub Actions installation
+
+To use GolangCI Lint as GitHub action in your repo please visit [GolangCI Lint Action](https://github.com/matoous/golangci-lint-action).
+and click on `View on Marketplace`. You can also take a look how to add badge from this action into the README.md in the
+GolangCI Lint Action repository README.
+
 ## Trusted By
 
 The following companies/products use golangci-lint:

--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ On Windows, you can run the above commands with Git Bash, which comes with [Git 
 
 ### GitHub Actions installation
 
-To use GolangCI Lint as GitHub action in your repo please visit [GolangCI Lint Action](https://github.com/matoous/golangci-lint-action).
-and click on `View on Marketplace`. You can also take a look how to add badge from this action into the README.md in the
-GolangCI Lint Action repository README.
+To use GolangCI Lint as GitHub action in your repo please visit [GolangCI Lint Action](https://github.com/marketplace/actions/action-golangci-lint) on the Marketplace.
+You can also take a look how to add badge from this action into the README.md in the GolangCI Lint Action repository README.
 
 ## Trusted By
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -110,6 +110,12 @@ go install -ldflags "-X 'main.version=$(git describe --tags)' -X 'main.commit=$(
 
 On Windows, you can run the above commands with Git Bash, which comes with [Git for Windows](https://git-scm.com/download/win).
 
+### GitHub Actions installation
+
+To use GolangCI Lint as GitHub action in your repo please visit [GolangCI Lint Action](https://github.com/matoous/golangci-lint-action).
+and click on `View on Marketplace`. You can also take a look how to add badge from this action into the README.md in the
+GolangCI Lint Action repository README.
+
 ## Trusted By
 
 The following companies/products use golangci-lint:

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -112,9 +112,8 @@ On Windows, you can run the above commands with Git Bash, which comes with [Git 
 
 ### GitHub Actions installation
 
-To use GolangCI Lint as GitHub action in your repo please visit [GolangCI Lint Action](https://github.com/matoous/golangci-lint-action).
-and click on `View on Marketplace`. You can also take a look how to add badge from this action into the README.md in the
-GolangCI Lint Action repository README.
+To use GolangCI Lint as GitHub action in your repo please visit [GolangCI Lint Action](https://github.com/marketplace/actions/action-golangci-lint) on the Marketplace.
+You can also take a look how to add badge from this action into the README.md in the GolangCI Lint Action repository README.
 
 ## Trusted By
 


### PR DESCRIPTION
Add GolangCI Lint action and mention it in README. This way GolangCI Lint can be added to any repository in a few clicks.