### PR TITLE
Update to funlen v0.0.2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
 	github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec
-	github.com/ultraware/funlen v0.0.1
+	github.com/ultraware/funlen v0.0.2
 	github.com/ultraware/whitespace v0.0.2
 	github.com/valyala/quicktemplate v1.1.1
 	golang.org/x/tools v0.0.0-20190911022129-16c5e0f7d110
@@ -51,9 +51,5 @@ require (
 	mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34
 )
 
-replace (
-	// https://github.com/ultraware/funlen/pull/1
-	github.com/ultraware/funlen => github.com/golangci/funlen v0.0.0-20190909161642-5e59b9546114
-	// https://github.com/golang/tools/pull/139
-	golang.org/x/tools => github.com/golangci/tools v0.0.0-20190910062050-3540c026601b
-)
+// https://github.com/golang/tools/pull/139
+replace golang.org/x/tools => github.com/golangci/tools v0.0.0-20190910062050-3540c026601b

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6 h1:YYWNAGTKWhKpcLLt7aSj/odlKrSrelQwlovBpDuf19w=
 github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6/go.mod h1:DbHgvLiFKX1Sh2T1w8Q/h4NAI8MHIpzCdnBUDTXU3I0=
-github.com/golangci/funlen v0.0.0-20190909161642-5e59b9546114 h1:eubR6yxVUUlbUuBBn1ONXalxuCjCrDfKvRc0eF6Xnio=
-github.com/golangci/funlen v0.0.0-20190909161642-5e59b9546114/go.mod h1:kJMYlbyWK6uaK+J3BjNrQMk0t3CgLgsXgQnOlS4iGeg=
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613 h1:9kfjN3AdxcbsZBf8NjltjWihK2QfBBBZuv91cMFfDHw=
 github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613/go.mod h1:SyvUF2NxV+sN8upjjeVYr5W7tyxaT1JVtvhKhOn2ii8=
 github.com/golangci/go-tools v0.0.0-20190318055746-e32c54105b7c h1:/7detzz5stiXWPzkTlPTzkBEIIE4WGpppBJYjKqBiPI=
@@ -233,6 +231,8 @@ github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec/go.mod h1:Qimiff
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ultraware/funlen v0.0.2 h1:Av96YVBwwNSe4MLR7iI/BIa3VyI7/djnto/pK3Uxbdo=
+github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.2 h1:iL4Un0C3VaMIBGfDogtcdBeSotjfSHYW8OdI1U9Vqas=
 github.com/ultraware/whitespace v0.0.2/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -187,7 +187,7 @@ github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec
 github.com/timakin/bodyclose/passes/bodyclose
-# github.com/ultraware/funlen v0.0.1 => github.com/golangci/funlen v0.0.0-20190909161642-5e59b9546114
+# github.com/ultraware/funlen v0.0.2
 github.com/ultraware/funlen
 # github.com/ultraware/whitespace v0.0.2
 github.com/ultraware/whitespace


### PR DESCRIPTION
Updates to vanilla upstream containing fix for  https://github.com/ultraware/funlen/pull/1.