### PR TITLE
Update Dockerfile to Go 1.13.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.13
 
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY golangci-lint /usr/bin/


### PR DESCRIPTION
Updates Dockerfile to Go 1.13. Fixes #683.