### PR TITLE
Update to valyala/quicktemplate v1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
     - NODE_VERSION=10.16.3
 
 before_script:
-  # use GO111MODULE=off otherwise libs can't be updates inside vendor/
-  - GO111MODULE=off go get github.com/valyala/quicktemplate # for tests
-  - GO111MODULE=off go get github.com/pkg/errors # for tests
   - nvm install "${NODE_VERSION}"
 
 script:

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec
 	github.com/ultraware/funlen v0.0.2
 	github.com/ultraware/whitespace v0.0.2
-	github.com/valyala/quicktemplate v1.1.1
+	github.com/valyala/quicktemplate v1.2.0
 	golang.org/x/tools v0.0.0-20190912215617-3720d1ec3678
 	gopkg.in/yaml.v2 v2.2.2
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/ultraware/whitespace v0.0.2/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
-github.com/valyala/quicktemplate v1.1.1 h1:C58y/wN0FMTi2PR0n3onltemfFabany53j7M6SDDB8k=
-github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
+github.com/valyala/quicktemplate v1.2.0 h1:BaO1nHTkspYzmAjPXj0QiDJxai96tlcZyKcI9dyEGvM=
+github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/vendor/github.com/valyala/quicktemplate/README.md
+++ b/vendor/github.com/valyala/quicktemplate/README.md
@@ -605,7 +605,6 @@ BenchmarkMarshalXMLQuickTemplate1000-4    	   30000	     53000 ns/op	      32 B/
       * Clear syntax insead of hard-to-understand magic stuff related
         to template arguments, template inheritance and embedding function
         templates into other templates.
-      * Performance optimizations.
 
 * *Is there a syntax highlighting for qtpl files?*
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/ultraware/funlen
 github.com/ultraware/whitespace
 # github.com/valyala/bytebufferpool v1.0.0
 github.com/valyala/bytebufferpool
-# github.com/valyala/quicktemplate v1.1.1
+# github.com/valyala/quicktemplate v1.2.0
 github.com/valyala/quicktemplate
 # golang.org/x/sys v0.0.0-20190911201528-7ad0cfa0b7b5
 golang.org/x/sys/unix


### PR DESCRIPTION
Updates Update to valyala/quicktemplate v1.2.0. to latest version and cleanup some obsolete `go get` commands that were bypassing go.mod dependency management in CI.
