### PR TITLE
Use entrypoint instead of cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM golang:1.13
 
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY golangci-lint /usr/bin/
-CMD ["golangci-lint"]
+ENTRYPOINT ["golangci-lint"]


### PR DESCRIPTION
Thank you for the pull request!

Fixes #706 

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make README.md`.
