### PR TITLE
Fix flaky cgo test failures

### DIFF
--- a/test/run_test.go
+++ b/test/run_test.go
@@ -59,8 +59,10 @@ func TestCgoOk(t *testing.T) {
 }
 
 func TestCgoWithIssues(t *testing.T) {
-	testshared.NewLintRunner(t).Run("--no-config", "--enable-all", getTestDataDir("cgo_with_issues")).
+	testshared.NewLintRunner(t).Run("--no-config", "--disable-all", "-Egovet", getTestDataDir("cgo_with_issues")).
 		ExpectHasIssue("Printf format %t has arg cs of wrong type")
+	testshared.NewLintRunner(t).Run("--no-config", "--disable-all", "-Estaticcheck", getTestDataDir("cgo_with_issues")).
+		ExpectHasIssue("SA5009: Printf format %t has arg #1 of wrong type")
 }
 
 func TestUnsafeOk(t *testing.T) {

--- a/test/testdata/govet.go
+++ b/test/testdata/govet.go
@@ -3,6 +3,7 @@
 package testdata
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
@@ -29,4 +30,9 @@ func GovetNolintVet() error {
 
 func GovetNolintVetShadow() error {
 	return &os.PathError{"first", "path", os.ErrNotExist} //nolint:vetshadow
+}
+
+func GovetPrintf() {
+	x := "dummy"
+	fmt.Printf("%d", x) // ERROR "printf: Printf format %d has arg x of wrong type string"
 }

--- a/test/testdata/staticcheck.go
+++ b/test/testdata/staticcheck.go
@@ -2,6 +2,7 @@
 package testdata
 
 import (
+	"fmt"
 	"runtime"
 )
 
@@ -22,4 +23,9 @@ func StaticcheckNolintMegacheck() {
 
 func StaticcheckDeprecated() {
 	_ = runtime.CPUProfile() // ERROR "SA1019: runtime.CPUProfile is deprecated"
+}
+
+func StaticcheckPrintf() {
+	x := "dummy"
+	fmt.Printf("%d", x) // ERROR "SA5009: Printf format %d has arg #1 of wrong type"
 }


### PR DESCRIPTION
Fixes spurious test failures caused by overlapping printf format checks in `staticcheck` and `go vet`. In general, this is a concurrency issue which can happen with any linters that detect similar issues with different reporting formats.

see:
https://travis-ci.com/golangci/golangci-lint/jobs/236978712
https://travis-ci.com/golangci/golangci-lint/jobs/237582672