### PR TITLE
Whitelist regexp and fmt.Errorf global vars

### DIFF
--- a/test/testdata/gochecknoglobals.go
+++ b/test/testdata/gochecknoglobals.go
@@ -8,7 +8,11 @@ import (
 
 var noGlobalsVar int // ERROR "`noGlobalsVar` is a global variable"
 var ErrSomeType = errors.New("test that global erorrs aren't warned")
+var ErrFmt1 = fmt.Errorf("test that global errors made with fmt aren't warned")
+
+//var re1 = regexp.MustComplile("/test that regexp aren't warned/")
 
 func NoGlobals() {
+	_ = ErrFmt1
 	fmt.Print(noGlobalsVar)
 }


### PR DESCRIPTION
I got some good exception from:
https://github.com/bombsimon/gochecknoglobals/tree/whitelisted-selectors

