### PR TITLE
Enable Go 1.11.x testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
+  - 1.11.x
   - 1.12.x
   - 1.13.x
 


### PR DESCRIPTION
Re-enables testing Go 1.11.x in CI.