### PR TITLE
Drop memory usage of go/analysis linters 5x

### DIFF
--- a/pkg/golinters/goanalysis/runner.go
+++ b/pkg/golinters/goanalysis/runner.go
@@ -872,6 +872,13 @@ func (lp *loadingPackage) decUse() {
 		pass.ImportPackageFact = nil
 		pass.ExportPackageFact = nil
 		act.pass = nil
+		act.deps = nil
+		if act.result != nil {
+			if isMemoryDebug {
+				debugf("%s: decUse: nilling act result of size %d bytes", act, sizeOfValueTreeBytes(act.result))
+			}
+			act.result = nil
+		}
 	}
 
 	lp.pkg.Syntax = nil
@@ -899,13 +906,6 @@ func (lp *loadingPackage) decUse() {
 		}
 		act.packageFacts = nil
 		act.objectFacts = nil
-		act.deps = nil
-		if act.result != nil {
-			if isMemoryDebug {
-				debugf("%s: decUse: nilling act result of size %d bytes", act, sizeOfValueTreeBytes(act.result))
-			}
-			act.result = nil
-		}
 	}
 	lp.actions = nil
 }


### PR DESCRIPTION
Set analysis pass results to nil early to garbage collect them
soon.
Memory can be reduced for the following linters:
  - staticcheck
  - stylecheck
  - gosimple
  - govet
  - bodyclose
  - any future go/analysis linter

Relates: #712, #634, #628, #598, #509, #483, #337