### PR TITLE
Enable consistent GOPROXY Go 1.12/1.13 behavior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 export GO111MODULE = on
 # opt-in to vendor deps across all go commands.
 export GOFLAGS = -mod=vendor
+# enable consistent Go 1.12/1.13 GOPROXY behavior.
+export GOPROXY = https://proxy.golang.org
 
 # Build
 


### PR DESCRIPTION
Explicitly set GOPROXY to enable consistent module behavior between Go 1.12 and 1.13. Fixes spurious Go 1.12.x build failures due to temporarily offline repos.

see:
https://travis-ci.com/golangci/golangci-lint/jobs/238269611