### PR TITLE
Cleanup obsolete go.mod/go.sum diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,12 @@ maintainer-clean: clean
 
 check_generated:
 	$(MAKE) --always-make generate
-	git checkout -- go.mod go.sum # can differ between go1.11 and go1.12
 	git checkout -- vendor/modules.txt # can differ between go1.12 and go1.13
 	git diff --exit-code # check no changes
 .PHONY: check_generated
 
 fast_check_generated:
 	$(MAKE) --always-make fast_generate
-	git checkout -- go.mod go.sum # can differ between go1.11 and go1.12
 	git checkout -- vendor/modules.txt # can differ between go1.12 and go1.13
 	git diff --exit-code # check no changes
 .PHONY: fast_check_generated


### PR DESCRIPTION
Cleanup go.mod/go.sum diff check which is now unnecessary since Go 1.11 is no longer supported.