### PR TITLE
Build godownloader/goreleaser tools before use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /test/path
 /golangci-lint
 /tools/Dracula.itermcolors
+/tools/godownloader
+/tools/goreleaser
 /tools/node_modules
 /tools/svg-term
 /.vscode/


### PR DESCRIPTION
Fixes release issues by building the godownloader/goreleaser binaries before using them from the project root.