### PR TITLE
govet: skip internal analyzers

### DIFF
--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -43,7 +43,8 @@ import (
 )
 
 func getAllAnalyzers() []*analysis.Analyzer {
-	return []*analysis.Analyzer{
+	var analyzers []*analysis.Analyzer
+	for _, a := range []*analysis.Analyzer{
 		asmdecl.Analyzer,
 		assign.Analyzer,
 		atomic.Analyzer,
@@ -76,7 +77,14 @@ func getAllAnalyzers() []*analysis.Analyzer {
 		unreachable.Analyzer,
 		unsafeptr.Analyzer,
 		unusedresult.Analyzer,
+	} {
+		if a.ResultType != nil {
+			// Skipping internal analyzers.
+			continue
+		}
+		analyzers = append(analyzers, a)
 	}
+	return analyzers
 }
 
 func getDefaultAnalyzers() []*analysis.Analyzer {


### PR DESCRIPTION
Following the comments in #759

Some analyzers are not intended for direct usage and are
just build blocks for other analyzers.
Seems like we can distinguish them by ResultType nillness.

Note that there is a `TestGovet` that checks that all default analyzers are in `getAllAnalyzers` result, so we are safe from accidentally disabling them.