### PR TITLE
Add version command to print golangci-lint version

### DIFF
--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -85,6 +85,7 @@ func NewExecutor(version, commit, date string) *Executor {
 	e.initLinters()
 	e.initConfig()
 	e.initCompletion()
+	e.initVersion()
 
 	// init e.cfg by values from config: flags parse will see these values
 	// like the default ones. It will overwrite them only if the same option

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -1,0 +1,17 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func (e *Executor) initVersion() {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Version",
+		Run: func(cmd *cobra.Command, _ []string) {
+			cmd.Printf("golangci-lint has version %s built from %s on %s\n", e.version, e.commit, e.date)
+		},
+	}
+
+	e.rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
This PR implements the `version` command as discussed in the linked issue.

It follows the same structure as the `golangci-lint --version` flag.

```console
➜ golangci-lint git:(implement-version-command) ✗ golangci-lint --version
golangci-lint has version (devel) built from (unknown, mod sum: "") on (unknown)
➜ golangci-lint git:(implement-version-command) ✗ golangci-lint version
golangci-lint has version (devel) built from (unknown, mod sum: "") on (unknown)
```

Fixes #675 
