### PR TITLE
Improve the error output from goimports

### DIFF
--- a/pkg/golinters/gofmt_common.go
+++ b/pkg/golinters/gofmt_common.go
@@ -229,6 +229,9 @@ func extractIssuesFromPatch(patch string, log logutils.Log, lintCtx *linter.Cont
 			var text string
 			if isGoimports {
 				text = "File is not `goimports`-ed"
+				if lintCtx.Settings().Goimports.LocalPrefixes != "" {
+					text += " with -local " + lintCtx.Settings().Goimports.LocalPrefixes
+				}
 			} else {
 				text = "File is not `gofmt`-ed"
 				if lintCtx.Settings().Gofmt.Simplify {


### PR DESCRIPTION
This causes goimports to provide additional information if the
"local-prefixes" option has been set.

Fixes https://github.com/golangci/golangci-lint/issues/773. See the new proposed output with this change:

```
$ golangci-lint run -c .golangci.yaml                               
main.go:6: File is not `goimports`-ed with -local github.com/ian-howell/foo (goimports)
        "github.com/ian-howell/foo/pkg"
```