### PR TITLE
fix misplaced backtick in example config in readme

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -184,7 +184,7 @@ linters-settings:
     disabled-checks:
       - regexpMust
 
-    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint` run to see all tags and checks.
+    # Enable multiple checks by tags, run `GL_DEBUG=gocritic golangci-lint run` to see all tags and checks.
     # Empty list by default. See https://github.com/go-critic/go-critic#usage -> section "Tags".
     enabled-tags:
       - performance


### PR DESCRIPTION
sorry, I'm a pedant 😄

Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make README.md`.

^^ 👍 