### PR TITLE
Enable all gocritic tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,9 +35,11 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
   gocritic:
     enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
       - performance
       - style
-      - experimental
     disabled-checks:
       - wrapperFunc
       - dupImport # https://github.com/go-critic/go-critic/issues/845

--- a/README.md
+++ b/README.md
@@ -919,9 +919,11 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
   gocritic:
     enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
       - performance
       - style
-      - experimental
     disabled-checks:
       - wrapperFunc
       - dupImport # https://github.com/go-critic/go-critic/issues/845


### PR DESCRIPTION
Enables all gocritic tags to run against the golangci-lint codebase.