### PR TITLE
Add ppc64le release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       - arm64
       - arm
       - 386
+      - ppc64le
     goarm:
       - 6
       - 7


### PR DESCRIPTION
Adds `ppc64le` as a goreleaser architecture.