### PR TITLE
Update WSL to v1.2.1

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -211,6 +211,15 @@ linters-settings:
   whitespace:
     multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
+  wsl:
+    # If true append is only allowed to be cuddled if appending value is
+    # matching variables, fields or types on line above. Default is true.
+    strict-append: true
+    # Allow calls and assignments to be cuddled as long as the lines have any
+    # matching variables, fields or types. Default is true.
+    allow-assign-and-call: true
+    # Allow multiline assignments to be cuddled. Default is true.
+    allow-multiline-assign: true
 
 linters:
   enable:

--- a/README.md
+++ b/README.md
@@ -804,6 +804,15 @@ linters-settings:
   whitespace:
     multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
+  wsl:
+    # If true append is only allowed to be cuddled if appending value is
+    # matching variables, fields or types on line above. Default is true.
+    strict-append: true
+    # Allow calls and assignments to be cuddled as long as the lines have any
+    # matching variables, fields or types. Default is true.
+    allow-assign-and-call: true
+    # Allow multiline assignments to be cuddled. Default is true.
+    allow-multiline-assign: true
 
 linters:
   enable:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/OpenPeeDeeP/depguard v1.0.1
-	github.com/bombsimon/wsl v1.0.1
+	github.com/bombsimon/wsl v1.2.1
 	github.com/fatih/color v1.7.0
 	github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db
 	github.com/go-lintpack/lintpack v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/bombsimon/wsl v1.0.1 h1:GkrpOj7ajds8re6EJXN+k6UtatYSktupigQ2ZfOUIOU=
-github.com/bombsimon/wsl v1.0.1/go.mod h1:DSRwCD8c7NecM11/LnZcTS8nS8OND5ybj04DWM4l8mc=
+github.com/bombsimon/wsl v1.2.1 h1:DcLf3V66dJi4a+KHt+F1FdOeBZ05adHqTMYFvjgv06k=
+github.com/bombsimon/wsl v1.2.1/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,6 +176,7 @@ type LintersSettings struct {
 		MultiFunc bool `mapstructure:"multi-func"`
 	}
 
+	WSL      WSLSettings
 	Lll      LllSettings
 	Unparam  UnparamSettings
 	Nakedret NakedretSettings
@@ -249,6 +250,12 @@ type GocognitSettings struct {
 	MinComplexity int `mapstructure:"min-complexity"`
 }
 
+type WSLSettings struct {
+	StrictAppend               bool `mapstructure:"strict-append"`
+	AllowAssignAndCallCuddle   bool `mapstructure:"allow-assign-and-call"`
+	AllowMultiLineAssignCuddle bool `mapstructure:"allow-multiline-assign"`
+}
+
 var defaultLintersSettings = LintersSettings{
 	Lll: LllSettings{
 		LineLength: 120,
@@ -276,6 +283,11 @@ var defaultLintersSettings = LintersSettings{
 	},
 	Gocognit: GocognitSettings{
 		MinComplexity: 30,
+	},
+	WSL: WSLSettings{
+		StrictAppend:               true,
+		AllowAssignAndCallCuddle:   true,
+		AllowMultiLineAssignCuddle: true,
 	},
 }
 

--- a/pkg/golinters/wsl.go
+++ b/pkg/golinters/wsl.go
@@ -33,13 +33,23 @@ func NewWSL() *goanalysis.Linter {
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
-			files := []string{}
+			var (
+				files        = []string{}
+				linterCfg    = lintCtx.Cfg.LintersSettings.WSL
+				processorCfg = wsl.DefaultConfig()
+			)
+
+			processorCfg.StrictAppend = linterCfg.StrictAppend
+			processorCfg.AllowAssignAndCallCuddle = linterCfg.AllowAssignAndCallCuddle
+			processorCfg.AllowMultiLineAssignCuddle = linterCfg.AllowMultiLineAssignCuddle
 
 			for _, file := range pass.Files {
 				files = append(files, pass.Fset.Position(file.Pos()).Filename)
 			}
 
-			wslErrors, _ := wsl.ProcessFiles(files)
+			wslErrors, _ := wsl.NewProcessorWithConfig(processorCfg).
+				ProcessFiles(files)
+
 			if len(wslErrors) == 0 {
 				return nil, nil
 			}

--- a/pkg/golinters/wsl.go
+++ b/pkg/golinters/wsl.go
@@ -36,12 +36,14 @@ func NewWSL() *goanalysis.Linter {
 			var (
 				files        = []string{}
 				linterCfg    = lintCtx.Cfg.LintersSettings.WSL
-				processorCfg = wsl.DefaultConfig()
+				processorCfg = wsl.Configuration{
+					StrictAppend:               linterCfg.StrictAppend,
+					AllowAssignAndCallCuddle:   linterCfg.AllowAssignAndCallCuddle,
+					AllowMultiLineAssignCuddle: linterCfg.AllowMultiLineAssignCuddle,
+					AllowCuddleWithCalls:       []string{"Lock", "RLock"},
+					AllowCuddleWithRHS:         []string{"Unlock", "RUnlock"},
+				}
 			)
-
-			processorCfg.StrictAppend = linterCfg.StrictAppend
-			processorCfg.AllowAssignAndCallCuddle = linterCfg.AllowAssignAndCallCuddle
-			processorCfg.AllowMultiLineAssignCuddle = linterCfg.AllowMultiLineAssignCuddle
 
 			for _, file := range pass.Files {
 				files = append(files, pass.Fset.Position(file.Pos()).Filename)

--- a/test/testdata/wsl.go
+++ b/test/testdata/wsl.go
@@ -52,6 +52,26 @@ func main() {
 	_, cf2 := context.WithCancel(context.Background())
 	defer cf1() // ERROR "only one cuddle assignment allowed before defer statement"
 	defer cf2()
+
+	err := multiline(
+		"spanning",
+		"multiple",
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	notErr := multiline(
+		"spanning",
+		"multiple",
+	)
+	if err != nil { // ERROR "if statements should only be cuddled with assignments used in the if statement itself"
+		panic(notErr)
+	}
+}
+
+func multiline(s ...string) error {
+	return nil
 }
 
 func f1() int {
@@ -78,3 +98,5 @@ func f3() int {
 
 	return sum + notSum
 }
+
+func onelineShouldNotError() error { return nil }

--- a/vendor/github.com/bombsimon/wsl/README.md
+++ b/vendor/github.com/bombsimon/wsl/README.md
@@ -14,6 +14,13 @@ good, making it harder for other people to read and understand. The linter will
 warn about newlines in and around blocks, in the beginning of files and other
 places in the code.
 
+**I know this linter is aggressive** and a lot of projects I've tested it on
+have failed miserably. For this linter to be useful at all I want to be open to
+new ideas, configurations and discussions! Also note that some of the warnings
+might be bugs or unintentional false positives so I would love an
+[issue](https://github.com/bombsimon/wsl/issues/new) to fix, discuss, change or
+make something configurable!
+
 ## Usage
 
 Install by using `go get -u github.com/bombsimon/wsl/cmd/...`.
@@ -25,6 +32,9 @@ relative or absolute path.
 By default, the linter will run on `./...` which means all go files in the
 current path and all subsequent paths, including test files. To disable linting
 test files, use `-n` or `--no-test`.
+
+This linter can also be used as a part of
+[golangci-lint](https://github.com/golangci/golangci-lint)
 
 ## Rules
 
@@ -335,6 +345,11 @@ fmt.Println(a)
 
 foo := true
 someFunc(false)
+
+if someBool() {
+    fmt.Println("doing things")
+}
+x.Calling()
 ```
 
 **Do**
@@ -350,6 +365,12 @@ someFunc(foo)
 bar := false
 
 someFunc(true)
+
+if someBool() {
+    fmt.Println("doing things")
+}
+
+x.Calling()
 ```
 
 #### Ranges

--- a/vendor/github.com/bombsimon/wsl/go.mod
+++ b/vendor/github.com/bombsimon/wsl/go.mod
@@ -1,7 +1,7 @@
 module github.com/bombsimon/wsl
 
 require (
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/vendor/github.com/bombsimon/wsl/go.sum
+++ b/vendor/github.com/bombsimon/wsl/go.sum
@@ -18,7 +18,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/BurntSushi/toml
 github.com/OpenPeeDeeP/depguard
 # github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
 github.com/StackExchange/wmi
-# github.com/bombsimon/wsl v1.0.1
+# github.com/bombsimon/wsl v1.2.1
 github.com/bombsimon/wsl
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew


### PR DESCRIPTION
After WSL v1.0.1 got merged last week I found a few false positives which is resolved in this version. I've also added support for some configuration which is bundled in this commit.

I aimed to use non-negative configuration names so defaulting them to `true` required me to create a config struct, hope this is OK.

I sent an email to Denis yesterday with a few questions regarding this linter but decided to create this PR even though I haven't gotten any response yet since I don't want to risk miss this update if a new release of `golangci-lint` is being created.