### PR TITLE
Add s390x release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ builds:
       - arm
       - 386
       - ppc64le
+      - s390x
     goarm:
       - 6
       - 7


### PR DESCRIPTION
Adds `s390x` as a goreleaser architecture.