### PR TITLE
Update WSL to v1.2.5

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -220,6 +220,10 @@ linters-settings:
     allow-assign-and-call: true
     # Allow multiline assignments to be cuddled. Default is true.
     allow-multiline-assign: true
+    # Allow case blocks to end with a whitespace.
+    allow-case-traling-whitespace: true
+    # Allow declarations (var) to be cuddled.
+    allow-cuddle-declarations: false
 
 linters:
   enable:

--- a/README.md
+++ b/README.md
@@ -819,6 +819,10 @@ linters-settings:
     allow-assign-and-call: true
     # Allow multiline assignments to be cuddled. Default is true.
     allow-multiline-assign: true
+    # Allow case blocks to end with a whitespace.
+    allow-case-traling-whitespace: true
+    # Allow declarations (var) to be cuddled.
+    allow-cuddle-declarations: false
 
 linters:
   enable:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/OpenPeeDeeP/depguard v1.0.1
-	github.com/bombsimon/wsl v1.2.1
+	github.com/bombsimon/wsl v1.2.4
 	github.com/fatih/color v1.7.0
 	github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db
 	github.com/go-lintpack/lintpack v0.5.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/OpenPeeDeeP/depguard v1.0.1
-	github.com/bombsimon/wsl v1.2.4
+	github.com/bombsimon/wsl v1.2.5
 	github.com/fatih/color v1.7.0
 	github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db
 	github.com/go-lintpack/lintpack v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/bombsimon/wsl v1.2.4 h1:QfZdYcCzHob9ZlHdC2rD+iZnhRVtncMebOifHhA3Wec=
-github.com/bombsimon/wsl v1.2.4/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
+github.com/bombsimon/wsl v1.2.5 h1:9gTOkIwVtoDZywvX802SDHokeX4kW1cKnV8ZTVAPkRs=
+github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/bombsimon/wsl v1.2.1 h1:DcLf3V66dJi4a+KHt+F1FdOeBZ05adHqTMYFvjgv06k=
-github.com/bombsimon/wsl v1.2.1/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
+github.com/bombsimon/wsl v1.2.4 h1:QfZdYcCzHob9ZlHdC2rD+iZnhRVtncMebOifHhA3Wec=
+github.com/bombsimon/wsl v1.2.4/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,7 +259,7 @@ type WSLSettings struct {
 	AllowAssignAndCallCuddle    bool `mapstructure:"allow-assign-and-call"`
 	AllowMultiLineAssignCuddle  bool `mapstructure:"allow-multiline-assign"`
 	AllowCaseTrailingWhitespace bool `mapstructure:"allow-case-trailing-whitespace"`
-	AllowCuddleDeclaration      bool `mapstructure:"allow-declarations"`
+	AllowCuddleDeclaration      bool `mapstructure:"allow-cuddle-declarations"`
 }
 
 var defaultLintersSettings = LintersSettings{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,9 +255,11 @@ type GocognitSettings struct {
 }
 
 type WSLSettings struct {
-	StrictAppend               bool `mapstructure:"strict-append"`
-	AllowAssignAndCallCuddle   bool `mapstructure:"allow-assign-and-call"`
-	AllowMultiLineAssignCuddle bool `mapstructure:"allow-multiline-assign"`
+	StrictAppend                bool `mapstructure:"strict-append"`
+	AllowAssignAndCallCuddle    bool `mapstructure:"allow-assign-and-call"`
+	AllowMultiLineAssignCuddle  bool `mapstructure:"allow-multiline-assign"`
+	AllowCaseTrailingWhitespace bool `mapstructure:"allow-case-trailing-whitespace"`
+	AllowCuddleDeclaration      bool `mapstructure:"allow-declarations"`
 }
 
 var defaultLintersSettings = LintersSettings{
@@ -289,9 +291,11 @@ var defaultLintersSettings = LintersSettings{
 		MinComplexity: 30,
 	},
 	WSL: WSLSettings{
-		StrictAppend:               true,
-		AllowAssignAndCallCuddle:   true,
-		AllowMultiLineAssignCuddle: true,
+		StrictAppend:                true,
+		AllowAssignAndCallCuddle:    true,
+		AllowMultiLineAssignCuddle:  true,
+		AllowCaseTrailingWhitespace: true,
+		AllowCuddleDeclaration:      false,
 	},
 }
 

--- a/pkg/golinters/wsl.go
+++ b/pkg/golinters/wsl.go
@@ -37,11 +37,13 @@ func NewWSL() *goanalysis.Linter {
 				files        = []string{}
 				linterCfg    = lintCtx.Cfg.LintersSettings.WSL
 				processorCfg = wsl.Configuration{
-					StrictAppend:               linterCfg.StrictAppend,
-					AllowAssignAndCallCuddle:   linterCfg.AllowAssignAndCallCuddle,
-					AllowMultiLineAssignCuddle: linterCfg.AllowMultiLineAssignCuddle,
-					AllowCuddleWithCalls:       []string{"Lock", "RLock"},
-					AllowCuddleWithRHS:         []string{"Unlock", "RUnlock"},
+					StrictAppend:                linterCfg.StrictAppend,
+					AllowAssignAndCallCuddle:    linterCfg.AllowAssignAndCallCuddle,
+					AllowMultiLineAssignCuddle:  linterCfg.AllowMultiLineAssignCuddle,
+					AllowCaseTrailingWhitespace: linterCfg.AllowCaseTrailingWhitespace,
+					AllowCuddleDeclaration:      linterCfg.AllowCuddleDeclaration,
+					AllowCuddleWithCalls:        []string{"Lock", "RLock"},
+					AllowCuddleWithRHS:          []string{"Unlock", "RUnlock"},
 				}
 			)
 

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -105,6 +105,7 @@ func testOneSource(t *testing.T, sourcePath string) {
 		"--print-issued-lines=false",
 		"--print-linter-name=false",
 		"--out-format=line-number",
+		"--max-same-issues=10",
 	}
 
 	rc := extractRunContextFromComments(t, sourcePath)

--- a/test/testdata/wsl.go
+++ b/test/testdata/wsl.go
@@ -164,3 +164,11 @@ func allowTrailing(i int) {
 		fmt.Println("three")
 	}
 }
+
+// ExampleSomeOutput simulates an example function.
+func ExampleSomeOutput() {
+	fmt.Println("Hello, world")
+
+	// Output:
+	// Hello, world
+}

--- a/test/testdata/wsl.go
+++ b/test/testdata/wsl.go
@@ -100,3 +100,67 @@ func f3() int {
 }
 
 func onelineShouldNotError() error { return nil }
+
+func multilineCase() {
+	// Multiline cases
+	switch {
+	case true,
+		false:
+		fmt.Println("ok")
+	case false ||
+		true:
+		fmt.Println("ok")
+	case true,
+		false:
+		fmt.Println("ok")
+	}
+}
+
+func sliceExpr() {
+	// Index- and slice expressions.
+	var aSlice = []int{1, 2, 3}
+
+	start := 2
+	if v := aSlice[start]; v == 1 {
+		fmt.Println("ok")
+	}
+
+	notOk := 1
+	if v := aSlice[start]; v == 1 { // ERROR "if statements should only be cuddled with assignments used in the if statement itself"
+		fmt.Println("notOk")
+		fmt.Println(notOk)
+	}
+
+	end := 2
+	if len(aSlice[start:end]) > 2 {
+		fmt.Println("ok")
+	}
+}
+
+func indexExpr() {
+	var aMap = map[string]struct{}{"key": {}}
+
+	key := "key"
+	if k, ok := aMap[key]; ok {
+		fmt.Println(k)
+	}
+
+	xxx := "xxx"
+	if _, ok := aMap[key]; ok { // ERROR "if statements should only be cuddled with assignments used in the if statement itself"
+		fmt.Println("not ok")
+		fmt.Println(xxx)
+	}
+}
+
+func allowTrailing(i int) {
+	switch i {
+	case 1:
+		fmt.Println("one")
+
+	case 2:
+		fmt.Println("two")
+
+	case 3:
+		fmt.Println("three")
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/BurntSushi/toml
 github.com/OpenPeeDeeP/depguard
 # github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
 github.com/StackExchange/wmi
-# github.com/bombsimon/wsl v1.2.4
+# github.com/bombsimon/wsl v1.2.5
 github.com/bombsimon/wsl
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/BurntSushi/toml
 github.com/OpenPeeDeeP/depguard
 # github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6
 github.com/StackExchange/wmi
-# github.com/bombsimon/wsl v1.2.1
+# github.com/bombsimon/wsl v1.2.4
 github.com/bombsimon/wsl
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew


### PR DESCRIPTION
* Fix false positive multiline case (test added)
* Fix false positive slice expression (test added)
* Fix false positive index expression (test added)
* Support to configure/allow cuddle declarations (example config added)
* Support to configure/allow case blocks to end with whitespace (example config added)
* Support cuddle defer http body close

Note: Had to update the test runner with `--max-same-issues=10` to allow my tests to cover added false-positives which yields the same error.