### PR TITLE
deadline is now deprecated, but should be taking its value from the configuration if set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,6 +112,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.19.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.20.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/README.md
+++ b/README.md
@@ -1022,7 +1022,7 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.19.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.20.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"
 ```

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -422,10 +422,12 @@ func (e *Executor) executeRun(_ *cobra.Command, args []string) {
 	e.setupExitCode(ctx)
 }
 
-// to be removed when deadline is finally removed
+// to be removed when deadline is finally decommissioned
 func (e *Executor) setTimeoutToDeadlineIfOnlyDeadlineIsSet() {
-	if e.cfg.Run.Deadline != defaultTimeout && e.cfg.Run.Timeout == defaultTimeout {
-		e.cfg.Run.Timeout = e.cfg.Run.Deadline
+	//lint:ignore SA1019 We want to promoted the deprecated config value when needed
+	deadlineValue := e.cfg.Run.Deadline // nolint: staticcheck
+	if deadlineValue != 0 && e.cfg.Run.Timeout == defaultTimeout {
+		e.cfg.Run.Timeout = deadlineValue
 	}
 }
 

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -54,6 +54,34 @@ func TestTimeout(t *testing.T) {
 		ExpectOutputContains(`Timeout exceeded: try increase it by passing --timeout option`)
 }
 
+func TestTimeoutInConfig(t *testing.T) {
+	type tc struct {
+		cfg string
+	}
+
+	cases := []tc{
+		{
+			cfg: `
+				run:
+				deadline: 1ms
+			`,
+		},
+		{
+			cfg: `
+				run:
+				timeout: 1ms
+			`,
+		},
+	}
+
+	r := testshared.NewLintRunner(t)
+	for _, c := range cases {
+		// Run with disallowed option set only in config
+		r.RunWithYamlConfig(c.cfg, withCommonRunArgs(minimalPkg)...).ExpectExitCode(exitcodes.Timeout).
+			ExpectOutputContains(`Timeout exceeded: try increase it by passing --timeout option`)
+	}
+}
+
 func TestTestsAreLintedByDefault(t *testing.T) {
 	testshared.NewLintRunner(t).Run(getTestDataDir("withtests")).
 		ExpectHasIssue("`if` block ends with a `return`")

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -63,13 +63,21 @@ func TestTimeoutInConfig(t *testing.T) {
 		{
 			cfg: `
 				run:
-				deadline: 1ms
+					deadline: 1ms
 			`,
 		},
 		{
 			cfg: `
 				run:
-				timeout: 1ms
+					timeout: 1ms
+			`,
+		},
+		{
+			// timeout should override deadline
+			cfg: `
+				run:
+					deadline: 100s
+					timeout: 1ms
 			`,
 		},
 	}


### PR DESCRIPTION
Hi,

  I'm afraid the PR https://github.com/golangci/golangci-lint/pull/793 generated a side effect: while deadline still works and becomes the effective timeout setting when supplying it as a flag/cmdline arg, we've realized deadline in the configuration file is no longer being honored (ok, its deprecated, but probably we wanted this to become a breaking change, forcing all consumers to immediately change their config): see the test we are incorporating, that clearly reproduces the situation.

 Proposing a fix (but not prod of it), so deadline is still considered (no matter where it comes from) if its value is different of the default timeout (that becomes a constant). There may be alternative implementations or better places to put this logic, but I didnt want to make the config package aware of the default value...

  Sorry if the explanation is not clear: let me know if that is the case and I will do my best to clarify.