### PR TITLE
Fixed unit test cases (build failed in master branch)

### DIFF
--- a/test/run_test.go
+++ b/test/run_test.go
@@ -44,8 +44,7 @@ func TestSymlinkLoop(t *testing.T) {
 func TestDeadline(t *testing.T) {
 	testshared.NewLintRunner(t).Run("--deadline=1ms", getProjectRoot()).
 		ExpectExitCode(exitcodes.Timeout).
-		ExpectOutputContains(`Timeout exceeded: try increase it by passing --timeout option`).
-		ExpectOutputContains(`Flag --deadline has been deprecated, flag will be removed soon, please, use .golangci.yml config`)
+		ExpectOutputContains(`Timeout exceeded: try increase it by passing --timeout option`)
 }
 
 func TestTimeout(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/golangci/golangci-lint/issues/847

Recent commit https://github.com/golangci/golangci-lint/commit/df279922f66c65ed1ba0f7407977ab26f5d3c8b0 hides the flag and not showing depreciated message. However, the related test case is still expecting `depreciated message`

Also fixed one test case in which `check-exported` is true, but the unused public function message is not expected.
