### PR TITLE
Fix depguard config in yml

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -138,9 +138,9 @@ linters-settings:
     include-go-root: false
     packages:
       - github.com/sirupsen/logrus
-    packages-with-error-messages:
+    packages-with-error-message:
       # specify an error message to output when a blacklisted package is used
-      github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,8 @@ linters-settings:
       # logging is allowed only by logutils.Log, logrus
       # is allowed to use only in logutils package
       - github.com/sirupsen/logrus
-    packages-with-error-messages:
-      github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+    packages-with-error-message:
+      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   misspell:
     locale: US
   lll:

--- a/README.md
+++ b/README.md
@@ -741,9 +741,9 @@ linters-settings:
     include-go-root: false
     packages:
       - github.com/sirupsen/logrus
-    packages-with-error-messages:
+    packages-with-error-message:
       # specify an error message to output when a blacklisted package is used
-      github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.
@@ -940,8 +940,8 @@ linters-settings:
       # logging is allowed only by logutils.Log, logrus
       # is allowed to use only in logutils package
       - github.com/sirupsen/logrus
-    packages-with-error-messages:
-      github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
+    packages-with-error-message:
+      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   misspell:
     locale: US
   lll:


### PR DESCRIPTION
This PR fixes the following issues:

* `packages-with-error-messages` should be `packages-with-error-message` based on the `mapstructure` tag from https://github.com/golangci/golangci-lint/blob/master/pkg/config/config.go#L165

* Due to https://github.com/spf13/viper/issues/348, after fixing above typo, it'll fail with
```
* 'linters-settings.Depguard.packages-with-error-message[github]' expected type 'string', got unconvertible type 'map[string]interface {}'
```
since alot of package names will have dots in them. A workaround is to specify as a list of maps, which will get merged by `mapstructure` (see [config](https://github.com/mitchellh/mapstructure/blob/master/mapstructure.go#L76)). Viper does have `WeaklyTypedInput` [enabled by default](https://github.com/spf13/viper/blob/master/viper.go#L874). 
