### PR TITLE
Propagate error when linter cannot be run

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -315,7 +315,11 @@ func (e *Executor) runAnalysis(ctx context.Context, args []string) ([]result.Iss
 		return nil, err
 	}
 
-	issues := runner.Run(ctx, enabledLinters, lintCtx)
+	issues, err := runner.Run(ctx, enabledLinters, lintCtx)
+	if err != nil {
+		return nil, err
+	}
+
 	fixer := processors.NewFixer(e.cfg, e.log, e.fileCache)
 	return fixer.Process(issues), nil
 }


### PR DESCRIPTION
We now return an error if any linter is unable to run to
not exit on 0 in that case.

Closes #451