### PR TITLE
Update golangci.com config to latest 1.22.x release

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,6 +105,6 @@ run:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.20.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.22.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/README.md
+++ b/README.md
@@ -1021,7 +1021,7 @@ run:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.20.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.22.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"
 ```


### PR DESCRIPTION
Updates to latest 1.22.x release to fix failing checks.