### PR TITLE
Add release for android OS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - windows
       - linux
       - freebsd
+      - android
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
Add release for android. Some of use Termux on Android as alternative development machine.