### PR TITLE
Re-enable `gomnd` linter with release > v1.23.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,7 @@ linters:
     - gofmt
     - goimports
     - golint
-#    - gomnd TODO: enable it with release > v1.23.0
+    - gomnd
     - goprintffuncname
     - gosec
     - gosimple

--- a/README.md
+++ b/README.md
@@ -1015,7 +1015,7 @@ linters:
     - gofmt
     - goimports
     - golint
-#    - gomnd TODO: enable it with release > v1.23.0
+    - gomnd
     - goprintffuncname
     - gosec
     - gosimple

--- a/test/testdata/govet_custom_formatter/main.go
+++ b/test/testdata/govet_custom_formatter/main.go
@@ -10,12 +10,15 @@ const (
 	escape = "\x1b"
 	reset  = escape + "[0m"
 	green  = escape + "[32m"
+
+	minValue = 0.0
+	maxValue = 1.0
 )
 
 // Bar is a progress bar.
 type Bar float64
 
-var _ fmt.Formatter = Bar(1.0)
+var _ fmt.Formatter = Bar(maxValue)
 
 // Format the progress bar as output
 func (h Bar) Format(state fmt.State, r rune) {
@@ -25,16 +28,16 @@ func (h Bar) Format(state fmt.State, r rune) {
 		panic(fmt.Sprintf("%v: unexpected format character", float64(h)))
 	}
 
-	if h > 1.0 {
-		h = 1.0
+	if h > maxValue {
+		h = maxValue
 	}
 
-	if h < 0.0 {
-		h = 0.0
+	if h < minValue {
+		h = minValue
 	}
 
 	if state.Flag('-') {
-		h = 1.0 - h
+		h = maxValue - h
 	}
 
 	width, ok := state.Width()


### PR DESCRIPTION
Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make README.md`.
