### PR TITLE
Change writeFixedFile to replace the right line-range.

### DIFF
--- a/pkg/result/processors/fixer.go
+++ b/pkg/result/processors/fixer.go
@@ -218,7 +218,7 @@ func (f Fixer) writeFixedFile(origFileLines [][]byte, issues []result.Issue, tmp
 		}
 
 		origFileLineNumber := i + 1
-		if nextIssue == nil || origFileLineNumber != nextIssue.Line() {
+		if nextIssue == nil || origFileLineNumber != nextIssue.GetLineRange().From {
 			outLine = string(origFileLines[i])
 		} else {
 			nextIssueIndex++


### PR DESCRIPTION
The function assumed, previously, that issue.Line always equals
issue.LineRange.From.  But this needn't be true, and the code needn't
assume it.  Now we actually replace the specified line-range.

Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make README.md`.
