### PR TITLE
fix typo

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -74,7 +74,7 @@ linters-settings:
     # tokens count to trigger issue, 150 by default
     threshold: 100
   errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.
     check-type-assertions: false
 


### PR DESCRIPTION
Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make README.md`.
