### PR TITLE
Fix failed_prerequisites error

### DIFF
--- a/pkg/lint/linter/context.go
+++ b/pkg/lint/linter/context.go
@@ -1,6 +1,8 @@
 package linter
 
 import (
+	"go/ast"
+
 	"golang.org/x/tools/go/packages"
 
 	"github.com/golangci/golangci-lint/internal/pkgcache"
@@ -29,4 +31,19 @@ type Context struct {
 
 func (c *Context) Settings() *config.LintersSettings {
 	return &c.Cfg.LintersSettings
+}
+
+func (c *Context) ClearTypesInPackages() {
+	for _, p := range c.Packages {
+		clearTypes(p)
+	}
+	for _, p := range c.OriginalPackages {
+		clearTypes(p)
+	}
+}
+
+func clearTypes(p *packages.Package) {
+	p.Types = nil
+	p.TypesInfo = nil
+	p.Syntax = []*ast.File{}
 }

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -111,29 +111,14 @@ func (r *Runner) runLinterSafe(ctx context.Context, lintCtx *linter.Context,
 		}
 	}()
 
-	// pkgs will get dirty while analyzing, which affects to other linters' result.
-	// To avoid this issue, we clone the loaded packages rather than directly using them.
-	oldPackages := lintCtx.Packages
-	oldOriginalPackages := lintCtx.OriginalPackages
-	clone := func(pkgs []*gopackages.Package) []*gopackages.Package {
-		clonedPkgs := make([]*gopackages.Package, len(pkgs))
-		for i, pkg := range pkgs {
-			p := *pkg
-			clonedPkgs[i] = &p
-		}
-		return clonedPkgs
-	}
-	lintCtx.Packages = clone(lintCtx.Packages)
-	lintCtx.OriginalPackages = clone(lintCtx.OriginalPackages)
-
 	specificLintCtx := *lintCtx
 	specificLintCtx.Log = r.Log.Child(lc.Name())
 
+	// Packages in lintCtx might be dirty due to the last analysis,
+	// which affects to the next analysis.
+	// To avoid this issue, we clear type information from the packages.
+	specificLintCtx.ClearTypesInPackages()
 	issues, err := lc.Linter.Run(ctx, &specificLintCtx)
-
-	lintCtx.Packages = oldPackages
-	lintCtx.OriginalPackages = oldOriginalPackages
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi,
I investigated some similar issues - #827, #840, #885, #824, #888, ... - and I found:

- unused linter is not combined into goanalysis_metalinter
  because unused linter's load mode is LoadModeWholeProgram,
  so two linters are executed by default.
- in this situation, unused linter and goanalysis_metalinter shares the package information.
- when unused linter is executed, packages in the linter context seems to change.
- goanalysis_metalinter uses the changed packages in part of the analysis,
  while "typecheck" linter in goanalysis_metalinter parses files by itself,
  which results in error of type checking for dependent packages
  by their inconsistency.
- the execution order of the linters randomly change because it is
  determined by `range` of `map`, this is why we do not always encounter these issues.

~~In this PR, I fixed this problem by cloning loaded packages in linter context
before the linter is executed to avoid sharing changed packages to another linter.
Cloning packages might not be the best solution from the perspective of
efficiency such as memory usage, but I think it's better than causing occasional failures.~~
**UPDATE:**
I found that the changed fields of the `Package` are `Types`, `TypesInfo` and `Syntax`, so I updated my changes to just clear those fields before the analysis.