### PR TITLE
fix #869 by removing lock file after unlocking

### DIFF
--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -223,4 +223,7 @@ func (e *Executor) releaseFileLock() {
 	if err := e.flock.Unlock(); err != nil {
 		e.debugf("Failed to unlock on file: %s", err)
 	}
+	if err := os.Remove(e.flock.Path()); err != nil {
+		e.debugf("Failed to remove lock file: %s", err)
+	}
 }


### PR DESCRIPTION
Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make README.md`.
