### PR TITLE
Add MIPS arch support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,8 @@ builds:
     goarm:
       - 6
       - 7
+    gomips:
+      - hardfloat
     env:
       - CGO_ENABLED=0
     main: ./cmd/golangci-lint/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,8 @@ builds:
       - 386
       - ppc64le
       - s390x
+      - mips64
+      - mips64le
     goarm:
       - 6
       - 7

--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,8 @@ get_binaries() {
     linux/armv7) BINARIES="golangci-lint" ;;
     linux/ppc64le) BINARIES="golangci-lint" ;;
     linux/s390x) BINARIES="golangci-lint" ;;
+    linux/mips64) BINARIES="golangci-lint" ;;
+    linux/mips64le) BINARIES="golangci-lint" ;;
     windows/386) BINARIES="golangci-lint" ;;
     windows/amd64) BINARIES="golangci-lint" ;;
     windows/arm64) BINARIES="golangci-lint" ;;


### PR DESCRIPTION
Signed-off-by: Xiang Dai <764524258@qq.com>

Fix #935

Refer to [prometheus release](https://github.com/prometheus/prometheus/releases), support `mips64` and `mips64le`.