### PR TITLE
autogenerated_exclude: increase scanner buffer

### DIFF
--- a/pkg/result/processors/autogenerated_exclude.go
+++ b/pkg/result/processors/autogenerated_exclude.go
@@ -124,10 +124,10 @@ func getDoc(filePath string) (string, error) {
 	// Issue 954: Some lines can be very long, e.g. auto-generated
 	// embedded resources. Reported on file of 86.2KB.
 	const (
-		naxSize     = 512 * 1024 // 512KB should be enough
+		maxSize     = 512 * 1024 // 512KB should be enough
 		initialSize = 4096       // same as startBufSize in bufio
 	)
-	scanner.Buffer(make([]byte, initialSize), naxSize)
+	scanner.Buffer(make([]byte, initialSize), maxSize)
 
 	var docLines []string
 	for scanner.Scan() {

--- a/pkg/result/processors/autogenerated_exclude.go
+++ b/pkg/result/processors/autogenerated_exclude.go
@@ -120,6 +120,12 @@ func getDoc(filePath string) (string, error) {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
+
+	// Issue 954: Some lines can be very long, e.g. auto-generated
+	// embedded resources. Reported on file of 86.2KB.
+	const maxTokenSize = 512 * 1024 // 512KB should be enough
+	scanner.Buffer(make([]byte, maxTokenSize), maxTokenSize)
+
 	var docLines []string
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/pkg/result/processors/autogenerated_exclude.go
+++ b/pkg/result/processors/autogenerated_exclude.go
@@ -123,8 +123,11 @@ func getDoc(filePath string) (string, error) {
 
 	// Issue 954: Some lines can be very long, e.g. auto-generated
 	// embedded resources. Reported on file of 86.2KB.
-	const maxTokenSize = 512 * 1024 // 512KB should be enough
-	scanner.Buffer(make([]byte, maxTokenSize), maxTokenSize)
+	const (
+		naxSize     = 512 * 1024 // 512KB should be enough
+		initialSize = 4096       // same as startBufSize in bufio
+	)
+	scanner.Buffer(make([]byte, initialSize), naxSize)
 
 	var docLines []string
 	for scanner.Scan() {


### PR DESCRIPTION
Some lines can be very long, so increase scanner
buffer to mitigate this.

Fix #954
