### PR TITLE
Change Increase to Increasing in Timeout Exceeded Error Message

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -446,7 +446,7 @@ func (e *Executor) setTimeoutToDeadlineIfOnlyDeadlineIsSet() {
 func (e *Executor) setupExitCode(ctx context.Context) {
 	if ctx.Err() != nil {
 		e.exitCode = exitcodes.Timeout
-		e.log.Errorf("Timeout exceeded: try increase it by passing --timeout option")
+		e.log.Errorf("Timeout exceeded: try increasing it by passing --timeout option")
 		return
 	}
 

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -44,13 +44,13 @@ func TestSymlinkLoop(t *testing.T) {
 func TestDeadline(t *testing.T) {
 	testshared.NewLintRunner(t).Run("--deadline=1ms", getProjectRoot()).
 		ExpectExitCode(exitcodes.Timeout).
-		ExpectOutputContains(`Timeout exceeded: try increase it by passing --timeout option`)
+		ExpectOutputContains(`Timeout exceeded: try increasing it by passing --timeout option`)
 }
 
 func TestTimeout(t *testing.T) {
 	testshared.NewLintRunner(t).Run("--timeout=1ms", getProjectRoot()).
 		ExpectExitCode(exitcodes.Timeout).
-		ExpectOutputContains(`Timeout exceeded: try increase it by passing --timeout option`)
+		ExpectOutputContains(`Timeout exceeded: try increasing it by passing --timeout option`)
 }
 
 func TestTimeoutInConfig(t *testing.T) {
@@ -85,7 +85,7 @@ func TestTimeoutInConfig(t *testing.T) {
 	for _, c := range cases {
 		// Run with disallowed option set only in config
 		r.RunWithYamlConfig(c.cfg, withCommonRunArgs(minimalPkg)...).ExpectExitCode(exitcodes.Timeout).
-			ExpectOutputContains(`Timeout exceeded: try increase it by passing --timeout option`)
+			ExpectOutputContains(`Timeout exceeded: try increasing it by passing --timeout option`)
 	}
 }
 


### PR DESCRIPTION
The current error message is `"Timeout exceeded: try increase it by passing --timeout option"`. I think it reads a little better as `"Timeout exceeded: try increasing it by passing --timeout option"`.
