### PR TITLE
autogenerated_exclude: increase scanner max buffer size

### DIFF
--- a/pkg/result/processors/autogenerated_exclude.go
+++ b/pkg/result/processors/autogenerated_exclude.go
@@ -124,8 +124,8 @@ func getDoc(filePath string) (string, error) {
 	// Issue 954: Some lines can be very long, e.g. auto-generated
 	// embedded resources. Reported on file of 86.2KB.
 	const (
-		maxSize     = 512 * 1024 // 512KB should be enough
-		initialSize = 4096       // same as startBufSize in bufio
+		maxSize     = 10 * 1024 * 1024 // 10MB should be enough
+		initialSize = 4096             // same as startBufSize in bufio
 	)
 	scanner.Buffer(make([]byte, initialSize), maxSize)
 


### PR DESCRIPTION
Ref: #954
