### PR TITLE
vet: Support disable rule when enable-all is true

### DIFF
--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -101,6 +101,11 @@ var (
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
 	if cfg.EnableAll {
+		for _, n := range cfg.Disable {
+			if n == name {
+				return false
+			}
+		}
 		return true
 	}
 	// Raw for loops should be OK on small slice lengths.

--- a/pkg/golinters/govet_test.go
+++ b/pkg/golinters/govet_test.go
@@ -79,6 +79,7 @@ func TestGovetAnalyzerIsEnabled(t *testing.T) {
 		{Name: "bools", Enabled: false, Disable: []string{"bools"}},
 		{Name: "unsafeptr", Enabled: true, Enable: []string{"unsafeptr"}},
 		{Name: "shift", Enabled: true, EnableAll: true},
+		{Name: "shadow", EnableAll: true, Disable: []string{"shadow"}, Enabled: false},
 	} {
 		cfg := &config.GovetSettings{
 			Enable:     tc.Enable,


### PR DESCRIPTION
Similar to the behavior of command line flags:
enable-all to enable existing linters then disable unwanted ones.
But for vet rules.

For example

```yaml
govet:
  enable-all: true
  disable:
    - nilfunc
```