### PR TITLE
WIP: Add gosec exclude to settings.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,6 +196,7 @@ type LintersSettings struct {
 	Godox    GodoxSettings
 	Dogsled  DogsledSettings
 	Gocognit GocognitSettings
+	Gosec    GosecSettings
 
 	Custom map[string]CustomLinterSettings
 }
@@ -271,6 +272,10 @@ type WSLSettings struct {
 	AllowSeparatedLeadingComment     bool `mapstructure:"allow-separated-leading-comment"`
 	ForceCuddleErrCheckAndAssign     bool `mapstructure:"force-err-cuddling"`
 	ForceCaseTrailingWhitespaceLimit int  `mapstructure:"force-case-trailing-whitespace"`
+}
+
+type GosecSettings struct {
+	Exclude []string `mapstructure:"exclude"`
 }
 
 //nolint:gomnd

--- a/pkg/golinters/gosec.go
+++ b/pkg/golinters/gosec.go
@@ -25,7 +25,6 @@ func NewGosec() *goanalysis.Linter {
 	var resIssues []goanalysis.Issue
 
 	gasConfig := gosec.NewConfig()
-	enabledRules := rules.Generate()
 	logger := log.New(ioutil.Discard, "", 0)
 
 	analyzer := &analysis.Analyzer{
@@ -38,7 +37,11 @@ func NewGosec() *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
+		cfg := lintCtx.Cfg.LintersSettings.Gosec
+		exclude := cfg.Exclude
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+			filter := rules.NewRuleFilter(true, exclude...)
+			enabledRules := rules.Generate(filter)
 			gosecAnalyzer := gosec.NewAnalyzer(gasConfig, true, logger)
 			gosecAnalyzer.LoadRules(enabledRules.Builders())
 			pkg := &packages.Package{


### PR DESCRIPTION
Thank you for the pull request!

Please make sure you didn't directly change `README.md`: it should be changed only by changing `README.tmpl.md` and running `make README.md`.

Hi, this is somewhat unfinished PR and I need help with it. Since the is no CONTRIBUTING.md, I'm clueless about correctly implementing and testing my changes.

The idea is that I want to be able to to do this in `.golangci-lint.yml`:
```yaml
linter-settings:
  gosec:
    exclude:
    - G102
    - G103
    ...
```

Instead of having to use `gosec -exclude=G102,G103 ./...`