### PR TITLE
Adding github actions output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ Usage:
   golangci-lint run [flags]
 
 Flags:
-      --out-format string              Format of output: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml (default "colored-line-number")
+      --out-format string              Format of output: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions (default "colored-line-number")
       --print-issued-lines             Print lines of code with issue (default true)
       --print-linter-name              Print linter name in issue line (default true)
       --uniq-by-line                   Make issues output unique by line (default true)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -396,6 +396,8 @@ func (e *Executor) createPrinter() (printers.Printer, error) {
 		p = printers.NewCodeClimate()
 	case config.OutFormatJunitXML:
 		p = printers.NewJunitXML()
+	case config.OutFormatGithubActions:
+		p = printers.NewGithub()
 	default:
 		return nil, fmt.Errorf("unknown output format %s", format)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ const (
 	OutFormatCheckstyle        = "checkstyle"
 	OutFormatCodeClimate       = "code-climate"
 	OutFormatJunitXML          = "junit-xml"
+	OutFormatGithubActions     = "github-actions"
 )
 
 var OutFormats = []string{
@@ -25,6 +26,7 @@ var OutFormats = []string{
 	OutFormatCheckstyle,
 	OutFormatCodeClimate,
 	OutFormatJunitXML,
+	OutFormatGithubActions,
 }
 
 type ExcludePattern struct {

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
 )

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -30,8 +30,9 @@ func formatIssueAsGithub(issue *result.Issue) string {
 }
 
 func (g *github) Print(ctx context.Context, issues []result.Issue) error {
-	for _, issue := range issues {
-		_, err := fmt.Fprintln(logutils.StdOut, formatIssueAsGithub(&issue))
+	for ind := range issues {
+		issue := &issues[ind]
+		_, err := fmt.Fprintln(logutils.StdOut, formatIssueAsGithub(issue))
 		if err != nil {
 			return err
 		}

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -3,6 +3,7 @@ package printers
 import (
 	"context"
 	"fmt"
+
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -17,19 +18,19 @@ func NewGithub() Printer {
 }
 
 // print each line as: ::error file=app.js,line=10,col=15::Something went wrong
-func formatIssueAsGithub(issue result.Issue) string {
-	result := fmt.Sprintf("::error file=%s,line=%d", issue.FilePath(), issue.Line())
+func formatIssueAsGithub(issue *result.Issue) string {
+	ret := fmt.Sprintf("::error file=%s,line=%d", issue.FilePath(), issue.Line())
 	if issue.Pos.Column != 0 {
-		result += fmt.Sprintf(",col=%d", issue.Pos.Column)
+		ret += fmt.Sprintf(",col=%d", issue.Pos.Column)
 	}
 
-	result += fmt.Sprintf("::%s (%s)", issue.Text, issue.FromLinter)
-	return result
+	ret += fmt.Sprintf("::%s (%s)", issue.Text, issue.FromLinter)
+	return ret
 }
 
 func (g *github) Print(ctx context.Context, issues []result.Issue) error {
 	for _, issue := range issues {
-		_, err := fmt.Fprintln(logutils.StdOut, formatIssueAsGithub(issue))
+		_, err := fmt.Fprintln(logutils.StdOut, formatIssueAsGithub(&issue))
 		if err != nil {
 			return err
 		}

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
 )

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -28,10 +28,9 @@ func formatIssueAsGithub(issue *result.Issue) string {
 	return ret
 }
 
-func (g *github) Print(ctx context.Context, issues []result.Issue) error {
+func (g *github) Print(_ context.Context, issues []result.Issue) error {
 	for ind := range issues {
-		issue := &issues[ind]
-		_, err := fmt.Fprintln(logutils.StdOut, formatIssueAsGithub(issue))
+		_, err := fmt.Fprintln(logutils.StdOut, formatIssueAsGithub(&issues[ind]))
 		if err != nil {
 			return err
 		}

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -1,0 +1,38 @@
+package printers
+
+import (
+	"context"
+	"fmt"
+	"github.com/golangci/golangci-lint/pkg/logutils"
+	"github.com/golangci/golangci-lint/pkg/result"
+)
+
+type github struct {
+}
+
+// Github output format outputs issues according to Github actions format:
+// https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+func NewGithub() Printer {
+	return &github{}
+}
+
+// print each line as: ::error file=app.js,line=10,col=15::Something went wrong
+func formatIssueAsGithub(issue result.Issue) string {
+	result := fmt.Sprintf("::error file=%s,line=%d", issue.FilePath(), issue.Line())
+	if issue.Pos.Column != 0 {
+		result += fmt.Sprintf(",col=%d", issue.Pos.Column)
+	}
+
+	result += fmt.Sprintf("::%s (%s)", issue.Text, issue.FromLinter)
+	return result
+}
+
+func (g *github) Print(ctx context.Context, issues []result.Issue) error {
+	for _, issue := range issues {
+		_, err := fmt.Fprintln(logutils.StdOut, formatIssueAsGithub(issue))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/printers/github_test.go
+++ b/pkg/printers/github_test.go
@@ -1,0 +1,25 @@
+package printers
+
+import (
+	"github.com/golangci/golangci-lint/pkg/result"
+	"github.com/stretchr/testify/require"
+	"go/token"
+	"testing"
+)
+
+func TestFormatGithubIssue(t *testing.T) {
+	sampleIssue := result.Issue{
+		FromLinter: "sample-linter",
+		Text:       "some issue",
+		Pos: token.Position{
+			Filename: "path/to/file.go",
+			Offset:   2,
+			Line:     10,
+			Column:   4,
+		},
+	}
+	require.Equal(t, "::error file=path/to/file.go,line=10,col=4::some issue (sample-linter)", formatIssueAsGithub(sampleIssue))
+
+	sampleIssue.Pos.Column = 0
+	require.Equal(t, "::error file=path/to/file.go,line=10::some issue (sample-linter)", formatIssueAsGithub(sampleIssue))
+}

--- a/pkg/printers/github_test.go
+++ b/pkg/printers/github_test.go
@@ -1,10 +1,12 @@
 package printers
 
 import (
-	"github.com/golangci/golangci-lint/pkg/result"
-	"github.com/stretchr/testify/require"
 	"go/token"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/golangci/golangci-lint/pkg/result"
 )
 
 func TestFormatGithubIssue(t *testing.T) {
@@ -18,8 +20,8 @@ func TestFormatGithubIssue(t *testing.T) {
 			Column:   4,
 		},
 	}
-	require.Equal(t, "::error file=path/to/file.go,line=10,col=4::some issue (sample-linter)", formatIssueAsGithub(sampleIssue))
+	require.Equal(t, "::error file=path/to/file.go,line=10,col=4::some issue (sample-linter)", formatIssueAsGithub(&sampleIssue))
 
 	sampleIssue.Pos.Column = 0
-	require.Equal(t, "::error file=path/to/file.go,line=10::some issue (sample-linter)", formatIssueAsGithub(sampleIssue))
+	require.Equal(t, "::error file=path/to/file.go,line=10::some issue (sample-linter)", formatIssueAsGithub(&sampleIssue))
 }


### PR DESCRIPTION
Github actions will annotate build failures in a special way if build errors are logged using their special format described in https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message . This allows easier inspection of linter failures inside github UI.
