### PR TITLE
Add tests, failures and errors attributes on testsuites

### DIFF
--- a/pkg/printers/junitxml.go
+++ b/pkg/printers/junitxml.go
@@ -17,6 +17,9 @@ type testSuitesXML struct {
 type testSuiteXML struct {
 	XMLName   xml.Name      `xml:"testsuite"`
 	Suite     string        `xml:"name,attr"`
+	Tests     int           `xml:"tests,attr"`
+	Errors    int           `xml:"errors,attr"`
+	Failures  int           `xml:"failures,attr"`
 	TestCases []testCaseXML `xml:"testcase"`
 }
 
@@ -46,6 +49,8 @@ func (JunitXML) Print(ctx context.Context, issues []result.Issue) error {
 		suiteName := i.FilePath()
 		testSuite := suites[suiteName]
 		testSuite.Suite = i.FilePath()
+		testSuite.Tests++
+		testSuite.Failures++
 
 		tc := testCaseXML{
 			Name:      i.FromLinter,


### PR DESCRIPTION
The Junit output format doesn't validate the Jenkins XSD:
https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd

So, I have added tests, failures and errors attributes on testsuite elements.