### PR TITLE
Add *println to exception EXC0001

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ Flags:
   -e, --exclude strings                Exclude issue by regexp
       --exclude-use-default            Use or not use default excludes:
                                          # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
-                                         - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+                                         - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
                                        
                                          # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
                                          - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,7 @@ var DefaultExcludePatterns = []ExcludePattern{
 	{
 		ID: "EXC0001",
 		Pattern: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close" +
-			"|.*Flush|os\\.Remove(All)?|.*printf?|os\\.(Un)?Setenv). is not checked",
+			"|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked",
 		Linter: "errcheck",
 		Why:    "Almost all programs ignore errors on these functions and in most cases it's ok",
 	},

--- a/test/testdata/errcheck/ignore_config.yml
+++ b/test/testdata/errcheck/ignore_config.yml
@@ -2,3 +2,6 @@ linters-settings:
   errcheck:
     check-blank: true
     ignore: os:.*,io/ioutil:^ReadF.*
+issues:
+  include:
+    - EXC0001


### PR DESCRIPTION
Exception EXC0001 ignores errors on functions like Sprint and Sprintf, but not Sprintln. Update the exception to include *println as well. This matches the default behavior of errcheck for `fmt.*print*`.