### PR TITLE
Add brew tap to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ and is constantly being improved. For any problems with golangci-lint, check out
 You can also install a binary release on macOS using [brew](https://brew.sh/):
 
 ```bash
+brew tap golangci/tap
 brew install golangci/tap/golangci-lint
 brew upgrade golangci/tap/golangci-lint
 ```

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -99,6 +99,7 @@ and is constantly being improved. For any problems with golangci-lint, check out
 You can also install a binary release on macOS using [brew](https://brew.sh/):
 
 ```bash
+brew tap golangci/tap
 brew install golangci/tap/golangci-lint
 brew upgrade golangci/tap/golangci-lint
 ```


### PR DESCRIPTION
Users can't install golangci-lint just by `brew install golangci/tap/golangci-lint`.
So, adding `brew tap` to README.md is kinder for them.