### PR TITLE
Fix CodeClimate formater panic

### DIFF
--- a/pkg/golinters/unused.go
+++ b/pkg/golinters/unused.go
@@ -43,6 +43,14 @@ func NewUnused() *goanalysis.Linter {
 					To:   p.End.Line,
 				},
 			}
+
+			// Set LineRange.To to the same value as LineRange.From if
+			// the Problem End line does not represent a valid Position
+			// See https://github.com/golangci/golangci-lint/issues/979
+			if !p.End.IsValid() {
+				i.LineRange.To = p.Pos.Line
+			}
+
 			// See https://github.com/golangci/golangci-lint/issues/1048
 			// If range is invalid, this will break `--fix` mode.
 			if i.LineRange.To >= i.LineRange.From {


### PR DESCRIPTION
In pkg/golinters/unused.go:NewUnused() set 'LineRange.To' equal to
LineRange.From when the the end position returned by u.ProblemObject(..)
is not valid.

When using 'code-climate' as formatter `golangci-lint` will panic with
"index out of range [0] with length 0".
This is caused because [DisplayPosition(..)](https://github.com/dominikh/go-tools/blob/v0.0.1-2020.1.3/unused/unused.go#L496) from honnef.co/go/tools
will return a zeroed token.Position struct if the given token
position does not contain any line information.

There should not be any side effects by setting 'LineRange.To' equal to
'From' since the 'unused' linter (mostly) only "targets" ONE line and
not many. But even if 'unused' targets multiple lines there should be no
issues because the returned "End" position will then be set to a correct
value.

Fixes #979