### PR TITLE
Update gosec2 dependency to a tagged version (v2.3.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/nakabonne/nestif v0.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/ryancurrah/gomodguard v1.0.4
-	github.com/securego/gosec/v2 v2.2.1-0.20200424144625-ee3146e63716
+	github.com/securego/gosec/v2 v2.3.0
 	github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada // v2.19.8
 	github.com/sirupsen/logrus v1.4.2
 	github.com/sourcegraph/go-diff v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/ryancurrah/gomodguard v1.0.4 h1:oCreMAt9GuFXDe9jW4HBpc3GjdX3R/sUEcLAG
 github.com/ryancurrah/gomodguard v1.0.4/go.mod h1:9T/Cfuxs5StfsocWr4WzDL36HqnX0fVb9d5fSEaLhoE=
 github.com/securego/gosec/v2 v2.2.1-0.20200424144625-ee3146e63716 h1:E/qamk0wO4PVhJhce201hAJWk/rKnGqKOk/blHzkY7o=
 github.com/securego/gosec/v2 v2.2.1-0.20200424144625-ee3146e63716/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
+github.com/securego/gosec/v2 v2.3.0 h1:y/9mCF2WPDbSDpL3QDWZD3HHGrSYw0QSHnCqTfs4JPE=
+github.com/securego/gosec/v2 v2.3.0/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada h1:WokF3GuxBeL+n4Lk4Fa8v9mbdjlrl7bHuneF4N1bk2I=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=


### PR DESCRIPTION
When raising #1062 I noted that the gosec dependency had been upgraded to v2,
but needed to be pulled from `master` due to some issues with the v2.2.0 tagged
release. That was tracked in https://github.com/securego/gosec/issues/470.

They've since cut v2.3.0, so let's update to that tagged release before we
release a new version of golangci-lint.

