### PR TITLE
Replace '{.LatestVersion}' with 'latest' as install.sh parameter

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -28,13 +28,13 @@ Here is the recommended way to install golangci-lint {.LatestVersion}:
 
 ```sh
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
 # or install it into ./bin/
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest
 
 # In alpine linux (as it does not come with curl by default)
-wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s {.LatestVersion}
+wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest
 
 golangci-lint --version
 ```
@@ -63,7 +63,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} g
 
 ```sh
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
 golangci-lint --version
 ```


### PR DESCRIPTION
install.sh expected `latest` as a parameter instead of `{.LatestVersion}`

    # wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s {.LatestVersion}
    2020-06-03 10:31:26 URL:https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh [10739/10739] -> "-" [1]
    golangci/golangci-lint info checking GitHub for tag '{.LatestVersion}'
    golangci/golangci-lint crit unable to find '{.LatestVersion}' - use 'latest' or see https://github.com/golangci/golangci-lint/releases for details