### PR TITLE
Build rpm and deb packages with goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,3 +95,15 @@ brews:
       prefix.install_metafiles
     test: |
       system "#{bin}/golangci-lint --version"
+
+nfpms:
+  -
+    id: golangci-lint-nfpms
+    package_name: golangci-lint
+    file_name_template: "'{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    homepage: https://golangci-lint.run/
+    description: Fast linters Runner for Go
+    license: GPLv3
+    formats:
+      - deb
+      - rpm

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -100,7 +100,7 @@ nfpms:
   -
     id: golangci-lint-nfpms
     package_name: golangci-lint
-    file_name_template: "'{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     homepage: https://golangci-lint.run/
     description: Fast linters Runner for Go
     license: GPLv3


### PR DESCRIPTION
Relates to #988 where we with this commit build `rpm` and `deb` packages.