### PR TITLE
Fix: goheader linter can throw nil pointer exception in case of a source file has not issues

### DIFF
--- a/pkg/golinters/goheader.go
+++ b/pkg/golinters/goheader.go
@@ -51,6 +51,9 @@ func NewGoHeader() *goanalysis.Linter {
 			var res []goanalysis.Issue
 			for _, file := range pass.Files {
 				i := a.Analyze(file)
+				if i == nil {
+					continue
+				}
 				issue := result.Issue{
 					Pos: token.Position{
 						Line:     i.Location().Line + 1,

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -193,6 +193,9 @@ func extractRunContextFromComments(t *testing.T, sourcePath string) *runContext 
 			skipMultilineComment(scanner)
 			continue
 		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 		if !strings.HasPrefix(line, "//") {
 			return rc
 		}

--- a/test/testdata/go-header_bad.go
+++ b/test/testdata/go-header_bad.go
@@ -1,0 +1,5 @@
+/*MY TITLE!*/ // ERROR "Expected:TITLE., Actual: TITLE!"
+
+//args: -Egoheader
+//config_path: testdata/configs/go-header.yml
+package testdata

--- a/test/testdata/go-header_good.go
+++ b/test/testdata/go-header_good.go
@@ -1,4 +1,5 @@
-/*MY TITLE!*/ // ERROR "Expected:TITLE., Actual: TITLE!"
+/*MY TITLE.*/
+
 //args: -Egoheader
 //config_path: testdata/configs/go-header.yml
 package testdata


### PR DESCRIPTION
## Description

During local testing latest golangci, we've found that go-header linter can throw nil pointer exception in case of a source file is valid.

## What is this patch doing?
- [x] Fix issue.
- [x] Add test to cover.
- [x] Allow using empty new lines in `testdata/.*\.go` files.

## Steps to reproduce the issue

1. Use next go-header config
```
linters-settings:
  goheader:
    template: "test"
```
2. Run golangci linter on file with valid header, for example
```
//test

//Package mypkg ...
package mypkg
```
Actual: nil pointer exception
Expected: Template has matched no issues should be found