### PR TITLE
chore: Bump go version to 1.14 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.12
+go 1.14
 
 require (
 	github.com/Djarvur/go-err113 v0.0.0-20200511133814-5174e21577d5


### PR DESCRIPTION
Golang 1.12 is EOL as per https://golang.org/doc/devel/release.html

Signed-off-by: Tam Mach <sayboras@yahoo.com>