### PR TITLE
Explicitly pass GITHUB_TOKEN env to goreleaser action

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,3 +23,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v1
         with:
           args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
       - name: Unshallow
@@ -20,8 +20,9 @@ jobs:
       - name: Login do docker.io
         run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
       - name: Create release
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
+          version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}

--- a/assets/github-action-config.json
+++ b/assets/github-action-config.json
@@ -69,8 +69,8 @@
       "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.27.0/golangci-lint-1.27.0-linux-amd64.tar.gz"
     },
     "v1.28": {
-      "TargetVersion": "v1.28.0",
-      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.28.0/golangci-lint-1.28.0-linux-amd64.tar.gz"
+      "TargetVersion": "v1.28.1",
+      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.28.1/golangci-lint-1.28.1-linux-amd64.tar.gz"
     },
     "v1.3": {
       "Error": "golangci-lint version 'v1.3' isn't supported: we support only v1.14.0 and later versions"


### PR DESCRIPTION
Fix a failing release workflow