### PR TITLE
Add ability to specify path prefix in output

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -72,6 +72,9 @@ output:
   # make issues output unique by line, default is true
   uniq-by-line: true
 
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+
 
 # all available settings of specific linters
 linters-settings:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -516,10 +516,11 @@ type Config struct {
 	Output struct {
 		Format              string
 		Color               string
-		PrintIssuedLine     bool `mapstructure:"print-issued-lines"`
-		PrintLinterName     bool `mapstructure:"print-linter-name"`
-		UniqByLine          bool `mapstructure:"uniq-by-line"`
-		PrintWelcomeMessage bool `mapstructure:"print-welcome"`
+		PrintIssuedLine     bool   `mapstructure:"print-issued-lines"`
+		PrintLinterName     bool   `mapstructure:"print-linter-name"`
+		UniqByLine          bool   `mapstructure:"uniq-by-line"`
+		PrintWelcomeMessage bool   `mapstructure:"print-welcome"`
+		PathPrefix          string `mapstructure:"path-prefix"`
 	}
 
 	LintersSettings LintersSettings `mapstructure:"linters-settings"`


### PR DESCRIPTION
## problem

It's often convenient in monorepos to run a tool from a different directory but still report issues relative to the root of the repository.

This is exactly the problem in the github action https://github.com/golangci/golangci-lint-action/issues/31

## proposed solution

Add a flag for specifying a path prefix in output. Default behavior remains the same.

---

Thanks for a great tool!