### PR TITLE
Use lowercase directories to fix test

### DIFF
--- a/test/run_test.go
+++ b/test/run_test.go
@@ -299,12 +299,12 @@ func TestPathPrefix(t *testing.T) {
 		Args    []string
 		Pattern string
 	}{
-		{"empty", nil, "^testdata/withTests/"},
-		{"prefixed", []string{"--path-prefix=cool"}, "^cool/testdata/withTests"},
+		{"empty", nil, "^testdata/withtests/"},
+		{"prefixed", []string{"--path-prefix=cool"}, "^cool/testdata/withtests"},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
 			testshared.NewLintRunner(t).Run(
-				append(tt.Args, getTestDataDir("withTests"))..., //nolint:scopelint
+				append(tt.Args, getTestDataDir("withtests"))..., //nolint:scopelint
 			).ExpectOutputRegexp(
 				tt.Pattern, //nolint:scopelint
 			)


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/pull/1226 appears to have introduced a test failure into master via a combination of factors.

My current theory:

1. A test refers to a test data directory in camel-case, but the directory isn't actually camel-case
2. This camel-case test passed locally for me because MacOS's fs is case-insensitive
3. This test somehow did not run on the PR build
4. It finally ran against master where the fs was not case-insensitive

[Success in PR](https://github.com/golangci/golangci-lint/runs/858079330) -- **TestPathPrefix** is nowhere present


[Failure in master](https://github.com/golangci/golangci-lint/runs/859880992?check_suite_focus=true#step:5:881)
![image](https://user-images.githubusercontent.com/1879661/87213610-1d716180-c2f4-11ea-97bb-67533447d472.png)