### PR TITLE
Improve 'no such linter' error message

### DIFF
--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -17,7 +17,7 @@ func NewValidator(m *Manager) *Validator {
 	}
 }
 
-func (v *Validator) validateLinterConfigNames(cfg *config.Linters) error {
+func (v Validator) validateLintersNames(cfg *config.Linters) error {
 	allNames := append([]string{}, cfg.Enable...)
 	allNames = append(allNames, cfg.Disable...)
 	for _, name := range allNames {
@@ -29,7 +29,7 @@ func (v *Validator) validateLinterConfigNames(cfg *config.Linters) error {
 	return nil
 }
 
-func (v *Validator) validatePresets(cfg *config.Linters) error {
+func (v Validator) validatePresets(cfg *config.Linters) error {
 	allPresets := v.m.allPresetsSet()
 	for _, p := range cfg.Presets {
 		if !allPresets[p] {
@@ -45,7 +45,7 @@ func (v *Validator) validatePresets(cfg *config.Linters) error {
 	return nil
 }
 
-func (v *Validator) validateAllDisableEnableOptions(cfg *config.Linters) error {
+func (v Validator) validateAllDisableEnableOptions(cfg *config.Linters) error {
 	if cfg.EnableAll && cfg.DisableAll {
 		return fmt.Errorf("--enable-all and --disable-all options must not be combined")
 	}
@@ -67,7 +67,7 @@ func (v *Validator) validateAllDisableEnableOptions(cfg *config.Linters) error {
 	return nil
 }
 
-func (v *Validator) validateDisabledAndEnabledAtOneMoment(cfg *config.Linters) error {
+func (v Validator) validateDisabledAndEnabledAtOneMoment(cfg *config.Linters) error {
 	enabledLintersSet := map[string]bool{}
 	for _, name := range cfg.Enable {
 		enabledLintersSet[name] = true
@@ -82,9 +82,9 @@ func (v *Validator) validateDisabledAndEnabledAtOneMoment(cfg *config.Linters) e
 	return nil
 }
 
-func (v *Validator) validateEnabledDisabledLintersConfig(cfg *config.Linters) error {
+func (v Validator) validateEnabledDisabledLintersConfig(cfg *config.Linters) error {
 	validators := []func(cfg *config.Linters) error{
-		v.validateLinterConfigNames,
+		v.validateLintersNames,
 		v.validatePresets,
 		v.validateAllDisableEnableOptions,
 		v.validateDisabledAndEnabledAtOneMoment,

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -17,19 +17,19 @@ func NewValidator(m *Manager) *Validator {
 	}
 }
 
-func (v Validator) validateLintersNames(cfg *config.Linters) error {
+func (v *Validator) validateLinterConfigNames(cfg *config.Linters) error {
 	allNames := append([]string{}, cfg.Enable...)
 	allNames = append(allNames, cfg.Disable...)
 	for _, name := range allNames {
 		if v.m.GetLinterConfigs(name) == nil {
-			return fmt.Errorf("no such linter %q", name)
+			return fmt.Errorf("no such linter %v, run 'golangci-lint linters' to see the list of supported linters", name)
 		}
 	}
 
 	return nil
 }
 
-func (v Validator) validatePresets(cfg *config.Linters) error {
+func (v *Validator) validatePresets(cfg *config.Linters) error {
 	allPresets := v.m.allPresetsSet()
 	for _, p := range cfg.Presets {
 		if !allPresets[p] {
@@ -45,7 +45,7 @@ func (v Validator) validatePresets(cfg *config.Linters) error {
 	return nil
 }
 
-func (v Validator) validateAllDisableEnableOptions(cfg *config.Linters) error {
+func (v *Validator) validateAllDisableEnableOptions(cfg *config.Linters) error {
 	if cfg.EnableAll && cfg.DisableAll {
 		return fmt.Errorf("--enable-all and --disable-all options must not be combined")
 	}
@@ -67,7 +67,7 @@ func (v Validator) validateAllDisableEnableOptions(cfg *config.Linters) error {
 	return nil
 }
 
-func (v Validator) validateDisabledAndEnabledAtOneMoment(cfg *config.Linters) error {
+func (v *Validator) validateDisabledAndEnabledAtOneMoment(cfg *config.Linters) error {
 	enabledLintersSet := map[string]bool{}
 	for _, name := range cfg.Enable {
 		enabledLintersSet[name] = true
@@ -82,9 +82,9 @@ func (v Validator) validateDisabledAndEnabledAtOneMoment(cfg *config.Linters) er
 	return nil
 }
 
-func (v Validator) validateEnabledDisabledLintersConfig(cfg *config.Linters) error {
+func (v *Validator) validateEnabledDisabledLintersConfig(cfg *config.Linters) error {
 	validators := []func(cfg *config.Linters) error{
-		v.validateLintersNames,
+		v.validateLinterConfigNames,
 		v.validatePresets,
 		v.validateAllDisableEnableOptions,
 		v.validateDisabledAndEnabledAtOneMoment,


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Steps to reproduce

1. Use new golangci-linter config file
2. Use old linter version (for example 1.26)

**Actual**: Printed err msg 'no such linter %v' for all new linters which was added since 1.26. The error message looks is not clear for new users. The message can confuse the user like 'Should I download missed linter?'. 

I think we need to point that the user can run  `golangci-lint linters` to see supported linter list of his `golangci-linter` tool.