### PR TITLE
Add tests-on-macos

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,6 @@ jobs:
   # We already run the current golangci-lint in tests, but here we test
   # our GitHub action with the latest stable golangci-lint.
   golangci-lint:
-    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -28,20 +27,29 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.14 # test only the latest go version to speed up CI
-      - name: Run tests on Windows
+      - name: Run tests
         run: make.exe test
+        continue-on-error: true
+  tests-on-macos:
+    needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14 # test only the latest go version to speed up CI
+      - name: Run tests
+        run: make test
         continue-on-error: true
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         golang:
           - 1.13
           - 1.14
-        os:
-          - ubuntu-latest
-          # don't enable mac os because it's machines are very slow
     steps:
       - uses: actions/checkout@v2
       - name: Install Go
@@ -54,7 +62,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ matrix.golang }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.golang }}-
-      - name: Run tests on Unix-like operating systems
+      - name: Run tests
         run: make test
   check_generated:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors


### PR DESCRIPTION
IMO we need to run the tests on macOS in same way we do for windows, so I added tests-on-macos as a parallel job with the go v1.14, so only ubuntu job will use different go version for testing.