### PR TITLE
Allow for serializing multiple golangci-lint invocations

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -111,6 +111,9 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	const allowParallelDesc = "Allow multiple parallel golangci-lint instances running. " +
 		"If false (default) - golangci-lint acquires file lock on start."
 	fs.BoolVar(&rc.AllowParallelRunners, "allow-parallel-runners", false, wh(allowParallelDesc))
+	const allowSerialDesc = "Allow multiple golangci-lint instances running, but serialize them	around a lock. " +
+		"If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start."
+	fs.BoolVar(&rc.AllowSerialRunners, "allow-serial-runners", false, wh(allowSerialDesc))
 
 	// Linters settings config
 	lsc := &cfg.LintersSettings

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,6 +152,7 @@ type Run struct {
 	UseDefaultSkipDirs bool     `mapstructure:"skip-dirs-use-default"`
 
 	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
+	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
 }
 
 type LintersSettings struct {


### PR DESCRIPTION
By default, golangci-lint fails after five seconds if another instance
is running. It is possible to disable that, but the discussion around
whether the cache is safe to use concurrently is not exactly full of
confidence. Add a flag that allows golangci-lint to wait forever
instead of failing.

see #1301