### PR TITLE
Upgrade go 1.15 for smaller binary

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14 # test only the latest go version to speed up CI
+          go-version: 1.15 # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
         continue-on-error: true
@@ -38,7 +38,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14 # test only the latest go version to speed up CI
+          go-version: 1.15 # test only the latest go version to speed up CI
       - name: Run tests
         run: make test
         continue-on-error: true
@@ -50,6 +50,7 @@ jobs:
         golang:
           - 1.13
           - 1.14
+          - 1.15
     steps:
       - uses: actions/checkout@v2
       - name: Install Go
@@ -77,6 +78,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Check generated files are up to date
         run: make fast_check_generated

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Login do docker.io

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.15
 
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY golangci-lint /usr/bin/

--- a/build/Dockerfile.alpine
+++ b/build/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine
+FROM golang:1.15-alpine
 
 # gcc is required to support cgo;
 # git and mercurial are needed most times for go get`, etc.

--- a/test/enabled_linters_test.go
+++ b/test/enabled_linters_test.go
@@ -176,7 +176,7 @@ func TestEnabledLinters(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			runArgs := []string{"-v"}
+			runArgs := []string{"--verbose"}
 			if !c.noImplicitFast {
 				runArgs = append(runArgs, "--fast")
 			}

--- a/test/testdata/nolintlint_unused.go
+++ b/test/testdata/nolintlint_unused.go
@@ -5,7 +5,7 @@ package testdata
 import "fmt"
 
 func Foo() {
-	fmt.Println("unused")          //nolint // ERROR "directive `//nolint .*` is unused"
-	fmt.Println("unused,specific") //nolint:varcheck // ERROR "directive `//nolint:varcheck .*` is unused for linter varcheck"
-	fmt.Println("not run")         //nolint:unparam // unparam is not run so this is ok
+	fmt.Println("unused")          // nolint // ERROR "directive `//nolint .*` is unused"
+	fmt.Println("unused,specific") // nolint:varcheck // ERROR "directive `//nolint:varcheck .*` is unused for linter varcheck"
+	fmt.Println("not run")         // nolint:unparam // unparam is not run so this is ok
 }


### PR DESCRIPTION
The binary is much smaller from 37MB to 31MB

```
-rwxrwxr-x  1 tammach tammach 38016216 Aug 12 22:36 golangci-lint.1.14
-rwxrwxr-x  1 tammach tammach 32142632 Aug 12 22:44 golangci-lint
```

Performance test

```
### Cilium project
$ golangci-lint cache clean
$ time golangci-lint run ./...
golangci-lint run ./...  100.29s user 2.16s system 382% cpu 26.753 total

$ golangci-lint-1.15 cache clean
$ time golangci-lint-1.15 run ./...
golangci-lint-1.15 run ./...  98.14s user 2.21s system 380% cpu 26.389 total

### Kubernetes project
$ golangci-lint cache clean
$ time golangci-lint run --timeout 30m ./...
golangci-lint run --timeout 30m ./...  996.16s user 15.05s system 1333% cpu 1:15.85 total

$ golangci-lint-1.15 cache clean
$ time golangci-lint-1.15 run --timeout 30m ./...
golangci-lint-1.15 run --timeout 30m ./...  989.70s user 15.09s system 1307% cpu 1:16.83 total
```

Please refer to the commit message for more details.

Signed-off-by: Tam Mach <sayboras@yahoo.com>