### PR TITLE
Bump up gci to v0.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Djarvur/go-err113 v0.0.0-20200511133814-5174e21577d5
 	github.com/OpenPeeDeeP/depguard v1.0.1
 	github.com/bombsimon/wsl/v3 v3.1.0
-	github.com/daixiang0/gci v0.2.1
+	github.com/daixiang0/gci v0.2.2
 	github.com/denis-tingajkin/go-header v0.3.1
 	github.com/fatih/color v1.9.0
 	github.com/go-critic/go-critic v0.5.0


### PR DESCRIPTION
Here is the output with v0.2.1 and v0.2.2:
```v0.2.1
$ gci -d galley/pkg/config/source/kube/interfaces.go
diff -u galley/pkg/config/source/kube/interfaces.go.orig galley/pkg/config/source/kube/interfaces.go
--- galley/pkg/config/source/kube/interfaces.go.orig	2020-08-17 10:32:06.048341665 +0800
+++ galley/pkg/config/source/kube/interfaces.go	2020-08-17 10:32:06.048341665 +0800
@@ -18,7 +18,9 @@
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // import GKE cluster authentication plugin
+
+	//  import GKE cluster authentication plugin   <===
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )

```

```v0.2.2
$ gci -d galley/pkg/config/source/kube/interfaces.go
diff -u galley/pkg/config/source/kube/interfaces.go.orig galley/pkg/config/source/kube/interfaces.go
--- galley/pkg/config/source/kube/interfaces.go.orig	2020-08-17 10:31:44.708207759 +0800
+++ galley/pkg/config/source/kube/interfaces.go	2020-08-17 10:31:44.708207759 +0800
@@ -18,7 +18,9 @@
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // import GKE cluster authentication plugin
+
+	// import GKE cluster authentication plugin
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
```

There is an extra blank in the comment, bump up version to fix it.


Signed-off-by: Xiang Dai <long0dai@foxmail.com>