### PR TITLE
Add home directory to config file search paths

### DIFF
--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -28,6 +28,7 @@ GolangCI-Lint looks for config files in the following paths from the current wor
 - `.golangci.json`
 
 GolangCI-Lint also searches for config files in all directories from the directory of the first analyzed path up to the root.
+If no configuration file has been found, GolangCI-Lint will try to find one in your home directory.
 To see which config file is being used and where it was sourced from run golangci-lint with `-v` option.
 
 Config options inside the file are identical to command-line options.

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -184,7 +184,7 @@ func (r *FileReader) setupConfigFileSearch() {
 	home, err := homedir.Dir()
 	if err != nil {
 		r.log.Warnf("Can't get user's home directory: %s", home)
-	} else {
+	} else if !sliceContains(configSearchPaths, home) {
 		configSearchPaths = append(configSearchPaths, home)
 	}
 
@@ -193,6 +193,15 @@ func (r *FileReader) setupConfigFileSearch() {
 	for _, p := range configSearchPaths {
 		viper.AddConfigPath(p)
 	}
+}
+
+func sliceContains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
 }
 
 var errConfigDisabled = errors.New("config is disabled by --no-config")

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -181,9 +181,8 @@ func (r *FileReader) setupConfigFileSearch() {
 	}
 
 	// find home directory for global config
-	home, err := homedir.Dir()
-	if err != nil {
-		r.log.Warnf("Can't get user's home directory: %s", home)
+	if home, err := homedir.Dir(); err != nil {
+		r.log.Warnf("Can't get user's home directory: %s", err.Error())
 	} else if !sliceContains(configSearchPaths, home) {
 		configSearchPaths = append(configSearchPaths, home)
 	}

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -170,6 +170,7 @@ func (r *FileReader) setupConfigFileSearch() {
 
 	// find all dirs from it up to the root
 	configSearchPaths := []string{"./"}
+
 	for {
 		configSearchPaths = append(configSearchPaths, curDir)
 		newCurDir := filepath.Dir(curDir)
@@ -177,6 +178,14 @@ func (r *FileReader) setupConfigFileSearch() {
 			break
 		}
 		curDir = newCurDir
+	}
+
+	// find home directory for global config
+	home, err := homedir.Dir()
+	if err != nil {
+		r.log.Warnf("Can't get user's home directory: %s", home)
+	} else {
+		configSearchPaths = append(configSearchPaths, home)
 	}
 
 	r.log.Infof("Config search paths: %s", configSearchPaths)


### PR DESCRIPTION
See #1324 

**Guidance required:** tests don't pass if you have a configuration file in your home directory. This is because some tests check that config is not found. I need assistance on how to update tests properly.