### PR TITLE
Fix typo in performance docs

### DIFF
--- a/docs/src/docs/usage/performance.mdx
+++ b/docs/src/docs/usage/performance.mdx
@@ -7,16 +7,16 @@ title: Performance
 A trade-off between memory usage and execution time can be controlled by [`GOGC`](https://golang.org/pkg/runtime/#hdr-Environment_Variables) environment variable.
 Less `GOGC` values trigger garbage collection more frequently and golangci-lint consumes less memory and more CPU. Below is the trade-off table for running on this repo:
 
-| `GOGC`          | Peak Memory, GB | Executon Time, s |
-| --------------- | --------------- | ---------------- |
-| `5`             | 1.1             | 60               |
-| `10`            | 1.1             | 34               |
-| `20`            | 1.3             | 25               |
-| `30`            | 1.6             | 20.2             |
-| `50`            | 2.0             | 17.1             |
-| `80`            | 2.2             | 14.1             |
-| `100` (default) | 2.2             | 13.8             |
-| `off`           | 3.2             | 9.3              |
+| `GOGC`          | Peak Memory, GB | Execution Time, s |
+| --------------- | --------------- | ----------------- |
+| `5`             | 1.1             | 60                |
+| `10`            | 1.1             | 34                |
+| `20`            | 1.3             | 25                |
+| `30`            | 1.6             | 20.2              |
+| `50`            | 2.0             | 17.1              |
+| `80`            | 2.2             | 14.1              |
+| `100` (default) | 2.2             | 13.8              |
+| `off`           | 3.2             | 9.3               |
 
 ## Why `golangci-lint` is so fast
 


### PR DESCRIPTION
Executon -> Execution