### PR TITLE
Mention macports installation procedure on macOS

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -53,6 +53,12 @@ brew install golangci/tap/golangci-lint
 brew upgrade golangci/tap/golangci-lint
 ```
 
+It can also be installed through [macport](https://www.macports.org/)
+
+```sh
+sudo port install golangci-lint
+```
+
 ### Docker
 
 ```sh

--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -53,7 +53,8 @@ brew install golangci/tap/golangci-lint
 brew upgrade golangci/tap/golangci-lint
 ```
 
-It can also be installed through [macport](https://www.macports.org/)
+It can also be installed through [macports](https://www.macports.org/)
+The macports installation mode is community driven, and not officially maintained by golangci team.
 
 ```sh
 sudo port install golangci-lint


### PR DESCRIPTION
The version of `golangci-lint` has been updated to the v1.30 version in macports. https://github.com/macports/macports-ports/commit/3703aa3bcc8fd46f8425947ca578e627936e2a30