### PR TITLE
Added `.golangci.yaml` to list of configuration files searched

### DIFF
--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -24,6 +24,7 @@ golangci-lint run -h
 GolangCI-Lint looks for config files in the following paths from the current working directory:
 
 - `.golangci.yml`
+- `.golangci.yaml`
 - `.golangci.toml`
 - `.golangci.json`
 


### PR DESCRIPTION
Just a very minor documentation change.

Noted that `.golangci.yaml` is also searched for on startup as a config file - which is great, as I prefer to use `.yaml` over `.yml` as a file extension - as suggested here: https://yaml.org/faq.html
