### PR TITLE
build(go): Check if go.mod and go.sum are up to date

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+go.sum linguist-generated

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,21 @@ on:
       - master
   pull_request:
 jobs:
+  # Check if there any dirty change for go mod tidy
+  go-mod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check go mod
+        run: |
+          go mod tidy
+          git diff --exit-code
+
   # We already run the current golangci-lint in tests, but here we test
   # our GitHub action with the latest stable golangci-lint.
   golangci-lint:


### PR DESCRIPTION
This commit is to add job to check if go.mod and go.sum are up to
date.

Also add go.sum into .gitattributes so that it will be considered
as generated file in PR review.

Signed-off-by: Tam Mach <sayboras@yahoo.com>