### PR TITLE
build(dep): Ignore known dependency failure in nancy

### DIFF
--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-      # We cannot use nancy-github-action because it is outdated, so it's better to use the latest
-      # docker image for the validation
-      - name: nancy
-        run: go list -json -m all | docker run -i sonatypecommunity/nancy:v0.3
+      - name: Run go list
+        run: go list -json -m all > go.list
+      - name: Nancy
+        uses: sonatype-nexus-community/nancy-github-action@master

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,11 @@
+# Skip for golang/golang.org/x/net@v0.0.0-20200904194848-62affa334b73
+CVE-2018-17848
+CVE-2018-17143
+CVE-2018-17847
+CVE-2018-17142
+CVE-2018-17846
+
+# Skip for indirect dependency github.com/coreos/etcd@3.3.13
+CVE-2020-15114
+CVE-2020-15115
+CVE-2020-15136


### PR DESCRIPTION
Currently nancy is always failed, and we seem to ignore it completely.
This reduces the value of having security scanning significantly.
Ideally, the underlying issue should be fixed, however it will require
long time for external collaboration.

This commit is to ignore two known dependency failures.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

Note: ignoring any dependency must be consious choice.