### PR TITLE
ci: prevent macos to be marked as passing upon failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,6 @@ jobs:
           go-version: 1.15 # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
-        continue-on-error: true
   tests-on-macos:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: macos-latest
@@ -56,7 +55,6 @@ jobs:
           go-version: 1.15 # test only the latest go version to speed up CI
       - name: Run tests
         run: make test
-        continue-on-error: true
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,7 @@ jobs:
           go-version: 1.15 # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
+        continue-on-error: true
   tests-on-macos:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: macos-latest


### PR DESCRIPTION
Our tests for macOS and Windows are using the `continue-on-error` option, making them always showing up as passing even when they fail. [Here's an example of a failing job being marked as passing](https://github.com/golangci/golangci-lint/pull/1380/checks?check_run_id=1141753724). This PR removes this option for macos because [Windows is broken](https://github.com/golangci/golangci-lint/pull/1381/checks?check_run_id=1141826954).