### PR TITLE
Releasing docker image for arm64

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,6 +17,15 @@ jobs:
           go-version: 1.15
       - name: Unshallow
         run: git fetch --prune --unshallow
+      - name: Login do docker.io
+        run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
+      - name: Create release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
       - name: Prepare
         id: prepare
         run: |
@@ -28,15 +37,6 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login do docker.io
-        run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
-      - name: Create release
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
       - name: build and publish main image
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,6 +17,17 @@ jobs:
           go-version: 1.15
       - name: Unshallow
         run: git fetch --prune --unshallow
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF#refs/tags/}
+            MAJOR=${TAG%.*}
+            echo ::set-output name=tag_name::${TAG}
+            echo ::set-output name=major_tag::${MAJOR}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login do docker.io
         run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
       - name: Create release
@@ -26,3 +37,27 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+      - name: build and publish main image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: build/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}
+            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}
+            golangci/golangci-lint:latest
+      - name: build and publish alpine image
+        id: docker_build_alpine
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: build/Dockerfile.alpine
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}-alpine
+            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}-alpine
+            golangci/golangci-lint:latest-alpine

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,22 +63,6 @@ changelog:
     - Merge pull request
     - Merge branch
 
-dockers:
-  - dockerfile: build/Dockerfile
-    binaries:
-      - golangci-lint
-    image_templates:
-      - "golangci/golangci-lint:latest"
-      - "golangci/golangci-lint:{{ .Tag }}"
-      - "golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}"
-  - dockerfile: build/Dockerfile.alpine
-    binaries:
-      - golangci-lint
-    image_templates:
-      - "golangci/golangci-lint:latest-alpine"
-      - "golangci/golangci-lint:{{ .Tag }}-alpine"
-      - "golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-alpine"
-
 brews:
   - tap:
       owner: golangci

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,12 @@
 # stage 1 building the code
 FROM golang:1.15 as builder
 
-# don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
-RUN git clone https://github.com/golangci/golangci-lint
-WORKDIR golangci-lint
-RUN go build -o /usr/bin/golangci-lint ./cmd/golangci-lint/main.go
+COPY / /golangci
+WORKDIR /golangci
+RUN go build -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.15
-COPY --from=builder /usr/bin/golangci-lint /usr/bin/
+# don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
+COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,12 @@
-FROM golang:1.15
+# stage 1 building the code
+FROM golang:1.15 as builder
 
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
-COPY golangci-lint /usr/bin/
+RUN git clone https://github.com/golangci/golangci-lint
+WORKDIR golangci-lint
+RUN go build -o /usr/bin/golangci-lint ./cmd/golangci-lint/main.go
+
+# stage 2
+FROM golang:1.15
+COPY --from=builder /usr/bin/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/Dockerfile.alpine
+++ b/build/Dockerfile.alpine
@@ -1,4 +1,5 @@
-FROM golang:1.15-alpine
+# stage 1 building the code
+FROM golang:1.15-alpine as builder
 
 # gcc is required to support cgo;
 # git and mercurial are needed most times for go get`, etc.
@@ -6,5 +7,12 @@ FROM golang:1.15-alpine
 RUN apk --no-cache add gcc musl-dev git mercurial
 
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
-COPY golangci-lint /usr/bin/
+RUN git clone https://github.com/golangci/golangci-lint
+WORKDIR golangci-lint
+RUN CGO_ENABLED=0 go build -o /usr/bin/golangci-lint ./cmd/golangci-lint/main.go
+
+# stage 2
+FROM golang:1.15-alpine
+RUN apk --no-cache add gcc musl-dev git mercurial
+COPY --from=builder /usr/bin/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/Dockerfile.alpine
+++ b/build/Dockerfile.alpine
@@ -1,18 +1,16 @@
 # stage 1 building the code
 FROM golang:1.15-alpine as builder
 
+COPY / /golangci
+WORKDIR /golangci
+RUN CGO_ENABLED=0 go build -o golangci-lint ./cmd/golangci-lint/main.go
+
+# stage 2
+FROM golang:1.15-alpine
 # gcc is required to support cgo;
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80
 RUN apk --no-cache add gcc musl-dev git mercurial
-
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
-RUN git clone https://github.com/golangci/golangci-lint
-WORKDIR golangci-lint
-RUN CGO_ENABLED=0 go build -o /usr/bin/golangci-lint ./cmd/golangci-lint/main.go
-
-# stage 2
-FROM golang:1.15-alpine
-RUN apk --no-cache add gcc musl-dev git mercurial
-COPY --from=builder /usr/bin/golangci-lint /usr/bin/
+COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]


### PR DESCRIPTION
**Updated below files:**

1. Updated **.github/workflows/tag.yml** file to release the image for amd64 and arm64 using https://github.com/docker/build-push-action.
2. Updated **build/Dockerfile** and **build/Dockerfile.alpine** files to build the golangci-lint binary from the source code and copy that binary to /usr/bin/ using multi-stage docker build.
3. Removed the docker file section from **.goreleaser.yml** as goreleaser does not support multi-arch builds currently.