### PR TITLE
fix Nancy's branch name

### DIFF
--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy
-        uses: sonatype-nexus-community/nancy-github-action@master
+        uses: sonatype-nexus-community/nancy-github-action@main


### PR DESCRIPTION
Nancy's Github action renamed their master branch to `main`, which broke everything. This PR fixes that.