### PR TITLE
Added support for only specifying default severity

### DIFF
--- a/pkg/result/processors/severity_rules.go
+++ b/pkg/result/processors/severity_rules.go
@@ -57,7 +57,7 @@ func createSeverityRules(rules []SeverityRule, prefix string) []severityRule {
 }
 
 func (p SeverityRules) Process(issues []result.Issue) ([]result.Issue, error) {
-	if len(p.rules) == 0 {
+	if len(p.rules) == 0 && len(p.defaultSeverity) == 0 {
 		return issues, nil
 	}
 	return transformIssues(issues, func(i *result.Issue) *result.Issue {

--- a/pkg/result/processors/severity_rules.go
+++ b/pkg/result/processors/severity_rules.go
@@ -57,7 +57,7 @@ func createSeverityRules(rules []SeverityRule, prefix string) []severityRule {
 }
 
 func (p SeverityRules) Process(issues []result.Issue) ([]result.Issue, error) {
-	if len(p.rules) == 0 && len(p.defaultSeverity) == 0 {
+	if len(p.rules) == 0 && p.defaultSeverity == "" {
 		return issues, nil
 	}
 	return transformIssues(issues, func(i *result.Issue) *result.Issue {


### PR DESCRIPTION
Default severity is only used when rules are not empty

Make sure the rules transformations for modifying severity are skipped if there are not rules AND no default severity specified