### PR TITLE
Add dummy maintainer to keep `dpkg` happy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -104,6 +104,7 @@ nfpms:
     package_name: golangci-lint
     file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     homepage: https://golangci-lint.run/
+    maintainer: "golangci-lint Team <golangci-releaser@users.noreply.github.com>"
     description: Fast linters Runner for Go
     license: GPLv3
     formats:


### PR DESCRIPTION
After installing the `deb` package many `dpkg` tools started to complain about the missing `Maintainer` field for this package in the system installed package database. This causes spam from cron.

Example:
```
$ LANG=C dpkg-query -s > /dev/null 
dpkg-query: warning: parsing file '/var/lib/dpkg/status' near line 14485 package 'golangci-lint:i386':
 missing 'Maintainer' field
```