### PR TITLE
feat(completion): Add support for powershell completion

### DIFF
--- a/pkg/commands/completion.go
+++ b/pkg/commands/completion.go
@@ -35,6 +35,13 @@ func (e *Executor) initCompletion() {
 		RunE:  e.executeFishCompletion,
 	}
 	completionCmd.AddCommand(fishCmd)
+
+	powerShell := &cobra.Command{
+		Use:   "powershell",
+		Short: "Output powershell completion script",
+		RunE:  e.executePowerShellCompletion,
+	}
+	completionCmd.AddCommand(powerShell)
 }
 
 func (e *Executor) executeBashCompletion(cmd *cobra.Command, args []string) error {
@@ -63,6 +70,15 @@ func (e *Executor) executeFishCompletion(cmd *cobra.Command, args []string) erro
 	err := cmd.Root().GenFishCompletion(os.Stdout, true)
 	if err != nil {
 		return errors.Wrap(err, "generate fish completion")
+	}
+
+	return nil
+}
+
+func (e *Executor) executePowerShellCompletion(cmd *cobra.Command, args []string) error {
+	err := cmd.Root().GenPowerShellCompletion(os.Stdout)
+	if err != nil {
+		return errors.Wrap(err, "generate powershell completion")
 	}
 
 	return nil


### PR DESCRIPTION
This commit is to add support for powershell completion script.

Note: PowerShell v5.0+ is required

For reviewers: please find below the completion script output for powershell.

<details>
<summary>Completion script powershell</summary>

```
using namespace System.Management.Automation
using namespace System.Management.Automation.Language
Register-ArgumentCompleter -Native -CommandName 'golangci-lint' -ScriptBlock {
    param($wordToComplete, $commandAst, $cursorPosition)
    $commandElements = $commandAst.CommandElements
    $command = @(
        'golangci-lint'
        for ($i = 1; $i -lt $commandElements.Count; $i++) {
            $element = $commandElements[$i]
            if ($element -isnot [StringConstantExpressionAst] -or
                $element.StringConstantType -ne [StringConstantType]::BareWord -or
                $element.Value.StartsWith('-')) {
                break
            }
            $element.Value
        }
    ) -join ';'
    $completions = @(switch ($command) {
        'golangci-lint' {
            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Use color when printing; can be ''always'', ''auto'', or ''never''')
            [CompletionResult]::new('-j', 'j', [CompletionResultType]::ParameterName, 'Concurrency (default NumCPU)')
            [CompletionResult]::new('--concurrency', 'concurrency', [CompletionResultType]::ParameterName, 'Concurrency (default NumCPU)')
            [CompletionResult]::new('--cpu-profile-path', 'cpu-profile-path', [CompletionResultType]::ParameterName, 'Path to CPU profile output file')
            [CompletionResult]::new('--mem-profile-path', 'mem-profile-path', [CompletionResultType]::ParameterName, 'Path to memory profile output file')
            [CompletionResult]::new('--trace-path', 'trace-path', [CompletionResultType]::ParameterName, 'Path to trace output file')
            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'verbose output')
            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'verbose output')
            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version')
            [CompletionResult]::new('cache', 'cache', [CompletionResultType]::ParameterValue, 'Cache control and information')
            [CompletionResult]::new('completion', 'completion', [CompletionResultType]::ParameterValue, 'Output completion script')
            [CompletionResult]::new('config', 'config', [CompletionResultType]::ParameterValue, 'Config')
            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Help')
            [CompletionResult]::new('linters', 'linters', [CompletionResultType]::ParameterValue, 'List current linters configuration')
            [CompletionResult]::new('run', 'run', [CompletionResultType]::ParameterValue, 'Run this tool in cloud on every github pull request in https://golangci.com for free (public repos)')
            [CompletionResult]::new('version', 'version', [CompletionResultType]::ParameterValue, 'Version')
            break
        }
        'golangci-lint;cache' {
            [CompletionResult]::new('clean', 'clean', [CompletionResultType]::ParameterValue, 'Clean cache')
            [CompletionResult]::new('status', 'status', [CompletionResultType]::ParameterValue, 'Show cache status')
            break
        }
        'golangci-lint;cache;clean' {
            break
        }
        'golangci-lint;cache;status' {
            break
        }
        'golangci-lint;completion' {
            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Use color when printing; can be ''always'', ''auto'', or ''never''')
            [CompletionResult]::new('-j', 'j', [CompletionResultType]::ParameterName, 'Concurrency (default NumCPU)')
            [CompletionResult]::new('--concurrency', 'concurrency', [CompletionResultType]::ParameterName, 'Concurrency (default NumCPU)')
            [CompletionResult]::new('--cpu-profile-path', 'cpu-profile-path', [CompletionResultType]::ParameterName, 'Path to CPU profile output file')
            [CompletionResult]::new('--mem-profile-path', 'mem-profile-path', [CompletionResultType]::ParameterName, 'Path to memory profile output file')
            [CompletionResult]::new('--trace-path', 'trace-path', [CompletionResultType]::ParameterName, 'Path to trace output file')
            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'verbose output')
            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'verbose output')
            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version')
            [CompletionResult]::new('bash', 'bash', [CompletionResultType]::ParameterValue, 'Output bash completion script')
            [CompletionResult]::new('fish', 'fish', [CompletionResultType]::ParameterValue, 'Output fish completion script')
            [CompletionResult]::new('powershell', 'powershell', [CompletionResultType]::ParameterValue, 'Output powershell completion script')
            [CompletionResult]::new('zsh', 'zsh', [CompletionResultType]::ParameterValue, 'Output zsh completion script')
            break
        }
        'golangci-lint;completion;bash' {
            break
        }
        'golangci-lint;completion;fish' {
            break
        }
        'golangci-lint;completion;powershell' {
            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Use color when printing; can be ''always'', ''auto'', or ''never''')
            [CompletionResult]::new('-j', 'j', [CompletionResultType]::ParameterName, 'Concurrency (default NumCPU)')
            [CompletionResult]::new('--concurrency', 'concurrency', [CompletionResultType]::ParameterName, 'Concurrency (default NumCPU)')
            [CompletionResult]::new('--cpu-profile-path', 'cpu-profile-path', [CompletionResultType]::ParameterName, 'Path to CPU profile output file')
            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'help for powershell')
            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'help for powershell')
            [CompletionResult]::new('--mem-profile-path', 'mem-profile-path', [CompletionResultType]::ParameterName, 'Path to memory profile output file')
            [CompletionResult]::new('--trace-path', 'trace-path', [CompletionResultType]::ParameterName, 'Path to trace output file')
            [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'verbose output')
            [CompletionResult]::new('--verbose', 'verbose', [CompletionResultType]::ParameterName, 'verbose output')
            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version')
            break
        }
        'golangci-lint;completion;zsh' {
            break
        }
        'golangci-lint;config' {
            [CompletionResult]::new('path', 'path', [CompletionResultType]::ParameterValue, 'Print used config path')
            break
        }
        'golangci-lint;config;path' {
            [CompletionResult]::new('--out-format', 'out-format', [CompletionResultType]::ParameterName, 'Format of output: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions')
            [CompletionResult]::new('--print-issued-lines', 'print-issued-lines', [CompletionResultType]::ParameterName, 'Print lines of code with issue')
            [CompletionResult]::new('--print-linter-name', 'print-linter-name', [CompletionResultType]::ParameterName, 'Print linter name in issue line')
            [CompletionResult]::new('--uniq-by-line', 'uniq-by-line', [CompletionResultType]::ParameterName, 'Make issues output unique by line')
            [CompletionResult]::new('--sort-results', 'sort-results', [CompletionResultType]::ParameterName, 'Sort linter results')
            [CompletionResult]::new('--path-prefix', 'path-prefix', [CompletionResultType]::ParameterName, 'Path prefix to add to output')
            [CompletionResult]::new('--modules-download-mode', 'modules-download-mode', [CompletionResultType]::ParameterName, 'Modules download mode. If not empty, passed as -mod=<mode> to go tools')
            [CompletionResult]::new('--issues-exit-code', 'issues-exit-code', [CompletionResultType]::ParameterName, 'Exit code when issues were found')
            [CompletionResult]::new('--build-tags', 'build-tags', [CompletionResultType]::ParameterName, 'Build tags')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'Timeout for total work')
            [CompletionResult]::new('--tests', 'tests', [CompletionResultType]::ParameterName, 'Analyze tests (*_test.go)')
            [CompletionResult]::new('--print-resources-usage', 'print-resources-usage', [CompletionResultType]::ParameterName, 'Print avg and max memory usage of golangci-lint and total time')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Read config from file path `PATH`')
            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Read config from file path `PATH`')
            [CompletionResult]::new('--no-config', 'no-config', [CompletionResultType]::ParameterName, 'Don''t read config')
            [CompletionResult]::new('--skip-dirs', 'skip-dirs', [CompletionResultType]::ParameterName, 'Regexps of directories to skip')
            [CompletionResult]::new('--skip-dirs-use-default', 'skip-dirs-use-default', [CompletionResultType]::ParameterName, 'Use or not use default excluded directories:
  - (^|/)vendor($|/)
  - (^|/)third_party($|/)
  - (^|/)testdata($|/)
  - (^|/)examples($|/)
  - (^|/)Godeps($|/)
  - (^|/)builtin($|/)
')
            [CompletionResult]::new('--skip-files', 'skip-files', [CompletionResultType]::ParameterName, 'Regexps of files to skip')
            [CompletionResult]::new('--allow-parallel-runners', 'allow-parallel-runners', [CompletionResultType]::ParameterName, 'Allow multiple parallel golangci-lint instances running. If false (default) - golangci-lint acquires file lock on start.')
            [CompletionResult]::new('--allow-serial-runners', 'allow-serial-runners', [CompletionResultType]::ParameterName, 'Allow multiple golangci-lint instances running, but serialize them	around a lock. If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start.')
            [CompletionResult]::new('-E', 'E', [CompletionResultType]::ParameterName, 'Enable specific linter')
            [CompletionResult]::new('--enable', 'enable', [CompletionResultType]::ParameterName, 'Enable specific linter')
            [CompletionResult]::new('-D', 'D', [CompletionResultType]::ParameterName, 'Disable specific linter')
            [CompletionResult]::new('--disable', 'disable', [CompletionResultType]::ParameterName, 'Disable specific linter')
            [CompletionResult]::new('--disable-all', 'disable-all', [CompletionResultType]::ParameterName, 'Disable all linters')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Enable presets (bugs|complexity|format|performance|style|unused) of linters. Run ''golangci-lint linters'' to see them. This option implies option --disable-all')
            [CompletionResult]::new('--presets', 'presets', [CompletionResultType]::ParameterName, 'Enable presets (bugs|complexity|format|performance|style|unused) of linters. Run ''golangci-lint linters'' to see them. This option implies option --disable-all')
            [CompletionResult]::new('--fast', 'fast', [CompletionResultType]::ParameterName, 'Run only fast linters from enabled linters set (first run won''t be fast)')
            [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Exclude issue by regexp')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'Exclude issue by regexp')
            [CompletionResult]::new('--exclude-use-default', 'exclude-use-default', [CompletionResultType]::ParameterName, 'Use or not use default excludes:
  # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it''s ok
  - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked

  # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
  - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)

  # EXC0003 golint: False positive when tests are defined in package ''test''
  - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this

  # EXC0004 govet: Common false positives
  - (possible misuse of unsafe.Pointer|should have signature)

  # EXC0005 staticcheck: Developers tend to write in C-style with an explicit ''break'' in a ''switch'', so it''s ok to ignore
  - ineffective break statement. Did you mean to break out of the outer loop

  # EXC0006 gosec: Too many false-positives on ''unsafe'' usage
  - Use of unsafe calls should be audited

  # EXC0007 gosec: Too many false-positives for parametrized shell calls
  - Subprocess launch(ed with variable|ing should be audited)

  # EXC0008 gosec: Duplicated errcheck checks
  - (G104|G307)

  # EXC0009 gosec: Too many issues in popular repos
  - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)

  # EXC0010 gosec: False positive is triggered by ''src, err := ioutil.ReadFile(filename)''
  - Potential file inclusion via variable
')
            [CompletionResult]::new('--exclude-case-sensitive', 'exclude-case-sensitive', [CompletionResultType]::ParameterName, 'If set to true exclude and exclude rules regular expressions are case sensitive')
            [CompletionResult]::new('--max-issues-per-linter', 'max-issues-per-linter', [CompletionResultType]::ParameterName, 'Maximum issues count per one linter. Set to 0 to disable')
            [CompletionResult]::new('--max-same-issues', 'max-same-issues', [CompletionResultType]::ParameterName, 'Maximum count of issues with the same text. Set to 0 to disable')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Show only new issues: if there are unstaged changes or untracked files, only those changes are analyzed, else only changes in HEAD~ are analyzed.
It''s a super-useful option for integration of golangci-lint into existing large codebase.
It''s not practical to fix all existing issues at the moment of integration: much better to not allow issues in new code.
For CI setups, prefer --new-from-rev=HEAD~, as --new can skip linting the current patch if any scripts generate unstaged files before golangci-lint runs.')
            [CompletionResult]::new('--new', 'new', [CompletionResultType]::ParameterName, 'Show only new issues: if there are unstaged changes or untracked files, only those changes are analyzed, else only changes in HEAD~ are analyzed.
It''s a super-useful option for integration of golangci-lint into existing large codebase.
It''s not practical to fix all existing issues at the moment of integration: much better to not allow issues in new code.
For CI setups, prefer --new-from-rev=HEAD~, as --new can skip linting the current patch if any scripts generate unstaged files before golangci-lint runs.')
            [CompletionResult]::new('--new-from-rev', 'new-from-rev', [CompletionResultType]::ParameterName, 'Show only new issues created after git revision `REV`')
            [CompletionResult]::new('--new-from-patch', 'new-from-patch', [CompletionResultType]::ParameterName, 'Show only new issues created in git patch with file path `PATH`')
            [CompletionResult]::new('--fix', 'fix', [CompletionResultType]::ParameterName, 'Fix found issues (if it''s supported by the linter)')
            break
        }
        'golangci-lint;help' {
            [CompletionResult]::new('linters', 'linters', [CompletionResultType]::ParameterValue, 'Help about linters')
            break
        }
        'golangci-lint;help;linters' {
            break
        }
        'golangci-lint;linters' {
            [CompletionResult]::new('--out-format', 'out-format', [CompletionResultType]::ParameterName, 'Format of output: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions')
            [CompletionResult]::new('--print-issued-lines', 'print-issued-lines', [CompletionResultType]::ParameterName, 'Print lines of code with issue')
            [CompletionResult]::new('--print-linter-name', 'print-linter-name', [CompletionResultType]::ParameterName, 'Print linter name in issue line')
            [CompletionResult]::new('--uniq-by-line', 'uniq-by-line', [CompletionResultType]::ParameterName, 'Make issues output unique by line')
            [CompletionResult]::new('--sort-results', 'sort-results', [CompletionResultType]::ParameterName, 'Sort linter results')
            [CompletionResult]::new('--path-prefix', 'path-prefix', [CompletionResultType]::ParameterName, 'Path prefix to add to output')
            [CompletionResult]::new('--modules-download-mode', 'modules-download-mode', [CompletionResultType]::ParameterName, 'Modules download mode. If not empty, passed as -mod=<mode> to go tools')
            [CompletionResult]::new('--issues-exit-code', 'issues-exit-code', [CompletionResultType]::ParameterName, 'Exit code when issues were found')
            [CompletionResult]::new('--build-tags', 'build-tags', [CompletionResultType]::ParameterName, 'Build tags')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'Timeout for total work')
            [CompletionResult]::new('--tests', 'tests', [CompletionResultType]::ParameterName, 'Analyze tests (*_test.go)')
            [CompletionResult]::new('--print-resources-usage', 'print-resources-usage', [CompletionResultType]::ParameterName, 'Print avg and max memory usage of golangci-lint and total time')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Read config from file path `PATH`')
            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Read config from file path `PATH`')
            [CompletionResult]::new('--no-config', 'no-config', [CompletionResultType]::ParameterName, 'Don''t read config')
            [CompletionResult]::new('--skip-dirs', 'skip-dirs', [CompletionResultType]::ParameterName, 'Regexps of directories to skip')
            [CompletionResult]::new('--skip-dirs-use-default', 'skip-dirs-use-default', [CompletionResultType]::ParameterName, 'Use or not use default excluded directories:
  - (^|/)vendor($|/)
  - (^|/)third_party($|/)
  - (^|/)testdata($|/)
  - (^|/)examples($|/)
  - (^|/)Godeps($|/)
  - (^|/)builtin($|/)
')
            [CompletionResult]::new('--skip-files', 'skip-files', [CompletionResultType]::ParameterName, 'Regexps of files to skip')
            [CompletionResult]::new('--allow-parallel-runners', 'allow-parallel-runners', [CompletionResultType]::ParameterName, 'Allow multiple parallel golangci-lint instances running. If false (default) - golangci-lint acquires file lock on start.')
            [CompletionResult]::new('--allow-serial-runners', 'allow-serial-runners', [CompletionResultType]::ParameterName, 'Allow multiple golangci-lint instances running, but serialize them	around a lock. If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start.')
            [CompletionResult]::new('-E', 'E', [CompletionResultType]::ParameterName, 'Enable specific linter')
            [CompletionResult]::new('--enable', 'enable', [CompletionResultType]::ParameterName, 'Enable specific linter')
            [CompletionResult]::new('-D', 'D', [CompletionResultType]::ParameterName, 'Disable specific linter')
            [CompletionResult]::new('--disable', 'disable', [CompletionResultType]::ParameterName, 'Disable specific linter')
            [CompletionResult]::new('--disable-all', 'disable-all', [CompletionResultType]::ParameterName, 'Disable all linters')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Enable presets (bugs|complexity|format|performance|style|unused) of linters. Run ''golangci-lint linters'' to see them. This option implies option --disable-all')
            [CompletionResult]::new('--presets', 'presets', [CompletionResultType]::ParameterName, 'Enable presets (bugs|complexity|format|performance|style|unused) of linters. Run ''golangci-lint linters'' to see them. This option implies option --disable-all')
            [CompletionResult]::new('--fast', 'fast', [CompletionResultType]::ParameterName, 'Run only fast linters from enabled linters set (first run won''t be fast)')
            [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Exclude issue by regexp')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'Exclude issue by regexp')
            [CompletionResult]::new('--exclude-use-default', 'exclude-use-default', [CompletionResultType]::ParameterName, 'Use or not use default excludes:
  # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it''s ok
  - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked

  # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
  - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)

  # EXC0003 golint: False positive when tests are defined in package ''test''
  - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this

  # EXC0004 govet: Common false positives
  - (possible misuse of unsafe.Pointer|should have signature)

  # EXC0005 staticcheck: Developers tend to write in C-style with an explicit ''break'' in a ''switch'', so it''s ok to ignore
  - ineffective break statement. Did you mean to break out of the outer loop

  # EXC0006 gosec: Too many false-positives on ''unsafe'' usage
  - Use of unsafe calls should be audited

  # EXC0007 gosec: Too many false-positives for parametrized shell calls
  - Subprocess launch(ed with variable|ing should be audited)

  # EXC0008 gosec: Duplicated errcheck checks
  - (G104|G307)

  # EXC0009 gosec: Too many issues in popular repos
  - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)

  # EXC0010 gosec: False positive is triggered by ''src, err := ioutil.ReadFile(filename)''
  - Potential file inclusion via variable
')
            [CompletionResult]::new('--exclude-case-sensitive', 'exclude-case-sensitive', [CompletionResultType]::ParameterName, 'If set to true exclude and exclude rules regular expressions are case sensitive')
            [CompletionResult]::new('--max-issues-per-linter', 'max-issues-per-linter', [CompletionResultType]::ParameterName, 'Maximum issues count per one linter. Set to 0 to disable')
            [CompletionResult]::new('--max-same-issues', 'max-same-issues', [CompletionResultType]::ParameterName, 'Maximum count of issues with the same text. Set to 0 to disable')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Show only new issues: if there are unstaged changes or untracked files, only those changes are analyzed, else only changes in HEAD~ are analyzed.
It''s a super-useful option for integration of golangci-lint into existing large codebase.
It''s not practical to fix all existing issues at the moment of integration: much better to not allow issues in new code.
For CI setups, prefer --new-from-rev=HEAD~, as --new can skip linting the current patch if any scripts generate unstaged files before golangci-lint runs.')
            [CompletionResult]::new('--new', 'new', [CompletionResultType]::ParameterName, 'Show only new issues: if there are unstaged changes or untracked files, only those changes are analyzed, else only changes in HEAD~ are analyzed.
It''s a super-useful option for integration of golangci-lint into existing large codebase.
It''s not practical to fix all existing issues at the moment of integration: much better to not allow issues in new code.
For CI setups, prefer --new-from-rev=HEAD~, as --new can skip linting the current patch if any scripts generate unstaged files before golangci-lint runs.')
            [CompletionResult]::new('--new-from-rev', 'new-from-rev', [CompletionResultType]::ParameterName, 'Show only new issues created after git revision `REV`')
            [CompletionResult]::new('--new-from-patch', 'new-from-patch', [CompletionResultType]::ParameterName, 'Show only new issues created in git patch with file path `PATH`')
            [CompletionResult]::new('--fix', 'fix', [CompletionResultType]::ParameterName, 'Fix found issues (if it''s supported by the linter)')
            break
        }
        'golangci-lint;run' {
            [CompletionResult]::new('--out-format', 'out-format', [CompletionResultType]::ParameterName, 'Format of output: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions')
            [CompletionResult]::new('--print-issued-lines', 'print-issued-lines', [CompletionResultType]::ParameterName, 'Print lines of code with issue')
            [CompletionResult]::new('--print-linter-name', 'print-linter-name', [CompletionResultType]::ParameterName, 'Print linter name in issue line')
            [CompletionResult]::new('--uniq-by-line', 'uniq-by-line', [CompletionResultType]::ParameterName, 'Make issues output unique by line')
            [CompletionResult]::new('--sort-results', 'sort-results', [CompletionResultType]::ParameterName, 'Sort linter results')
            [CompletionResult]::new('--path-prefix', 'path-prefix', [CompletionResultType]::ParameterName, 'Path prefix to add to output')
            [CompletionResult]::new('--modules-download-mode', 'modules-download-mode', [CompletionResultType]::ParameterName, 'Modules download mode. If not empty, passed as -mod=<mode> to go tools')
            [CompletionResult]::new('--issues-exit-code', 'issues-exit-code', [CompletionResultType]::ParameterName, 'Exit code when issues were found')
            [CompletionResult]::new('--build-tags', 'build-tags', [CompletionResultType]::ParameterName, 'Build tags')
            [CompletionResult]::new('--timeout', 'timeout', [CompletionResultType]::ParameterName, 'Timeout for total work')
            [CompletionResult]::new('--tests', 'tests', [CompletionResultType]::ParameterName, 'Analyze tests (*_test.go)')
            [CompletionResult]::new('--print-resources-usage', 'print-resources-usage', [CompletionResultType]::ParameterName, 'Print avg and max memory usage of golangci-lint and total time')
            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Read config from file path `PATH`')
            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'Read config from file path `PATH`')
            [CompletionResult]::new('--no-config', 'no-config', [CompletionResultType]::ParameterName, 'Don''t read config')
            [CompletionResult]::new('--skip-dirs', 'skip-dirs', [CompletionResultType]::ParameterName, 'Regexps of directories to skip')
            [CompletionResult]::new('--skip-dirs-use-default', 'skip-dirs-use-default', [CompletionResultType]::ParameterName, 'Use or not use default excluded directories:
  - (^|/)vendor($|/)
  - (^|/)third_party($|/)
  - (^|/)testdata($|/)
  - (^|/)examples($|/)
  - (^|/)Godeps($|/)
  - (^|/)builtin($|/)
')
            [CompletionResult]::new('--skip-files', 'skip-files', [CompletionResultType]::ParameterName, 'Regexps of files to skip')
            [CompletionResult]::new('--allow-parallel-runners', 'allow-parallel-runners', [CompletionResultType]::ParameterName, 'Allow multiple parallel golangci-lint instances running. If false (default) - golangci-lint acquires file lock on start.')
            [CompletionResult]::new('--allow-serial-runners', 'allow-serial-runners', [CompletionResultType]::ParameterName, 'Allow multiple golangci-lint instances running, but serialize them	around a lock. If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start.')
            [CompletionResult]::new('-E', 'E', [CompletionResultType]::ParameterName, 'Enable specific linter')
            [CompletionResult]::new('--enable', 'enable', [CompletionResultType]::ParameterName, 'Enable specific linter')
            [CompletionResult]::new('-D', 'D', [CompletionResultType]::ParameterName, 'Disable specific linter')
            [CompletionResult]::new('--disable', 'disable', [CompletionResultType]::ParameterName, 'Disable specific linter')
            [CompletionResult]::new('--disable-all', 'disable-all', [CompletionResultType]::ParameterName, 'Disable all linters')
            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Enable presets (bugs|complexity|format|performance|style|unused) of linters. Run ''golangci-lint linters'' to see them. This option implies option --disable-all')
            [CompletionResult]::new('--presets', 'presets', [CompletionResultType]::ParameterName, 'Enable presets (bugs|complexity|format|performance|style|unused) of linters. Run ''golangci-lint linters'' to see them. This option implies option --disable-all')
            [CompletionResult]::new('--fast', 'fast', [CompletionResultType]::ParameterName, 'Run only fast linters from enabled linters set (first run won''t be fast)')
            [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Exclude issue by regexp')
            [CompletionResult]::new('--exclude', 'exclude', [CompletionResultType]::ParameterName, 'Exclude issue by regexp')
            [CompletionResult]::new('--exclude-use-default', 'exclude-use-default', [CompletionResultType]::ParameterName, 'Use or not use default excludes:
  # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it''s ok
  - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked

  # EXC0002 golint: Annoying issue about not having a comment. The rare codebase has such comments
  - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)

  # EXC0003 golint: False positive when tests are defined in package ''test''
  - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this

  # EXC0004 govet: Common false positives
  - (possible misuse of unsafe.Pointer|should have signature)

  # EXC0005 staticcheck: Developers tend to write in C-style with an explicit ''break'' in a ''switch'', so it''s ok to ignore
  - ineffective break statement. Did you mean to break out of the outer loop

  # EXC0006 gosec: Too many false-positives on ''unsafe'' usage
  - Use of unsafe calls should be audited

  # EXC0007 gosec: Too many false-positives for parametrized shell calls
  - Subprocess launch(ed with variable|ing should be audited)

  # EXC0008 gosec: Duplicated errcheck checks
  - (G104|G307)

  # EXC0009 gosec: Too many issues in popular repos
  - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)

  # EXC0010 gosec: False positive is triggered by ''src, err := ioutil.ReadFile(filename)''
  - Potential file inclusion via variable
')
            [CompletionResult]::new('--exclude-case-sensitive', 'exclude-case-sensitive', [CompletionResultType]::ParameterName, 'If set to true exclude and exclude rules regular expressions are case sensitive')
            [CompletionResult]::new('--max-issues-per-linter', 'max-issues-per-linter', [CompletionResultType]::ParameterName, 'Maximum issues count per one linter. Set to 0 to disable')
            [CompletionResult]::new('--max-same-issues', 'max-same-issues', [CompletionResultType]::ParameterName, 'Maximum count of issues with the same text. Set to 0 to disable')
            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Show only new issues: if there are unstaged changes or untracked files, only those changes are analyzed, else only changes in HEAD~ are analyzed.
It''s a super-useful option for integration of golangci-lint into existing large codebase.
It''s not practical to fix all existing issues at the moment of integration: much better to not allow issues in new code.
For CI setups, prefer --new-from-rev=HEAD~, as --new can skip linting the current patch if any scripts generate unstaged files before golangci-lint runs.')
            [CompletionResult]::new('--new', 'new', [CompletionResultType]::ParameterName, 'Show only new issues: if there are unstaged changes or untracked files, only those changes are analyzed, else only changes in HEAD~ are analyzed.
It''s a super-useful option for integration of golangci-lint into existing large codebase.
It''s not practical to fix all existing issues at the moment of integration: much better to not allow issues in new code.
For CI setups, prefer --new-from-rev=HEAD~, as --new can skip linting the current patch if any scripts generate unstaged files before golangci-lint runs.')
            [CompletionResult]::new('--new-from-rev', 'new-from-rev', [CompletionResultType]::ParameterName, 'Show only new issues created after git revision `REV`')
            [CompletionResult]::new('--new-from-patch', 'new-from-patch', [CompletionResultType]::ParameterName, 'Show only new issues created in git patch with file path `PATH`')
            [CompletionResult]::new('--fix', 'fix', [CompletionResultType]::ParameterName, 'Fix found issues (if it''s supported by the linter)')
            break
        }
        'golangci-lint;version' {
            [CompletionResult]::new('--format', 'format', [CompletionResultType]::ParameterName, 'The version''s format can be: ''short'', ''json''')
            break
        }
    })
    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
        Sort-Object -Property ListItemText
}
```

</details>