### PR TITLE
ci(cleanup): Remove go 1.13 run as part of github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,7 +62,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.13
           - 1.14
           - 1.15
     steps:


### PR DESCRIPTION
As per https://golang.org/doc/devel/release.html, only the last golang
versions are supported i.e. golang 1.13 is end of line, so there is no
point running golang 1.13 in CI.

This commit is to remove 1.13 in github action matrix

Signed-off-by: Tam Mach <sayboras@yahoo.com>