### PR TITLE
ci(dependabot): Change interval for npm to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,6 @@ updates:
   - package-ecosystem: npm
     directory: "/docs"
     schedule:
-      interval: weekly
+      interval: monthly
     reviewers:
       - "golangci/team"


### PR DESCRIPTION
npm packages are used for website only in this repo. Consider that
golangci-lint normally releases once a month, this commit is to change
interval for npm dependabot from weekly to monthly.

Main benefits could be:

- Reduce the noise for maintainers.
- Improve generated CHANGELOG. These changes are not useful for 
end users.

Signed-off-by: Tam Mach <sayboras@yahoo.com>