### PR TITLE
build(docker): Fix version details in docker image

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -45,6 +45,10 @@ jobs:
           file: build/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.prepare.outputs.tag_name }}
+            SHORT_COMMIT=${GITHUB_SHA::8}
+            DATE=$(date '+%Y-%m-%dT%H:%M:%SZ')
           tags: |
             golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}
             golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}
@@ -56,6 +60,10 @@ jobs:
           context: .
           file: build/Dockerfile.alpine
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.prepare.outputs.tag_name }}
+            SHORT_COMMIT=${GITHUB_SHA::8}
+            DATE=$(date '+%Y-%m-%dT%H:%M:%SZ')
           push: true
           tags: |
             golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}-alpine

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,14 +18,15 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Login do docker.io
-        run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
-      - name: Create release
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+        run: docker login -u sayboras -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
+#      - name: Create release
+#        uses: goreleaser/goreleaser-action@v2
+#        with:
+#          version: latest
+#          args: release --rm-dist
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+
       - name: Prepare
         id: prepare
         run: |
@@ -50,9 +51,9 @@ jobs:
             SHORT_COMMIT=${GITHUB_SHA::8}
             DATE=$(date '+%Y-%m-%dT%H:%M:%SZ')
           tags: |
-            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}
-            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}
-            golangci/golangci-lint:latest
+            sayboras/golangci-lint:${{ steps.prepare.outputs.tag_name }}
+            sayboras/golangci-lint:${{ steps.prepare.outputs.major_tag }}
+            sayboras/golangci-lint:latest
       - name: build and publish alpine image
         id: docker_build_alpine
         uses: docker/build-push-action@v2
@@ -66,6 +67,6 @@ jobs:
             DATE=$(date '+%Y-%m-%dT%H:%M:%SZ')
           push: true
           tags: |
-            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}-alpine
-            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}-alpine
-            golangci/golangci-lint:latest-alpine
+            sayboras/golangci-lint:${{ steps.prepare.outputs.tag_name }}-alpine
+            sayboras/golangci-lint:${{ steps.prepare.outputs.major_tag }}-alpine
+            sayboras/golangci-lint:latest-alpine

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,13 @@
 # stage 1 building the code
 FROM golang:1.15 as builder
 
+ARG VERSION
+ARG SHORT_COMMIT
+ARG DATE
+
 COPY / /golangci
 WORKDIR /golangci
-RUN go build -o golangci-lint ./cmd/golangci-lint/main.go
+RUN go build -s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.15

--- a/build/Dockerfile.alpine
+++ b/build/Dockerfile.alpine
@@ -1,9 +1,13 @@
 # stage 1 building the code
 FROM golang:1.15-alpine as builder
 
+ARG VERSION
+ARG SHORT_COMMIT
+ARG DATE
+
 COPY / /golangci
 WORKDIR /golangci
-RUN CGO_ENABLED=0 go build -o golangci-lint ./cmd/golangci-lint/main.go
+RUN go build -s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.15-alpine


### PR DESCRIPTION
As part of #1383, multi-arch docker build was supported. However,
ldflags for version details was missing.

This commit is to add -ldflags
as part of Docker build.

Fixes #1468

Signed-off-by: Tam Mach <sayboras@yahoo.com>