### PR TITLE
build(docker): Fix version details in docker image

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,8 +17,7 @@ jobs:
           go-version: 1.15
       - name: Unshallow
         run: git fetch --prune --unshallow
-      - name: Login do docker.io
-        run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
+
       - name: Create release
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -26,18 +25,44 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+
+  docker-release:
+    needs: [ release ]
+    runs-on: ubuntu-latest
+    env:
+      GOLANGCI_LINT_DOCKER_TOKEN: ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
       - name: Prepare
         id: prepare
         run: |
             TAG=${GITHUB_REF#refs/tags/}
             MAJOR=${TAG%.*}
+            SHORT_COMMIT=${GITHUB_SHA::8}
+            DATE=$(date '+%Y-%m-%dT%H:%M:%SZ')
             echo ::set-output name=tag_name::${TAG}
             echo ::set-output name=major_tag::${MAJOR}
+            echo ::set-output name=short_commit::${SHORT_COMMIT}
+            echo ::set-output name=date::${DATE}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: build and publish main image
+
+      - name: Login do docker.io
+        run: docker login -u sayboras -p ${{ env.GOLANGCI_LINT_DOCKER_TOKEN }}
+
+      - name: Build and publish main image
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -45,19 +70,28 @@ jobs:
           file: build/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.prepare.outputs.tag_name }}
+            SHORT_COMMIT=${{ steps.prepare.outputs.short_commit }}
+            DATE=${{ steps.prepare.outputs.date }}
           tags: |
-            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}
-            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}
-            golangci/golangci-lint:latest
-      - name: build and publish alpine image
+            sayboras/golangci-lint:${{ steps.prepare.outputs.tag_name }}
+            sayboras/golangci-lint:${{ steps.prepare.outputs.major_tag }}
+            sayboras/golangci-lint:latest
+
+      - name: Build and publish alpine image
         id: docker_build_alpine
         uses: docker/build-push-action@v2
         with:
           context: .
           file: build/Dockerfile.alpine
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.prepare.outputs.tag_name }}
+            SHORT_COMMIT=${{ steps.prepare.outputs.short_commit }}
+            DATE=${{ steps.prepare.outputs.date }}
           push: true
           tags: |
-            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}-alpine
-            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}-alpine
-            golangci/golangci-lint:latest-alpine
+            sayboras/golangci-lint:${{ steps.prepare.outputs.tag_name }}-alpine
+            sayboras/golangci-lint:${{ steps.prepare.outputs.major_tag }}-alpine
+            sayboras/golangci-lint:latest-alpine

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -29,8 +29,11 @@ jobs:
   docker-release:
     needs: [ release ]
     runs-on: ubuntu-latest
-    env:
-      GOLANGCI_LINT_DOCKER_TOKEN: ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
+    strategy:
+      matrix:
+        target:
+          - Dockerfile: build/Dockerfile
+          - Dockerfile: build/Dockerfile.alpine
     steps:
       - uses: actions/checkout@v2
 
@@ -38,6 +41,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
+
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -60,14 +64,13 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login do docker.io
-        run: docker login -u sayboras -p ${{ env.GOLANGCI_LINT_DOCKER_TOKEN }}
+        run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
 
-      - name: Build and publish main image
-        id: docker_build
+      - name: Build and publish ${{ matrix.target.Dockerfile }}
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: build/Dockerfile
+          file: ${{ matrix.target.Dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
@@ -75,23 +78,6 @@ jobs:
             SHORT_COMMIT=${{ steps.prepare.outputs.short_commit }}
             DATE=${{ steps.prepare.outputs.date }}
           tags: |
-            sayboras/golangci-lint:${{ steps.prepare.outputs.tag_name }}
-            sayboras/golangci-lint:${{ steps.prepare.outputs.major_tag }}
-            sayboras/golangci-lint:latest
-
-      - name: Build and publish alpine image
-        id: docker_build_alpine
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: build/Dockerfile.alpine
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            VERSION=${{ steps.prepare.outputs.tag_name }}
-            SHORT_COMMIT=${{ steps.prepare.outputs.short_commit }}
-            DATE=${{ steps.prepare.outputs.date }}
-          push: true
-          tags: |
-            sayboras/golangci-lint:${{ steps.prepare.outputs.tag_name }}-alpine
-            sayboras/golangci-lint:${{ steps.prepare.outputs.major_tag }}-alpine
-            sayboras/golangci-lint:latest-alpine
+            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}
+            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}
+            golangci/golangci-lint:latest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,13 @@
 # stage 1 building the code
 FROM golang:1.15 as builder
 
+ARG VERSION
+ARG SHORT_COMMIT
+ARG DATE
+
 COPY / /golangci
 WORKDIR /golangci
-RUN go build -o golangci-lint ./cmd/golangci-lint/main.go
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.15

--- a/build/Dockerfile.alpine
+++ b/build/Dockerfile.alpine
@@ -1,9 +1,18 @@
 # stage 1 building the code
 FROM golang:1.15-alpine as builder
 
+ARG VERSION
+ARG SHORT_COMMIT
+ARG DATE
+
 COPY / /golangci
 WORKDIR /golangci
-RUN CGO_ENABLED=0 go build -o golangci-lint ./cmd/golangci-lint/main.go
+
+# gcc is required to support cgo;
+# git and mercurial are needed most times for go get`, etc.
+# See https://github.com/docker-library/golang/issues/80
+RUN apk --no-cache add gcc musl-dev git mercurial
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.15-alpine


### PR DESCRIPTION
## Description

As part of #1383, multi-arch docker build was supported. However,
ldflags for version details and CGO_ENABLED=0 were missing.

This commit is to add -ldflags as part of Docker build.

Fixes #1468

Signed-off-by: Tam Mach <sayboras@yahoo.com>

## Testing

Testing was done with my docker hub and tag v1.32.1

<details>
<summary>Testing with arm64</summary>

```shell script
$ docker run --rm sayboras/golangci-lint:v1.32.1 golangci-lint version
golangci-lint has version v1.32.1 built from 89647eba on 2020-10-26T10:16:00Z

$ docker run --rm sayboras/golangci-lint:v1.32.1 golangci-lint --version 
golangci-lint has version v1.32.1 built from 89647eba on 2020-10-26T10:16:00Z


$ docker run --rm -w /src -v $PWD:/src sayboras/golangci-lint:v1.32.1 golangci-lint run ./...

$ uname -a
Linux ubuntu 5.4.0-1021-raspi #24-Ubuntu SMP PREEMPT Mon Oct 5 09:59:23 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
```

</details>

<details>
<summary>Testing with amd64</summary>

```shell script
$ docker run --rm sayboras/golangci-lint:v1.32.1 golangci-lint version
golangci-lint has version v1.32.1 built from 89647eba on 2020-10-26T10:16:00Z

$ docker run --rm sayboras/golangci-lint:v1.32.1 golangci-lint --version 
golangci-lint has version v1.32.1 built from 89647eba on 2020-10-26T10:16:00Z

$ docker run --rm -w /src -v $PWD:/src sayboras/golangci-lint:v1.32.1 golangci-lint run ./... -v
level=info msg="[config_reader] Config search paths: [./ /src / /root]"
level=info msg="[lintersdb] Active 10 linters: [deadcode errcheck gosimple govet ineffassign staticcheck structcheck typecheck unused varcheck]"
level=info msg="[loader] Go packages loading at mode 575 (imports|name|compiled_files|exports_file|files|deps|types_sizes) took 4.834417647s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 9.205305ms"
level=info msg="[linters context/goanalysis] analyzers took 5.778376571s with top 10 stages: buildir: 4.313237995s, fact_purity: 163.142737ms, inspect: 154.257723ms, ctrlflow: 143.652437ms, printf: 138.532273ms, fact_deprecated: 97.744815ms, ineffassign: 85.125717ms, isgenerated: 50.530356ms, deadcode: 41.686738ms, S1038: 22.20593ms"
level=info msg="[linters context/goanalysis] analyzers took 960.62409ms with top 10 stages: buildir: 837.647488ms, U1000: 122.976602ms"
level=info msg="[runner] Issues before processing: 29, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): skip_dirs: 29/29, autogenerated_exclude: 29/29, identifier_marker: 29/29, filename_unadjuster: 29/29, skip_files: 29/29, path_prettifier: 29/29, exclude: 0/29, cgo: 29/29"
level=info msg="[runner] processing took 4.160422ms with stages: exclude: 1.744207ms, identifier_marker: 939.523µs, autogenerated_exclude: 596.772µs, path_prettifier: 532.22µs, skip_dirs: 310.208µs, cgo: 19.848µs, filename_unadjuster: 11.893µs, nolint: 1.222µs, max_same_issues: 923ns, severity-rules: 731ns, uniq_by_line: 411ns, diff: 401ns, skip_files: 370ns, source_code: 312ns, exclude-rules: 290ns, max_from_linter: 260ns, path_shortener: 240ns, path_prefixer: 230ns, max_per_file_from_linter: 191ns, sort_results: 170ns"
level=info msg="[runner] linters took 2.031282027s with stages: goanalysis_metalinter: 1.81668173s, unused: 210.319902ms"
level=info msg="File cache stats: 0 entries of total size 0B"
level=info msg="Memory: 70 samples, avg is 127.8MB, max is 409.7MB"
level=info msg="Execution took 6.88345463s"

$ uname -a                      
Linux ubuntu20 5.4.0-52-generic #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

</details>

