### PR TITLE
feat(release): Update metadata for golangci-lint-action

### DIFF
--- a/assets/github-action-config.json
+++ b/assets/github-action-config.json
@@ -1,8 +1,8 @@
 {
   "MinorVersionToConfig": {
     "latest": {
-      "TargetVersion": "v1.32.0",
-      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.0/golangci-lint-1.32.0-linux-amd64.tar.gz"
+      "TargetVersion": "v1.32.1",
+      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.1/golangci-lint-1.32.1-linux-amd64.tar.gz"
     },
     "v1.10": {
       "Error": "golangci-lint version 'v1.10' isn't supported: we support only v1.14.0 and later versions"
@@ -92,8 +92,8 @@
       "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.31.0/golangci-lint-1.31.0-linux-amd64.tar.gz"
     },
     "v1.32": {
-      "TargetVersion": "v1.32.0",
-      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.0/golangci-lint-1.32.0-linux-amd64.tar.gz"
+      "TargetVersion": "v1.32.1",
+      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.1/golangci-lint-1.32.1-linux-amd64.tar.gz"
     },
     "v1.4": {
       "Error": "golangci-lint version 'v1.4' isn't supported: we support only v1.14.0 and later versions"


### PR DESCRIPTION
This commit is to update metadata for golangci-lint-action after 1.32.1
release for couples of bug fixes.

https://github.com/golangci/golangci-lint/releases/tag/v1.32.1

NOTE: Once #1208 is resolved, this step will be automated

Relates #1208

Signed-off-by: Tam Mach <sayboras@yahoo.com>