### PR TITLE
pkg/lint/lintersdb: report all unknown linters at once

### DIFF
--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -20,10 +20,18 @@ func NewValidator(m *Manager) *Validator {
 func (v Validator) validateLintersNames(cfg *config.Linters) error {
 	allNames := append([]string{}, cfg.Enable...)
 	allNames = append(allNames, cfg.Disable...)
+
+	unknownNames := []string{}
+
 	for _, name := range allNames {
 		if v.m.GetLinterConfigs(name) == nil {
-			return fmt.Errorf("no such linter %v, run 'golangci-lint linters' to see the list of supported linters", name)
+			unknownNames = append(unknownNames, name)
 		}
+	}
+
+	if len(unknownNames) > 0 {
+		return fmt.Errorf("unknown linters: '%v', run 'golangci-lint linters' to see the list of supported linters",
+			strings.Join(unknownNames, ","))
 	}
 
 	return nil


### PR DESCRIPTION
Otherwise, if one configures multiple invalid linters, or jumps between
the versions, it is annoying to get same error with different value N
times.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>