### PR TITLE
fix(docker): Fix docker tag for alpine build

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -56,6 +56,15 @@ jobs:
             echo ::set-output name=major_tag::${MAJOR}
             echo ::set-output name=short_commit::${SHORT_COMMIT}
             echo ::set-output name=date::${DATE}
+            if [[ ${{ matrix.target.Dockerfile }} == *"alpine"* ]]; then
+              echo ::set-output name=full_tag_name::${TAG}-alpine
+              echo ::set-output name=full_major_tag::${MAJOR}-alpine
+              echo ::set-output name=latest_tag::latest-alpine
+            else
+              echo ::set-output name=full_tag_name::${TAG}
+              echo ::set-output name=full_major_tag::${MAJOR}
+              echo ::set-output name=latest_tag::latest
+            fi
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -78,6 +87,6 @@ jobs:
             SHORT_COMMIT=${{ steps.prepare.outputs.short_commit }}
             DATE=${{ steps.prepare.outputs.date }}
           tags: |
-            golangci/golangci-lint:${{ steps.prepare.outputs.tag_name }}
-            golangci/golangci-lint:${{ steps.prepare.outputs.major_tag }}
-            golangci/golangci-lint:latest
+            golangci/golangci-lint:${{ steps.prepare.outputs.full_tag_name }}
+            golangci/golangci-lint:${{ steps.prepare.outputs.full_major_tag }}
+            golangci/golangci-lint:${{ steps.prepare.outputs.latest_tag }}


### PR DESCRIPTION
## Description

This commit is to avoid tag overriding due to parallel build for
multiple base images (e.g. debian and alpine).

Closes #1483 
Closes #1486

Signed-off-by: Tam Mach <sayboras@yahoo.com>

## Testing

Testing was done for forked docker hub (e.g. sayboras/golangci-lint).

```shell script
$ docker run -it --entrypoint /bin/sh sayboras/golangci-lint:v1.32.2 -c 'cat /etc/os-release'
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```


```shell script
$ docker run -it --entrypoint /bin/sh sayboras/golangci-lint:latest -c 'cat /etc/os-release'
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

```

```shell script
$ docker run -it --entrypoint /bin/sh sayboras/golangci-lint:v1.32.2-alpine -c 'cat /etc/os-release'
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.12.1
PRETTY_NAME="Alpine Linux v3.12"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```

```shell script
$ docker run -it --entrypoint /bin/sh sayboras/golangci-lint:latest-alpine -c 'cat /etc/os-release'
Unable to find image 'sayboras/golangci-lint:latest-alpine' locally
latest-alpine: Pulling from sayboras/golangci-lint
Digest: sha256:677a3a1a3a4b5f0fc0bc3af0b5c08253e2f6ed02b0bf4ffe614b1b7cfaefc320
Status: Downloaded newer image for sayboras/golangci-lint:latest-alpine
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.12.1
PRETTY_NAME="Alpine Linux v3.12"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```


