### PR TITLE
feat(release): Update metadata for golangci-lint-action

### DIFF
--- a/assets/github-action-config.json
+++ b/assets/github-action-config.json
@@ -1,8 +1,8 @@
 {
   "MinorVersionToConfig": {
     "latest": {
-      "TargetVersion": "v1.32.1",
-      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.1/golangci-lint-1.32.1-linux-amd64.tar.gz"
+      "TargetVersion": "v1.32.2",
+      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.2/golangci-lint-1.32.2-linux-amd64.tar.gz"
     },
     "v1.10": {
       "Error": "golangci-lint version 'v1.10' isn't supported: we support only v1.14.0 and later versions"
@@ -92,8 +92,8 @@
       "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.31.0/golangci-lint-1.31.0-linux-amd64.tar.gz"
     },
     "v1.32": {
-      "TargetVersion": "v1.32.1",
-      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.1/golangci-lint-1.32.1-linux-amd64.tar.gz"
+      "TargetVersion": "v1.32.2",
+      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.32.2/golangci-lint-1.32.2-linux-amd64.tar.gz"
     },
     "v1.4": {
       "Error": "golangci-lint version 'v1.4' isn't supported: we support only v1.14.0 and later versions"

--- a/docs/template_data.state
+++ b/docs/template_data.state
@@ -1,2 +1,2 @@
 This file stores hash of website templates to trigger Netlify rebuild when something changes, e.g. new linter is added.
-1bfe6c52f1d4be2bd91b2b278231dcf3929d64d9722d99d9357296c25d419525
+2b6a9052ffa990bb96a44996da5a28dc84b85e330def6ccc5f91cadd13083e7e


### PR DESCRIPTION
This commit is to update metadata for golangci-lint-action after 1.32.2
release for couples of bug fixes.

NOTE: Once #1208 is resolved, this step will be automated

Relates #1208

Signed-off-by: Tam Mach <sayboras@yahoo.com>

**PS**: The related PR made some progress on this, hopefully this is the last time we need to do this step.