### PR TITLE
DefaultExcludePatterns should only be used for specified linter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,6 +127,22 @@ func GetExcludePatternsStrings(include []string) []string {
 	return ret
 }
 
+func GetExcludePatterns(include []string) []ExcludePattern {
+	includeMap := make(map[string]bool, len(include))
+	for _, inc := range include {
+		includeMap[inc] = true
+	}
+
+	var ret []ExcludePattern
+	for _, p := range DefaultExcludePatterns {
+		if !includeMap[p.ID] {
+			ret = append(ret, p)
+		}
+	}
+
+	return ret
+}
+
 type Run struct {
 	IsVerbose           bool `mapstructure:"verbose"`
 	Silent              bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,6 +99,12 @@ var DefaultExcludePatterns = []ExcludePattern{
 		Linter:  "gosec",
 		Why:     "False positive is triggered by 'src, err := ioutil.ReadFile(filename)'",
 	},
+	{
+		ID:      "EXC0011",
+		Pattern: "at least one file in a package should have a package comment",
+		Linter:  "stylecheck",
+		Why:     "Annoying issue about not having a package comment.",
+	},
 }
 
 func GetDefaultExcludePatternsStrings() []string {

--- a/pkg/golinters/goanalysis/runner.go
+++ b/pkg/golinters/goanalysis/runner.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package checker defines the implementation of the checker commands.
+// Package goanalysis defines the implementation of the checker commands.
 // The same code drives the multi-analysis driver, the single-analysis
 // driver that is conventionally provided for convenience along with
 // each analysis package, and the test driver.

--- a/pkg/golinters/gocognit.go
+++ b/pkg/golinters/gocognit.go
@@ -1,4 +1,4 @@
-// nolint:dupl
+// nolint:dupl,stylecheck
 package golinters
 
 import (

--- a/pkg/golinters/gocyclo.go
+++ b/pkg/golinters/gocyclo.go
@@ -1,4 +1,4 @@
-// nolint:dupl
+// nolint:dupl,stylecheck
 package golinters
 
 import (

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -85,7 +85,7 @@ func enableLinterConfigs(lcs []*linter.Config, isEnabled func(lc *linter.Config)
 	return ret
 }
 
-//nolint:funlen
+//nolint:funlen,stylecheck
 func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var govetCfg *config.GovetSettings
 	var testpackageCfg *config.TestpackageSettings

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -225,21 +225,22 @@ func (r *Runner) processIssues(issues []result.Issue, sw *timeutils.Stopwatch, s
 }
 
 func getExcludeProcessor(cfg *config.Issues) processors.Processor {
-	excludePatterns := cfg.ExcludePatterns
-	if cfg.UseDefaultExcludes {
-		excludePatterns = append(excludePatterns, config.GetExcludePatternsStrings(cfg.IncludeDefaultExcludes)...)
+	var excludeTotalPattern string
+	excludeGlobalPatterns := cfg.ExcludePatterns
+	if len(excludeGlobalPatterns) != 0 {
+		excludeTotalPattern = fmt.Sprintf("(%s)", strings.Join(excludeGlobalPatterns, "|"))
 	}
 
-	var excludeTotalPattern string
-	if len(excludePatterns) != 0 {
-		excludeTotalPattern = fmt.Sprintf("(%s)", strings.Join(excludePatterns, "|"))
+	var excludePatterns []config.ExcludePattern
+	if cfg.UseDefaultExcludes {
+		excludePatterns = config.DefaultExcludePatterns
 	}
 
 	var excludeProcessor processors.Processor
 	if cfg.ExcludeCaseSensitive {
-		excludeProcessor = processors.NewExcludeCaseSensitive(excludeTotalPattern)
+		excludeProcessor = processors.NewExcludeCaseSensitive(excludeTotalPattern, excludePatterns)
 	} else {
-		excludeProcessor = processors.NewExclude(excludeTotalPattern)
+		excludeProcessor = processors.NewExclude(excludeTotalPattern, excludePatterns)
 	}
 
 	return excludeProcessor

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -233,7 +233,7 @@ func getExcludeProcessor(cfg *config.Issues) processors.Processor {
 
 	var excludePatterns []config.ExcludePattern
 	if cfg.UseDefaultExcludes {
-		excludePatterns = config.DefaultExcludePatterns
+		excludePatterns = config.GetExcludePatterns(cfg.IncludeDefaultExcludes)
 	}
 
 	var excludeProcessor processors.Processor

--- a/pkg/packages/errors.go
+++ b/pkg/packages/errors.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-//nolint:gomnd
+//nolint:gomnd,stylecheck
 func ParseErrorPosition(pos string) (*token.Position, error) {
 	// file:line(<optional>:colon)
 	parts := strings.Split(pos, ":")

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -13,7 +13,7 @@ type github struct {
 
 const defaultGithubSeverity = "error"
 
-// Github output format outputs issues according to Github actions format:
+// NewGithub output format outputs issues according to Github actions format:
 // https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
 func NewGithub() Printer {
 	return &github{}

--- a/pkg/result/processors/exclude_test.go
+++ b/pkg/result/processors/exclude_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestExclude(t *testing.T) {
-	p := NewExclude("^exclude$")
+	p := NewExclude("^exclude$", nil)
 	texts := []string{"excLude", "1", "", "exclud", "notexclude"}
 	var issues []result.Issue
 	for _, t := range texts {
@@ -27,11 +27,11 @@ func TestExclude(t *testing.T) {
 }
 
 func TestNoExclude(t *testing.T) {
-	processAssertSame(t, NewExclude(""), newIssueFromTextTestCase("test"))
+	processAssertSame(t, NewExclude("", nil), newIssueFromTextTestCase("test"))
 }
 
 func TestExcludeCaseSensitive(t *testing.T) {
-	p := NewExcludeCaseSensitive("^exclude$")
+	p := NewExcludeCaseSensitive("^exclude$", nil)
 	texts := []string{"excLude", "1", "", "exclud", "exclude"}
 	var issues []result.Issue
 	for _, t := range texts {

--- a/pkg/result/processors/sort_results.go
+++ b/pkg/result/processors/sort_results.go
@@ -91,10 +91,10 @@ var (
 
 type ByName struct{ next comparator }
 
-//nolint:golint
+//nolint:golint,stylecheck
 func (cmp ByName) Next() comparator { return cmp.next }
 
-//nolint:golint
+//nolint:golint,stylecheck
 func (cmp ByName) Compare(a, b *result.Issue) compareResult {
 	var res compareResult
 
@@ -111,10 +111,10 @@ func (cmp ByName) Compare(a, b *result.Issue) compareResult {
 
 type ByLine struct{ next comparator }
 
-//nolint:golint
+//nolint:golint,stylecheck
 func (cmp ByLine) Next() comparator { return cmp.next }
 
-//nolint:golint
+//nolint:golint,stylecheck,stylecheck
 func (cmp ByLine) Compare(a, b *result.Issue) compareResult {
 	var res compareResult
 
@@ -131,10 +131,10 @@ func (cmp ByLine) Compare(a, b *result.Issue) compareResult {
 
 type ByColumn struct{ next comparator }
 
-//nolint:golint
+//nolint:golint,stylecheck
 func (cmp ByColumn) Next() comparator { return cmp.next }
 
-//nolint:golint
+//nolint:golint,stylecheck
 func (cmp ByColumn) Compare(a, b *result.Issue) compareResult {
 	var res compareResult
 

--- a/test/testdata/stylecheck.go
+++ b/test/testdata/stylecheck.go
@@ -1,5 +1,5 @@
 //args: -Estylecheck
-package testdata
+package main // don't need package comment
 
 func Stylecheck(x int) {
 	switch x {


### PR DESCRIPTION
Fix https://github.com/golangci/golangci-lint/issues/1474

This PR add "EXC0011", because most of package in golangci-lint does not having a package comment, also fix testdata.