### PR TITLE
Unknown linter breaks //nolint

### DIFF
--- a/pkg/result/processors/nolint.go
+++ b/pkg/result/processors/nolint.go
@@ -250,24 +250,20 @@ func (p *Nolint) extractInlineRangeFromComment(text string, g ast.Node, fset *to
 	var linters []string
 	text = strings.Split(text, "//")[0] // allow another comment after this comment
 	linterItems := strings.Split(strings.TrimPrefix(text, "nolint:"), ",")
-	var gotUnknownLinters bool
 	for _, linter := range linterItems {
 		linterName := strings.ToLower(strings.TrimSpace(linter))
 
 		lcs := p.dbManager.GetLinterConfigs(linterName)
 		if lcs == nil {
 			p.unknownLintersSet[linterName] = true
-			gotUnknownLinters = true
+			linters = append(linters, linterName)
+			nolintDebugf("unknown linter %s on line %d", linterName, fset.Position(g.Pos()).Line)
 			continue
 		}
 
 		for _, lc := range lcs {
 			linters = append(linters, lc.Name()) // normalize name to work with aliases
 		}
-	}
-
-	if gotUnknownLinters {
-		return buildRange(nil) // ignore all linters to not annoy user
 	}
 
 	nolintDebugf("%d: linters are %s", fset.Position(g.Pos()).Line, linters)

--- a/pkg/result/processors/nolint_test.go
+++ b/pkg/result/processors/nolint_test.go
@@ -149,6 +149,28 @@ func TestNolintInvalidLinterName(t *testing.T) {
 	p.Finish()
 }
 
+func TestNolintInvalidLinterNameWithViolationOnTheSameLine(t *testing.T) {
+	log := getMockLog()
+	log.On("Warnf", "Found unknown linters in //nolint directives: %s", "foobar")
+	issues := []result.Issue{
+		{
+			Pos: token.Position{
+				Filename: filepath.Join("testdata", "nolint_apply_to_unknown.go"),
+				Line:     4,
+			},
+			FromLinter: "gofmt",
+		},
+	}
+
+	p := newTestNolintProcessor(log)
+	processedIssues, err := p.Process(issues)
+	p.Finish()
+
+	assert.Len(t, processedIssues, 1)
+	assert.Equal(t, issues, processedIssues)
+	assert.NoError(t, err)
+}
+
 func TestNolintAliases(t *testing.T) {
 	p := newTestNolintProcessor(getMockLog())
 	for _, line := range []int{47, 49, 51} {

--- a/pkg/result/processors/testdata/nolint_apply_to_unknown.go
+++ b/pkg/result/processors/testdata/nolint_apply_to_unknown.go
@@ -1,0 +1,5 @@
+package testdata
+
+func bar() {
+	_ =  0 //nolint: foobar
+}

--- a/test/testdata/nolint_apply_to_unknown.go
+++ b/test/testdata/nolint_apply_to_unknown.go
@@ -1,6 +1,0 @@
-//args: -Egofmt
-package testdata
-
-func bar() {
-	_ =  0 //nolint: foobar // ERROR "File is not `gofmt`-ed with `-s`"
-}

--- a/test/testdata/nolint_apply_to_unknown.go
+++ b/test/testdata/nolint_apply_to_unknown.go
@@ -1,0 +1,6 @@
+//args: -Egofmt
+package testdata
+
+func bar() {
+	_ =  0 //nolint: foobar // ERROR "File is not `gofmt`-ed with `-s`"
+}


### PR DESCRIPTION
Fixes #1450 by applying `//nolint` directive to a non-existent linter only.