### PR TITLE
More formal testdata

### DIFF
--- a/test/testdata/cgo/main.go
+++ b/test/testdata/cgo/main.go
@@ -1,3 +1,4 @@
+// Package cgoexample ...
 package cgoexample
 
 /*
@@ -14,6 +15,7 @@ import (
 	"unsafe"
 )
 
+// Example ...
 func Example() {
 	cs := C.CString("Hello from stdio\n")
 	C.myprint(cs)

--- a/test/testdata/unsafe/pkg.go
+++ b/test/testdata/unsafe/pkg.go
@@ -1,3 +1,4 @@
+// Package pkg ...
 package pkg
 
 import (
@@ -5,6 +6,7 @@ import (
 	"unsafe"
 )
 
+// F ...
 func F() {
 	x := 123 // of type int
 	p := unsafe.Pointer(&x)


### PR DESCRIPTION
Because we use `testshared.NewLintRunner(t).Run("--no-config", "--enable-all", getTestDataDir("unsafe")).ExpectNoIssues()` to both `test/testdata/cgo` and `test/testdata/unsafe`. It assume that these directories can pass all linters by default,  but if someone(like me) develop a strict linter, the test can be failed, since they are not standard enough. This PR add some comments to make it more formal.