### PR TITLE
Cobra.Command.SetOutput is deprecated

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -287,7 +287,8 @@ func (e *Executor) initRun() {
 	}
 	e.rootCmd.AddCommand(e.runCmd)
 
-	e.runCmd.SetOutput(logutils.StdOut) // use custom output to properly color it in Windows terminals
+	e.runCmd.SetOut(logutils.StdOut) // use custom output to properly color it in Windows terminals
+	e.runCmd.SetErr(logutils.StdErr)
 
 	e.initRunConfiguration(e.runCmd)
 }


### PR DESCRIPTION
We should remove a call to deprecated function.