### PR TITLE
Using upstream maligned and updating error message 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a
 	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
-	github.com/mdempsky/maligned v0.0.0-20201101000000-d73c43cb16d0
 	github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770
 	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21
 	github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0
@@ -36,6 +35,7 @@ require (
 	github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb // v1.0
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mbilski/exhaustivestruct v1.1.0
+	github.com/mdempsky/maligned v0.0.0-20201101000000-d73c43cb16d0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/moricho/tparallel v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a
 	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
-	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
+	github.com/mdempsky/maligned v0.0.0-20201101000000-d73c43cb16d0
 	github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770
 	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21
 	github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,6 @@ github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc h1:gLLhTLMk2/
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc/go.mod h1:e5tpTHCfVze+7EpLEozzMB3eafxo2KT5veNg1k6byQU=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
-github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29MYHubXix4aDDuE3RWHkPvopM/EDv/MA=
-github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca/go.mod h1:tvlJhZqDe4LMs4ZHD0oMUlt9G2LWuDGoisJTBzLMV9o=
 github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770 h1:EL/O5HGrF7Jaq0yNhBLucz9hTuRzj2LdwGBOaENgxIk=
 github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770/go.mod h1:dEbvlSfYbMQDtrpRMQU675gSDLDNa8sCPPChZ7PhiVA=
 github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 h1:leSNB7iYzLYSSx3J/s5sVf4Drkc68W2wm4Ixh/mr0us=

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,8 @@ github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpe
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mbilski/exhaustivestruct v1.1.0 h1:4ykwscnAFeHJruT+EY3M3vdeP8uXMh0VV2E61iR7XD8=
 github.com/mbilski/exhaustivestruct v1.1.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
+github.com/mdempsky/maligned v0.0.0-20201101000000-d73c43cb16d0 h1:+6XJvFZBYbNv/nSekNWFZyaGNMXcPnZ4n/HHoCXn+Ms=
+github.com/mdempsky/maligned v0.0.0-20201101000000-d73c43cb16d0/go.mod h1:3UB4iTzhLciyWcrrvXSkrtCIU+IJ5GCfEmnleHRsxL4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -563,6 +565,7 @@ golang.org/x/tools v0.0.0-20201001104356-43ebab892c4c/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/tools v0.0.0-20201002184944-ecd9fd270d5d/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201007032633-0806396f153e/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201011145850-ed2f50202694/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201030204249-4fc0492b8eca/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394 h1:O3VD5Fds21mB1WVRTbkiz/HTXESx6Jql5ucPZi69oiM=
 golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201121010211-780cb80bd7fb h1:z5+u0pkAUPUWd3taoTialQ2JAMo4Wo1Z3L25U4ZV9r0=

--- a/pkg/golinters/maligned.go
+++ b/pkg/golinters/maligned.go
@@ -1,72 +1,17 @@
 package golinters
 
 import (
-	//"fmt"
-	//"sync"
-
-	"fmt"
-
 	"github.com/mdempsky/maligned/passes/maligned"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
-	"github.com/golangci/golangci-lint/pkg/lint/linter"
-	//"github.com/golangci/golangci-lint/pkg/result"
-
-	//"github.com/golangci/golangci-lint/pkg/lint/linter"
-	//"github.com/golangci/golangci-lint/pkg/result"
 )
 
 func NewMaligned() *goanalysis.Linter {
 	return goanalysis.NewLinter(
 		"maligned",
-		"",
+		maligned.Analyzer.Doc,
 		[]*analysis.Analyzer{maligned.Analyzer},
 		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo).WithIssuesReporter(func(ctx *linter.Context) []goanalysis.Issue {
-		fmt.Print(ctx.Packages[0].)
-		return nil
-	})
-	//const linterName = "maligned"
-	//var mu sync.Mutex
-	//var res []goanalysis.Issue
-	//analyzer := &analysis.Analyzer{
-	//	Name: linterName,
-	//	Doc:  goanalysis.TheOnlyanalyzerDoc,
-	//}
-	//return goanalysis.NewLinter(
-	//	linterName,
-	//	"Tool to detect Go structs that would take less memory if their fields were sorted",
-	//	[]*analysis.Analyzer{analyzer},
-	//	nil,
-	//).WithContextSetter(func(lintCtx *linter.Context) {
-	//	analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
-	//		prog := goanalysis.MakeFakeLoaderProgram(pass)
-	//
-	//		malignedIssues := malignedAPI.Run(prog)
-	//		if len(malignedIssues) == 0 {
-	//			return nil, nil
-	//		}
-	//
-	//		issues := make([]goanalysis.Issue, 0, len(malignedIssues))
-	//		for _, i := range malignedIssues {
-	//			text := fmt.Sprintf("struct of size %d bytes could be of size %d bytes", i.OldSize, i.NewSize)
-	//			if lintCtx.Settings().Maligned.SuggestNewOrder {
-	//				text += fmt.Sprintf(":\n%s", formatCodeBlock(i.NewStructDef, lintCtx.Cfg))
-	//			}
-	//			issues = append(issues, goanalysis.NewIssue(&result.Issue{
-	//				Pos:        i.Pos,
-	//				Text:       text,
-	//				FromLinter: linterName,
-	//			}, pass))
-	//		}
-	//
-	//		mu.Lock()
-	//		res = append(res, issues...)
-	//		mu.Unlock()
-	//		return nil, nil
-	//	}
-	//}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
-	//	return res
-	//}).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/maligned.go
+++ b/pkg/golinters/maligned.go
@@ -1,58 +1,72 @@
 package golinters
 
 import (
-	"fmt"
-	"sync"
+	//"fmt"
+	//"sync"
 
-	malignedAPI "github.com/golangci/maligned"
+	"fmt"
+
+	"github.com/mdempsky/maligned/passes/maligned"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
-	"github.com/golangci/golangci-lint/pkg/result"
+	//"github.com/golangci/golangci-lint/pkg/result"
+
+	//"github.com/golangci/golangci-lint/pkg/lint/linter"
+	//"github.com/golangci/golangci-lint/pkg/result"
 )
 
 func NewMaligned() *goanalysis.Linter {
-	const linterName = "maligned"
-	var mu sync.Mutex
-	var res []goanalysis.Issue
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-	}
 	return goanalysis.NewLinter(
-		linterName,
-		"Tool to detect Go structs that would take less memory if their fields were sorted",
-		[]*analysis.Analyzer{analyzer},
+		"maligned",
+		"",
+		[]*analysis.Analyzer{maligned.Analyzer},
 		nil,
-	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
-			prog := goanalysis.MakeFakeLoaderProgram(pass)
-
-			malignedIssues := malignedAPI.Run(prog)
-			if len(malignedIssues) == 0 {
-				return nil, nil
-			}
-
-			issues := make([]goanalysis.Issue, 0, len(malignedIssues))
-			for _, i := range malignedIssues {
-				text := fmt.Sprintf("struct of size %d bytes could be of size %d bytes", i.OldSize, i.NewSize)
-				if lintCtx.Settings().Maligned.SuggestNewOrder {
-					text += fmt.Sprintf(":\n%s", formatCodeBlock(i.NewStructDef, lintCtx.Cfg))
-				}
-				issues = append(issues, goanalysis.NewIssue(&result.Issue{
-					Pos:        i.Pos,
-					Text:       text,
-					FromLinter: linterName,
-				}, pass))
-			}
-
-			mu.Lock()
-			res = append(res, issues...)
-			mu.Unlock()
-			return nil, nil
-		}
-	}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
-		return res
-	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeTypesInfo).WithIssuesReporter(func(ctx *linter.Context) []goanalysis.Issue {
+		fmt.Print(ctx.Packages[0].)
+		return nil
+	})
+	//const linterName = "maligned"
+	//var mu sync.Mutex
+	//var res []goanalysis.Issue
+	//analyzer := &analysis.Analyzer{
+	//	Name: linterName,
+	//	Doc:  goanalysis.TheOnlyanalyzerDoc,
+	//}
+	//return goanalysis.NewLinter(
+	//	linterName,
+	//	"Tool to detect Go structs that would take less memory if their fields were sorted",
+	//	[]*analysis.Analyzer{analyzer},
+	//	nil,
+	//).WithContextSetter(func(lintCtx *linter.Context) {
+	//	analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+	//		prog := goanalysis.MakeFakeLoaderProgram(pass)
+	//
+	//		malignedIssues := malignedAPI.Run(prog)
+	//		if len(malignedIssues) == 0 {
+	//			return nil, nil
+	//		}
+	//
+	//		issues := make([]goanalysis.Issue, 0, len(malignedIssues))
+	//		for _, i := range malignedIssues {
+	//			text := fmt.Sprintf("struct of size %d bytes could be of size %d bytes", i.OldSize, i.NewSize)
+	//			if lintCtx.Settings().Maligned.SuggestNewOrder {
+	//				text += fmt.Sprintf(":\n%s", formatCodeBlock(i.NewStructDef, lintCtx.Cfg))
+	//			}
+	//			issues = append(issues, goanalysis.NewIssue(&result.Issue{
+	//				Pos:        i.Pos,
+	//				Text:       text,
+	//				FromLinter: linterName,
+	//			}, pass))
+	//		}
+	//
+	//		mu.Lock()
+	//		res = append(res, issues...)
+	//		mu.Unlock()
+	//		return nil, nil
+	//	}
+	//}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
+	//	return res
+	//}).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/util.go
+++ b/pkg/golinters/util.go
@@ -14,11 +14,3 @@ func formatCode(code string, _ *config.Config) string {
 
 	return fmt.Sprintf("`%s`", code)
 }
-
-func formatCodeBlock(code string, _ *config.Config) string {
-	if strings.Contains(code, "`") {
-		return code // TODO: properly escape or remove
-	}
-
-	return fmt.Sprintf("```\n%s\n```", code)
-}

--- a/test/testdata/maligned.go
+++ b/test/testdata/maligned.go
@@ -1,7 +1,7 @@
 //args: -Emaligned
 package testdata
 
-type BadAlignedStruct struct { // ERROR "struct of size 24 bytes could be of size 16 bytes"
+type BadAlignedStruct struct { // ERROR "struct of size 24 could be 16"
 	B  bool
 	I  int
 	B2 bool


### PR DESCRIPTION
It seems that we can swap our `maligned` fork for the upstream version, **but** messages from upstream are slightly different from those that have been used so far. I'm not sure how big issue it can be and I would like to discuss it.

https://github.com/golangci/maligned/commits/master
https://github.com/mdempsky/maligned/commits/master