### PR TITLE
Validate gocritic settings. Return error if settings includes a unsupported gocritic checker

### DIFF
--- a/pkg/config/config_gocritic.go
+++ b/pkg/config/config_gocritic.go
@@ -242,13 +242,7 @@ func (s *GocriticSettings) Validate(log logutils.Log) error {
 		return errors.Wrap(err, "validate disabled checks")
 	}
 
-	for checkName := range s.SettingsPerCheck {
-		if !s.IsCheckEnabled(checkName) {
-			log.Warnf("Gocritic settings were provided for not enabled check %q", checkName)
-		}
-	}
-
-	if err := s.validateCheckerNames(); err != nil {
+	if err := s.validateCheckerNames(log); err != nil {
 		return errors.Wrap(err, "validation failed")
 	}
 
@@ -272,6 +266,7 @@ func sprintStrings(ss []string) string {
 	return fmt.Sprint(ss)
 }
 
+// getAllCheckerNames returns a map containing all checker names supported by gocritic.
 func getAllCheckerNames() map[string]bool {
 	allCheckerNames := map[string]bool{}
 	for _, checker := range allGocriticCheckers {
@@ -311,7 +306,7 @@ func getDefaultDisabledGocriticCheckersNames() []string {
 	return disabled
 }
 
-func (s *GocriticSettings) validateCheckerNames() error {
+func (s *GocriticSettings) validateCheckerNames(log logutils.Log) error {
 	allowedNames := getAllCheckerNames()
 
 	for _, name := range s.EnabledChecks {
@@ -325,6 +320,16 @@ func (s *GocriticSettings) validateCheckerNames() error {
 		if !allowedNames[strings.ToLower(name)] {
 			return fmt.Errorf("disabled checker %s doesn't exist, all existing checkers: %s",
 				name, sprintAllowedCheckerNames(allowedNames))
+		}
+	}
+
+	for checkName := range s.SettingsPerCheck {
+		if _, ok := allowedNames[checkName]; !ok {
+			return fmt.Errorf("Invalid setting, checker %s doesn't exist, all existing checkers: %s",
+				checkName, sprintAllowedCheckerNames(allowedNames))
+		}
+		if !s.IsCheckEnabled(checkName) {
+			log.Warnf("Gocritic settings were provided for not enabled check %q", checkName)
 		}
 	}
 

--- a/pkg/config/config_gocritic.go
+++ b/pkg/config/config_gocritic.go
@@ -325,7 +325,7 @@ func (s *GocriticSettings) validateCheckerNames(log logutils.Log) error {
 
 	for checkName := range s.SettingsPerCheck {
 		if _, ok := allowedNames[checkName]; !ok {
-			return fmt.Errorf("Invalid setting, checker %s doesn't exist, all existing checkers: %s",
+			return fmt.Errorf("invalid setting, checker %s doesn't exist, all existing checkers: %s",
 				checkName, sprintAllowedCheckerNames(allowedNames))
 		}
 		if !s.IsCheckEnabled(checkName) {


### PR DESCRIPTION
This PR performs additional gocritic settings validation. The `settings` attribute is supposed to be a map where each key is the name of a supported gocritic checker. 

The existing validation already warns if the config data contains a settings for a disabled checker. But it does not validate the checker is supported. There is also an existing validation that the specific parameter is supported or not.

For example, as shown in the yaml config data below, `ruleguard` is a supported gocritic checker, but `rangeValueCopy` is not (the actual checker is `rangeValCopy`).

```
  gocritic:
    settings:
      rangeValueCopy:
        sizeThreshold: 32
      ruleguard:
        rules: myrules.go
```