### PR TITLE
Allow excluding unused nolint checks on a per-linter or per-line basis

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -331,6 +331,8 @@ linters-settings:
     require-explanation: true
     # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
     require-specific: true
+    # Ignore nolints for specific linters
+    ignore: []
   rowserrcheck:
     packages:
       - github.com/jmoiron/sqlx

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -332,7 +332,7 @@ linters-settings:
     # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
     require-specific: true
     # Ignore nolints for specific linters
-    ignore: []
+    ignore-unused: []
   rowserrcheck:
     packages:
       - github.com/jmoiron/sqlx

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,6 +366,7 @@ type NoLintLintSettings struct {
 	RequireSpecific    bool     `mapstructure:"require-specific"`
 	AllowNoExplanation []string `mapstructure:"allow-no-explanation"`
 	AllowUnused        bool     `mapstructure:"allow-unused"`
+	IgnoreUnused       []string `mapstructure:"ignore-unused"`
 }
 
 type TestpackageSettings struct {

--- a/pkg/golinters/nolintlint.go
+++ b/pkg/golinters/nolintlint.go
@@ -54,6 +54,12 @@ func NewNoLintLint() *goanalysis.Linter {
 			for _, n := range pass.Files {
 				nodes = append(nodes, n)
 			}
+
+			ignoredLinters := make(map[string]struct{}, len(settings.IgnoreUnused))
+			for _, l := range settings.IgnoreUnused {
+				ignoredLinters[l] = struct{}{}
+			}
+
 			issues, err := lnt.Run(pass.Fset, nodes...)
 			if err != nil {
 				return nil, fmt.Errorf("linter failed to run: %s", err)
@@ -65,6 +71,9 @@ func NewNoLintLint() *goanalysis.Linter {
 				if ii, ok := i.(nolintlint.UnusedCandidate); ok {
 					expectedNolintLinter = ii.ExpectedLinter
 					expectNoLint = true
+					if _, ignored := ignoredLinters[expectedNolintLinter]; ignored {
+						continue
+					}
 				}
 				issue := &result.Issue{
 					FromLinter:           NolintlintName,

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -188,6 +188,7 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 				}
 				lintersText, explanation := fullMatches[1], fullMatches[2]
 				var linters []string
+				ignoreUnused := false
 				if len(lintersText) > 0 {
 					lls := strings.Split(lintersText[1:], ",")
 					linters = make([]string, 0, len(lls))
@@ -195,6 +196,9 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 						ll = strings.TrimSpace(ll)
 						if ll != "" {
 							linters = append(linters, ll)
+						}
+						if ll == "nolintlint" {
+							ignoreUnused = true
 						}
 					}
 				}
@@ -205,7 +209,7 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 				}
 
 				// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
-				if l.needs&NeedsUnused != 0 {
+				if l.needs&NeedsUnused != 0 && !ignoreUnused {
 					if len(linters) == 0 {
 						issues = append(issues, UnusedCandidate{BaseIssue: base})
 					} else {

--- a/test/testdata/configs/nolintlint_unused.yml
+++ b/test/testdata/configs/nolintlint_unused.yml
@@ -1,0 +1,5 @@
+linters-settings:
+  nolintlint:
+    allow-unused: false
+    ignore-unused:
+      - deadcode

--- a/test/testdata/nolintlint_unused.go
+++ b/test/testdata/nolintlint_unused.go
@@ -1,5 +1,5 @@
-//args: -Enolintlint -Evarcheck
-//config: linters-settings.nolintlint.allow-unused=false
+//args: -Enolintlint -Evarcheck -Edeadcode
+//config_path: testdata/configs/nolintlint_unused.yml
 package testdata
 
 import "fmt"
@@ -8,4 +8,8 @@ func Foo() {
 	fmt.Println("unused")          // nolint // ERROR "directive `//nolint .*` is unused"
 	fmt.Println("unused,specific") // nolint:varcheck // ERROR "directive `//nolint:varcheck .*` is unused for linter varcheck"
 	fmt.Println("not run")         // nolint:unparam // unparam is not run so this is ok
+
+	fmt.Println("unused but ignored by line") // nolint:varcheck,nolintlint // varcheck is unused but nolintlint is marked as nolint itself
+
+	fmt.Println("unused but ignored by config") // nolint:deadcode // this linter is ignored for unused checking in config
 }


### PR DESCRIPTION
Because some linters may be implementation dependent based on tags or OS, we allow excluding nolint checks.  This can be done either by adding a linter to the "ignore-unused" in settings, or by adding `nolintlint` to the `nolint` directive, such as  `//nolint:my-linter,nolintlint`.

Fixes #1542.