### PR TITLE
Update nolintlint to fix nolint formatting and remove unused nolint statements

### DIFF
--- a/pkg/golinters/nolintlint.go
+++ b/pkg/golinters/nolintlint.go
@@ -72,6 +72,7 @@ func NewNoLintLint() *goanalysis.Linter {
 					Pos:                  i.Position(),
 					ExpectNoLint:         expectNoLint,
 					ExpectedNoLintLinter: expectedNolintLinter,
+					Replacement:          i.Replacement(),
 				}
 				res = append(res, goanalysis.NewIssue(issue, pass))
 			}

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -8,16 +8,21 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"github.com/golangci/golangci-lint/pkg/result"
 )
 
 type BaseIssue struct {
 	fullDirective                     string
 	directiveWithOptionalLeadingSpace string
 	position                          token.Position
+	replacement                       *result.Replacement
 }
 
-func (b BaseIssue) Position() token.Position {
-	return b.position
+func (b BaseIssue) Position() token.Position { return b.position }
+
+func (b BaseIssue) Replacement() *result.Replacement {
+	return b.replacement
 }
 
 type ExtraLeadingSpace struct {
@@ -85,7 +90,7 @@ type UnusedCandidate struct {
 func (i UnusedCandidate) Details() string {
 	details := fmt.Sprintf("directive `%s` is unused", i.fullDirective)
 	if i.ExpectedLinter != "" {
-		details += fmt.Sprintf(" for linter %s", i.ExpectedLinter)
+		details += fmt.Sprintf(" for linter %q", i.ExpectedLinter)
 	}
 	return details
 }
@@ -100,6 +105,7 @@ type Issue interface {
 	Details() string
 	Position() token.Position
 	String() string
+	Replacement() *result.Replacement
 }
 
 type Needs uint
@@ -115,7 +121,7 @@ const (
 var commentPattern = regexp.MustCompile(`^//\s*(nolint)(:\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*)?\b`)
 
 // matches a complete nolint directive
-var fullDirectivePattern = regexp.MustCompile(`^//\s*nolint(:\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*)?\s*(//.*)?\s*\n?$`)
+var fullDirectivePattern = regexp.MustCompile(`^//\s*nolint(?::(\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*))?\s*(//.*)?\s*\n?$`)
 
 type Linter struct {
 	excludes        []string // lists individual linters that don't require explanations
@@ -164,19 +170,34 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 						directiveWithOptionalLeadingSpace = "// " + strings.TrimSpace(split[1])
 					}
 
+					pos := fset.Position(comment.Pos())
+					end := fset.Position(comment.End())
+
 					base := BaseIssue{
 						fullDirective:                     comment.Text,
 						directiveWithOptionalLeadingSpace: directiveWithOptionalLeadingSpace,
-						position:                          fset.Position(comment.Pos()),
+						position:                          pos,
 					}
 
 					// check for, report and eliminate leading spaces so we can check for other issues
-					if len(leadingSpace) > 1 {
-						issues = append(issues, ExtraLeadingSpace{BaseIssue: base})
-					}
+					if len(leadingSpace) > 0 {
+						machineReadableReplacement := &result.Replacement{
+							Inline: &result.InlineFix{
+								StartCol:  pos.Column - 1,
+								Length:    len(leadingSpace) + 2,
+								NewString: "//",
+							},
+						}
 
-					if (l.needs&NeedsMachineOnly) != 0 && len(leadingSpace) > 0 {
-						issues = append(issues, NotMachine{BaseIssue: base})
+						if (l.needs & NeedsMachineOnly) != 0 {
+							issue := NotMachine{BaseIssue: base}
+							issue.BaseIssue.replacement = machineReadableReplacement
+							issues = append(issues, issue)
+						} else if len(leadingSpace) > 1 {
+							issue := ExtraLeadingSpace{BaseIssue: base}
+							issue.BaseIssue.replacement = machineReadableReplacement
+							issues = append(issues, issue)
+						}
 					}
 
 					fullMatches := fullDirectivePattern.FindStringSubmatch(comment.Text)
@@ -188,7 +209,7 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 					lintersText, explanation := fullMatches[1], fullMatches[2]
 					var linters []string
 					if len(lintersText) > 0 {
-						lls := strings.Split(lintersText[1:], ",")
+						lls := strings.Split(lintersText, ",")
 						linters = make([]string, 0, len(lls))
 						for _, ll := range lls {
 							ll = strings.TrimSpace(ll)
@@ -206,11 +227,34 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 
 					// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
 					if (l.needs & NeedsUnused) != 0 {
+						removeNolintCompletely := &result.Replacement{
+							Inline: &result.InlineFix{
+								StartCol:  pos.Column - 1,
+								Length:    end.Column - pos.Column,
+								NewString: "",
+							},
+						}
+
 						if len(linters) == 0 {
-							issues = append(issues, UnusedCandidate{BaseIssue: base})
+							issue := UnusedCandidate{BaseIssue: base}
+							issue.replacement = removeNolintCompletely
+							issues = append(issues, issue)
 						} else {
-							for _, linter := range linters {
-								issues = append(issues, UnusedCandidate{BaseIssue: base, ExpectedLinter: linter})
+							for i, linter := range linters {
+								issue := UnusedCandidate{BaseIssue: base, ExpectedLinter: linter}
+								replacement := removeNolintCompletely
+								if len(linters) > 1 {
+									otherLinters := append(append([]string(nil), linters[0:i]...), linters[i+1:]...)
+									replacement = &result.Replacement{
+										Inline: &result.InlineFix{
+											StartCol:  (pos.Column - 1) + len("//") + len(leadingSpace) + len("nolint:"),
+											Length:    len(lintersText) - 1,
+											NewString: strings.Join(otherLinters, ","),
+										},
+									}
+								}
+								issue.replacement = replacement
+								issues = append(issues, issue)
 							}
 						}
 					}

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -14,7 +14,7 @@ type Range struct {
 
 type Replacement struct {
 	NeedOnlyDelete bool     // need to delete all lines of the issue without replacement with new lines
-	NewLines       []string // is NeedDelete is false it's the replacement lines
+	NewLines       []string // if NeedDelete is false it's the replacement lines
 	Inline         *InlineFix
 }
 

--- a/test/testdata/fix/in/nolintlint.go
+++ b/test/testdata/fix/in/nolintlint.go
@@ -1,0 +1,13 @@
+//args: -Enolintlint -Elll
+//config: linters-settings.nolintlint.allow-leading-space=false
+package p
+
+func nolintlint() {
+	run() // nolint:bob // leading space should be dropped
+	run() //  nolint:bob // leading spaces should be dropped
+	// note that the next lines will retain trailing whitespace when fixed
+	run() //nolint // nolint should be dropped
+	run() //nolint:lll // nolint should be dropped
+	run() //nolint:alice,lll,bob // enabled linter should be dropped
+	run() //nolint:alice,lll,bob,nolintlint // enabled linter should not be dropped when nolintlint is nolinted
+}

--- a/test/testdata/fix/out/nolintlint.go
+++ b/test/testdata/fix/out/nolintlint.go
@@ -1,0 +1,13 @@
+//args: -Enolintlint -Elll
+//config: linters-settings.nolintlint.allow-leading-space=false
+package p
+
+func nolintlint() {
+	run() //nolint:bob // leading space should be dropped
+	run() //nolint:bob // leading spaces should be dropped
+	// note that the next lines will retain trailing whitespace when fixed
+	run() 
+	run() 
+	run() //nolint:alice,bob // enabled linter should be dropped
+	run() //nolint:alice,lll,bob,nolintlint // enabled linter should not be dropped when nolintlint is nolinted
+}

--- a/test/testdata/nolintlint.go
+++ b/test/testdata/nolintlint.go
@@ -1,7 +1,7 @@
 //args: -Enolintlint
 //config: linters-settings.nolintlint.require-explanation=true
 //config: linters-settings.nolintlint.require-specific=true
-//config: linters-settings.nolintlint.allowing-leading-space=false
+//config: linters-settings.nolintlint.allow-leading-space=false
 package testdata
 
 import "fmt"

--- a/test/testdata/nolintlint.go
+++ b/test/testdata/nolintlint.go
@@ -1,4 +1,4 @@
-//args: -Enolintlint
+//args: -Enolintlint -Emisspell
 //config: linters-settings.nolintlint.require-explanation=true
 //config: linters-settings.nolintlint.require-specific=true
 //config: linters-settings.nolintlint.allow-leading-space=false
@@ -10,4 +10,11 @@ func Foo() {
 	fmt.Println("not specific")         //nolint // ERROR "directive `.*` should mention specific linter such as `//nolint:my-linter`"
 	fmt.Println("not machine readable") // nolint // ERROR "directive `.*`  should be written as `//nolint`"
 	fmt.Println("extra spaces")         //  nolint:deadcode // because // ERROR "directive `.*` should not have more than one leading space"
+
+	// test expanded range
+	//nolint:misspell // deliberate misspelling to trigger nolintlint
+	func() {
+		mispell := true
+		fmt.Println(mispell)
+	}()
 }


### PR DESCRIPTION
This PR adds a fixing capability to `nolintlint`.  It doesn't try to fix everything. 

What it does (when --fix is enabled):
1) Removes non-specific `//nolint` directives that are not used.
2) Removes a linter from a linter-dispecific `//nolint` directive if that linter is not used for that line.
3) Removes all leading whitespace from `//. nolint` directives for any violations on the number of spaces.

What it does not do:
1)  Offer explanations when explanations for `nolint` are required but not provided.  I suppose it could add a placeholder that the user could replace but that doesn't seem really in the spirit of how the fix option is supposed to work (since the user might check in that placeholder).
2) Make non-specific linter directives specific.  This could be done but there is a risk that it cannot divine the intent of the user in setting the `nolint` directive and I'd argue it's best for the user to make this determination on their own.

Note that fies may leave trailing spaces or empty lines behind.  Presumably, this would be cleaned up by gofmt in most cases which could also fix these cases.  I'm not sure whether it's really possible or necessary to try to remove such spaces.  It would be nice to at least remove empty lines if there is a way to identify if a comment is the only thing on a line, but I'm not sure how to do that just given the AST.  One possibility might be to give the fixer a hint to clean up trailing whitespace or remove blank lines.  That could potentially be useful for other linters as well.

This PR also runs the fix on golangci-lint itself to enforce machine-readable nolint styling.  (I can back this out if anyone things this isn't a good idea but I just wanted to see it in action).