### PR TITLE
Bump go-header to v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ashanbrown/makezero v0.0.0-20201205152432-7b7cdbb3025a
 	github.com/bombsimon/wsl/v3 v3.1.0
 	github.com/daixiang0/gci v0.2.7
-	github.com/denis-tingajkin/go-header v0.3.1
+	github.com/denis-tingajkin/go-header v0.4.1
 	github.com/fatih/color v1.10.0
 	github.com/go-critic/go-critic v0.5.2
 	github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/daixiang0/gci v0.2.7/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKgg
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denis-tingajkin/go-header v0.3.1 h1:ymEpSiFjeItCy1FOP+x0M2KdCELdEAHUsNa8F+hHc6w=
-github.com/denis-tingajkin/go-header v0.3.1/go.mod h1:sq/2IxMhaZX+RRcgHfCRx/m0M5na0fBt4/CRe7Lrji0=
+github.com/denis-tingajkin/go-header v0.4.1 h1:FucmoUixpHFcqD/OudVxy1RplDT8aqShlNqCwlNlR60=
+github.com/denis-tingajkin/go-header v0.4.1/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/pkg/golinters/goheader.go
+++ b/pkg/golinters/goheader.go
@@ -50,7 +50,11 @@ func NewGoHeader() *goanalysis.Linter {
 			a := goheader.New(goheader.WithTemplate(template), goheader.WithValues(values))
 			var res []goanalysis.Issue
 			for _, file := range pass.Files {
-				i := a.Analyze(file)
+				path := pass.Fset.Position(file.Pos()).Filename
+				i := a.Analyze(&goheader.Target{
+					File: file,
+					Path: path,
+				})
 				if i == nil {
 					continue
 				}
@@ -58,7 +62,7 @@ func NewGoHeader() *goanalysis.Linter {
 					Pos: token.Position{
 						Line:     i.Location().Line + 1,
 						Column:   i.Location().Position,
-						Filename: pass.Fset.Position(file.Pos()).Filename,
+						Filename: path,
 					},
 					Text:       i.Message(),
 					FromLinter: goHeaderName,


### PR DESCRIPTION
This PR updates dependency on the go-header linter to [v0.4.1](https://github.com/denis-tingajkin/go-header/releases/tag/v0.4.1)

https://github.com/denis-tingajkin/go-header/compare/v0.3.1...v0.4.1

Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>