### PR TITLE
nolintlint: allow to fix //nolint lines

### DIFF
--- a/pkg/golinters/nolintlint.go
+++ b/pkg/golinters/nolintlint.go
@@ -72,6 +72,7 @@ func NewNoLintLint() *goanalysis.Linter {
 					Pos:                  i.Position(),
 					ExpectNoLint:         expectNoLint,
 					ExpectedNoLintLinter: expectedNolintLinter,
+					Replacement:          i.Replacement(),
 				}
 				res = append(res, goanalysis.NewIssue(issue, pass))
 			}

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -8,16 +8,21 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"github.com/golangci/golangci-lint/pkg/result"
 )
 
 type BaseIssue struct {
 	fullDirective                     string
 	directiveWithOptionalLeadingSpace string
 	position                          token.Position
+	replacement                       *result.Replacement
 }
 
-func (b BaseIssue) Position() token.Position {
-	return b.position
+func (b BaseIssue) Position() token.Position { return b.position }
+
+func (b BaseIssue) Replacement() *result.Replacement {
+	return b.replacement
 }
 
 type ExtraLeadingSpace struct {
@@ -85,7 +90,7 @@ type UnusedCandidate struct {
 func (i UnusedCandidate) Details() string {
 	details := fmt.Sprintf("directive `%s` is unused", i.fullDirective)
 	if i.ExpectedLinter != "" {
-		details += fmt.Sprintf(" for linter %s", i.ExpectedLinter)
+		details += fmt.Sprintf(" for linter %q", i.ExpectedLinter)
 	}
 	return details
 }
@@ -100,6 +105,7 @@ type Issue interface {
 	Details() string
 	Position() token.Position
 	String() string
+	Replacement() *result.Replacement
 }
 
 type Needs uint
@@ -115,7 +121,7 @@ const (
 var commentPattern = regexp.MustCompile(`^//\s*(nolint)(:\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*)?\b`)
 
 // matches a complete nolint directive
-var fullDirectivePattern = regexp.MustCompile(`^//\s*nolint(:\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*)?\s*(//.*)?\s*\n?$`)
+var fullDirectivePattern = regexp.MustCompile(`^//\s*nolint(?::(\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*))?\s*(//.*)?\s*\n?$`)
 
 type Linter struct {
 	excludes        []string // lists individual linters that don't require explanations
@@ -164,19 +170,34 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 						directiveWithOptionalLeadingSpace = "// " + strings.TrimSpace(split[1])
 					}
 
+					pos := fset.Position(comment.Pos())
+					end := fset.Position(comment.End())
+
 					base := BaseIssue{
 						fullDirective:                     comment.Text,
 						directiveWithOptionalLeadingSpace: directiveWithOptionalLeadingSpace,
-						position:                          fset.Position(comment.Pos()),
+						position:                          pos,
 					}
 
 					// check for, report and eliminate leading spaces so we can check for other issues
-					if len(leadingSpace) > 1 {
-						issues = append(issues, ExtraLeadingSpace{BaseIssue: base})
-					}
-
-					if (l.needs&NeedsMachineOnly) != 0 && len(leadingSpace) > 0 {
-						issues = append(issues, NotMachine{BaseIssue: base})
+					if len(leadingSpace) > 0 {
+						removeWhitespace := &result.Replacement{
+							Inline: &result.InlineFix{
+								StartCol:  pos.Column + 1,
+								Length:    len(leadingSpace),
+								NewString: "",
+							},
+						}
+						if (l.needs & NeedsMachineOnly) != 0 {
+							issue := NotMachine{BaseIssue: base}
+							issue.BaseIssue.replacement = removeWhitespace
+							issues = append(issues, issue)
+						} else if len(leadingSpace) > 1 {
+							issue := ExtraLeadingSpace{BaseIssue: base}
+							issue.BaseIssue.replacement = removeWhitespace
+							issue.BaseIssue.replacement.Inline.NewString = " " // assume a single space was intended
+							issues = append(issues, issue)
+						}
 					}
 
 					fullMatches := fullDirectivePattern.FindStringSubmatch(comment.Text)
@@ -187,14 +208,22 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 
 					lintersText, explanation := fullMatches[1], fullMatches[2]
 					var linters []string
+					var linterRange []result.Range
 					if len(lintersText) > 0 {
-						lls := strings.Split(lintersText[1:], ",")
+						lls := strings.Split(lintersText, ",")
 						linters = make([]string, 0, len(lls))
-						for _, ll := range lls {
-							ll = strings.TrimSpace(ll)
-							if ll != "" {
-								linters = append(linters, ll)
+						rangeStart := (pos.Column - 1) + len("//") + len(leadingSpace) + len("nolint:")
+						for i, ll := range lls {
+							rangeEnd := rangeStart + len(ll)
+							if i < len(lls)-1 {
+								rangeEnd++ // include trailing comma
 							}
+							trimmedLinterName := strings.TrimSpace(ll)
+							if trimmedLinterName != "" {
+								linters = append(linters, trimmedLinterName)
+								linterRange = append(linterRange, result.Range{From: rangeStart, To: rangeEnd})
+							}
+							rangeStart = rangeEnd
 						}
 					}
 
@@ -206,11 +235,28 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 
 					// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
 					if (l.needs & NeedsUnused) != 0 {
+						removeNolintCompletely := &result.Replacement{
+							Inline: &result.InlineFix{
+								StartCol:  pos.Column - 1,
+								Length:    end.Column - pos.Column,
+								NewString: "",
+							},
+						}
+
 						if len(linters) == 0 {
-							issues = append(issues, UnusedCandidate{BaseIssue: base})
+							issue := UnusedCandidate{BaseIssue: base}
+							issue.replacement = removeNolintCompletely
+							issues = append(issues, issue)
 						} else {
 							for _, linter := range linters {
-								issues = append(issues, UnusedCandidate{BaseIssue: base, ExpectedLinter: linter})
+								issue := UnusedCandidate{BaseIssue: base, ExpectedLinter: linter}
+								// only offer replacement if there is a single linter
+								// because of issues around commas and the possibility of all
+								// linters being removed
+								if len(linters) == 1 {
+									issue.replacement = removeNolintCompletely
+								}
+								issues = append(issues, issue)
 							}
 						}
 					}

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -19,7 +19,9 @@ type BaseIssue struct {
 	replacement                       *result.Replacement
 }
 
-func (b BaseIssue) Position() token.Position { return b.position }
+func (b BaseIssue) Position() token.Position {
+	return b.position
+}
 
 func (b BaseIssue) Replacement() *result.Replacement {
 	return b.replacement
@@ -149,135 +151,138 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 	var issues []Issue
 
 	for _, node := range nodes {
-		if file, ok := node.(*ast.File); ok {
-			for _, c := range file.Comments {
-				for _, comment := range c.List {
-					if !commentPattern.MatchString(comment.Text) {
-						continue
+		file, ok := node.(*ast.File)
+		if !ok {
+			continue
+		}
+
+		for _, c := range file.Comments {
+			for _, comment := range c.List {
+				if !commentPattern.MatchString(comment.Text) {
+					continue
+				}
+
+				// check for a space between the "//" and the directive
+				leadingSpaceMatches := leadingSpacePattern.FindStringSubmatch(comment.Text)
+
+				var leadingSpace string
+				if len(leadingSpaceMatches) > 0 {
+					leadingSpace = leadingSpaceMatches[1]
+				}
+
+				directiveWithOptionalLeadingSpace := comment.Text
+				if len(leadingSpace) > 0 {
+					split := strings.Split(strings.SplitN(comment.Text, ":", 2)[0], "//")
+					directiveWithOptionalLeadingSpace = "// " + strings.TrimSpace(split[1])
+				}
+
+				pos := fset.Position(comment.Pos())
+				end := fset.Position(comment.End())
+
+				base := BaseIssue{
+					fullDirective:                     comment.Text,
+					directiveWithOptionalLeadingSpace: directiveWithOptionalLeadingSpace,
+					position:                          pos,
+				}
+
+				// check for, report and eliminate leading spaces so we can check for other issues
+				if len(leadingSpace) > 0 {
+					removeWhitespace := &result.Replacement{
+						Inline: &result.InlineFix{
+							StartCol:  pos.Column + 1,
+							Length:    len(leadingSpace),
+							NewString: "",
+						},
 					}
-
-					// check for a space between the "//" and the directive
-					leadingSpaceMatches := leadingSpacePattern.FindStringSubmatch(comment.Text)
-
-					var leadingSpace string
-					if len(leadingSpaceMatches) > 0 {
-						leadingSpace = leadingSpaceMatches[1]
+					if (l.needs & NeedsMachineOnly) != 0 {
+						issue := NotMachine{BaseIssue: base}
+						issue.BaseIssue.replacement = removeWhitespace
+						issues = append(issues, issue)
+					} else if len(leadingSpace) > 1 {
+						issue := ExtraLeadingSpace{BaseIssue: base}
+						issue.BaseIssue.replacement = removeWhitespace
+						issue.BaseIssue.replacement.Inline.NewString = " " // assume a single space was intended
+						issues = append(issues, issue)
 					}
+				}
 
-					directiveWithOptionalLeadingSpace := comment.Text
-					if len(leadingSpace) > 0 {
-						split := strings.Split(strings.SplitN(comment.Text, ":", 2)[0], "//")
-						directiveWithOptionalLeadingSpace = "// " + strings.TrimSpace(split[1])
-					}
+				fullMatches := fullDirectivePattern.FindStringSubmatch(comment.Text)
+				if len(fullMatches) == 0 {
+					issues = append(issues, ParseError{BaseIssue: base})
+					continue
+				}
 
-					pos := fset.Position(comment.Pos())
-					end := fset.Position(comment.End())
-
-					base := BaseIssue{
-						fullDirective:                     comment.Text,
-						directiveWithOptionalLeadingSpace: directiveWithOptionalLeadingSpace,
-						position:                          pos,
-					}
-
-					// check for, report and eliminate leading spaces so we can check for other issues
-					if len(leadingSpace) > 0 {
-						removeWhitespace := &result.Replacement{
-							Inline: &result.InlineFix{
-								StartCol:  pos.Column + 1,
-								Length:    len(leadingSpace),
-								NewString: "",
-							},
+				lintersText, explanation := fullMatches[1], fullMatches[2]
+				var linters []string
+				var linterRange []result.Range
+				if len(lintersText) > 0 {
+					lls := strings.Split(lintersText, ",")
+					linters = make([]string, 0, len(lls))
+					rangeStart := (pos.Column - 1) + len("//") + len(leadingSpace) + len("nolint:")
+					for i, ll := range lls {
+						rangeEnd := rangeStart + len(ll)
+						if i < len(lls)-1 {
+							rangeEnd++ // include trailing comma
 						}
-						if (l.needs & NeedsMachineOnly) != 0 {
-							issue := NotMachine{BaseIssue: base}
-							issue.BaseIssue.replacement = removeWhitespace
+						trimmedLinterName := strings.TrimSpace(ll)
+						if trimmedLinterName != "" {
+							linters = append(linters, trimmedLinterName)
+							linterRange = append(linterRange, result.Range{From: rangeStart, To: rangeEnd})
+						}
+						rangeStart = rangeEnd
+					}
+				}
+
+				if (l.needs & NeedsSpecific) != 0 {
+					if len(linters) == 0 {
+						issues = append(issues, NotSpecific{BaseIssue: base})
+					}
+				}
+
+				// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
+				if (l.needs & NeedsUnused) != 0 {
+					removeNolintCompletely := &result.Replacement{
+						Inline: &result.InlineFix{
+							StartCol:  pos.Column - 1,
+							Length:    end.Column - pos.Column,
+							NewString: "",
+						},
+					}
+
+					if len(linters) == 0 {
+						issue := UnusedCandidate{BaseIssue: base}
+						issue.replacement = removeNolintCompletely
+						issues = append(issues, issue)
+					} else {
+						for _, linter := range linters {
+							issue := UnusedCandidate{BaseIssue: base, ExpectedLinter: linter}
+							// only offer replacement if there is a single linter
+							// because of issues around commas and the possibility of all
+							// linters being removed
+							if len(linters) == 1 {
+								issue.replacement = removeNolintCompletely
+							}
 							issues = append(issues, issue)
-						} else if len(leadingSpace) > 1 {
-							issue := ExtraLeadingSpace{BaseIssue: base}
-							issue.BaseIssue.replacement = removeWhitespace
-							issue.BaseIssue.replacement.Inline.NewString = " " // assume a single space was intended
-							issues = append(issues, issue)
+						}
+					}
+				}
+
+				if (l.needs&NeedsExplanation) != 0 && (explanation == "" || strings.TrimSpace(explanation) == "//") {
+					needsExplanation := len(linters) == 0 // if no linters are mentioned, we must have explanation
+					// otherwise, check if we are excluding all of the mentioned linters
+					for _, ll := range linters {
+						if !l.excludeByLinter[ll] { // if a linter does require explanation
+							needsExplanation = true
+							break
 						}
 					}
 
-					fullMatches := fullDirectivePattern.FindStringSubmatch(comment.Text)
-					if len(fullMatches) == 0 {
-						issues = append(issues, ParseError{BaseIssue: base})
-						continue
-					}
-
-					lintersText, explanation := fullMatches[1], fullMatches[2]
-					var linters []string
-					var linterRange []result.Range
-					if len(lintersText) > 0 {
-						lls := strings.Split(lintersText, ",")
-						linters = make([]string, 0, len(lls))
-						rangeStart := (pos.Column - 1) + len("//") + len(leadingSpace) + len("nolint:")
-						for i, ll := range lls {
-							rangeEnd := rangeStart + len(ll)
-							if i < len(lls)-1 {
-								rangeEnd++ // include trailing comma
-							}
-							trimmedLinterName := strings.TrimSpace(ll)
-							if trimmedLinterName != "" {
-								linters = append(linters, trimmedLinterName)
-								linterRange = append(linterRange, result.Range{From: rangeStart, To: rangeEnd})
-							}
-							rangeStart = rangeEnd
-						}
-					}
-
-					if (l.needs & NeedsSpecific) != 0 {
-						if len(linters) == 0 {
-							issues = append(issues, NotSpecific{BaseIssue: base})
-						}
-					}
-
-					// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
-					if (l.needs & NeedsUnused) != 0 {
-						removeNolintCompletely := &result.Replacement{
-							Inline: &result.InlineFix{
-								StartCol:  pos.Column - 1,
-								Length:    end.Column - pos.Column,
-								NewString: "",
-							},
-						}
-
-						if len(linters) == 0 {
-							issue := UnusedCandidate{BaseIssue: base}
-							issue.replacement = removeNolintCompletely
-							issues = append(issues, issue)
-						} else {
-							for _, linter := range linters {
-								issue := UnusedCandidate{BaseIssue: base, ExpectedLinter: linter}
-								// only offer replacement if there is a single linter
-								// because of issues around commas and the possibility of all
-								// linters being removed
-								if len(linters) == 1 {
-									issue.replacement = removeNolintCompletely
-								}
-								issues = append(issues, issue)
-							}
-						}
-					}
-
-					if (l.needs&NeedsExplanation) != 0 && (explanation == "" || strings.TrimSpace(explanation) == "//") {
-						needsExplanation := len(linters) == 0 // if no linters are mentioned, we must have explanation
-						// otherwise, check if we are excluding all of the mentioned linters
-						for _, ll := range linters {
-							if !l.excludeByLinter[ll] { // if a linter does require explanation
-								needsExplanation = true
-								break
-							}
-						}
-
-						if needsExplanation {
-							fullDirectiveWithoutExplanation := trailingBlankExplanation.ReplaceAllString(comment.Text, "")
-							issues = append(issues, NoExplanation{
-								BaseIssue:                       base,
-								fullDirectiveWithoutExplanation: fullDirectiveWithoutExplanation,
-							})
-						}
+					if needsExplanation {
+						fullDirectiveWithoutExplanation := trailingBlankExplanation.ReplaceAllString(comment.Text, "")
+						issues = append(issues, NoExplanation{
+							BaseIssue:                       base,
+							fullDirectiveWithoutExplanation: fullDirectiveWithoutExplanation,
+						})
 					}
 				}
 			}

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -40,10 +40,10 @@ func foo() {
 	other() //nolintother
 }`,
 			expected: []issueWithReplacement{
-				{"directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:5:1", nil},
-				{"directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:7:9", nil},
-				{"directive `//nolint //` should provide explanation such as `//nolint // this is why` at testing.go:8:9", nil},
-				{"directive `//nolint // ` should provide explanation such as `//nolint // this is why` at testing.go:9:9", nil},
+				{issue: "directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:5:1"},
+				{issue: "directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:7:9"},
+				{issue: "directive `//nolint //` should provide explanation such as `//nolint // this is why` at testing.go:8:9"},
+				{issue: "directive `//nolint // ` should provide explanation such as `//nolint // this is why` at testing.go:9:9"},
 			},
 		},
 		{
@@ -57,7 +57,7 @@ package bar
 //nolint:dupl
 func foo() {}`,
 			expected: []issueWithReplacement{
-				{"directive `//nolint:dupl` should provide explanation such as `//nolint:dupl // this is why` at testing.go:6:1", nil},
+				{issue: "directive `//nolint:dupl` should provide explanation such as `//nolint:dupl // this is why` at testing.go:6:1"},
 			},
 		},
 		{
@@ -83,8 +83,8 @@ func foo() {
   bad() // nolint // because
 }`,
 			expected: []issueWithReplacement{
-				{"directive `//nolint` should mention specific linter such as `//nolint:my-linter` at testing.go:6:9", nil},
-				{"directive `// nolint // because` should mention specific linter such as `// nolint:my-linter` at testing.go:7:9", nil},
+				{issue: "directive `//nolint` should mention specific linter such as `//nolint:my-linter` at testing.go:6:9"},
+				{issue: "directive `// nolint // because` should mention specific linter such as `// nolint:my-linter` at testing.go:7:9"},
 			},
 		},
 		{
@@ -99,8 +99,8 @@ func foo() {
 }`,
 			expected: []issueWithReplacement{
 				{
-					"directive `// nolint` should be written without leading space as `//nolint` at testing.go:5:9",
-					&result.Replacement{
+					issue: "directive `// nolint` should be written without leading space as `//nolint` at testing.go:5:9",
+					replacement: &result.Replacement{
 						Inline: &result.InlineFix{
 							StartCol:  10,
 							Length:    1,
@@ -121,8 +121,8 @@ func foo() {
 }`,
 			expected: []issueWithReplacement{
 				{
-					"directive `//  nolint` should not have more than one leading space at testing.go:5:9",
-					&result.Replacement{
+					issue: "directive `//  nolint` should not have more than one leading space at testing.go:5:9",
+					replacement: &result.Replacement{
 						Inline: &result.InlineFix{
 							StartCol:  10,
 							Length:    2,
@@ -144,7 +144,7 @@ func foo() {
   good() // nolint: linter1, linter2
 }`,
 			expected: []issueWithReplacement{
-				{"directive `// nolint:linter1 linter2` should match `// nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9", nil}, //nolint:lll // this is a string
+				{issue: "directive `// nolint:linter1 linter2` should match `// nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9"}, //nolint:lll // this is a string
 			},
 		},
 		{
@@ -168,8 +168,8 @@ func foo() {
 }`,
 			expected: []issueWithReplacement{
 				{
-					"directive `//nolint` is unused at testing.go:5:9",
-					&result.Replacement{
+					issue: "directive `//nolint` is unused at testing.go:5:9",
+					replacement: &result.Replacement{
 						Inline: &result.InlineFix{
 							StartCol:  8,
 							Length:    8,
@@ -190,8 +190,8 @@ func foo() {
 }`,
 			expected: []issueWithReplacement{
 				{
-					"directive `//nolint:somelinter` is unused for linter \"somelinter\" at testing.go:5:9",
-					&result.Replacement{
+					issue: "directive `//nolint:somelinter` is unused for linter \"somelinter\" at testing.go:5:9",
+					replacement: &result.Replacement{
 						Inline: &result.InlineFix{
 							StartCol:  8,
 							Length:    19,
@@ -212,12 +212,10 @@ func foo() {
 }`,
 			expected: []issueWithReplacement{
 				{
-					"directive `//nolint:linter1,linter2` is unused for linter \"linter1\" at testing.go:5:9",
-					nil,
+					issue: "directive `//nolint:linter1,linter2` is unused for linter \"linter1\" at testing.go:5:9",
 				},
 				{
-					"directive `//nolint:linter1,linter2` is unused for linter \"linter2\" at testing.go:5:9",
-					nil,
+					issue: "directive `//nolint:linter1,linter2` is unused for linter \"linter2\" at testing.go:5:9",
 				},
 			},
 		},

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -7,16 +7,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/golangci/golangci-lint/pkg/result"
 )
 
 //nolint:funlen
 func TestNoLintLint(t *testing.T) {
+	type issueWithReplacement struct {
+		issue       string
+		replacement *result.Replacement
+	}
 	testCases := []struct {
 		desc     string
 		needs    Needs
 		excludes []string
 		contents string
-		expected []string
+		expected []issueWithReplacement
 	}{
 		{
 			desc:  "when no explanation is provided",
@@ -33,11 +39,11 @@ func foo() {
   good() //nolint // this is ok
 	other() //nolintother
 }`,
-			expected: []string{
-				"directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:5:1",
-				"directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:7:9",
-				"directive `//nolint //` should provide explanation such as `//nolint // this is why` at testing.go:8:9",
-				"directive `//nolint // ` should provide explanation such as `//nolint // this is why` at testing.go:9:9",
+			expected: []issueWithReplacement{
+				{"directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:5:1", nil},
+				{"directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:7:9", nil},
+				{"directive `//nolint //` should provide explanation such as `//nolint // this is why` at testing.go:8:9", nil},
+				{"directive `//nolint // ` should provide explanation such as `//nolint // this is why` at testing.go:9:9", nil},
 			},
 		},
 		{
@@ -50,8 +56,8 @@ package bar
 //nolint // this is ok
 //nolint:dupl
 func foo() {}`,
-			expected: []string{
-				"directive `//nolint:dupl` should provide explanation such as `//nolint:dupl // this is why` at testing.go:6:1",
+			expected: []issueWithReplacement{
+				{"directive `//nolint:dupl` should provide explanation such as `//nolint:dupl // this is why` at testing.go:6:1", nil},
 			},
 		},
 		{
@@ -76,9 +82,9 @@ func foo() {
   bad() //nolint
   bad() // nolint // because
 }`,
-			expected: []string{
-				"directive `//nolint` should mention specific linter such as `//nolint:my-linter` at testing.go:6:9",
-				"directive `// nolint // because` should mention specific linter such as `// nolint:my-linter` at testing.go:7:9",
+			expected: []issueWithReplacement{
+				{"directive `//nolint` should mention specific linter such as `//nolint:my-linter` at testing.go:6:9", nil},
+				{"directive `// nolint // because` should mention specific linter such as `// nolint:my-linter` at testing.go:7:9", nil},
 			},
 		},
 		{
@@ -91,8 +97,17 @@ func foo() {
   bad() // nolint
   good() //nolint
 }`,
-			expected: []string{
-				"directive `// nolint` should be written without leading space as `//nolint` at testing.go:5:9",
+			expected: []issueWithReplacement{
+				{
+					"directive `// nolint` should be written without leading space as `//nolint` at testing.go:5:9",
+					&result.Replacement{
+						Inline: &result.InlineFix{
+							StartCol:  10,
+							Length:    1,
+							NewString: "",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -104,8 +119,17 @@ func foo() {
   bad() //  nolint
   good() // nolint
 }`,
-			expected: []string{
-				"directive `//  nolint` should not have more than one leading space at testing.go:5:9",
+			expected: []issueWithReplacement{
+				{
+					"directive `//  nolint` should not have more than one leading space at testing.go:5:9",
+					&result.Replacement{
+						Inline: &result.InlineFix{
+							StartCol:  10,
+							Length:    2,
+							NewString: " ",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -119,8 +143,8 @@ func foo() {
   good() // nolint: linter1,linter2
   good() // nolint: linter1, linter2
 }`,
-			expected: []string{
-				"directive `// nolint:linter1 linter2` should match `// nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9", //nolint:lll // this is a string
+			expected: []issueWithReplacement{
+				{"directive `// nolint:linter1 linter2` should match `// nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9", nil}, //nolint:lll // this is a string
 			},
 		},
 		{
@@ -132,6 +156,70 @@ func foo() {
   //nolint:test
   // something else
 }`,
+		},
+		{
+			desc:  "needs unused without specific linter generates replacement",
+			needs: NeedsUnused,
+			contents: `
+package bar
+
+func foo() {
+  bad() //nolint
+}`,
+			expected: []issueWithReplacement{
+				{
+					"directive `//nolint` is unused at testing.go:5:9",
+					&result.Replacement{
+						Inline: &result.InlineFix{
+							StartCol:  8,
+							Length:    8,
+							NewString: "",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:  "needs unused with one specific linter generates replacement",
+			needs: NeedsUnused,
+			contents: `
+package bar
+
+func foo() {
+  bad() //nolint:somelinter
+}`,
+			expected: []issueWithReplacement{
+				{
+					"directive `//nolint:somelinter` is unused for linter \"somelinter\" at testing.go:5:9",
+					&result.Replacement{
+						Inline: &result.InlineFix{
+							StartCol:  8,
+							Length:    19,
+							NewString: "",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:  "needs unused with multiple specific linters does not generate replacements",
+			needs: NeedsUnused,
+			contents: `
+package bar
+
+func foo() {
+  bad() //nolint:linter1,linter2
+}`,
+			expected: []issueWithReplacement{
+				{
+					"directive `//nolint:linter1,linter2` is unused for linter \"linter1\" at testing.go:5:9",
+					nil,
+				},
+				{
+					"directive `//nolint:linter1,linter2` is unused for linter \"linter2\" at testing.go:5:9",
+					nil,
+				},
+			},
 		},
 	}
 
@@ -149,12 +237,16 @@ func foo() {
 			actualIssues, err := linter.Run(fset, expr)
 			require.NoError(t, err)
 
-			actualIssueStrs := make([]string, 0, len(actualIssues))
+			actualIssuesWithReplacements := make([]issueWithReplacement, 0, len(actualIssues))
 			for _, i := range actualIssues {
-				actualIssueStrs = append(actualIssueStrs, i.String())
+				actualIssuesWithReplacements = append(actualIssuesWithReplacements, issueWithReplacement{
+					issue:       i.String(),
+					replacement: i.Replacement(),
+				})
 			}
 
-			assert.ElementsMatch(t, test.expected, actualIssueStrs, "expected %s \nbut got %s", test.expected, actualIssues)
+			assert.ElementsMatch(t, test.expected, actualIssuesWithReplacements,
+				"expected %s \nbut got %s", test.expected, actualIssuesWithReplacements)
 		})
 	}
 }

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -14,7 +14,7 @@ type Range struct {
 
 type Replacement struct {
 	NeedOnlyDelete bool     // need to delete all lines of the issue without replacement with new lines
-	NewLines       []string // is NeedDelete is false it's the replacement lines
+	NewLines       []string // if NeedDelete is false it's the replacement lines
 	Inline         *InlineFix
 }
 

--- a/pkg/result/processors/nolint_test.go
+++ b/pkg/result/processors/nolint_test.go
@@ -291,11 +291,29 @@ func TestNolintUnused(t *testing.T) {
 		ExpectedNoLintLinter: "varcheck",
 	}
 
+	// the issue below is another nolintlint issue that would be generated for the test file
+	nolintlintIssueVarcheckUnusedOK := result.Issue{
+		Pos: token.Position{
+			Filename: fileName,
+			Line:     5,
+		},
+		FromLinter:           golinters.NolintlintName,
+		ExpectNoLint:         true,
+		ExpectedNoLintLinter: "varcheck",
+	}
+
 	t.Run("when an issue does not occur, it is not removed from the nolintlint issues", func(t *testing.T) {
 		p := createProcessor(t, log, []string{"nolintlint", "varcheck"})
 		defer p.Finish()
 
 		processAssertSame(t, p, nolintlintIssueVarcheck)
+	})
+
+	t.Run("when an issue does not occur but nolintlint is nolinted, it is removed from the nolintlint issues", func(t *testing.T) {
+		p := createProcessor(t, log, []string{"nolintlint", "varcheck"})
+		defer p.Finish()
+
+		processAssertEmpty(t, p, nolintlintIssueVarcheckUnusedOK)
 	})
 
 	t.Run("when an issue occurs, it is removed from the nolintlint issues", func(t *testing.T) {

--- a/pkg/result/processors/testdata/nolint_unused.go
+++ b/pkg/result/processors/testdata/nolint_unused.go
@@ -1,3 +1,5 @@
 package testdata
 
 var nolintVarcheck int // nolint:varcheck
+
+var nolintVarcheckUnusedOK int // nolint:varcheck,nolintlint

--- a/test/testdata/fix/in/nolintlint.go
+++ b/test/testdata/fix/in/nolintlint.go
@@ -1,4 +1,5 @@
 //args: -Enolintlint -Elll
+//expected_linter: nolintlint
 //config: linters-settings.nolintlint.allow-leading-space=false
 package p
 

--- a/test/testdata/fix/in/nolintlint.go
+++ b/test/testdata/fix/in/nolintlint.go
@@ -1,0 +1,16 @@
+//args: -Enolintlint -Elll
+//config: linters-settings.nolintlint.allow-leading-space=false
+package p
+
+import "fmt"
+
+func nolintlint() {
+	fmt.Println() // nolint:bob // leading space should be dropped
+	fmt.Println() //  nolint:bob // leading spaces should be dropped
+
+	// note that the next lines will retain trailing whitespace when fixed
+	fmt.Println() //nolint // nolint should be dropped
+	fmt.Println() //nolint:lll // nolint should be dropped
+
+	fmt.Println() //nolint:alice,lll // we don't drop individual linters from lists
+}

--- a/test/testdata/fix/out/nolintlint.go
+++ b/test/testdata/fix/out/nolintlint.go
@@ -1,0 +1,16 @@
+//args: -Enolintlint -Elll
+//config: linters-settings.nolintlint.allow-leading-space=false
+package p
+
+import "fmt"
+
+func nolintlint() {
+	fmt.Println() //nolint:bob // leading space should be dropped
+	fmt.Println() //nolint:bob // leading spaces should be dropped
+
+	// note that the next lines will retain trailing whitespace when fixed
+	fmt.Println() 
+	fmt.Println() 
+
+	fmt.Println() //nolint:alice,lll // we don't drop individual linters from lists
+}

--- a/test/testdata/fix/out/nolintlint.go
+++ b/test/testdata/fix/out/nolintlint.go
@@ -1,4 +1,5 @@
 //args: -Enolintlint -Elll
+//expected_linter: nolintlint
 //config: linters-settings.nolintlint.allow-leading-space=false
 package p
 

--- a/test/testdata/nolintlint.go
+++ b/test/testdata/nolintlint.go
@@ -1,7 +1,7 @@
-//args: -Enolintlint
+//args: -Enolintlint -Emisspell
 //config: linters-settings.nolintlint.require-explanation=true
 //config: linters-settings.nolintlint.require-specific=true
-//config: linters-settings.nolintlint.allowing-leading-space=false
+//config: linters-settings.nolintlint.allow-leading-space=false
 package testdata
 
 import "fmt"
@@ -10,4 +10,11 @@ func Foo() {
 	fmt.Println("not specific")         //nolint // ERROR "directive `.*` should mention specific linter such as `//nolint:my-linter`"
 	fmt.Println("not machine readable") // nolint // ERROR "directive `.*`  should be written as `//nolint`"
 	fmt.Println("extra spaces")         //  nolint:deadcode // because // ERROR "directive `.*` should not have more than one leading space"
+
+	// test expanded range
+	//nolint:misspell // deliberate misspelling to trigger nolintlint
+	func() {
+		mispell := true
+		fmt.Println(mispell)
+	}()
 }

--- a/test/testdata/nolintlint.go
+++ b/test/testdata/nolintlint.go
@@ -1,4 +1,5 @@
 //args: -Enolintlint -Emisspell
+//expected_linter: nolintlint
 //config: linters-settings.nolintlint.require-explanation=true
 //config: linters-settings.nolintlint.require-specific=true
 //config: linters-settings.nolintlint.allow-leading-space=false


### PR DESCRIPTION
This PR adds a fixing capability to nolintlint. It doesn't try to fix everything.

What it does (when --fix is enabled):

* Removes non-specific //nolint directives that are not used.
* Removes a linter from a linter-dispecific //nolint directive if that linter is not used for that line.
* Removes extra leading whitespace from //. nolint directives for any violations on the number of spaces.  We assume the intent was to have a single leading space unless `allow-leading-whitespace` is set to `false`, in which case we assume no leading spaces (i.e. `//nolint`).

What it does not do:

* Offer explanations when explanations for nolint are required but not provided. I suppose it could add a placeholder that the user could replace but that doesn't seem really in the spirit of how the fix option is supposed to work (since the user might check in that placeholder).
* Make non-specific linter directives specific. This could be done but there is a risk that it cannot divine the intent of the user in setting the nolint directive and I'd argue it's best for the user to make this determination on their own.
* Try to remove linters when multiple linters are specified on a line.  This case is not common and creates some trickiness around handling of commas and the case when all linters are removed.  It's simpler just to ignore it.

Note that fixes may leave trailing spaces or empty lines behind. Presumably, this would be cleaned up by gofmt in most cases which could also fix these cases. I'm not sure whether it's really possible or necessary to try to remove such spaces. It would be nice to at least remove empty lines if there is a way to identify if a comment is the only thing on a line, but I'm not sure how to do that just given the AST. One possibility might be to give the fixer a hint to clean up trailing whitespace or remove blank lines. That could potentially be useful for other linters as well.

Fixes #1579
Fixes #1580
Fixes #1581
Related to #1573