### PR TITLE
Bump go-header to v0.4.2

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -209,27 +209,28 @@ linters-settings:
     values:
       const:
         # define here const type values in format k:v, for example:
-        # YEAR: 2020
         # COMPANY: MY COMPANY
       regexp:
         # define here regexp type values, for example
         # AUTHOR: .*@mycompany\.com
-    template:
+    template: # |
       # put here copyright header template for source code files, for example:
-      #    {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
-      #    SPDX-License-Identifier: Apache-2.0
+      # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
       #
-      #    Licensed under the Apache License, Version 2.0 (the "License");
-      #    you may not use this file except in compliance with the License.
-      #    You may obtain a copy of the License at:
-      #
-      #      http://www.apache.org/licenses/LICENSE-2.0
-      #
-      #    Unless required by applicable law or agreed to in writing, software
-      #    distributed under the License is distributed on an "AS IS" BASIS,
-      #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      #    See the License for the specific language governing permissions and
-      #    limitations under the License.
+      # {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
+      # SPDX-License-Identifier: Apache-2.0
+  
+      # Licensed under the Apache License, Version 2.0 (the "License");
+      # you may not use this file except in compliance with the License.
+      # You may obtain a copy of the License at:
+  
+      #   http://www.apache.org/licenses/LICENSE-2.0
+  
+      # Unless required by applicable law or agreed to in writing, software
+      # distributed under the License is distributed on an "AS IS" BASIS,
+      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      # See the License for the specific language governing permissions and
+      # limitations under the License.
     template-path:
       # also as alternative of directive 'template' you may put the path to file with the template source
   goimports:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ashanbrown/makezero v0.0.0-20201205152432-7b7cdbb3025a
 	github.com/bombsimon/wsl/v3 v3.1.0
 	github.com/daixiang0/gci v0.2.7
-	github.com/denis-tingajkin/go-header v0.4.1
+	github.com/denis-tingajkin/go-header v0.4.2
 	github.com/fatih/color v1.10.0
 	github.com/go-critic/go-critic v0.5.2
 	github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/daixiang0/gci v0.2.7/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKgg
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denis-tingajkin/go-header v0.4.1 h1:FucmoUixpHFcqD/OudVxy1RplDT8aqShlNqCwlNlR60=
-github.com/denis-tingajkin/go-header v0.4.1/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
+github.com/denis-tingajkin/go-header v0.4.2 h1:jEeSF4sdv8/3cT/WY8AgDHUoItNSoEZ7qg9dX7pc218=
+github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

This PR updates dependency on the go-header linter to [v0.4.2](https://github.com/denis-tingajkin/go-header/releases/tag/v0.4.2)

https://github.com/denis-tingajkin/go-header/compare/v0.4.1...v0.4.2
