### PR TITLE
Documentation on contributing

### DIFF
--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -19,8 +19,8 @@ After that:
 3. Add the new struct for the linter (which you've implemented in `pkg/golinters/{yourlintername}.go`) to the
    list of all supported linters in [`pkg/lint/lintersdb/manager.go`](https://github.com/golangci/golangci-lint/blob/master/pkg/lint/lintersdb/manager.go)
    to the function `GetAllSupportedLinterConfigs`. Enable it by default only if you are sure.
-4. Find out what options do you need to configure for the linter. For example, `govet` has
-   only 1 option: [`check-shadowing`](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml).
+4. Find out what options do you need to configure for the linter. For example, `nakedret` has
+   only 1 option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml).
    Choose default values to not being annoying for users of golangci-lint. Add configuration options to:
 
 - [.golangci.example.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml) - the example of a configuration file. You can also add


### PR DESCRIPTION
This PR fix the reference to `govet` in contributing docs as linter that has one option. Not critical, just cleaning. 
