### PR TITLE
Add docs on using homebrew tap

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -57,7 +57,7 @@ Note: Previously we used a [homebrew tap](https://github.com/golangci/homebrew-t
 isn't immediately available via homebrew core due to manual updates that need to occur from homebrew core maintainers. In this case, the tap formula, which is updated automatically,
 can be used to install the latest version of `golangci-lint`:
 
-```
+```sh
 brew tap golangci/tap
 brew install golangci/tap/golangci-lint
 ```

--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -53,7 +53,14 @@ brew install golangci-lint
 brew upgrade golangci-lint
 ```
 
-Note: previously we use [tap](https://github.com/golangci/homebrew-tap), but it is obsoleted. We recommend using official formula instead of an obsolete tap.
+Note: Previously we used a [homebrew tap](https://github.com/golangci/homebrew-tap). We recommend using official formula instead of the tap, but sometimes the most recent release 
+isn't immediately available via homebrew core due to manual updates that need to occur from homebrew core maintainers. In this case, the tap formula, which is updated automatically,
+can be used to install the latest version of `golangci-lint`:
+
+```
+brew tap golangci/tap
+brew install golangci/tap/golangci-lint
+```
 
 It can also be installed through [macports](https://www.macports.org/)
 The macports installation mode is community driven, and not officially maintained by golangci team.


### PR DESCRIPTION
While use of the tap is discouraged, there are times that homebrew core doesn't immediately update the formula to the latest version. This provides docs on using the tap to help get the latest released quicker through brew.

An example of this is recently as brew install only installs v1.33 at the moment. 