### PR TITLE
fix(cmd/linters): truncate multiline descriptions

### DIFF
--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -45,8 +45,16 @@ func printLinterConfigs(lcs []*linter.Config) {
 		if len(lc.AlternativeNames) != 0 {
 			altNamesStr = fmt.Sprintf(" (%s)", strings.Join(lc.AlternativeNames, ", "))
 		}
+
+		// If the linter description spans multiple lines, truncate everything following the first newline
+		linterDescription := lc.Linter.Desc()
+		firstNewline := strings.IndexRune(linterDescription, '\n')
+		if firstNewline > 0 {
+			linterDescription = linterDescription[:firstNewline]
+		}
+
 		fmt.Fprintf(logutils.StdOut, "%s%s: %s [fast: %t, auto-fix: %t]\n", color.YellowString(lc.Name()),
-			altNamesStr, lc.Linter.Desc(), !lc.IsSlowLinter(), lc.CanAutoFix)
+			altNamesStr, linterDescription, !lc.IsSlowLinter(), lc.CanAutoFix)
 	}
 }
 


### PR DESCRIPTION
For any linters that have a multiline description, displaying such as part of the `golangci-lint linters` output can be confusing, especially without colourised output on your terminal.

Fixes #1594.