### PR TITLE
Print error message and exit with non-zero status when ruleguard parse error occurs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/denis-tingajkin/go-header v0.4.2
 	github.com/esimonov/ifshort v1.0.0
 	github.com/fatih/color v1.10.0
-	github.com/go-critic/go-critic v0.5.3
+	github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4
 	github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b
 	github.com/gofrs/flock v0.8.0
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/denis-tingajkin/go-header v0.4.2
 	github.com/esimonov/ifshort v1.0.0
 	github.com/fatih/color v1.10.0
-	github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4
+	github.com/go-critic/go-critic v0.5.4
 	github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b
 	github.com/gofrs/flock v0.8.0
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2

--- a/go.sum
+++ b/go.sum
@@ -69,10 +69,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-critic/go-critic v0.5.3 h1:xQEweNxzBNpSqI3wotXZAixRarETng3PTG4pkcrLCOA=
-github.com/go-critic/go-critic v0.5.3/go.mod h1:2Lrs1m4jtOnnG/EdezbSpAoL0F2pRW+9HWJUZ+QaktY=
-github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4 h1:73zIKiNknr7JRuAu0LPz1DQJgb9GtSTUy6mXDN72bCk=
-github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4/go.mod h1:cjB4YGw+n/+X8gREApej7150Uyy1Tg8If6F2XOAUXNE=
 github.com/go-critic/go-critic v0.5.4 h1:fPNMqImVjELN6Du7NVVuvKA4cgASNmc7e4zSYQCOnv8=
 github.com/go-critic/go-critic v0.5.4/go.mod h1:cjB4YGw+n/+X8gREApej7150Uyy1Tg8If6F2XOAUXNE=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -337,8 +333,6 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c h1:JoUA0uz9U0FVFq5p4LjEq4C0VgQ0El320s3Ms0V4eww=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
-github.com/quasilyte/go-ruleguard v0.2.1-0.20201030093329-408e96760278 h1:5gcJ7tORNCNB2QjOJF+MYjzS9aiWpxhP3gntf7RVrOQ=
-github.com/quasilyte/go-ruleguard v0.2.1-0.20201030093329-408e96760278/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8+1G3Rs2fxmlYnw=
 github.com/quasilyte/go-ruleguard v0.3.0 h1:A3OfpsK2ynOTbz/KMi62qWzignjGCOZVChATSf4P+A0=
 github.com/quasilyte/go-ruleguard v0.3.0/go.mod h1:p2miAhLp6fERzFNbcuQ4bevXs8rgK//uCHsUDkumITg=
 github.com/quasilyte/go-ruleguard/dsl v0.0.0-20210106184943-e47d54850b18/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
@@ -598,7 +592,6 @@ golang.org/x/tools v0.0.0-20201001104356-43ebab892c4c/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/tools v0.0.0-20201002184944-ecd9fd270d5d/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201011145850-ed2f50202694/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201028025901-8cd080b735b3/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20201030010431-2feb2bb1ff51/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201114224030-61ea331ec02b/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394 h1:O3VD5Fds21mB1WVRTbkiz/HTXESx6Jql5ucPZi69oiM=
 golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/go-critic/go-critic v0.5.3 h1:xQEweNxzBNpSqI3wotXZAixRarETng3PTG4pkcr
 github.com/go-critic/go-critic v0.5.3/go.mod h1:2Lrs1m4jtOnnG/EdezbSpAoL0F2pRW+9HWJUZ+QaktY=
 github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4 h1:73zIKiNknr7JRuAu0LPz1DQJgb9GtSTUy6mXDN72bCk=
 github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4/go.mod h1:cjB4YGw+n/+X8gREApej7150Uyy1Tg8If6F2XOAUXNE=
+github.com/go-critic/go-critic v0.5.4 h1:fPNMqImVjELN6Du7NVVuvKA4cgASNmc7e4zSYQCOnv8=
+github.com/go-critic/go-critic v0.5.4/go.mod h1:cjB4YGw+n/+X8gREApej7150Uyy1Tg8If6F2XOAUXNE=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-critic/go-critic v0.5.3 h1:xQEweNxzBNpSqI3wotXZAixRarETng3PTG4pkcrLCOA=
 github.com/go-critic/go-critic v0.5.3/go.mod h1:2Lrs1m4jtOnnG/EdezbSpAoL0F2pRW+9HWJUZ+QaktY=
+github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4 h1:73zIKiNknr7JRuAu0LPz1DQJgb9GtSTUy6mXDN72bCk=
+github.com/go-critic/go-critic v0.5.4-0.20210131194654-6090d88757f4/go.mod h1:cjB4YGw+n/+X8gREApej7150Uyy1Tg8If6F2XOAUXNE=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -88,6 +90,7 @@ github.com/go-toolsmith/astequal v1.0.0 h1:4zxD8j3JRFNyLN46lodQuqz3xdKSrur7U/sr0
 github.com/go-toolsmith/astequal v1.0.0/go.mod h1:H+xSiq0+LtiDC11+h1G32h7Of5O3CYFJ99GVbS5lDKY=
 github.com/go-toolsmith/astfmt v1.0.0 h1:A0vDDXt+vsvLEdbMFJAUBI/uTbRw1ffOPnxsILnFL6k=
 github.com/go-toolsmith/astfmt v1.0.0/go.mod h1:cnWmsOAuq4jJY6Ct5YWlVLmcmLMn1JUPuQIHCY7CJDw=
+github.com/go-toolsmith/astinfo v0.0.0-20180906194353-9809ff7efb21 h1:wP6mXeB2V/d1P1K7bZ5vDUO3YqEzcvOREOxZPEu3gVI=
 github.com/go-toolsmith/astinfo v0.0.0-20180906194353-9809ff7efb21/go.mod h1:dDStQCHtmZpYOmjRP/8gHHnCCch3Zz3oEgCdZVdtweU=
 github.com/go-toolsmith/astp v1.0.0 h1:alXE75TXgcmupDsMK1fRAy0YUzLzqPVvBKoyWV+KPXg=
 github.com/go-toolsmith/astp v1.0.0/go.mod h1:RSyrtpVlfTFGDYRbrjyWP1pYu//tSFcvdYrA8meBmLI=
@@ -261,6 +264,7 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/goveralls v0.0.2 h1:7eJB6EqsPhRVxvwEXGnqdO2sJI0PTsrWoTMXEk9/OQc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mbilski/exhaustivestruct v1.1.0 h1:4ykwscnAFeHJruT+EY3M3vdeP8uXMh0VV2E61iR7XD8=
@@ -329,9 +333,16 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c h1:JoUA0uz9U0FVFq5p4LjEq4C0VgQ0El320s3Ms0V4eww=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.2.1-0.20201030093329-408e96760278 h1:5gcJ7tORNCNB2QjOJF+MYjzS9aiWpxhP3gntf7RVrOQ=
 github.com/quasilyte/go-ruleguard v0.2.1-0.20201030093329-408e96760278/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8+1G3Rs2fxmlYnw=
+github.com/quasilyte/go-ruleguard v0.3.0 h1:A3OfpsK2ynOTbz/KMi62qWzignjGCOZVChATSf4P+A0=
+github.com/quasilyte/go-ruleguard v0.3.0/go.mod h1:p2miAhLp6fERzFNbcuQ4bevXs8rgK//uCHsUDkumITg=
+github.com/quasilyte/go-ruleguard/dsl v0.0.0-20210106184943-e47d54850b18/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/quasilyte/go-ruleguard/dsl v0.0.0-20210115110123-c73ee1cbff1f h1:e+uECJCDesYxvHKYsB1xWY/WpReTQoN6F14Nhny2Vik=
+github.com/quasilyte/go-ruleguard/dsl v0.0.0-20210115110123-c73ee1cbff1f/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95 h1:L8QM9bvf68pVdQ3bCFZMDmnt9yqcMBro1pC7F+IPYMY=
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -118,23 +118,22 @@ func buildEnabledCheckers(lintCtx *linter.Context, linterCtx *gocriticlinter.Con
 			continue
 		}
 
-		err := func() (err error) {
+		if err := func() (er error) {
 			defer func() {
 				// Recover when a gocritic checker panics during initialization.
 				// In particular, this can happen if the ruleguard 'failOnError' flag is set to true
 				// and one or more ruleguard input rules have a syntax error.
 				if r := recover(); r != nil {
-					err = fmt.Errorf("gocritic checker '%v' initialization failed: %v", info.Name, r)
+					er = fmt.Errorf("gocritic checker '%v' initialization failed: %v", info.Name, r)
 				}
 			}()
-			if err = configureCheckerInfo(info, allParams); err != nil {
-				return err
+			if er = configureCheckerInfo(info, allParams); er != nil {
+				return er
 			}
 			c := gocriticlinter.NewChecker(linterCtx, info)
 			enabledCheckers = append(enabledCheckers, c)
 			return nil
-		}()
-		if err != nil {
+		}(); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -122,11 +122,11 @@ func buildEnabledCheckers(lintCtx *linter.Context, linterCtx *gocriticlinter.Con
 			return nil, err
 		}
 
-		if c, err := gocriticlinter.NewChecker(linterCtx, info); err != nil {
+		c, err := gocriticlinter.NewChecker(linterCtx, info)
+		if err != nil {
 			return nil, err
-		} else {
-			enabledCheckers = append(enabledCheckers, c)
 		}
+		enabledCheckers = append(enabledCheckers, c)
 	}
 
 	return enabledCheckers, nil

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -118,17 +118,17 @@ func buildEnabledCheckers(lintCtx *linter.Context, linterCtx *gocriticlinter.Con
 			continue
 		}
 
-		if err := func() (er error) {
+		if err := func() (err error) {
 			defer func() {
 				// Recover when a gocritic checker panics during initialization.
 				// In particular, this can happen if the ruleguard 'failOnError' flag is set to true
 				// and one or more ruleguard input rules have a syntax error.
 				if r := recover(); r != nil {
-					er = fmt.Errorf("gocritic checker '%v' initialization failed: %v", info.Name, r)
+					err = fmt.Errorf("gocritic checker '%v' initialization failed: %v", info.Name, r)
 				}
 			}()
-			if er = configureCheckerInfo(info, allParams); er != nil {
-				return er
+			if err := configureCheckerInfo(info, allParams); err != nil {
+				return err
 			}
 			c := gocriticlinter.NewChecker(linterCtx, info)
 			enabledCheckers = append(enabledCheckers, c)

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -117,9 +117,11 @@ func buildEnabledCheckers(lintCtx *linter.Context, linterCtx *gocriticlinter.Con
 		if !s.IsCheckEnabled(info.Name) {
 			continue
 		}
+
 		if err := configureCheckerInfo(info, allParams); err != nil {
 			return nil, err
 		}
+
 		if c, err := gocriticlinter.NewChecker(linterCtx, info); err != nil {
 			return nil, err
 		} else {

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -117,24 +117,13 @@ func buildEnabledCheckers(lintCtx *linter.Context, linterCtx *gocriticlinter.Con
 		if !s.IsCheckEnabled(info.Name) {
 			continue
 		}
-
-		if err := func() (err error) {
-			defer func() {
-				// Recover when a gocritic checker panics during initialization.
-				// In particular, this can happen if the ruleguard 'failOnError' flag is set to true
-				// and one or more ruleguard input rules have a syntax error.
-				if r := recover(); r != nil {
-					err = fmt.Errorf("gocritic checker '%v' initialization failed: %v", info.Name, r)
-				}
-			}()
-			if err := configureCheckerInfo(info, allParams); err != nil {
-				return err
-			}
-			c := gocriticlinter.NewChecker(linterCtx, info)
-			enabledCheckers = append(enabledCheckers, c)
-			return nil
-		}(); err != nil {
+		if err := configureCheckerInfo(info, allParams); err != nil {
 			return nil, err
+		}
+		if c, err := gocriticlinter.NewChecker(linterCtx, info); err != nil {
+			return nil, err
+		} else {
+			enabledCheckers = append(enabledCheckers, c)
 		}
 	}
 


### PR DESCRIPTION
This PR ensures that parsing errors of `ruleguard` input rules are caught; in that case, golangci-lint will print a human-friendly error message (include file name and line number) and exit with non-zero status. Without this PR, a verbose stack trace is printed.

The ruleguard checker makes it possible to write dynamic rules, which means the rules files may have syntax errors that need to be caught. When a ruleguard parsing error occurs, golangci-lint will print the following message and exit.
```bash
ERRO Running error: gocritic: gocritic checker 'ruleguard' initialization failed:
ruleguard init error: parse file error: rules.go:18:1: expected declaration, found FOO 
```
The actual error is raised when the `failOnError` flag is set to true in the golangci.yaml file, as explained in https://github.com/go-critic/go-critic/pull/1015.

1. When failOnError is set to false (default), a ruleguard file that contains at least one syntax error is skipped.
1. When failOnError is set to true, a panic occurs if at least one ruleguard file contains a syntax error.

As of 01/25/2021, the latest `goangci-lint` release is v1.35.2. It uses gocritic v0.5.3, which does not have the new `failOnError` flag yet, but the https://github.com/go-critic/go-critic/pull/1015 PR has already been merged to gocritic master. The error handling will be enabled in golangci-lint when 1) a new version of gocritic is released with support for the `failOnError` flag; and 2) golangci-lint needs to be bumped to the new gocritic version. 

Fixes #1565

Without this PR, a verbose stack trace is printed as shown below.

```bash
WARN [linters context] Panic: gocritic: package "mos" (isInitialPkg: true, needAnalyzeSource: true): ruleguard init error: parse file error: /home/USER/goroot/src/REPO/gorules/rules.go:18:1: expected declaration, found FOO: goroutine 11646 [running]:
runtime/debug.Stack(0x12e2c7a, 0x3c, 0xc00e3bf558)
	/usr/lib/golang/src/runtime/debug/stack.go:24 +0x9f
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1(0xc00235d950)
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner.go:508 +0x1be
panic(0x10e5640, 0xc004bc3ae0)
	/usr/lib/golang/src/runtime/panic.go:969 +0x1b9
log.Panicf(0x12c08a3, 0x19, 0xc00e3bf8f0, 0x1, 0x1)
	/usr/lib/golang/src/log/log.go:358 +0xc5
github.com/go-critic/go-critic/checkers.newRuleguardChecker(0xc0000be090, 0xc000900308, 0xc00b470088)
	/home/USER/goroot/pkg/mod/github.com/go-critic/go-critic@v0.0.0-20210122221838-51cc26ffe53d/checkers/ruleguard_checker.go:93 +0x775
github.com/go-critic/go-critic/checkers.init.55.func1(0xc000900308, 0xc00b470088, 0x21)
	/home/USER/goroot/pkg/mod/github.com/go-critic/go-critic@v0.0.0-20210122221838-51cc26ffe53d/checkers/ruleguard_checker.go:43 +0x34
github.com/go-critic/go-critic/framework/linter.addChecker.func2(0xc00e1d3c20, 0xc0001a0b70)
	/home/USER/goroot/pkg/mod/github.com/go-critic/go-critic@v0.0.0-20210122221838-51cc26ffe53d/framework/linter/checkers_db.go:78 +0xd2
github.com/go-critic/go-critic/framework/linter.newChecker(0xc00e1d3c20, 0xc0008f6a20, 0x0)
	/home/USER/goroot/pkg/mod/github.com/go-critic/go-critic@v0.0.0-20210122221838-51cc26ffe53d/framework/linter/checkers_db.go:91 +0x71
github.com/go-critic/go-critic/framework/linter.NewChecker(...)
	/home/USER/goroot/pkg/mod/github.com/go-critic/go-critic@v0.0.0-20210122221838-51cc26ffe53d/framework/linter/lintpack.go:143
github.com/golangci/golangci-lint/pkg/golinters.buildEnabledCheckers(0xc000268af0, 0xc00e1d3c20, 0x0, 0xc00089a140, 0xc004dba1e0, 0xc0019bdcd0, 0xc0019bdc38)
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/gocritic.go:131 +0x23a
github.com/golangci/golangci-lint/pkg/golinters.NewGocritic.func1.1(0xc00e1cef70, 0x102d4f7c0, 0x1c531a0, 0xc00004c388, 0x2)
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/gocritic.go:42 +0x11f
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc00235d950)
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner.go:590 +0xa83
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner.go:512 +0x2a
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0016e0f00, 0x1246c94, 0x8, 0xc0028a3f70)
	/home/USER/goroot/src/github.com/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x50
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc00235d950)
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner.go:511 +0x91
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0xc00de4aad0, 0xc00235d950)
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner.go:1059 +0x65
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
	/home/USER/goroot/src/github.com/golangci-lint/pkg/golinters/goanalysis/runner.go:1054 +0x305 
WARN [runner] Can't run linter goanalysis_metalinter: goanalysis_metalinter: gocritic: package "mos" (isInitialPkg: true, needAnalyzeSource: true): ruleguard init error: parse file error: /home/USER/goroot/src/REPO/gorules/rules.go:18:1: expected declaration, found FOO 
ERRO Running error: goanalysis_metalinter: gocritic: package "mos" (isInitialPkg: true, needAnalyzeSource: true): ruleguard init error: parse file error: /home/USER/goroot/src/REPO/gorules/rules.go:18:1: expected declaration, found FOO 
```