### PR TITLE
Add "exclude" option for godot linter

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -193,6 +193,10 @@ linters-settings:
   godot:
     # comments to be checked: `declarations`, `toplevel`, or `all`
     scope: declarations
+    # list of regexps for excluding particular comment lines from check
+    exclude:
+      # example: exclude comments which contain numbers
+      # - '[0-9]+'
     # check that each sentence starts with a capital letter
     capital: false
   godox:
@@ -294,7 +298,7 @@ linters-settings:
       # specify an error message to output when a blacklisted package is used
       - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   ifshort:
-    # Maximum length of variable declaration measured in number of lines, after which linter won't suggest using short syntax. 
+    # Maximum length of variable declaration measured in number of lines, after which linter won't suggest using short syntax.
     # Has higher priority than max-decl-chars.
     max-decl-lines: 1
     # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -356,8 +356,9 @@ type WSLSettings struct {
 }
 
 type GodotSettings struct {
-	Scope   string `mapstructure:"scope"`
-	Capital bool   `mapstructure:"capital"`
+	Scope   string   `mapstructure:"scope"`
+	Exclude []string `mapstructure:"exclude"`
+	Capital bool     `mapstructure:"capital"`
 
 	// Deprecated: use `Scope` instead
 	CheckAll bool `mapstructure:"check-all"`

--- a/pkg/golinters/godot.go
+++ b/pkg/golinters/godot.go
@@ -30,6 +30,7 @@ func NewGodot() *goanalysis.Linter {
 		cfg := lintCtx.Cfg.LintersSettings.Godot
 		settings := godot.Settings{
 			Scope:   godot.Scope(cfg.Scope),
+			Exclude: cfg.Exclude,
 			Period:  true,
 			Capital: cfg.Capital,
 		}


### PR DESCRIPTION
This option already exists in godot linter. I just made it available in golangci-lint config.