### PR TITLE
ifshort: add missing configuration.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -485,6 +485,10 @@ var defaultLintersSettings = LintersSettings{
 	ErrorLint: ErrorLintSettings{
 		Errorf: true,
 	},
+	Ifshort: IfshortSettings{
+		MaxDeclLines: 1,
+		MaxDeclChars: 30,
+	},
 	Predeclared: PredeclaredSettings{
 		Ignore:    "",
 		Qualified: false,

--- a/pkg/golinters/ifshort.go
+++ b/pkg/golinters/ifshort.go
@@ -4,14 +4,25 @@ import (
 	"github.com/esimonov/ifshort/pkg/analyzer"
 	"golang.org/x/tools/go/analysis"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-func NewIfshort() *goanalysis.Linter {
+func NewIfshort(settings *config.IfshortSettings) *goanalysis.Linter {
+	var cfg map[string]map[string]interface{}
+	if settings != nil {
+		cfg = map[string]map[string]interface{}{
+			analyzer.Analyzer.Name: {
+				"max-decl-lines": settings.MaxDeclLines,
+				"max-decl-chars": settings.MaxDeclChars,
+			},
+		}
+	}
+
 	return goanalysis.NewLinter(
 		"ifshort",
 		"Checks that your code uses short syntax for if-statements whenever possible",
 		[]*analysis.Analyzer{analyzer.Analyzer},
-		nil,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -95,6 +95,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var errorlintCfg *config.ErrorLintSettings
 	var thelperCfg *config.ThelperSettings
 	var predeclaredCfg *config.PredeclaredSettings
+	var ifshortCfg *config.IfshortSettings
 	if m.cfg != nil {
 		govetCfg = &m.cfg.LintersSettings.Govet
 		testpackageCfg = &m.cfg.LintersSettings.Testpackage
@@ -102,6 +103,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		errorlintCfg = &m.cfg.LintersSettings.ErrorLint
 		thelperCfg = &m.cfg.LintersSettings.Thelper
 		predeclaredCfg = &m.cfg.LintersSettings.Predeclared
+		ifshortCfg = &m.cfg.LintersSettings.Ifshort
 	}
 	const megacheckName = "megacheck"
 	lcs := []*linter.Config{
@@ -344,7 +346,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewForbidigo()).
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/ashanbrown/forbidigo"),
-		linter.NewConfig(golinters.NewIfshort()).
+		linter.NewConfig(golinters.NewIfshort(ifshortCfg)).
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/esimonov/ifshort"),
 		linter.NewConfig(golinters.NewPredeclared(predeclaredCfg)).


### PR DESCRIPTION
the configuration is not linked to the linter flags.