### PR TITLE
Add plugin option for Goland

### DIFF
--- a/docs/src/docs/usage/integrations.mdx
+++ b/docs/src/docs/usage/integrations.mdx
@@ -19,6 +19,7 @@ title: Integrations
 
 2. Sublime Text - [plugin](https://github.com/alecthomas/SublimeLinter-contrib-golang-cilint) for SublimeLinter.
 3. GoLand
+   - Install [plugin](https://plugins.jetbrains.com/plugin/12496-go-linter)
    - Add [File Watcher](https://www.jetbrains.com/help/go/settings-tools-file-watchers.html) using existing `golangci-lint` template.
    - If your version of GoLand does not have the `golangci-lint` [File Watcher](https://www.jetbrains.com/help/go/settings-tools-file-watchers.html) template you can configure your own and use arguments `run --disable=typecheck $FileDir$`.
 4. GNU Emacs


### PR DESCRIPTION
I'm writing a plugin for Goland to support `golangci-lint` inline, also providing possible quick fixes: https://github.com/xxpxxxxp/intellij-plugin-golangci-lint
Should be stable now, I'd like to suggest it as an option for Goland users.
Thank you all authors, `golangci-lint` is widely used in my org and improved code quality significantly.