### PR TITLE
fix: wrong load mode

### DIFF
--- a/pkg/golinters/asciicheck.go
+++ b/pkg/golinters/asciicheck.go
@@ -15,5 +15,5 @@ func NewAsciicheck() *goanalysis.Linter {
 			asciicheck.NewAnalyzer(),
 		},
 		nil,
-	)
+	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -201,6 +201,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL(""),
 		linter.NewConfig(golinters.NewAsciicheck()).
 			WithPresets(linter.PresetBugs, linter.PresetStyle).
+			WithLoadForGoAnalysis().
 			WithURL("https://github.com/tdakkota/asciicheck"),
 
 		linter.NewConfig(golinters.NewGofmt()).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -345,6 +345,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/kunwardeep/paralleltest"),
 		linter.NewConfig(golinters.NewMakezero()).
 			WithPresets(linter.PresetStyle, linter.PresetBugs).
+			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ashanbrown/makezero"),
 		linter.NewConfig(golinters.NewForbidigo()).
 			WithPresets(linter.PresetStyle).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -333,6 +333,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/moricho/tparallel"),
 		linter.NewConfig(golinters.NewExhaustiveStruct()).
 			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
 			WithURL("https://github.com/mbilski/exhaustivestruct"),
 		linter.NewConfig(golinters.NewErrorLint(errorlintCfg)).
 			WithPresets(linter.PresetBugs).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -305,6 +305,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/nakabonne/nestif"),
 		linter.NewConfig(golinters.NewExportLoopRef()).
 			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kyoh86/exportloopref"),
 		linter.NewConfig(golinters.NewExhaustive(exhaustiveCfg)).
 			WithPresets(linter.PresetBugs).

--- a/test/testdata/asciicheck.go
+++ b/test/testdata/asciicheck.go
@@ -1,4 +1,8 @@
 //args: -Easciicheck
 package testdata
 
-type TеstStruct struct{} // ERROR `identifier "TеstStruct" contain non-ASCII character: U\+0435 'е'`
+import "time"
+
+type TеstStruct struct { // ERROR `identifier "TеstStruct" contain non-ASCII character: U\+0435 'е'`
+	Date time.Time
+}

--- a/test/testdata/exhaustivestruct.go
+++ b/test/testdata/exhaustivestruct.go
@@ -1,11 +1,14 @@
 //args: -Eexhaustivestruct
 package testdata
 
+import "time"
+
 type Test struct {
 	A string
 	B int
 	c bool // private field inside the same package are not ignored
 	D float64
+	E time.Time
 }
 
 var pass = Test{
@@ -13,21 +16,25 @@ var pass = Test{
 	B: 0,
 	c: false,
 	D: 1.0,
+	E: time.Now(),
 }
 
 var failPrivate = Test{ // ERROR "c is missing in Test"
 	A: "a",
 	B: 0,
 	D: 1.0,
+	E: time.Now(),
 }
 
 var fail = Test{ // ERROR "B is missing in Test"
 	A: "a",
 	c: false,
 	D: 1.0,
+	E: time.Now(),
 }
 
 var failMultiple = Test{ // ERROR "B, D are missing in Test"
 	A: "a",
 	c: false,
+	E: time.Now(),
 }

--- a/test/testdata/exportloopref.go
+++ b/test/testdata/exportloopref.go
@@ -1,13 +1,15 @@
 //args: -Eexportloopref
 package testdata
 
+import "fmt"
+
 func dummyFunction() {
 	var array [4]*int
 	var slice []*int
 	var ref *int
 	var str struct{ x *int }
 
-	println("loop expecting 10, 11, 12, 13")
+	fmt.Println("loop expecting 10, 11, 12, 13")
 	for i, p := range []int{10, 11, 12, 13} {
 		printp(&p)
 		slice = append(slice, &p) // ERROR "exporting a pointer for the loop variable p"
@@ -27,18 +29,18 @@ func dummyFunction() {
 		_ = v
 	}
 
-	println(`slice expecting "10, 11, 12, 13" but "13, 13, 13, 13"`)
+	fmt.Println(`slice expecting "10, 11, 12, 13" but "13, 13, 13, 13"`)
 	for _, p := range slice {
 		printp(p)
 	}
-	println(`array expecting "10, 11, 12, 13" but "13, 13, 13, 13"`)
+	fmt.Println(`array expecting "10, 11, 12, 13" but "13, 13, 13, 13"`)
 	for _, p := range array {
 		printp(p)
 	}
-	println(`captured value expecting "12" but "13"`)
+	fmt.Println(`captured value expecting "12" but "13"`)
 	printp(ref)
 }
 
 func printp(p *int) {
-	println(*p)
+	fmt.Println(*p)
 }

--- a/test/testdata/makezero.go
+++ b/test/testdata/makezero.go
@@ -1,12 +1,14 @@
 //args: -Emakezero
 package testdata
 
+import "math"
+
 func Makezero() []int {
-	x := make([]int, 5)
+	x := make([]int, math.MaxInt8)
 	return append(x, 1) // ERROR "append to slice `x` with non-zero initialized length"
 }
 
 func MakezeroNolint() []int {
-	x := make([]int, 5)
+	x := make([]int, math.MaxInt8)
 	return append(x, 1) //nolint:makezero // ok that we're appending to an uninitialized slice
 }

--- a/test/testdata/makezero_always.go
+++ b/test/testdata/makezero_always.go
@@ -2,12 +2,14 @@
 //config: linters-settings.makezero.always=true
 package testdata
 
+import "math"
+
 func MakezeroAlways() []int {
-	x := make([]int, 5) // ERROR "slice `x` does not have non-zero initial length"
+	x := make([]int, math.MaxInt8) // ERROR "slice `x` does not have non-zero initial length"
 	return x
 }
 
 func MakezeroAlwaysNolint() []int {
-	x := make([]int, 5) //nolint:makezero // ok that this is not initialized
+	x := make([]int, math.MaxInt8) //nolint:makezero // ok that this is not initialized
 	return x
 }


### PR DESCRIPTION
Fixes #1515

I tested all the linters.

To avoid that in the future, every testdata for a linter must contain at least one import.

Before the fix:

```console
$ go run ./cmd/golangci-lint/ run --no-config --disable-all --enable=asciicheck ./test/testdata/depguard.go 
WARN [runner] Can't run linter asciicheck: asciicheck: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
ERRO Running error: asciicheck: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
exit status 3
```

```console
$ go run ./cmd/golangci-lint/ run --no-config --disable-all --enable=exhaustivestruct ./test/testdata/depguard.go
WARN [runner] Can't run linter exhaustivestruct: inspect: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
ERRO Running error: inspect: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
exit status 3
```

```console
$ go run ./cmd/golangci-lint/ run --no-config --disable-all --enable=exportloopref ./test/testdata/depguard.go
WARN [runner] Can't run linter exportloopref: inspect: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
ERRO Running error: inspect: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
exit status 3
```

```console
$ go run ./cmd/golangci-lint/ run --no-config --disable-all --enable=makezero ./test/testdata/depguard.go
WARN [runner] Can't run linter makezero: makezero: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
ERRO Running error: makezero: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:6:2: could not import compress/gzip (Config.Importer.Import(compress/gzip) returned nil but no error) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/test/testdata/depguard.go:7:2: could not import log (Config.Importer.Import(log) returned nil but no error)] 
exit status 3
```