### PR TITLE
Add go1.16 support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Check go mod
@@ -41,7 +41,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15 # test only the latest go version to speed up CI
+          go-version: 1.16 # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
         continue-on-error: true
@@ -53,7 +53,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15 # test only the latest go version to speed up CI
+          go-version: 1.16 # test only the latest go version to speed up CI
       - name: Run tests
         run: make test
   tests-on-unix:
@@ -62,9 +62,9 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.13
           - 1.14
           - 1.15
+          - 1.16
     steps:
       - uses: actions/checkout@v2
       - name: Install Go
@@ -92,6 +92,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check generated files are up to date
         run: make fast_check_generated

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ fast_generate: assets/github-action-config.json
 
 fast_check_generated:
 	$(MAKE) --always-make fast_generate
-	git checkout -- go.mod go.sum # can differ between go1.12 and go1.13
+	git checkout -- go.mod go.sum # can differ between go1.15 and go1.16
 	git diff --exit-code # check no changes
 
 release: .goreleaser.yml tools/goreleaser
@@ -78,7 +78,8 @@ assets/demo.svg: tools/svg-term tools/Dracula.itermcolors
 	./tools/svg-term --cast=183662 --out assets/demo.svg --window --width 110 --height 30 --from 2000 --to 20000 --profile ./tools/Dracula.itermcolors --term iterm2
 
 assets/github-action-config.json: FORCE golangci-lint
-	go run ./scripts/gen_github_action_config/main.go $@
+	# go run ./scripts/gen_github_action_config/main.go $@
+	cd ./scripts/gen_github_action_config/; go run ./main.go ../../$@
 
 go.mod: FORCE
 	go mod tidy

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -10,7 +10,7 @@ WORKDIR /golangci
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.15
+FROM golang:1.16
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/Dockerfile.alpine
+++ b/build/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.15-alpine as builder
+FROM golang:1.16-alpine as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -15,7 +15,7 @@ RUN apk --no-cache add gcc musl-dev git mercurial
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.15-alpine
+FROM golang:1.16-alpine
 # gcc is required to support cgo;
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
-github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-toolsmith/astcast v1.0.0 h1:JojxlmI6STnFVG9yOImLeGREv8W2ocNUM+iOhR6jE7g=
@@ -213,7 +212,6 @@ github.com/jingyugao/rowserrcheck v0.0.0-20210130005344-c6a0c12dd98d h1:BYDZtm80
 github.com/jingyugao/rowserrcheck v0.0.0-20210130005344-c6a0c12dd98d/go.mod h1:/EZlaYCnEX24i7qdVhT9du5JrtFWYRQr67bVgR7JJC8=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3 h1:jNYPNLe3d8smommaoQlK7LOA5ESyUJJ+Wf79ZtA7Vp4=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
-github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -241,7 +239,6 @@ github.com/kunwardeep/paralleltest v1.0.2/go.mod h1:ZPqNm1fVHPllh5LPVujzbVz1JN2G
 github.com/kyoh86/exportloopref v0.1.8 h1:5Ry/at+eFdkX9Vsdw3qU4YkvGtzuVfzT4X7S77LoN/M=
 github.com/kyoh86/exportloopref v0.1.8/go.mod h1:1tUcJeiioIs7VWe5gcOObrux3lb66+sBqGZrRkMwPgg=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
@@ -261,7 +258,6 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-sqlite3 v1.9.0 h1:pDRiWfl+++eC2FEFRy6jXmQlvp4Yh3z1MJKg4UeYM/4=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/test/testdata/govet.go
+++ b/test/testdata/govet.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Govet() error {
-	return &os.PathError{"first", "path", os.ErrNotExist} // ERROR "composites: `os.PathError` composite literal uses unkeyed fields"
+	return &os.PathError{"first", "path", os.ErrNotExist} // ERROR "composites: \\`io/fs.PathError\\` composite literal uses unkeyed fields"
 }
 
 func GovetShadow(f io.Reader, buf []byte) (err error) {

--- a/test/testdata/govet.go
+++ b/test/testdata/govet.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Govet() error {
-	return &os.PathError{"first", "path", os.ErrNotExist} // ERROR "composites: \\`(os|io/fs)?\\.PathError\\` composite literal uses unkeyed fields"
+	return &os.PathError{"first", "path", os.ErrNotExist} // ERROR "composites: \\`(os|io/fs)\\.PathError\\` composite literal uses unkeyed fields"
 }
 
 func GovetShadow(f io.Reader, buf []byte) (err error) {

--- a/test/testdata/govet.go
+++ b/test/testdata/govet.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Govet() error {
-	return &os.PathError{"first", "path", os.ErrNotExist} // ERROR "composites: \\`io/fs.PathError\\` composite literal uses unkeyed fields"
+	return &os.PathError{"first", "path", os.ErrNotExist} // ERROR "composites: \\`(os|io/fs)?\\.PathError\\` composite literal uses unkeyed fields"
 }
 
 func GovetShadow(f io.Reader, buf []byte) (err error) {

--- a/test/testdata/sqlclosecheck.go
+++ b/test/testdata/sqlclosecheck.go
@@ -6,15 +6,11 @@ import (
 	"database/sql"
 	"log"
 	"strings"
-
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/jmoiron/sqlx"
 )
 
 var (
 	ctx    context.Context
 	db     *sql.DB
-	dbx    *sqlx.DB
 	age    = 27
 	userID = 43
 )
@@ -258,85 +254,4 @@ func stmtReturn() (*sql.Stmt, error) {
 
 func stmtReturnShort() (*sql.Stmt, error) {
 	return db.PrepareContext(ctx, "SELECT username FROM users WHERE id = ?")
-}
-
-func sqlxCorrectDefer() {
-	rows, err := dbx.Queryx("SELECT name FROM users WHERE age=?", age)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer rows.Close()
-
-	names := make([]string, 0)
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			log.Fatal(err)
-		}
-		names = append(names, name)
-	}
-
-	// Check for errors from iterating over rows.
-	if err := rows.Err(); err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("%s are %d years old", strings.Join(names, ", "), age)
-}
-
-func sqlxNonDeferClose() {
-	rows, err := dbx.Queryx("SELECT name FROM users WHERE age=?", age)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	names := make([]string, 0)
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			log.Fatal(err)
-		}
-		names = append(names, name)
-	}
-
-	// Check for errors from iterating over rows.
-	if err := rows.Err(); err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("%s are %d years old", strings.Join(names, ", "), age)
-
-	rows.Close() // ERROR "Close should use defer"
-}
-
-func sqlxMissingClose() {
-	rows, err := dbx.Queryx("SELECT name FROM users WHERE age=?", age) // ERROR "Rows/Stmt was not closed"
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// defer rows.Close()
-
-	names := make([]string, 0)
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			log.Fatal(err)
-		}
-		names = append(names, name)
-	}
-
-	// Check for errors from iterating over rows.
-	if err := rows.Err(); err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("%s are %d years old", strings.Join(names, ", "), age)
-}
-
-func sqlxReturnRows() (*sqlx.Rows, error) {
-	rows, err := dbx.Queryx("SELECT name FROM users WHERE age=?", age)
-	if err != nil {
-		return nil, err
-	}
-
-	return rows, nil
 }


### PR DESCRIPTION
- drop go1.13
- add go1.16

We have to wait for the new alpine Docker image for go1.16 before merging the PR.
https://github.com/docker-library/official-images/pull/9639


Also, we will have to update the CI check requirements settings in GitHub

Fixes #1725