### PR TITLE
revive: fix types and default configuration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a
+	github.com/BurntSushi/toml v0.3.1
 	github.com/Djarvur/go-err113 v0.0.0-20200511133814-5174e21577d5
 	github.com/OpenPeeDeeP/depguard v1.0.1
 	github.com/alexkohler/prealloc v0.0.0-20210204145425-77a5b5dd9799

--- a/test/testdata/configs/revive.yml
+++ b/test/testdata/configs/revive.yml
@@ -5,3 +5,15 @@ linters-settings:
     rules:
       - name: indent-error-flow
         severity: warning
+      - name: cognitive-complexity
+        arguments: [ 7 ]
+      - name: line-length-limit
+        arguments: [ 110 ]
+      - name: function-result-limit
+        arguments: [ 3 ]
+      - name: argument-limit
+        arguments: [ 4 ]
+      - name: cyclomatic
+        arguments: [ 10 ]
+      - name: max-public-structs
+        arguments: [ 3 ]


### PR DESCRIPTION
Fixes #1745

The types are hardcoded, example: https://github.com/mgechev/revive/blob/389ba853b0b3587f0c3b71b5f0c61ea4e23928ec/rule/cognitive-complexity.go#L23

So to be able to get the expected types, the configuration will be marshaled to TOML and then the TOML will be unmarshaled to the expected configuration object.