### PR TITLE
Exclude PRs about doc dependencies from release changelog.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,6 +64,7 @@ changelog:
     - '^test:'
     - '^dev:'
     - 'README'
+    - 'build\(deps\): bump .* in /docs \(#\d+\)'
     - Merge pull request
     - Merge branch
 


### PR DESCRIPTION
Exclude PRs about doc dependencies from release changelog.

Example of the previous changelog: https://github.com/golangci/golangci-lint/releases/tag/v1.37.0