### PR TITLE
Deprecate maligned, add govet `fieldalignment` as replacement

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -297,6 +297,7 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
 
     # enable or disable analyzers by name
+    # run `go tool vet help` to see all analyzers
     enable:
       - atomicalign
     enable-all: false

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -15,6 +15,7 @@ import (
 	_ "golang.org/x/tools/go/analysis/passes/ctrlflow" // unused, internal analyzer
 	"golang.org/x/tools/go/analysis/passes/deepequalerrors"
 	"golang.org/x/tools/go/analysis/passes/errorsas"
+	"golang.org/x/tools/go/analysis/passes/fieldalignment"
 	"golang.org/x/tools/go/analysis/passes/findcall"
 	"golang.org/x/tools/go/analysis/passes/httpresponse"
 	"golang.org/x/tools/go/analysis/passes/ifaceassert"
@@ -55,6 +56,7 @@ var (
 		copylock.Analyzer,
 		deepequalerrors.Analyzer,
 		errorsas.Analyzer,
+		fieldalignment.Analyzer,
 		findcall.Analyzer,
 		httpresponse.Analyzer,
 		ifaceassert.Analyzer,

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -238,7 +238,8 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewMaligned()).
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetPerformance).
-			WithURL("https://github.com/mdempsky/maligned"),
+			WithURL("https://github.com/mdempsky/maligned").
+			Deprecated("The repository of the linter has been archived by the owner. Use govet 'fieldalignment' instead."),
 		linter.NewConfig(golinters.NewDepguard()).
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).

--- a/test/testdata/govet_fieldalignment.go
+++ b/test/testdata/govet_fieldalignment.go
@@ -1,0 +1,57 @@
+//args: -Egovet
+//config: linters-settings.govet.enable=fieldalignment
+package testdata
+
+type gvfaGood struct {
+	y int32
+	x byte
+	z byte
+}
+
+type gvfaBad struct { // ERROR "struct of size 12 could be 8"
+	x byte
+	y int32
+	z byte
+}
+
+type gvfaPointerGood struct {
+	P   *int
+	buf [1000]uintptr
+}
+
+type gvfaPointerBad struct { // ERROR "struct with 8008 pointer bytes could be 8"
+	buf [1000]uintptr
+	P   *int
+}
+
+type gvfaPointerSorta struct {
+	a struct {
+		p *int
+		q uintptr
+	}
+	b struct {
+		p *int
+		q [2]uintptr
+	}
+}
+
+type gvfaPointerSortaBad struct { // ERROR "struct with 32 pointer bytes could be 24"
+	a struct {
+		p *int
+		q [2]uintptr
+	}
+	b struct {
+		p *int
+		q uintptr
+	}
+}
+
+type gvfaZeroGood struct {
+	a [0]byte
+	b uint32
+}
+
+type gvfaZeroBad struct { // ERROR "struct of size 8 could be 4"
+	a uint32
+	b [0]byte
+}

--- a/test/testdata/maligned.go
+++ b/test/testdata/maligned.go
@@ -1,4 +1,4 @@
-//args: -Emaligned
+//args: -Emaligned --internal-cmd-test
 package testdata
 
 type BadAlignedStruct struct { // ERROR "struct of size 24 bytes could be of size 16 bytes"


### PR DESCRIPTION
Last week, [maligned has been deprecated](https://github.com/mdempsky/maligned).

The recommendation is to switch to https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment

Related to #1555

Currently, we don't support `SuggestedFixes` but it's a more global topic.