### PR TITLE
Update deprecated hyperlink for Sublime Text plugin.

### DIFF
--- a/docs/src/docs/usage/integrations.mdx
+++ b/docs/src/docs/usage/integrations.mdx
@@ -17,7 +17,7 @@ title: Integrations
    Using it in an editor without `--fast` can freeze your editor.
    Golangci-lint automatically discovers `.golangci.yml` config for edited file: you don't need to configure it in VS Code settings.
 
-2. Sublime Text - [plugin](https://github.com/alecthomas/SublimeLinter-contrib-golang-cilint) for SublimeLinter.
+2. Sublime Text - [plugin](https://github.com/SublimeLinter/SublimeLinter-golangcilint) for SublimeLinter.
 3. GoLand
    - Install [plugin](https://plugins.jetbrains.com/plugin/12496-go-linter)
    - Add [File Watcher](https://www.jetbrains.com/help/go/settings-tools-file-watchers.html) using existing `golangci-lint` template.


### PR DESCRIPTION
Updated existing `DEPRECATED` Sublime Text [plugin](https://github.com/alecthomas/SublimeLinter-contrib-golang-cilint) hyperlink  to new [SublimeLinter repo](https://github.com/SublimeLinter/SublimeLinter-golangcilint) location.