### PR TITLE
Fix go-header usage

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -231,7 +231,7 @@ linters-settings:
       regexp:
         # define here regexp type values, for example
         # AUTHOR: .*@mycompany\.com
-    template: # |
+    template: # |-
       # put here copyright header template for source code files, for example:
       # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
       #


### PR DESCRIPTION
There's a known behavior of YAML template blocks using `|` that they insert a trailing newline.
To remove it add `-` a.k.a block chomping indicator.

This would address some of the "weird" copyright header linting offenses that happen by following the example golangci-lint config by heart.

```
pkg/base64/service.go:13:34: Missed string: (goheader)
// limitations under the License.
                                 ^
pkg/hcl/test/testing.go:13:34: Missed string: (goheader)
// limitations under the License.
                                 ^
pkg/ini/service.go:13:34: Missed string: (goheader)
// limitations under the License.
                                 ^
```
                               