### PR TITLE
docs: update url of gocyclo linter

### DIFF
--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -201,7 +201,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/remyoudompheng/go-misc/tree/master/deadcode"),
 		linter.NewConfig(golinters.NewGocyclo()).
 			WithPresets(linter.PresetComplexity).
-			WithURL("https://github.com/alecthomas/gocyclo"),
+			WithURL("https://github.com/fzipp/gocyclo"),
 		linter.NewConfig(golinters.NewCyclop(cyclopCfg)).
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetComplexity).


### PR DESCRIPTION
👋 As I saw, the correct link is https://github.com/fzipp/gocyclo, not https://github.com/alecthomas/gocyclo, but maybe I wrong.

https://github.com/golangci/golangci-lint/blob/5dcc3eafd1beece80cbab940b1130225e1cf6c68/go.mod#L20
https://github.com/golangci/golangci-lint/blob/5dcc3eafd1beece80cbab940b1130225e1cf6c68/pkg/golinters/gocyclo.go#L7