### PR TITLE
Use go v1.14 in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.13
+go 1.14
 
 require (
 	4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a


### PR DESCRIPTION
Change the go version in `go.mod` from `v1.13` to `v1.14`, since the tests for go `v1.13` were dropped in CI