### PR TITLE
revive: the default config is only applied when no dedicated config

### DIFF
--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/token"
 	"io/ioutil"
+	"reflect"
 
 	"github.com/BurntSushi/toml"
 	"github.com/mgechev/dots"
@@ -136,20 +137,22 @@ func NewRevive(cfg *config.ReviveSettings) *goanalysis.Linter {
 // https://github.com/golangci/golangci-lint/issues/1745
 // https://github.com/mgechev/revive/blob/389ba853b0b3587f0c3b71b5f0c61ea4e23928ec/config/config.go#L155
 func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
-	rawRoot := createConfigMap(cfg)
-
-	buf := bytes.NewBuffer(nil)
-
-	err := toml.NewEncoder(buf).Encode(rawRoot)
-	if err != nil {
-		return nil, err
-	}
-
 	conf := defaultConfig()
 
-	_, err = toml.DecodeReader(buf, conf)
-	if err != nil {
-		return nil, err
+	if !reflect.DeepEqual(cfg, &config.ReviveSettings{}) {
+		rawRoot := createConfigMap(cfg)
+		buf := bytes.NewBuffer(nil)
+
+		err := toml.NewEncoder(buf).Encode(rawRoot)
+		if err != nil {
+			return nil, err
+		}
+
+		conf = &lint.Config{}
+		_, err = toml.DecodeReader(buf, conf)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	normalizeConfig(conf)

--- a/test/testdata/configs/revive.yml
+++ b/test/testdata/configs/revive.yml
@@ -3,12 +3,10 @@ linters-settings:
     ignore-generated-header: true
     severity: warning
     rules:
-      - name: indent-error-flow
-        severity: warning
       - name: cognitive-complexity
         arguments: [ 7 ]
       - name: line-length-limit
-        arguments: [ 110 ]
+        arguments: [ 130 ]
       - name: function-result-limit
         arguments: [ 3 ]
       - name: argument-limit

--- a/test/testdata/revive_default.go
+++ b/test/testdata/revive_default.go
@@ -1,5 +1,4 @@
 //args: -Erevive
-//config_path: testdata/configs/revive.yml
 package testdata
 
 import (
@@ -7,15 +6,15 @@ import (
 	"time"
 )
 
-func testRevive(t *time.Duration) error {
+func testReviveDefault(t *time.Duration) error {
 	if t == nil {
 		return nil
-	} else {
+	} else { // ERROR "indent-error-flow: if block ends with a return statement, .*"
 		return nil
 	}
 }
 
-func testReviveComplexity(s string) { // ERROR "cyclomatic: function testReviveComplexity has cyclomatic complexity 22"
+func testReviveComplexityDefault(s string) {
 	if s == http.MethodGet || s == "2" || s == "3" || s == "4" || s == "5" || s == "6" || s == "7" {
 		return
 	}


### PR DESCRIPTION
Fix #1770

https://github.com/golangci/golangci-lint/issues/1770#issuecomment-794887358

The code from revive:
```go
// GetConfig yields the configuration
func GetConfig(configPath string) (*lint.Config, error) {
	config := defaultConfig()
	if configPath != "" {
		var err error
		config, err = parseConfig(configPath)
		if err != nil {
			return nil, err
		}
	}
	normalizeConfig(config)
	return config, nil
}
```

The same thing in this PR:
```go
func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
	conf := defaultConfig()

	if !reflect.DeepEqual(cfg, &config.ReviveSettings{}) {
		rawRoot := createConfigMap(cfg)
		buf := bytes.NewBuffer(nil)

		err := toml.NewEncoder(buf).Encode(rawRoot)
		if err != nil {
			return nil, err
		}

		conf = &lint.Config{}
		_, err = toml.DecodeReader(buf, conf)
		if err != nil {
			return nil, err
		}
	}

	normalizeConfig(conf)
```

