### PR TITLE
docs: adding missing format options

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -60,7 +60,8 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # default is "colored-line-number"
   format: colored-line-number
 
   # print lines of code with issue, default is true


### PR DESCRIPTION
Adds two missing for mat options to the example config