### PR TITLE
Add new presets

### DIFF
--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -5,19 +5,19 @@ import (
 )
 
 const (
-	PresetBugs        = "bugs"
-	PresetComment     = "comment"
-	PresetComplexity  = "complexity"
-	PresetError       = "error"
-	PresetFormatting  = "format"
-	PresetImport      = "import"
-	PresetMetaLinter  = "metalinter"
-	PresetModule      = "module"
-	PresetPerformance = "performance"
-	PresetSQL         = "sql"
-	PresetStyle       = "style"
-	PresetTest        = "test"
-	PresetUnused      = "unused"
+	PresetBugs        = "bugs"        // Related to bugs detection.
+	PresetComment     = "comment"     // Related to comments analysis.
+	PresetComplexity  = "complexity"  // Related to code complexity analysis.
+	PresetError       = "error"       // Related to error handling analysis.
+	PresetFormatting  = "format"      // Related to code formatting.
+	PresetImport      = "import"      // Related to imports analysis.
+	PresetMetaLinter  = "metalinter"  // Related to linter that contains multiple rules or multiple linters.
+	PresetModule      = "module"      // Related to Go modules analysis.
+	PresetPerformance = "performance" // Related to performance.
+	PresetSQL         = "sql"         // Related to SQL.
+	PresetStyle       = "style"       // Related to coding style.
+	PresetTest        = "test"        // Related to the analysis of the code of the tests.
+	PresetUnused      = "unused"      // Related to the detection of unused code.
 )
 
 type Config struct {

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -5,12 +5,19 @@ import (
 )
 
 const (
-	PresetFormatting  = "format"
-	PresetComplexity  = "complexity"
-	PresetStyle       = "style"
 	PresetBugs        = "bugs"
-	PresetUnused      = "unused"
+	PresetComment     = "comment"
+	PresetComplexity  = "complexity"
+	PresetError       = "error"
+	PresetFormatting  = "format"
+	PresetImport      = "import"
+	PresetMetaLinter  = "metalinter"
+	PresetModule      = "module"
 	PresetPerformance = "performance"
+	PresetSQL         = "sql"
+	PresetStyle       = "style"
+	PresetTest        = "test"
+	PresetUnused      = "unused"
 )
 
 type Config struct {

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -59,8 +59,19 @@ func (m *Manager) WithCustomLinters() *Manager {
 
 func (Manager) AllPresets() []string {
 	return []string{
-		linter.PresetBugs, linter.PresetComplexity, linter.PresetFormatting,
-		linter.PresetPerformance, linter.PresetStyle, linter.PresetUnused,
+		linter.PresetBugs,
+		linter.PresetComment,
+		linter.PresetComplexity,
+		linter.PresetError,
+		linter.PresetFormatting,
+		linter.PresetImport,
+		linter.PresetMetaLinter,
+		linter.PresetModule,
+		linter.PresetPerformance,
+		linter.PresetSQL,
+		linter.PresetStyle,
+		linter.PresetTest,
+		linter.PresetUnused,
 	}
 }
 
@@ -119,7 +130,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	lcs := []*linter.Config{
 		linter.NewConfig(golinters.NewGovet(govetCfg)).
 			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs).
+			WithPresets(linter.PresetBugs, linter.PresetMetaLinter).
 			WithAlternativeNames("vet", "vetshadow").
 			WithURL("https://golang.org/cmd/vet/"),
 		linter.NewConfig(golinters.NewBodyclose()).
@@ -132,7 +143,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/sonatard/noctx"),
 		linter.NewConfig(golinters.NewErrcheck()).
 			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs).
+			WithPresets(linter.PresetBugs, linter.PresetError).
 			WithURL("https://github.com/kisielk/errcheck"),
 		linter.NewConfig(golinters.NewGolint()).
 			WithLoadForGoAnalysis().
@@ -140,12 +151,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/golang/lint"),
 		linter.NewConfig(golinters.NewRowsErrCheck()).
 			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetPerformance, linter.PresetBugs).
+			WithPresets(linter.PresetBugs, linter.PresetSQL).
 			WithURL("https://github.com/jingyugao/rowserrcheck"),
 
 		linter.NewConfig(golinters.NewStaticcheck()).
 			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs).
+			WithPresets(linter.PresetBugs, linter.PresetMetaLinter).
 			WithAlternativeNames(megacheckName).
 			WithURL("https://staticcheck.io/"),
 		linter.NewConfig(golinters.NewUnused()).
@@ -229,7 +240,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithAutoFix().
 			WithURL("https://github.com/mvdan/gofumpt"),
 		linter.NewConfig(golinters.NewGoimports()).
-			WithPresets(linter.PresetFormatting).
+			WithPresets(linter.PresetFormatting, linter.PresetImport).
 			WithAutoFix().
 			WithURL("https://godoc.org/golang.org/x/tools/cmd/goimports"),
 		linter.NewConfig(golinters.NewGoHeader()).
@@ -237,7 +248,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/denis-tingajkin/go-header"),
 		linter.NewConfig(golinters.NewGci()).
-			WithPresets(linter.PresetFormatting).
+			WithPresets(linter.PresetFormatting, linter.PresetImport).
 			WithLoadForGoAnalysis().
 			WithAutoFix().
 			WithURL("https://github.com/daixiang0/gci"),
@@ -248,10 +259,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			Deprecated("The repository of the linter has been archived by the owner. Use govet 'fieldalignment' instead."),
 		linter.NewConfig(golinters.NewDepguard()).
 			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
 			WithURL("https://github.com/OpenPeeDeeP/depguard"),
 		linter.NewConfig(golinters.NewMisspell()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetComment).
 			WithAutoFix().
 			WithURL("https://github.com/client9/misspell"),
 		linter.NewConfig(golinters.NewLLL()).
@@ -264,7 +275,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/alexkohler/dogsled"),
 		linter.NewConfig(golinters.NewNakedret()).
-			WithPresets(linter.PresetComplexity).
+			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/alexkohler/nakedret"),
 		linter.NewConfig(golinters.NewPrealloc()).
 			WithPresets(linter.PresetPerformance).
@@ -274,7 +285,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/kyoh86/scopelint").
 			Deprecated("The repository of the linter has been deprecated by the owner. Use 'exportloopref' instead."),
 		linter.NewConfig(golinters.NewGocritic()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/go-critic/go-critic"),
 		linter.NewConfig(golinters.NewGochecknoinits()).
@@ -284,10 +295,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/leighmcculloch/gochecknoglobals"),
 		linter.NewConfig(golinters.NewGodox()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetComment).
 			WithURL("https://github.com/matoous/godox"),
 		linter.NewConfig(golinters.NewFunlen()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetComplexity).
 			WithURL("https://github.com/ultraware/funlen"),
 		linter.NewConfig(golinters.NewWhitespace()).
 			WithPresets(linter.PresetStyle).
@@ -303,19 +314,19 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/tommy-muehle/go-mnd"),
 		linter.NewConfig(golinters.NewGoerr113()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetError).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/Djarvur/go-err113"),
 		linter.NewConfig(golinters.NewGomodguard()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ryancurrah/gomodguard"),
 		linter.NewConfig(golinters.NewGodot()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetComment).
 			WithAutoFix().
 			WithURL("https://github.com/tetafro/godot"),
 		linter.NewConfig(golinters.NewTestpackage(testpackageCfg)).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetTest).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/maratori/testpackage"),
 		linter.NewConfig(golinters.NewNestif()).
@@ -330,7 +341,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/nishanths/exhaustive"),
 		linter.NewConfig(golinters.NewSQLCloseCheck()).
-			WithPresets(linter.PresetBugs).
+			WithPresets(linter.PresetBugs, linter.PresetSQL).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ryanrolds/sqlclosecheck"),
 		linter.NewConfig(golinters.NewNLReturn()).
@@ -338,7 +349,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ssgreg/nlreturn"),
 		linter.NewConfig(golinters.NewWrapcheck()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetError).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/tomarrell/wrapcheck"),
 		linter.NewConfig(golinters.NewThelper(thelperCfg)).
@@ -346,19 +357,19 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kulti/thelper"),
 		linter.NewConfig(golinters.NewTparallel()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetTest).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/moricho/tparallel"),
 		linter.NewConfig(golinters.NewExhaustiveStruct(exhaustiveStructCfg)).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetTest).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/mbilski/exhaustivestruct"),
 		linter.NewConfig(golinters.NewErrorLint(errorlintCfg)).
-			WithPresets(linter.PresetBugs).
+			WithPresets(linter.PresetBugs, linter.PresetError).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/polyfloyd/go-errorlint"),
 		linter.NewConfig(golinters.NewParallelTest()).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetTest).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kunwardeep/paralleltest"),
 		linter.NewConfig(golinters.NewMakezero()).
@@ -375,7 +386,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/nishanths/predeclared"),
 		linter.NewConfig(golinters.NewRevive(reviveCfg)).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
 			ConsiderSlow().
 			WithURL("https://github.com/mgechev/revive"),
 		linter.NewConfig(golinters.NewDurationCheck()).
@@ -399,7 +410,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/gostaticanalysis/forcetypeassert"),
 		linter.NewConfig(golinters.NewGoModDirectives(goModDirectivesCfg)).
-			WithPresets(linter.PresetStyle).
+			WithPresets(linter.PresetStyle, linter.PresetModule).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ldez/gomoddirectives"),
 


### PR DESCRIPTION
I would like to add new presets:

- `import`
- `module`
- `comment`
- `metalinter`
- `test`
- `error`
- `sql`

<details>

|                    | `format` | `complexity` | `style` | `bugs` | `unused` | `performance` | PROPOSAL             |
|--------------------|:--------:|:------------:|:-------:|:------:|:--------:|:-------------:|----------------------|
| `deadcode`         |          |              |         |        |     ✔    |               |                      |
| `errcheck`         |          |              |         |    ✔   |          |               | `error`              |
| `gosimple`         |          |              |    ✔    |        |          |               |                      |
| `govet`            |          |              |         |    ✔   |          |               | `metalinter`         |
| `ineffassign`      |          |              |         |        |     ✔    |               |                      |
| `staticcheck`      |          |              |         |    ✔   |          |               | `metalinter`         |
| `structcheck`      |          |              |         |        |     ✔    |               |                      |
| `typecheck`        |          |              |         |    ✔   |          |               |                      |
| `unused`           |          |              |         |        |     ✔    |               |                      |
| `varcheck`         |          |              |         |        |     ✔    |               |                      |
| `asciicheck`       |          |              |    ✔    |    ✔   |          |               |                      |
| `bodyclose`        |          |              |         |    ✔   |          |       ✔       | `http`?              |
| `cyclop`           |          |       ✔      |         |        |          |               |                      |
| `depguard`         |          |              |    ✔    |        |          |               | `import`, `module`   |
| `dogsled`          |          |              |    ✔    |        |          |               |                      |
| `dupl`             |          |              |    ✔    |        |          |               |                      |
| `durationcheck`    |          |              |         |    ✔   |          |               |                      |
| `errorlint`        |          |              |         |    ✔   |          |               | `error`              |
| `exhaustive`       |          |              |         |    ✔   |          |               |                      |
| `exhaustivestruct` |          |              |    ✔    |        |          |               |                      |
| `exportloopref`    |          |              |         |    ✔   |          |               |                      |
| `forbidigo`        |          |              |    ✔    |        |          |               |                      |
| `forcetypeassert`  |          |              |    ✔    |        |          |               |                      |
| `funlen`           |          |              |    ✔    |        |          |               | move to `complexity` |
| `gci`              |     ✔    |              |         |        |          |               | `import`             |
| `gochecknoglobals` |          |              |    ✔    |        |          |               |                      |
| `gochecknoinits`   |          |              |    ✔    |        |          |               |                      |
| `gocognit`         |          |       ✔      |         |        |          |               |                      |
| `goconst`          |          |              |    ✔    |        |          |               |                      |
| `gocritic`         |          |              |    ✔    |        |          |               | `metalinter`         |
| `gocyclo`          |          |       ✔      |         |        |          |               |                      |
| `godot`            |          |              |    ✔    |        |          |               | `comment`            |
| `godox`            |          |              |    ✔    |        |          |               | `comment`            |
| `goerr113`         |          |              |    ✔    |        |          |               | `error`              |
| `gofmt`            |     ✔    |              |         |        |          |               |                      |
| `gofumpt`          |     ✔    |              |         |        |          |               |                      |
| `goheader`         |          |              |    ✔    |        |          |               |                      |
| `goimports`        |     ✔    |              |         |        |          |               | `import`             |
| `golint`           |          |              |    ✔    |        |          |               |                      |
| `gomnd`            |          |              |    ✔    |        |          |               |                      |
| `gomoddirectives`  |          |              |    ✔    |        |          |               | `module`             |
| `gomodguard`       |          |              |    ✔    |        |          |               | `import`, `module`   |
| `goprintffuncname` |          |              |    ✔    |        |          |               |                      |
| `gosec`            |          |              |         |    ✔   |          |               | `metalinter`?        |
| `ifshort`          |          |              |    ✔    |        |          |               |                      |
| `importas`         |          |              |    ✔    |        |          |               |                      |
| ~~`interfacer`~~   |          |              |    ✔    |        |          |               |                      |
| `lll`              |          |              |    ✔    |        |          |               |                      |
| `makezero`         |          |              |    ✔    |    ✔   |          |               |                      |
| ~~`maligned`~~     |          |              |         |        |          |       ✔       |                      |
| `misspell`         |          |              |    ✔    |        |          |               | `comment`            |
| `nakedret`         |          |       ✔      |         |        |          |               | move to `style`      |
| `nestif`           |          |       ✔      |         |        |          |               |                      |
| `nilerr`           |          |              |         |    ✔   |          |               |                      |
| `nlreturn`         |          |              |    ✔    |        |          |               |                      |
| `noctx`            |          |              |         |    ✔   |          |       ✔       | `http`?              |
| `nolintlint`       |          |              |    ✔    |        |          |               |                      |
| `paralleltest`     |          |              |    ✔    |        |          |               | `test`               |
| `prealloc`         |          |              |         |        |          |       ✔       |                      |
| `predeclared`      |          |              |    ✔    |        |          |               |                      |
| `revive`           |          |              |    ✔    |        |          |               | `metalinter`         |
| `rowserrcheck`     |          |              |         |    ✔   |          |       ✔       | `sql`                |
| ~~`scopelint`~~    |          |              |         |    ✔   |          |               |                      |
| `sqlclosecheck`    |          |              |         |    ✔   |          |               | `sql`                |
| `stylecheck`       |          |              |    ✔    |        |          |               |                      |
| `testpackage`      |          |              |    ✔    |        |          |               | `test`               |
| `thelper`          |          |              |    ✔    |        |          |               | `test`               |
| `tparallel`        |          |              |    ✔    |        |          |               | `test`               |
| `unconvert`        |          |              |    ✔    |        |          |               |                      |
| `unparam`          |          |              |         |        |     ✔    |               |                      |
| `wastedassign`     |          |              |    ✔    |        |          |               |                      |
| `whitespace`       |          |              |    ✔    |        |          |               |                      |
| `wrapcheck`        |          |              |    ✔    |        |          |               | `error`              |
| `wsl`              |          |              |    ✔    |        |          |               |                      |

</details>
