### PR TITLE
Improve compilation errors output

### DIFF
--- a/pkg/golinters/makezero.go
+++ b/pkg/golinters/makezero.go
@@ -56,5 +56,5 @@ func NewMakezero() *goanalysis.Linter {
 		}
 	}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
 		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeSyntax | goanalysis.LoadModeTypesInfo)
+	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/typecheck.go
+++ b/pkg/golinters/typecheck.go
@@ -8,6 +8,7 @@ import (
 
 func NewTypecheck() *goanalysis.Linter {
 	const linterName = "typecheck"
+
 	analyzer := &analysis.Analyzer{
 		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
@@ -15,12 +16,17 @@ func NewTypecheck() *goanalysis.Linter {
 			return nil, nil
 		},
 	}
+
+	// Note: typecheck doesn't require the LoadModeWholeProgram
+	// but it's a hack to force this linter to be the first linter in all the cases.
 	linter := goanalysis.NewLinter(
 		linterName,
 		"Like the front-end of a Go compiler, parses and type-checks Go code",
 		[]*analysis.Analyzer{analyzer},
 		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeWholeProgram)
+
 	linter.SetTypecheckMode()
+
 	return linter
 }

--- a/pkg/golinters/unused.go
+++ b/pkg/golinters/unused.go
@@ -59,7 +59,7 @@ func NewUnused() *goanalysis.Linter {
 		nil,
 	).WithIssuesReporter(func(lintCtx *linter.Context) []goanalysis.Issue {
 		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeSyntax | goanalysis.LoadModeTypesInfo)
+	}).WithLoadMode(goanalysis.LoadModeWholeProgram)
 
 	return lnt
 }

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -20,6 +20,14 @@ const (
 	PresetUnused      = "unused"      // Related to the detection of unused code.
 )
 
+const (
+	// typecheck must be first because it checks the compiling errors.
+	FirstLinter = "typecheck"
+
+	// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives.
+	LastLinter = "nolintlint"
+)
+
 type Deprecation struct {
 	Since       string
 	Message     string

--- a/pkg/lint/lintersdb/enabled_set.go
+++ b/pkg/lint/lintersdb/enabled_set.go
@@ -111,6 +111,15 @@ func (es EnabledSet) GetOptimizedLinters() ([]*linter.Config, error) {
 	// Make order of execution of linters (go/analysis metalinter and unused) stable.
 	sort.Slice(resultLinters, func(i, j int) bool {
 		a, b := resultLinters[i], resultLinters[j]
+
+		if a.Name() == linter.FirstLinter || b.Name() == linter.LastLinter {
+			return true
+		}
+
+		if a.Name() == linter.LastLinter || b.Name() == linter.FirstLinter {
+			return false
+		}
+
 		if a.DoesChangeTypes != b.DoesChangeTypes {
 			return b.DoesChangeTypes // move type-changing linters to the end to optimize speed
 		}
@@ -149,8 +158,19 @@ func (es EnabledSet) combineGoAnalysisLinters(linters map[string]*linter.Config)
 
 	// Make order of execution of go/analysis analyzers stable.
 	sort.Slice(goanalysisLinters, func(i, j int) bool {
-		return strings.Compare(goanalysisLinters[i].Name(), goanalysisLinters[j].Name()) <= 0
+		a, b := goanalysisLinters[i], goanalysisLinters[j]
+
+		if a.Name() == linter.FirstLinter || b.Name() == linter.LastLinter {
+			return true
+		}
+
+		if a.Name() == linter.LastLinter || b.Name() == linter.FirstLinter {
+			return false
+		}
+
+		return strings.Compare(a.Name(), b.Name()) <= 0
 	})
+
 	ml := goanalysis.NewMetaLinter(goanalysisLinters)
 
 	var presets []string

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -131,6 +131,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	const megacheckName = "megacheck"
 
 	lcs := []*linter.Config{
+		linter.NewConfig(golinters.NewTypecheck()).
+			WithSince("v1.3.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetBugs).
+			WithURL(""),
+
 		linter.NewConfig(golinters.NewGovet(govetCfg)).
 			WithSince("v1.0.0").
 			WithLoadForGoAnalysis().
@@ -247,11 +253,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.20.0").
 			WithPresets(linter.PresetComplexity).
 			WithURL("https://github.com/uudashr/gocognit"),
-		linter.NewConfig(golinters.NewTypecheck()).
-			WithSince("v1.3.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs).
-			WithURL(""),
 		linter.NewConfig(golinters.NewAsciicheck()).
 			WithSince("v1.26.0").
 			WithPresets(linter.PresetBugs, linter.PresetStyle).

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -200,7 +200,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 		sw.TrackStage(lc.Name(), func() {
 			linterIssues, err := r.runLinterSafe(ctx, lintCtx, lc)
 			if err != nil {
-				r.Log.Warnf("Can't run linter %s: %s", lc.Linter.Name(), err)
+				r.Log.Warnf("Can't run linter %s: %v", lc.Linter.Name(), err)
 				if os.Getenv("GOLANGCI_COM_RUN") == "" {
 					// Don't stop all linters on one linter failure for golangci.com.
 					runErr = err
@@ -209,6 +209,10 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 			}
 			issues = append(issues, linterIssues...)
 		})
+
+		if lc.Name() == linter.FirstLinter && len(issues) > 0 {
+			return r.processLintResults(issues), nil
+		}
 	}
 
 	return r.processLintResults(issues), runErr


### PR DESCRIPTION
Fixes #1002
Related to #1820 and #886

I think this also fixes partially #1792 (https://github.com/golangci/golangci-lint/issues/1792#issuecomment-797860983)

This PR will improve in the report when the analyzed code contains compilation errors.

It's a bit complex to explain but I will try to explain it.

`typecheck` is like the front-end of a Go compiler, parses and type-checks Go code.
This linter is able to manage compilation error, that's his role.
So this linter must be the first linter.

To put `typecheck` as the first linter, I improved the sort of the linters inside `enabled_set.go` and I changed the load mode to `goanalysis.LoadModeWholeProgram` (because the linters with `goanalysis.LoadModeWholeProgram` are not put inside the metalinter and they are executed before the metalinter)

This change will not improve the output when only one linter is launched, it's another topic.
But I think that the output will be better in 90% of the use-cases: when several linters (including `typecheck`) are run

<details>
<summary>Before my PR</summary>

```console
$ golangci-lint run
WARN [runner] Can't run linter goanalysis_metalinter: bodyclose: failed prerequisites: [buildssa@github.com/golangci/golangci-lint/pkg/lint: analysis skipped: errors in package: [/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/lint/runner.go:18:2: could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/deadcode.go:21:9: undeclared name: linterName)) /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/lint/runner.go:22:2: could not import github.com/golangci/golangci-lint/pkg/result/processors (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/result/processors/nolint.go:11:2: could not import github.com/golangci/golangci-lint/pkg/golinters (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/deadcode.go:21:9: undeclared name: linterName))]] 
WARN [runner] Can't run linter unused: buildir: failed to load package golinters: could not load export data: no export data for "github.com/golangci/golangci-lint/pkg/golinters" 
ERRO Running error: buildir: failed to load package golinters: could not load export data: no export data for "github.com/golangci/golangci-lint/pkg/golinters"
```

</details>

<details>
<summary>With my PR</summary>

```console
$ ./golangci-lint run
pkg/lint/runner.go:18:2: could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName)) (typecheck)
        "github.com/golangci/golangci-lint/pkg/lint/lintersdb"
        ^
pkg/lint/runner.go:22:2: could not import github.com/golangci/golangci-lint/pkg/result/processors (pkg/result/processors/nolint.go:11:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName)) (typecheck)
        "github.com/golangci/golangci-lint/pkg/result/processors"
        ^
pkg/commands/executor.go:26:2: could not import github.com/golangci/golangci-lint/pkg/lint (pkg/lint/runner.go:18:2: could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName))) (typecheck)
        "github.com/golangci/golangci-lint/pkg/lint"
        ^
pkg/commands/executor.go:27:2: could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName)) (typecheck)
        "github.com/golangci/golangci-lint/pkg/lint/lintersdb"
        ^
pkg/commands/run.go:26:2: could not import github.com/golangci/golangci-lint/pkg/result/processors (pkg/result/processors/nolint.go:11:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName)) (typecheck)
        "github.com/golangci/golangci-lint/pkg/result/processors"
        ^
cmd/golangci-lint/main.go:7:2: could not import github.com/golangci/golangci-lint/pkg/commands (pkg/commands/executor.go:26:2: could not import github.com/golangci/golangci-lint/pkg/lint (pkg/lint/runner.go:18:2: could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName)))) (typecheck)
        "github.com/golangci/golangci-lint/pkg/commands"
        ^
scripts/expand_website_templates/main.go:21:2: could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName)) (typecheck)
        "github.com/golangci/golangci-lint/pkg/lint/lintersdb"
        ^
pkg/golinters/deadcode.go:21:9: undeclared name: `linterName` (typecheck)
                Name: linterName,
                      ^
pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName) (typecheck)
        "github.com/golangci/golangci-lint/pkg/golinters"
        ^
pkg/lint/lintersdb/manager.go:501:2: isLocalRun declared but not used (typecheck)
        isLocalRun := os.Getenv("GOLANGCI_COM_RUN") == ""
        ^
pkg/result/processors/nolint.go:11:2: could not import github.com/golangci/golangci-lint/pkg/golinters (pkg/golinters/deadcode.go:21:9: undeclared name: linterName) (typecheck)
        "github.com/golangci/golangci-lint/pkg/golinters"
        ^
```


</details>





