### PR TITLE
fix: wrong linters load mode

### DIFF
--- a/pkg/golinters/forcetypeassert.go
+++ b/pkg/golinters/forcetypeassert.go
@@ -15,5 +15,5 @@ func NewForceTypeAssert() *goanalysis.Linter {
 		"finds forced type assertions",
 		[]*analysis.Analyzer{a},
 		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/ineffassign.go
+++ b/pkg/golinters/ineffassign.go
@@ -13,5 +13,5 @@ func NewIneffassign() *goanalysis.Linter {
 		"Detects when assignments to existing variables are not used",
 		[]*analysis.Analyzer{ineffassign.Analyzer},
 		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/makezero.go
+++ b/pkg/golinters/makezero.go
@@ -56,5 +56,5 @@ func NewMakezero() *goanalysis.Linter {
 		}
 	}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
 		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeSyntax | goanalysis.LoadModeTypesInfo)
+	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/paralleltest.go
+++ b/pkg/golinters/paralleltest.go
@@ -17,5 +17,5 @@ func NewParallelTest() *goanalysis.Linter {
 		"paralleltest detects missing usage of t.Parallel() method in your Go test",
 		analyzers,
 		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/unused.go
+++ b/pkg/golinters/unused.go
@@ -59,7 +59,7 @@ func NewUnused() *goanalysis.Linter {
 		nil,
 	).WithIssuesReporter(func(lintCtx *linter.Context) []goanalysis.Issue {
 		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeSyntax | goanalysis.LoadModeTypesInfo)
+	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
 
 	return lnt
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -218,7 +218,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/mdempsky/unconvert"),
 		linter.NewConfig(golinters.NewIneffassign()).
 			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetUnused).
 			WithURL("https://github.com/gordonklaus/ineffassign"),
 		linter.NewConfig(golinters.NewDupl()).
@@ -226,7 +225,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/mibk/dupl"),
 		linter.NewConfig(golinters.NewGoconst()).
-			WithSince("").
+			WithSince("v1.0.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/jgautheron/goconst"),
 		linter.NewConfig(golinters.NewDeadcode()).
@@ -255,7 +254,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewAsciicheck()).
 			WithSince("v1.26.0").
 			WithPresets(linter.PresetBugs, linter.PresetStyle).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/tdakkota/asciicheck"),
 
 		linter.NewConfig(golinters.NewGofmt()).
@@ -276,12 +274,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewGoHeader()).
 			WithSince("v1.28.0").
 			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/denis-tingajkin/go-header"),
 		linter.NewConfig(golinters.NewGci()).
 			WithSince("v1.30.0").
 			WithPresets(linter.PresetFormatting, linter.PresetImport).
-			WithLoadForGoAnalysis().
 			WithAutoFix().
 			WithURL("https://github.com/daixiang0/gci"),
 		linter.NewConfig(golinters.NewMaligned()).
@@ -371,7 +367,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewGomodguard()).
 			WithSince("v1.25.0").
 			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ryancurrah/gomodguard"),
 		linter.NewConfig(golinters.NewGodot()).
 			WithSince("v1.25.0").
@@ -381,7 +376,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewTestpackage(testpackageCfg)).
 			WithSince("v1.25.0").
 			WithPresets(linter.PresetStyle, linter.PresetTest).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/maratori/testpackage"),
 		linter.NewConfig(golinters.NewNestif()).
 			WithSince("v1.25.0").
@@ -405,7 +399,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewNLReturn()).
 			WithSince("v1.30.0").
 			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ssgreg/nlreturn"),
 		linter.NewConfig(golinters.NewWrapcheck()).
 			WithSince("v1.32.0").
@@ -435,7 +428,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewParallelTest()).
 			WithSince("v1.33.0").
 			WithPresets(linter.PresetStyle, linter.PresetTest).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kunwardeep/paralleltest"),
 		linter.NewConfig(golinters.NewMakezero()).
 			WithSince("v1.34.0").
@@ -482,12 +474,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewForceTypeAssert()).
 			WithSince("v1.38.0").
 			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/gostaticanalysis/forcetypeassert"),
 		linter.NewConfig(golinters.NewGoModDirectives(goModDirectivesCfg)).
 			WithSince("v1.39.0").
 			WithPresets(linter.PresetStyle, linter.PresetModule).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ldez/gomoddirectives"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives

--- a/test/testdata/asciicheck.go
+++ b/test/testdata/asciicheck.go
@@ -1,8 +1,23 @@
 //args: -Easciicheck
 package testdata
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
-type TеstStruct struct { // ERROR `identifier "TеstStruct" contain non-ASCII character: U\+0435 'е'`
+type AsciicheckTеstStruct struct { // ERROR `identifier "AsciicheckTеstStruct" contain non-ASCII character: U\+0435 'е'`
 	Date time.Time
+}
+
+type AsciicheckField struct{}
+
+type AsciicheckJustStruct struct {
+	Tеst AsciicheckField // ERROR `identifier "Tеst" contain non-ASCII character: U\+0435 'е'`
+}
+
+func AsciicheckTеstFunc() { // ERROR `identifier "AsciicheckTеstFunc" contain non-ASCII character: U\+0435 'е'`
+	var tеstVar int // ERROR `identifier "tеstVar" contain non-ASCII character: U\+0435 'е'`
+	tеstVar = 0
+	fmt.Println(tеstVar)
 }


### PR DESCRIPTION
The `LoadMode` `LoadModeTypesInfo` in the `goanalysis.Linter` says that the linter needs to resolve all the types.

The `LoadMode` `WithLoadForGoAnalysis` in the `linter.Config` says that the linter needs more information about dependencies and sizes.

Each of these loading modes has an impact on how the linter can be executed, how the cache is used, and on the speed.

For example, if a linter uses the `LoadMode` `LoadModeTypesInfo` in the `goanalysis.Linter`, this linter will no be able to analyze a single file with elements not defined in that file.

Another example, the impact of the wrong load mode on the speed of `ineffassign`:

|        | real | user  | sys  |
|--------|------|-------|------|
| before | 2.88 | 12.71 | 1.28 |
| after  | 1.53 | 4.39  | 0.64 |

**The loading mode depends on the internal requirements of a linter, it's neither a way to optimize speed nor a way to allow a linter to be executed on a single file.**
But if the loading mode is wrong, it has an impact on the capacities and the performance of a linter.
