### PR TITLE
Set version command output to Stdout

### DIFF
--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -49,7 +49,7 @@ func (e *Executor) initVersion() {
 				}
 				fmt.Println(string(data))
 			default:
-				cmd.Printf("golangci-lint has version %s built from %s on %s\n", e.version, e.commit, e.date)
+				fmt.Printf("golangci-lint has version %s built from %s on %s\n", e.version, e.commit, e.date)
 			}
 			return nil
 		},

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -33,6 +34,7 @@ func (e *Executor) initVersion() {
 		Use:   "version",
 		Short: "Version",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SetOut(os.Stdout)
 			switch strings.ToLower(e.cfg.Version.Format) {
 			case "short":
 				cmd.Println(e.version)

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -2,7 +2,7 @@ package commands
 
 import (
 	"encoding/json"
-	"os"
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -34,10 +34,9 @@ func (e *Executor) initVersion() {
 		Use:   "version",
 		Short: "Version",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.SetOut(os.Stdout)
 			switch strings.ToLower(e.cfg.Version.Format) {
 			case "short":
-				cmd.Println(e.version)
+				fmt.Println(e.version)
 			case "json":
 				ver := jsonVersion{
 					Version: e.version,
@@ -48,7 +47,7 @@ func (e *Executor) initVersion() {
 				if err != nil {
 					return err
 				}
-				cmd.Println(string(data))
+				fmt.Println(string(data))
 			default:
 				cmd.Printf("golangci-lint has version %s built from %s on %s\n", e.version, e.commit, e.date)
 			}


### PR DESCRIPTION
Default command output was set to Stderr, now set to Stdout.

Fixes #1868