### PR TITLE
Bump importas to HEAD

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -464,6 +464,10 @@ linters-settings:
     servingv1: knative.dev/serving/pkg/apis/serving/v1
     # using `autoscalingv1alpha1` alias for `knative.dev/serving/pkg/apis/autoscaling/v1alpha1` package
     autoscalingv1alpha1: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
+    # You can specify the package path by regular expression,
+    # and alias by regular expression expansion syntax like below.
+    # see https://github.com/julz/importas#use-regular-expression for details
+    "$1$2": 'knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)'
   gomoddirectives:
     # Allow local `replace` directives. Default is false.
     replace-local: false

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/jgautheron/goconst v1.4.0
 	github.com/jingyugao/rowserrcheck v0.0.0-20210315055705-d907ca737bb1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
-	github.com/julz/importas v0.0.0-20210228071311-d0bf5cb4e1db
+	github.com/julz/importas v0.0.0-20210405141620-a22c8f743dc9
 	github.com/kisielk/errcheck v1.6.0
 	github.com/kulti/thelper v0.4.0
 	github.com/kunwardeep/paralleltest v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julz/importas v0.0.0-20210228071311-d0bf5cb4e1db h1:ZmwBthGFMVAieuVpLzuedUH9l4pY/0iFG16DN9dS38o=
-github.com/julz/importas v0.0.0-20210228071311-d0bf5cb4e1db/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
+github.com/julz/importas v0.0.0-20210405141620-a22c8f743dc9 h1:CyQB3TMIEjaoKL2AdYyrkRYX0NV8F4pO/zRBgbZfvIY=
+github.com/julz/importas v0.0.0-20210405141620-a22c8f743dc9/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=


### PR DESCRIPTION
* Update importas version
    * Diff: https://github.com/julz/importas/compare/d0bf5cb4e1db...a22c8f743dc9
* Add new feature's example to .golangci.example.yml
    * importas supports regular expression now.