### PR TITLE
Fix release stats badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Documentation is hosted at https://golangci-lint.run.
 [![License](https://img.shields.io/github/license/golangci/golangci-lint)](/LICENSE)
 [![Release](https://img.shields.io/github/release/golangci/golangci-lint.svg)](https://github.com/golangci/golangci-lint/releases/latest)
 [![Docker](https://img.shields.io/docker/pulls/golangci/golangci-lint)](https://hub.docker.com/r/golangci/golangci-lint)
-[![Github Releases Stats of golangci-lint](https://img.shields.io/github/downloads/golangci/golangci-lint/total.svg?logo=github)](https://somsubhra.com/github-release-stats/?username=golangci&repository=golangci-lint)
+[![Github Releases Stats of golangci-lint](https://img.shields.io/github/downloads/golangci/golangci-lint/total.svg?logo=github)](https://somsubhra.github.io/github-release-stats/?username=golangci&repository=golangci-lint)
 
 ## Contributors
 


### PR DESCRIPTION
This updates the GitHub release stats badge to point to a working link. https://somsubhra.com now hosts a very sketchy looking crypto blog. The original application is available at https://somsubhra.github.io/github-release-stats/.