### PR TITLE
fix: comma in exclude pattern leads to unexpected results

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -313,24 +313,15 @@ func fixSlicesFlags(fs *pflag.FlagSet) {
 			return
 		}
 
-		// custom join to handle string with comma.
-		var g string
-		for i, v := range s {
-			if strings.Contains(v, ",") {
-				// add quotes to escape comma because spf13/pflag use a CSV parser:
-				// https://github.com/spf13/pflag/blob/85dd5c8bc61cfa382fecd072378089d4e856579d/string_slice.go#L43
-				g += `"` + v + `"`
-			} else {
-				g += v
-			}
-
-			if i < len(s)-1 {
-				g += ","
-			}
+		var safe []string
+		for _, v := range s {
+			// add quotes to escape comma because spf13/pflag use a CSV parser:
+			// https://github.com/spf13/pflag/blob/85dd5c8bc61cfa382fecd072378089d4e856579d/string_slice.go#L43
+			safe = append(safe, `"`+v+`"`)
 		}
 
 		// calling Set sets Changed to true: next Set calls will append, not overwrite
-		_ = f.Value.Set(g)
+		_ = f.Value.Set(strings.Join(safe, ","))
 	})
 }
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -313,8 +313,24 @@ func fixSlicesFlags(fs *pflag.FlagSet) {
 			return
 		}
 
+		// custom join to handle string with comma.
+		var g string
+		for i, v := range s {
+			if strings.Contains(v, ",") {
+				// add quotes to escape comma because spf13/pflag use a CSV parser:
+				// https://github.com/spf13/pflag/blob/85dd5c8bc61cfa382fecd072378089d4e856579d/string_slice.go#L43
+				g += `"` + v + `"`
+			} else {
+				g += v
+			}
+
+			if i < len(s)-1 {
+				g += ","
+			}
+		}
+
 		// calling Set sets Changed to true: next Set calls will append, not overwrite
-		_ = f.Value.Set(strings.Join(s, ","))
+		_ = f.Value.Set(g)
 	})
 }
 

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 
 	"github.com/golangci/golangci-lint/pkg/fsutils"

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -237,9 +237,9 @@ func (r *Runner) processIssues(issues []result.Issue, sw *timeutils.Stopwatch, s
 
 func getExcludeProcessor(cfg *config.Issues) processors.Processor {
 	var excludeTotalPattern string
-	excludeGlobalPatterns := cfg.ExcludePatterns
-	if len(excludeGlobalPatterns) != 0 {
-		excludeTotalPattern = fmt.Sprintf("(%s)", strings.Join(excludeGlobalPatterns, "|"))
+
+	if len(cfg.ExcludePatterns) != 0 {
+		excludeTotalPattern = fmt.Sprintf("(%s)", strings.Join(cfg.ExcludePatterns, "|"))
 	}
 
 	var excludeProcessor processors.Processor


### PR DESCRIPTION
Fixes #665

to check the PR:

<details>
<summary>main.go</summary>

```go
package main

import (
	"fmt"
)

func main() {
	foo := "get"
	bar := "get"
	more := "get"
	again := "get"

	fmt.Println(foo+bar+more, again)

	goo()
}

func goo() {
	foo := "example"
	bar := "example"
	more := "example"
	again := "example"

	fmt.Println(foo+bar+more, again)
}
```

</details>

<details>
<summary>.golangci.yml</summary>

```yml
linters:
  disable-all: true
  enable:
    - goconst

issues:
  exclude:
    - string .get. has \d+ occurrences, make it a constant
```

</details>


before the PR:
```console
$ golangci-lint run
```

after the PR:
```console
$ ./golangci-lint run
main.go:19:9: string `example` has 4 occurrences, make it a constant (goconst)
        foo := "example"
               ^
```
