### PR TITLE
Set the minimum Go version to build the binary to go1.15

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,6 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.14
           - 1.15
           - 1.16
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.14
+go 1.15
 
 require (
 	4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a

--- a/scripts/gen_github_action_config/go.mod
+++ b/scripts/gen_github_action_config/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/scripts/gen_github_action_config
 
-go 1.14
+go 1.15
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20200627185320-e003124d66e4


### PR DESCRIPTION
We will try to support only the latest two versions of Go to following the [release policy of Go](https://golang.org/doc/devel/release.html#policy)

Since the recommended way to install `golangci-lint` is to download and/or install a pre-built binary we see don't see a major problem with this.

Linked to #1925