### PR TITLE
Update wrapcheck to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b
 	github.com/tetafro/godot v1.4.5
 	github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94
-	github.com/tomarrell/wrapcheck v1.1.0
+	github.com/tomarrell/wrapcheck v1.2.0
 	github.com/tommy-muehle/go-mnd/v2 v2.3.2
 	github.com/ultraware/funlen v0.0.3
 	github.com/ultraware/whitespace v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -625,6 +625,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomarrell/wrapcheck v1.1.0 h1:zMmCL57nBBeB375MZ5i91Vde8utQTdyOn7ZId6WFIEo=
 github.com/tomarrell/wrapcheck v1.1.0/go.mod h1:Bd3i1FaEKe3XmcPoHhNQ+HM0S8P6eIXoQIoGj/ndJkU=
+github.com/tomarrell/wrapcheck v1.2.0 h1:N1PWGT8l+6jZVTcm00kGjx9IEA8oDMSjipqY73ye5c0=
+github.com/tomarrell/wrapcheck v1.2.0/go.mod h1:Bd3i1FaEKe3XmcPoHhNQ+HM0S8P6eIXoQIoGj/ndJkU=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tommy-muehle/go-mnd/v2 v2.3.2 h1:SLkFtxVVkoypCu6eTERr5U2IC3Kce/zOhA4IyNesPV4=
 github.com/tommy-muehle/go-mnd/v2 v2.3.2/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=


### PR DESCRIPTION
Updates the wrapcheck linter to v1.2.0.

Changelog:
- Added `.Error` to the list of default ignore sigs due to tomarrell/wrapcheck#8