### PR TITLE
Set stderr and stdout explicitly

### DIFF
--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -30,6 +30,11 @@ import (
 	"github.com/golangci/golangci-lint/pkg/timeutils"
 )
 
+var (
+	stderr = io.Writer(os.Stderr)
+	stdout = io.Writer(os.Stdout)
+)
+
 type Executor struct {
 	rootCmd    *cobra.Command
 	runCmd     *cobra.Command
@@ -92,7 +97,7 @@ func NewExecutor(version, commit, date string) *Executor {
 
 	// init of commands must be done before config file reading because
 	// init sets config with the default values of flags
-	e.initRoot()
+	e.initRoot(stderr, stdout)
 	e.initRun()
 	e.initHelp()
 	e.initLinters()

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -114,7 +115,7 @@ func getDefaultConcurrency() int {
 	return runtime.NumCPU()
 }
 
-func (e *Executor) initRoot() {
+func (e *Executor) initRoot(stderr, stdout io.Writer) {
 	rootCmd := &cobra.Command{
 		Use:   "golangci-lint",
 		Short: "golangci-lint is a smart linters runner.",
@@ -130,6 +131,8 @@ func (e *Executor) initRoot() {
 		PersistentPreRun:  e.persistentPreRun,
 		PersistentPostRun: e.persistentPostRun,
 	}
+	rootCmd.SetErr(stderr)
+	rootCmd.SetOut(stdout)
 
 	initRootFlagSet(rootCmd.PersistentFlags(), e.cfg, e.needVersionOption())
 	e.rootCmd = rootCmd

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -36,7 +35,7 @@ func (e *Executor) initVersion() {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			switch strings.ToLower(e.cfg.Version.Format) {
 			case "short":
-				fmt.Println(e.version)
+				cmd.Println(e.version)
 			case "json":
 				ver := jsonVersion{
 					Version: e.version,
@@ -47,9 +46,9 @@ func (e *Executor) initVersion() {
 				if err != nil {
 					return err
 				}
-				fmt.Println(string(data))
+				cmd.Println(string(data))
 			default:
-				fmt.Printf("golangci-lint has version %s built from %s on %s\n", e.version, e.commit, e.date)
+				cmd.Printf("golangci-lint has version %s built from %s on %s\n", e.version, e.commit, e.date)
 			}
 			return nil
 		},


### PR DESCRIPTION
Related to: https://github.com/golangci/golangci-lint/pull/1869

Motivation: the patch uses stdout implicitly and affects testability.

Tested:

```bash
$ go run ./cmd/golangci-lint/ version 2>/dev/null
golangci-lint has version (devel) built from (unknown, mod sum: "") on (unknown)
$ go run ./cmd/golangci-lint/ version 1>/dev/null
```