### PR TITLE
Update importAs to HEAD

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -401,14 +401,18 @@ linters-settings:
     max-decl-chars: 30
 
   importas:
-    # using `servingv1` alias for `knative.dev/serving/pkg/apis/serving/v1` package
-    servingv1: knative.dev/serving/pkg/apis/serving/v1
-    # using `autoscalingv1alpha1` alias for `knative.dev/serving/pkg/apis/autoscaling/v1alpha1` package
-    autoscalingv1alpha1: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
-    # You can specify the package path by regular expression,
-    # and alias by regular expression expansion syntax like below.
-    # see https://github.com/julz/importas#use-regular-expression for details
-    "$1$2": 'knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)'
+    # if set to `true`, force to use alias.
+    no-unaliased: true
+    # List of aliases
+    alias:
+      # using `servingv1` alias for `knative.dev/serving/pkg/apis/serving/v1` package
+      servingv1: knative.dev/serving/pkg/apis/serving/v1
+      # using `autoscalingv1alpha1` alias for `knative.dev/serving/pkg/apis/autoscaling/v1alpha1` package
+      autoscalingv1alpha1: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
+      # You can specify the package path by regular expression,
+      # and alias by regular expression expansion syntax like below.
+      # see https://github.com/julz/importas#use-regular-expression for details
+      "$1$2": 'knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)'
 
   lll:
     # max line length, lines longer will be reported. Default is 120.

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/jgautheron/goconst v1.4.0
 	github.com/jingyugao/rowserrcheck v0.0.0-20210315055705-d907ca737bb1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
-	github.com/julz/importas v0.0.0-20210405141620-a22c8f743dc9
+	github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d
 	github.com/kisielk/errcheck v1.6.0
 	github.com/kulti/thelper v0.4.0
 	github.com/kunwardeep/paralleltest v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julz/importas v0.0.0-20210405141620-a22c8f743dc9 h1:CyQB3TMIEjaoKL2AdYyrkRYX0NV8F4pO/zRBgbZfvIY=
-github.com/julz/importas v0.0.0-20210405141620-a22c8f743dc9/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
+github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d h1:XeSMXURZPtUffuWAaq90o6kLgZdgu+QA8wk4MPC8ikI=
+github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -306,7 +306,10 @@ type IfshortSettings struct {
 	MaxDeclChars int `mapstructure:"max-decl-chars"`
 }
 
-type ImportAsSettings map[string]string
+type ImportAsSettings struct {
+	Alias       map[string]string
+	NoUnaliased bool `mapstructure:"no-unaliased"`
+}
 
 type LllSettings struct {
 	LineLength int `mapstructure:"line-length"`

--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -2,6 +2,7 @@ package golinters
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/julz/importas" // nolint: misspell
 	"golang.org/x/tools/go/analysis"
@@ -24,7 +25,12 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			return
 		}
 
-		for alias, pkg := range *settings {
+		err := analyzer.Flags.Set("no-unaliased", strconv.FormatBool(settings.NoUnaliased))
+		if err != nil {
+			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
+		}
+
+		for alias, pkg := range settings.Alias {
 			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", pkg, alias))
 			if err != nil {
 				lintCtx.Log.Errorf("failed to parse configuration: %v", err)

--- a/test/testdata/configs/importas_strict.yml
+++ b/test/testdata/configs/importas_strict.yml
@@ -1,5 +1,6 @@
 linters-settings:
   importas:
+    no-unaliased: true
     alias:
       fff: fmt
       std_os: os

--- a/test/testdata/importas.go
+++ b/test/testdata/importas.go
@@ -3,11 +3,13 @@
 package testdata
 
 import (
-	wrong_alias "fmt"      // ERROR `import "fmt" imported as "wrong_alias" but must be "fff" according to config`
+	wrong_alias "fmt" // ERROR `import "fmt" imported as "wrong_alias" but must be "fff" according to config`
+	"os"
 	wrong_alias_again "os" // ERROR `import "os" imported as "wrong_alias_again" but must be "std_os" according to config`
 )
 
 func ImportAsWrongAlias() {
 	wrong_alias.Println("foo")
 	wrong_alias_again.Stdout.WriteString("bar")
+	os.Stdout.WriteString("test")
 }

--- a/test/testdata/importas_strict.go
+++ b/test/testdata/importas_strict.go
@@ -1,0 +1,15 @@
+//args: -Eimportas
+//config_path: testdata/configs/importas_strict.yml
+package testdata
+
+import (
+	wrong_alias "fmt"      // ERROR `import "fmt" imported as "wrong_alias" but must be "fff" according to config`
+	"os"                   // ERROR `import "os" imported without alias but must be with alias "std_os" according to config`
+	wrong_alias_again "os" // ERROR `import "os" imported as "wrong_alias_again" but must be "std_os" according to config`
+)
+
+func ImportAsStrictWrongAlias() {
+	wrong_alias.Println("foo")
+	wrong_alias_again.Stdout.WriteString("bar")
+	os.Stdout.WriteString("test")
+}


### PR DESCRIPTION
https://github.com/julz/importas/compare/a22c8f743dc9...841f0c0fe66d

Contains a breaking change in the importAs configuration.


This update is done by hand because dependabot is not able to update non-semver dependency.