### PR TITLE
revive: convert hard coded excludes into default exclude patterns

### DIFF
--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -77,6 +77,18 @@ var DefaultExcludePatterns = []ExcludePattern{
 		Linter: "stylecheck",
 		Why:    "Annoying issue about not having a comment. The rare codebase has such comments",
 	},
+	{
+		ID:      "EXC0012",
+		Pattern: "exported (method|function|type|const) (.+) should have comment or be unexported",
+		Linter:  "revive",
+		Why:     "Annoying issue about not having a comment. The rare codebase has such comments",
+	},
+	{
+		ID:      "EXC0013",
+		Pattern: `package comment should be of the form "Package (.+) ..."`,
+		Linter:  "revive",
+		Why:     "Annoying issue about not having a comment. The rare codebase has such comments",
+	},
 }
 
 type Issues struct {

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -29,7 +29,7 @@ type jsonObject struct {
 	lint.Failure `json:",inline"`
 }
 
-// NewNewRevive returns a new Revive linter.
+// NewRevive returns a new Revive linter.
 func NewRevive(cfg *config.ReviveSettings) *goanalysis.Linter {
 	var issues []goanalysis.Issue
 
@@ -156,11 +156,6 @@ func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
 	}
 
 	normalizeConfig(conf)
-
-	// By default golangci-lint ignores missing doc comments, follow same convention by removing this default rule
-	// Relevant issue: https://github.com/golangci/golangci-lint/issues/456
-	delete(conf.Rules, "package-comments")
-	delete(conf.Rules, "exported")
 
 	return conf, nil
 }

--- a/test/testdata/configs/revive.yml
+++ b/test/testdata/configs/revive.yml
@@ -3,6 +3,8 @@ linters-settings:
     ignore-generated-header: true
     severity: warning
     rules:
+      - name: exported
+      - name: package-comments
       - name: cognitive-complexity
         arguments: [ 7 ]
       - name: line-length-limit

--- a/test/testdata/revive.go
+++ b/test/testdata/revive.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func testRevive(t *time.Duration) error {
+func SampleRevive(t *time.Duration) error {
 	if t == nil {
 		return nil
 	} else {


### PR DESCRIPTION
Fix #1937

The default behavior is still the same, but the PR allows users to use `exported` and `package-comments` rules.