### PR TITLE
Update Wrapcheck to v2, add configuration

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -551,6 +551,9 @@ linters-settings:
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
 
   wrapcheck:
+    # See https://github.com/tomarrell/wrapcheck#configuration for documentation
+    # about available settings. The set of signatures below is considered the
+    # default set if no sigs are provided.
     ignoreSigs:
       - .Errorf(
       - errors.New(

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -551,11 +551,9 @@ linters-settings:
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
 
   wrapcheck:
-    # See https://github.com/tomarrell/wrapcheck#configuration for documentation
-    # about available settings. The set of signatures below is considered the
-    # default set if no sigs are provided.
     # An array of strings that specify substrings of signatures to ignore.
     # If this set, it will override the default set of ignored signatures.
+    # See https://github.com/tomarrell/wrapcheck#configuration for more information.
     ignoreSigs:
       - .Errorf(
       - errors.New(

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -554,6 +554,8 @@ linters-settings:
     # See https://github.com/tomarrell/wrapcheck#configuration for documentation
     # about available settings. The set of signatures below is considered the
     # default set if no sigs are provided.
+    # An array of strings that specify substrings of signatures to ignore.
+    # If this set, it will override the default set of ignored signatures.
     ignoreSigs:
       - .Errorf(
       - errors.New(

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -550,6 +550,15 @@ linters-settings:
     multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
 
+  wrapcheck:
+    ignoreSigs:
+      - .Errorf(
+      - errors.New(
+      - errors.Unwrap(
+      - .Wrap(
+      - .Wrapf(
+      - .WithMessage(
+
   wsl:
     # See https://github.com/bombsimon/wsl/blob/master/doc/configuration.md for
     # documentation of available settings. These are the defaults for

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b
 	github.com/tetafro/godot v1.4.6
 	github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94
-	github.com/tomarrell/wrapcheck v1.2.0
+	github.com/tomarrell/wrapcheck/v2 v2.1.0
 	github.com/tommy-muehle/go-mnd/v2 v2.3.2
 	github.com/ultraware/funlen v0.0.3
 	github.com/ultraware/whitespace v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1g
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tomarrell/wrapcheck v1.2.0 h1:N1PWGT8l+6jZVTcm00kGjx9IEA8oDMSjipqY73ye5c0=
-github.com/tomarrell/wrapcheck v1.2.0/go.mod h1:Bd3i1FaEKe3XmcPoHhNQ+HM0S8P6eIXoQIoGj/ndJkU=
+github.com/tomarrell/wrapcheck/v2 v2.1.0 h1:LTzwrYlgBUwi9JldazhbJN84fN9nS2UNGrZIo2syqxE=
+github.com/tomarrell/wrapcheck/v2 v2.1.0/go.mod h1:crK5eI4RGSUrb9duDTQ5GqcukbKZvi85vX6nbhsBAeI=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tommy-muehle/go-mnd/v2 v2.3.2 h1:SLkFtxVVkoypCu6eTERr5U2IC3Kce/zOhA4IyNesPV4=
 github.com/tommy-muehle/go-mnd/v2 v2.3.2/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -130,6 +130,7 @@ type LintersSettings struct {
 	Unused           StaticCheckSettings
 	Varcheck         VarCheckSettings
 	Whitespace       WhitespaceSettings
+	Wrapcheck        WrapcheckSettings
 	WSL              WSLSettings
 
 	Custom map[string]CustomLinterSettings
@@ -428,6 +429,10 @@ type VarCheckSettings struct {
 type WhitespaceSettings struct {
 	MultiIf   bool `mapstructure:"multi-if"`
 	MultiFunc bool `mapstructure:"multi-func"`
+}
+
+type WrapcheckSettings struct {
+	IgnoreSigs []string `mapstructure:"ignoreSigs"`
 }
 
 type WSLSettings struct {

--- a/pkg/golinters/wrapcheck.go
+++ b/pkg/golinters/wrapcheck.go
@@ -13,7 +13,9 @@ const wrapcheckName = "wrapcheck"
 func NewWrapcheck(cfg *config.WrapcheckSettings) *goanalysis.Linter {
 	c := wrapcheck.NewDefaultConfig()
 	if cfg != nil {
-		c.IgnoreSigs = cfg.IgnoreSigs
+		if len(cfg.IgnoreSigs) != 0 {
+			c.IgnoreSigs = cfg.IgnoreSigs
+		}
 	}
 
 	a := wrapcheck.NewAnalyzer(c)

--- a/pkg/golinters/wrapcheck.go
+++ b/pkg/golinters/wrapcheck.go
@@ -10,15 +10,15 @@ import (
 
 const wrapcheckName = "wrapcheck"
 
-func NewWrapcheck(cfg *config.WrapcheckSettings) *goanalysis.Linter {
-	c := wrapcheck.NewDefaultConfig()
-	if cfg != nil {
-		if len(cfg.IgnoreSigs) != 0 {
-			c.IgnoreSigs = cfg.IgnoreSigs
+func NewWrapcheck(settings *config.WrapcheckSettings) *goanalysis.Linter {
+	cfg := wrapcheck.NewDefaultConfig()
+	if settings != nil {
+		if len(settings.IgnoreSigs) != 0 {
+			cfg.IgnoreSigs = settings.IgnoreSigs
 		}
 	}
 
-	a := wrapcheck.NewAnalyzer(c)
+	a := wrapcheck.NewAnalyzer(cfg)
 
 	return goanalysis.NewLinter(
 		wrapcheckName,

--- a/pkg/golinters/wrapcheck.go
+++ b/pkg/golinters/wrapcheck.go
@@ -10,9 +10,11 @@ import (
 
 const wrapcheckName = "wrapcheck"
 
-func NewWrapcheck(cfg config.WrapcheckSettings) *goanalysis.Linter {
+func NewWrapcheck(cfg *config.WrapcheckSettings) *goanalysis.Linter {
 	c := wrapcheck.NewDefaultConfig()
-	c.IgnoreSigs = cfg.IgnoreSigs
+	if cfg != nil {
+		c.IgnoreSigs = cfg.IgnoreSigs
+	}
 
 	a := wrapcheck.NewAnalyzer(c)
 

--- a/pkg/golinters/wrapcheck.go
+++ b/pkg/golinters/wrapcheck.go
@@ -1,19 +1,25 @@
 package golinters
 
 import (
-	"github.com/tomarrell/wrapcheck/wrapcheck"
+	"github.com/tomarrell/wrapcheck/v2/wrapcheck"
 	"golang.org/x/tools/go/analysis"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
 const wrapcheckName = "wrapcheck"
 
-func NewWrapcheck() *goanalysis.Linter {
+func NewWrapcheck(cfg config.WrapcheckSettings) *goanalysis.Linter {
+	c := wrapcheck.NewDefaultConfig()
+	c.IgnoreSigs = cfg.IgnoreSigs
+
+	a := wrapcheck.NewAnalyzer(c)
+
 	return goanalysis.NewLinter(
 		wrapcheckName,
-		wrapcheck.Analyzer.Doc,
-		[]*analysis.Analyzer{wrapcheck.Analyzer},
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -117,6 +117,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var staticcheckCfg *config.StaticCheckSettings
 	var stylecheckCfg *config.StaticCheckSettings
 	var unusedCfg *config.StaticCheckSettings
+	var wrapcheckCfg *config.WrapcheckSettings
 
 	if m.cfg != nil {
 		govetCfg = &m.cfg.LintersSettings.Govet
@@ -137,6 +138,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		staticcheckCfg = &m.cfg.LintersSettings.Staticcheck
 		stylecheckCfg = &m.cfg.LintersSettings.Stylecheck
 		unusedCfg = &m.cfg.LintersSettings.Unused
+		wrapcheckCfg = &m.cfg.LintersSettings.Wrapcheck
 	}
 
 	const megacheckName = "megacheck"
@@ -411,7 +413,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.30.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/ssgreg/nlreturn"),
-		linter.NewConfig(golinters.NewWrapcheck()).
+		linter.NewConfig(golinters.NewWrapcheck(wrapcheckCfg)).
 			WithSince("v1.32.0").
 			WithPresets(linter.PresetStyle, linter.PresetError).
 			WithLoadForGoAnalysis().


### PR DESCRIPTION
Another wrapcheck update, this time with some configuration.

Recently added support to specify custom signatures to ignore when checking for wrapped errors making it more useful to people who want to use non-stdlib error wrapping.

Have given it a whirl, all looks good.