### PR TITLE
importas: add message if settings contain no aliases

### DIFF
--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -24,6 +24,9 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 		if settings == nil {
 			return
 		}
+		if len(settings.Alias) == 0 {
+			lintCtx.Log.Infof("importas settings found, but no aliases listed. List aliases under alias: key.") // nolint: misspell
+		}
 
 		err := analyzer.Flags.Set("no-unaliased", strconv.FormatBool(settings.NoUnaliased))
 		if err != nil {

--- a/test/testdata/configs/importas_noalias.yml
+++ b/test/testdata/configs/importas_noalias.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  importas:
+    fff: fmt
+    std_os: os

--- a/test/testdata/importas_noalias.go
+++ b/test/testdata/importas_noalias.go
@@ -1,0 +1,15 @@
+//args: -Eimportas
+//config_path: testdata/configs/importas_noalias.yml
+package testdata
+
+import (
+	wrong_alias "fmt"
+	"os"
+	wrong_alias_again "os"
+)
+
+func ImportAsNoAlias() {
+	wrong_alias.Println("foo")
+	wrong_alias_again.Stdout.WriteString("bar")
+	os.Stdout.WriteString("test")
+}


### PR DESCRIPTION
I wanted to use the strict feature of importas, but forgot to also move my aliases under the `alias:` key, and couldn't figure out why they weren't being applied. This message would have saved me a couple hours debugging the code to find out I should have just read the docs more closely.

Initially I had it as a warning so it would show when running normally, but the tests (with --no-config) still created a default config for ImportAs, and so the output was flagged. An info message will be shown with --verbose, and should be sufficient, as that was the first thing I did to try to figure out if importas was getting filtered out for some reason.