### PR TITLE
Flip importas configuration

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -410,13 +410,13 @@ linters-settings:
     # List of aliases
     alias:
       # using `servingv1` alias for `knative.dev/serving/pkg/apis/serving/v1` package
-      servingv1: knative.dev/serving/pkg/apis/serving/v1
+      knative.dev/serving/pkg/apis/serving/v1: servingv1
       # using `autoscalingv1alpha1` alias for `knative.dev/serving/pkg/apis/autoscaling/v1alpha1` package
-      autoscalingv1alpha1: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
+      knative.dev/serving/pkg/apis/autoscaling/v1alpha1: autoscalingv1alpha1
       # You can specify the package path by regular expression,
       # and alias by regular expression expansion syntax like below.
       # see https://github.com/julz/importas#use-regular-expression for details
-      "$1$2": 'knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)'
+      'knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)': '$1$2'
 
   lll:
     # max line length, lines longer will be reported. Default is 120.

--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -33,7 +33,7 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 		}
 
-		for alias, pkg := range settings.Alias {
+		for pkg, alias := range settings.Alias {
 			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", pkg, alias))
 			if err != nil {
 				lintCtx.Log.Errorf("failed to parse configuration: %v", err)

--- a/test/testdata/configs/importas.yml
+++ b/test/testdata/configs/importas.yml
@@ -1,5 +1,5 @@
 linters-settings:
   importas:
     alias:
-      fff: fmt
-      std_os: os
+      fmt: fff
+      os: std_os

--- a/test/testdata/configs/importas_noalias.yml
+++ b/test/testdata/configs/importas_noalias.yml
@@ -1,4 +1,4 @@
 linters-settings:
   importas:
-    fff: fmt
-    std_os: os
+    fmt: fff
+    os: std_os

--- a/test/testdata/configs/importas_strict.yml
+++ b/test/testdata/configs/importas_strict.yml
@@ -2,5 +2,5 @@ linters-settings:
   importas:
     no-unaliased: true
     alias:
-      fff: fmt
-      std_os: os
+      fmt: fff
+      os: std_os


### PR DESCRIPTION
The standalone [importas](https://github.com/julz/importas) tool takes arguments in [the form `{package}:{alias}`](https://github.com/julz/importas/blob/841f0c0fe66d8a78d66676e024272dfd69b57668/flags.go#L12) and [stores them in a map](https://github.com/julz/importas/blob/841f0c0fe66d8a78d66676e024272dfd69b57668/flags.go#L25) in which [`package` is the key](https://github.com/julz/importas/blob/841f0c0fe66d8a78d66676e024272dfd69b57668/config.go#L17). The intent is to describe the one alias that is appropriate for a unique [package path](https://golang.org/ref/mod#modules-overview).

The golangci-lint configuration does the opposite; the `alias` is the key. This effectively "reserves" an alias for one package. This difference in configuration limits the number of packages that can be configured and doesn't align with the goals and documentation of the standalone tool.

This PR aligns our configuration with the standalone tool. It is a breaking change, but another breaking change to this linter's configuration is waiting to be released in ffe80615b079a2cfe9b28e2d8323d58061b795d6. 