### PR TITLE
importas: allow repeated aliases

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -410,13 +410,16 @@ linters-settings:
     # List of aliases
     alias:
       # using `servingv1` alias for `knative.dev/serving/pkg/apis/serving/v1` package
-      servingv1: knative.dev/serving/pkg/apis/serving/v1
+      - pkg: knative.dev/serving/pkg/apis/serving/v1
+        alias: servingv1
       # using `autoscalingv1alpha1` alias for `knative.dev/serving/pkg/apis/autoscaling/v1alpha1` package
-      autoscalingv1alpha1: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
+      - pkg: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
+        alias: autoscalingv1alpha1
       # You can specify the package path by regular expression,
       # and alias by regular expression expansion syntax like below.
       # see https://github.com/julz/importas#use-regular-expression for details
-      "$1$2": 'knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)'
+      - pkg: knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
 
   lll:
     # max line length, lines longer will be reported. Default is 120.

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -312,8 +312,13 @@ type IfshortSettings struct {
 }
 
 type ImportAsSettings struct {
-	Alias       map[string]string
+	Alias       []ImportAsAlias
 	NoUnaliased bool `mapstructure:"no-unaliased"`
+}
+
+type ImportAsAlias struct {
+	Pkg   string
+	Alias string
 }
 
 type LllSettings struct {

--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -33,8 +33,13 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 		}
 
-		for i := range settings.Alias {
-			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", settings.Alias[i].Pkg, settings.Alias[i].Alias))
+		for _, a := range settings.Alias {
+			if a.Pkg == "" {
+				lintCtx.Log.Errorf("invalid configuration, empty package: pkg=%s alias=%s", a.Pkg, a.Alias)
+				continue
+			}
+
+			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", a.Pkg, a.Alias))
 			if err != nil {
 				lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 			}

--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -33,8 +33,8 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 		}
 
-		for alias, pkg := range settings.Alias {
-			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", pkg, alias))
+		for i := range settings.Alias {
+			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", settings.Alias[i].Pkg, settings.Alias[i].Alias))
 			if err != nil {
 				lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 			}

--- a/test/testdata/configs/importas.yml
+++ b/test/testdata/configs/importas.yml
@@ -1,5 +1,9 @@
 linters-settings:
   importas:
     alias:
-      fff: fmt
-      std_os: os
+      - pkg: fmt
+        alias: fff
+      - pkg: os
+        alias: std_os
+      - pkg: github.com/pkg/errors
+        alias: pkgerr

--- a/test/testdata/configs/importas_strict.yml
+++ b/test/testdata/configs/importas_strict.yml
@@ -2,5 +2,9 @@ linters-settings:
   importas:
     no-unaliased: true
     alias:
-      fff: fmt
-      std_os: os
+      - pkg: fmt
+        alias: fff
+      - pkg: os
+        alias: std_os
+      - pkg: github.com/pkg/errors
+        alias: pkgerr

--- a/test/testdata/importas.go
+++ b/test/testdata/importas.go
@@ -6,10 +6,13 @@ import (
 	wrong_alias "fmt" // ERROR `import "fmt" imported as "wrong_alias" but must be "fff" according to config`
 	"os"
 	wrong_alias_again "os" // ERROR `import "os" imported as "wrong_alias_again" but must be "std_os" according to config`
+
+	wrong "github.com/pkg/errors" // ERROR `import "github.com/pkg/errors" imported as "wrong" but must be "pkgerr" according to config`
 )
 
 func ImportAsWrongAlias() {
 	wrong_alias.Println("foo")
 	wrong_alias_again.Stdout.WriteString("bar")
 	os.Stdout.WriteString("test")
+	_ = wrong.New("baz")
 }

--- a/test/testdata/importas_strict.go
+++ b/test/testdata/importas_strict.go
@@ -6,10 +6,13 @@ import (
 	wrong_alias "fmt"      // ERROR `import "fmt" imported as "wrong_alias" but must be "fff" according to config`
 	"os"                   // ERROR `import "os" imported without alias but must be with alias "std_os" according to config`
 	wrong_alias_again "os" // ERROR `import "os" imported as "wrong_alias_again" but must be "std_os" according to config`
+
+	wrong "github.com/pkg/errors" // ERROR `import "github.com/pkg/errors" imported as "wrong" but must be "pkgerr" according to config`
 )
 
 func ImportAsStrictWrongAlias() {
 	wrong_alias.Println("foo")
 	wrong_alias_again.Stdout.WriteString("bar")
 	os.Stdout.WriteString("test")
+	_ = wrong.New("baz")
 }


### PR DESCRIPTION
As described in #1959, the standalone [importas](https://github.com/julz/importas) tool does not restrict an alias to a single package. This aligns our configuration with the standalone tool.

It is a breaking change, but another breaking change to this linter's configuration is waiting to be released in ffe80615b079a2cfe9b28e2d8323d58061b795d6.