### PR TITLE
fix: example config yaml

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -227,7 +227,7 @@ linters-settings:
       underef:
         # whether to skip (*x).method() calls where x is a pointer receiver (default true)
         skipRecvDeref: true
-    	unnamedResult:
+      unnamedResult:
         # whether to check exported functions
         checkExported: true
 


### PR DESCRIPTION
Minor fix, remove one tab character in the `.golangci.example.yaml` which breaks yaml parsing (in the case if .golangci.example.yaml used to automate `golangci-lint` testing).