### PR TITLE
docs: exhaustivestruct example explanation

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -134,11 +134,13 @@ linters-settings:
     default-signifies-exhaustive: false
 
   exhaustivestruct:
+    # Struct Patterns is list of expressions to match struct packages and names
+    # The struct packages have the form example.com/package.ExampleStruct
+    # The matching patterns can use matching syntax from https://pkg.go.dev/path#Match
+    # If this list is empty, all structs are tested.
     struct-patterns:
       - '*.Test'
-      - '*.Test2'
-      - '*.Embedded'
-      - '*.External'
+      - 'example.com/package.ExampleStruct'
 
   forbidigo:
     # Forbid the following identifiers


### PR DESCRIPTION
Comment add context on `struct-patterns` patterns, so it's not unexpected for users that patterns behave in next way:

1. e.g. `*.Text` can match struct Test if golangci-lint launched against the file
   `golangcli-lint run example/example.go`

1. e.g. `*.Text` do not match struct Test if golangci-lint launched against package
   `golangcli-lint run example`