### PR TITLE
revive: improve 'exported' rule output.

### DIFF
--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -108,21 +108,7 @@ func NewRevive(cfg *config.ReviveSettings) *goanalysis.Linter {
 			}
 
 			for i := range results {
-				issues = append(issues, goanalysis.NewIssue(&result.Issue{
-					Severity: string(results[i].Severity),
-					Text:     fmt.Sprintf("%s: %s", results[i].RuleName, results[i].Failure.Failure),
-					Pos: token.Position{
-						Filename: results[i].Position.Start.Filename,
-						Line:     results[i].Position.Start.Line,
-						Offset:   results[i].Position.Start.Offset,
-						Column:   results[i].Position.Start.Column,
-					},
-					LineRange: &result.Range{
-						From: results[i].Position.Start.Line,
-						To:   results[i].Position.End.Line,
-					},
-					FromLinter: reviveName,
-				}, pass))
+				issues = append(issues, reviveToIssue(pass, &results[i]))
 			}
 
 			return nil, nil
@@ -130,6 +116,29 @@ func NewRevive(cfg *config.ReviveSettings) *goanalysis.Linter {
 	}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
 		return issues
 	}).WithLoadMode(goanalysis.LoadModeSyntax)
+}
+
+func reviveToIssue(pass *analysis.Pass, object *jsonObject) goanalysis.Issue {
+	lineRangeTo := object.Position.End.Line
+	if object.RuleName == (&rule.ExportedRule{}).Name() {
+		lineRangeTo = object.Position.Start.Line
+	}
+
+	return goanalysis.NewIssue(&result.Issue{
+		Severity: string(object.Severity),
+		Text:     fmt.Sprintf("%s: %s", object.RuleName, object.Failure.Failure),
+		Pos: token.Position{
+			Filename: object.Position.Start.Filename,
+			Line:     object.Position.Start.Line,
+			Offset:   object.Position.Start.Offset,
+			Column:   object.Position.Start.Column,
+		},
+		LineRange: &result.Range{
+			From: object.Position.Start.Line,
+			To:   lineRangeTo,
+		},
+		FromLinter: reviveName,
+	}, pass)
 }
 
 // This function mimics the GetConfig function of revive.


### PR DESCRIPTION
Fixes #1993

<details>
<summary>example.go</summary>

```go
package main

import "fmt"

var HorribleGlobalVar = map[int]string{
	1:    "s1",
	2:    "s2",
	3:    "s3",
	2000: "s2000",
}

var (
	GroupOfHorribleGlobalVar = map[int]string{
		1:    "s1",
		2:    "s2",
		3:    "s3",
		2000: "s2000",
	}
)

type Foo struct {
	S1 string
	S2 string
	S3 string
	S4 string
	S5 string
}

func Goo() {
	to := "test"

	fmt.Println(to)
}

```

</details>

<details>
<summary>.golangci.yml</summary>

```yml
linters:

  disable-all: true
  enable:
    - revive

issues:
  exclude-use-default: false

```

</details>

<details>
<summary>before the PR</summary>

```console
$ golangci-lint run --disable-all -Erevive
main.go:5:5: exported: exported var HorribleGlobalVar should have comment or be unexported (revive)
var HorribleGlobalVar = map[int]string{
        1:    "s1",
        2:    "s2",
        3:    "s3",
        2000: "s2000",
}
main.go:13:2: exported: exported var GroupOfHorribleGlobalVar should have comment or be unexported (revive)
        GroupOfHorribleGlobalVar = map[int]string{
                1:    "s1",
                2:    "s2",
                3:    "s3",
                2000: "s2000",
        }
main.go:21:6: exported: exported type Foo should have comment or be unexported (revive)
type Foo struct {
        S1 string
        S2 string
        S3 string
        S4 string
        S5 string
}
main.go:29:1: exported: exported function Goo should have comment or be unexported (revive)
func Goo() {
        to := "test"

        fmt.Println(to)
}

```

</details>

<details>
<summary>with the PR</summary>

```console
$ ./golangci-lint run --disable-all -Erevive
main.go:5:5: exported: exported var HorribleGlobalVar should have comment or be unexported (revive)
var HorribleGlobalVar = map[int]string{
    ^
main.go:13:2: exported: exported var GroupOfHorribleGlobalVar should have comment or be unexported (revive)
        GroupOfHorribleGlobalVar = map[int]string{
        ^
main.go:21:6: exported: exported type Foo should have comment or be unexported (revive)
type Foo struct {
     ^
main.go:29:1: exported: exported function Goo should have comment or be unexported (revive)
func Goo() {
^
```

</details>

