### PR TITLE
docs: fix pattern of forbidigo in example config yaml 

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -145,9 +145,9 @@ linters-settings:
   forbidigo:
     # Forbid the following identifiers
     forbid:
-      - fmt.Errorf # consider errors.Errorf in github.com/pkg/errors
-      - fmt.Print.* # too much log noise
-      - ginkgo\\.F.* # these are used just for local development
+      - ^fmt\.Errorf$ # consider errors.Errorf in github.com/pkg/errors
+      - ^fmt\.Print.*$ # too much log noise
+      - ^ginkgo\.F[A-Z].*$ # these are used just for local development
     # Exclude godoc examples from forbidigo checks.  Default is true.
     exclude_godoc_examples: false
 

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -143,9 +143,9 @@ linters-settings:
       - 'example.com/package.ExampleStruct'
 
   forbidigo:
-    # Forbid the following identifiers
+    # Forbid the following identifiers (identifiers are written using regexp):
     forbid:
-      - ^print.*$ # Identifiers are written using regexp.
+      - ^print.*$
       - 'fmt\.Print.*'
     # Exclude godoc examples from forbidigo checks.  Default is true.
     exclude_godoc_examples: false

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -145,9 +145,8 @@ linters-settings:
   forbidigo:
     # Forbid the following identifiers
     forbid:
-      - ^fmt\.Errorf$ # consider errors.Errorf in github.com/pkg/errors
-      - ^fmt\.Print.*$ # too much log noise
-      - ^ginkgo\.F[A-Z].*$ # these are used just for local development
+      - ^print.*$ # Identifiers are written using regexp.
+      - 'fmt\.Print.*'
     # Exclude godoc examples from forbidigo checks.  Default is true.
     exclude_godoc_examples: false
 


### PR DESCRIPTION
The pattern of forbidigo in `.golangci.example.yaml` was not the correct pattern so I fixed.
It has been modified with reference to the original [usage](https://github.com/ashanbrown/forbidigo#usage).

`ginkgo\\.F.*` in the pattern before modification does not behave as expected.