### PR TITLE
revive: fix add-constant rule support.

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -496,7 +496,7 @@ linters-settings:
   rowserrcheck:
     packages:
       - github.com/jmoiron/sqlx
-      -
+
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: true
@@ -504,6 +504,13 @@ linters-settings:
     rules:
       - name: indent-error-flow
         severity: warning
+      - name: add-constant
+        severity: warning
+        arguments:
+          - maxLitCount: "3"
+            allowStrs: '""'
+            allowInts: "0,1,2"
+            allowFloats: "0.0,0.,1.0,1.,2.0,2."
 
   staticcheck:
     # Select the Go version to target. The default is '1.13'.

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
 
 	"github.com/golangci/golangci-lint/internal/cache"
 	"github.com/golangci/golangci-lint/internal/pkgcache"
@@ -194,7 +194,7 @@ func computeConfigSalt(cfg *config.Config) ([]byte, error) {
 	// We don't hash all config fields to reduce meaningless cache
 	// invalidations. At least, it has a huge impact on tests speed.
 
-	lintersSettingsBytes, err := json.Marshal(cfg.LintersSettings)
+	lintersSettingsBytes, err := yaml.Marshal(cfg.LintersSettings)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to json marshal config linter settings")
 	}


### PR DESCRIPTION
Fixes #2002

The root problem is the difference between the JSON parser and the YAML parser.
The YAML parser produces `map[interface{}]interface{}` but the JSON is not able to marshall `map` with a struct as a key.

And there is a second problem, the difference between the TOML parser and the YAML parser.
Revive uses "raw" map based on TOML parser, but it's not the same "raw" map as the YAML parser.
