### PR TITLE
New Feature: support nolint range

### DIFF
--- a/pkg/result/processors/nolint.go
+++ b/pkg/result/processors/nolint.go
@@ -18,6 +18,10 @@ import (
 
 var nolintDebugf = logutils.Debug("nolint")
 
+const (
+	nolintKey = "nolint"
+)
+
 type ignoredRange struct {
 	linters                []string
 	matchedIssueFromLinter map[string]bool
@@ -85,7 +89,7 @@ func NewNolint(log logutils.Log, dbManager *lintersdb.Manager, enabledLinters ma
 var _ Processor = &Nolint{}
 
 func (p Nolint) Name() string {
-	return "nolint"
+	return nolintKey
 }
 
 func (p *Nolint) Process(issues []result.Issue) ([]result.Issue, error) {
@@ -339,7 +343,7 @@ func (p *Nolint) extractInlineRangeFromComment(text string, g ast.Node, fset *to
 
 	text = strings.Split(text, "//")[0] // allow another comment after this comment
 	text = strings.TrimSpace(text)
-	if text == "nolint" {
+	if text == nolintKey {
 		return buildRange(nil) // ignore all linters
 	}
 

--- a/pkg/result/processors/nolint_test.go
+++ b/pkg/result/processors/nolint_test.go
@@ -122,6 +122,41 @@ func TestNolint(t *testing.T) {
 	}
 }
 
+func newNolintRangeFileIssue(line int, fromLinter string) result.Issue {
+	return result.Issue{
+		Pos: token.Position{
+			Filename: filepath.Join("testdata", "nolintrange.go"),
+			Line:     line,
+		},
+		FromLinter: fromLinter,
+	}
+}
+
+func TestNolintRange(t *testing.T) {
+	p := newTestNolintProcessor(getMockLog())
+	defer p.Finish()
+
+	// normal nolint range
+	for i := 3; i <= 6; i++ {
+		processAssertEmpty(t, p, newNolintRangeFileIssue(i, "gofmt"))
+	}
+
+	processAssertSame(t, p, newNolintRangeFileIssue(7, "any"))
+
+	// nested nolint range
+	for i := 8; i <= 13; i++ {
+		processAssertEmpty(t, p, newNolintRangeFileIssue(i, "unused"))
+	}
+	for i := 9; i <= 12; i++ {
+		processAssertEmpty(t, p, newNolintRangeFileIssue(i, "gofmt"))
+	}
+
+	// without nolint-end
+	for i := 15; i <= 20; i++ {
+		processAssertEmpty(t, p, newNolintRangeFileIssue(i, "deadcode"))
+	}
+}
+
 func TestNolintInvalidLinterName(t *testing.T) {
 	fileName := filepath.Join("testdata", "nolint_bad_names.go")
 	issues := []result.Issue{

--- a/pkg/result/processors/testdata/nolintrange.go
+++ b/pkg/result/processors/testdata/nolintrange.go
@@ -1,0 +1,20 @@
+package testdata
+
+//nolint-begin:gofmt
+var nolintRange int
+
+//nolint-end:gofmt
+
+//nolint-begin:unused
+//nolint-begin:gofmt
+var nolintRangeNested int
+
+//nolint-end:gofmt
+//nolint-end:unused
+
+//nolint-begin:deadcode
+
+var nolintRangeWithoutEnd1 int
+var nolintRangeWithoutEnd2 int
+var nolintRangeWithoutEnd3 int
+var nolintRangeWithoutEnd4 int


### PR DESCRIPTION
Hi team :D

Fixes #129

Support the new feature nolint range.
Now, we can ignore reports with `nolint-begin` and `nolint-end`

```
func Save() {
  //nolint-begin:lll
  very long line of code 
  another very long line of code
  one more 
  ...
  //nolint-end:lll
}
```

I've opened it early to hear any feedback on the syntax. I'll open it as a formal PR once I've written some tests and can get everyone to agree on the above syntax.