### PR TITLE
gomodguard: fix problem where duplicate issues were being reported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/nishanths/predeclared v0.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/polyfloyd/go-errorlint v0.0.0-20210510181950-ab96adb96fea
-	github.com/ryancurrah/gomodguard v1.2.0
+	github.com/ryancurrah/gomodguard v1.2.1
 	github.com/ryanrolds/sqlclosecheck v0.3.0
 	github.com/sanposhiho/wastedassign v1.0.0
 	github.com/securego/gosec/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/ryancurrah/gomodguard v1.2.0 h1:YWfhGOrXwLGiqcC/u5EqG6YeS8nh+1fw0HEc85CVZro=
-github.com/ryancurrah/gomodguard v1.2.0/go.mod h1:rNqbC4TOIdUDcVMSIpNNAzTbzXAZa6W5lnUepvuMMgQ=
+github.com/ryancurrah/gomodguard v1.2.1 h1:t1WWL0RGJJBo5KZ0u2c/FGY1QQgx2gUbHWzBmOKWs98=
+github.com/ryancurrah/gomodguard v1.2.1/go.mod h1:tpI+C/nzvfUR3bF28b5QHpTn/jM/zlGniI++6ZlIWeE=
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/pkg/golinters/gomodguard.go
+++ b/pkg/golinters/gomodguard.go
@@ -72,7 +72,7 @@ func NewGomodguard() *goanalysis.Linter {
 		}
 
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
-			files := []string{}
+			var files []string
 
 			for _, file := range pass.Files {
 				files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)

--- a/pkg/golinters/gomodguard.go
+++ b/pkg/golinters/gomodguard.go
@@ -24,8 +24,8 @@ func NewGomodguard() *goanalysis.Linter {
 		issues   []goanalysis.Issue
 		mu       = sync.Mutex{}
 		analyzer = &analysis.Analyzer{
-			Name: gomodguardName,
-			Doc:  gomodguardDesc,
+			Name: goanalysis.TheOnlyAnalyzerName,
+			Doc:  goanalysis.TheOnlyanalyzerDoc,
 		}
 	)
 

--- a/pkg/golinters/gomodguard.go
+++ b/pkg/golinters/gomodguard.go
@@ -13,6 +13,9 @@ import (
 
 const (
 	gomodguardName = "gomodguard"
+	gomodguardDesc = "Allow and block list linter for direct Go module dependencies. " +
+		"This is different from depguard where there are different block " +
+		"types for example version constraints and module recommendations."
 )
 
 // NewGomodguard returns a new Gomodguard linter.
@@ -21,75 +24,70 @@ func NewGomodguard() *goanalysis.Linter {
 		issues   []goanalysis.Issue
 		mu       = sync.Mutex{}
 		analyzer = &analysis.Analyzer{
-			Name: goanalysis.TheOnlyAnalyzerName,
-			Doc:  goanalysis.TheOnlyanalyzerDoc,
+			Name: gomodguardName,
+			Doc:  gomodguardDesc,
 		}
 	)
 
 	return goanalysis.NewLinter(
 		gomodguardName,
-		"Allow and block list linter for direct Go module dependencies. "+
-			"This is different from depguard where there are different block "+
-			"types for example version constraints and module recommendations.",
+		gomodguardDesc,
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
-			var (
-				files        = []string{}
-				linterCfg    = lintCtx.Cfg.LintersSettings.Gomodguard
-				processorCfg = &gomodguard.Configuration{}
-			)
-			processorCfg.Allowed.Modules = linterCfg.Allowed.Modules
-			processorCfg.Allowed.Domains = linterCfg.Allowed.Domains
-			for n := range linterCfg.Blocked.Modules {
-				for k, v := range linterCfg.Blocked.Modules[n] {
-					m := map[string]gomodguard.BlockedModule{k: {
-						Recommendations: v.Recommendations,
-						Reason:          v.Reason,
-					}}
-					processorCfg.Blocked.Modules = append(processorCfg.Blocked.Modules, m)
-					break
-				}
-			}
+		linterCfg := lintCtx.Cfg.LintersSettings.Gomodguard
 
-			for n := range linterCfg.Blocked.Versions {
-				for k, v := range linterCfg.Blocked.Versions[n] {
-					m := map[string]gomodguard.BlockedVersion{k: {
-						Version: v.Version,
-						Reason:  v.Reason,
-					}}
-					processorCfg.Blocked.Versions = append(processorCfg.Blocked.Versions, m)
-					break
-				}
+		processorCfg := &gomodguard.Configuration{}
+		processorCfg.Allowed.Modules = linterCfg.Allowed.Modules
+		processorCfg.Allowed.Domains = linterCfg.Allowed.Domains
+		processorCfg.Blocked.LocalReplaceDirectives = linterCfg.Blocked.LocalReplaceDirectives
+
+		for n := range linterCfg.Blocked.Modules {
+			for k, v := range linterCfg.Blocked.Modules[n] {
+				m := map[string]gomodguard.BlockedModule{k: {
+					Recommendations: v.Recommendations,
+					Reason:          v.Reason,
+				}}
+				processorCfg.Blocked.Modules = append(processorCfg.Blocked.Modules, m)
+				break
 			}
+		}
+
+		for n := range linterCfg.Blocked.Versions {
+			for k, v := range linterCfg.Blocked.Versions[n] {
+				m := map[string]gomodguard.BlockedVersion{k: {
+					Version: v.Version,
+					Reason:  v.Reason,
+				}}
+				processorCfg.Blocked.Versions = append(processorCfg.Blocked.Versions, m)
+				break
+			}
+		}
+
+		processor, err := gomodguard.NewProcessor(processorCfg)
+		if err != nil {
+			lintCtx.Log.Warnf("running gomodguard failed: %s: if you are not using go modules "+
+				"it is suggested to disable this linter", err)
+			return
+		}
+
+		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+			files := []string{}
 
 			for _, file := range pass.Files {
 				files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
 			}
 
-			processorCfg.Blocked.LocalReplaceDirectives = linterCfg.Blocked.LocalReplaceDirectives
-
-			processor, err := gomodguard.NewProcessor(processorCfg)
-			if err != nil {
-				lintCtx.Log.Warnf("running gomodguard failed: %s: if you are not using go modules "+
-					"it is suggested to disable this linter", err)
-				return nil, nil
-			}
-
-			gomodguardErrors := processor.ProcessFiles(files)
-			if len(gomodguardErrors) == 0 {
-				return nil, nil
-			}
+			gomodguardIssues := processor.ProcessFiles(files)
 
 			mu.Lock()
 			defer mu.Unlock()
 
-			for _, err := range gomodguardErrors {
+			for _, gomodguardIssue := range gomodguardIssues {
 				issues = append(issues, goanalysis.NewIssue(&result.Issue{
 					FromLinter: gomodguardName,
-					Pos:        err.Position,
-					Text:       err.Reason,
+					Pos:        gomodguardIssue.Position,
+					Text:       gomodguardIssue.Reason,
 				}, pass))
 			}
 


### PR DESCRIPTION
Gomodguard was saving issues to a global variable and when it was the process issues functioned returned results it would end up returning duplicates. This issue solves that by the process function returning only new issues found.

Also ensure we only configure and initialize gomodguard once by removing those steps from the `Run` func.


https://github.com/ryancurrah/gomodguard/compare/v1.2.0...v1.2.1