### PR TITLE
Add IgnoreTests to goconst configuration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/gostaticanalysis/forcetypeassert v0.0.0-20200621232751-01d4955beaa5
 	github.com/gostaticanalysis/nilerr v0.1.1
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/jgautheron/goconst v1.4.0
+	github.com/jgautheron/goconst v1.5.1
 	github.com/jingyugao/rowserrcheck v1.1.0
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,8 @@ github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jgautheron/goconst v1.4.0 h1:hp9XKUpe/MPyDamUbfsrGpe+3dnY2whNK4EtB86dvLM=
-github.com/jgautheron/goconst v1.4.0/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
+github.com/jgautheron/goconst v1.5.1 h1:HxVbL1MhydKs8R8n/HE5NPvzfaYmQJA3o879lE4+WcM=
+github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jingyugao/rowserrcheck v1.1.0 h1:u6h4eiNuCLqk73Ic5TXQq9yZS+uEXTdusn7c3w1Mr6A=
 github.com/jingyugao/rowserrcheck v1.1.0/go.mod h1:TOQpc2SLx6huPfoFGK3UOnEG+u02D3C1GeosjupAKCA=
@@ -554,8 +554,6 @@ github.com/securego/gosec/v2 v2.8.0/go.mod h1:hJZ6NT5TqoY+jmOsaxAV4cXoEdrMRLVaNP
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c h1:W65qqJCIOVP4jpqPQ0YvHYKwcMEMVWIzWC5iNQQfBTU=
 github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c/go.mod h1:/PevMnwAxekIXwN8qQyfc5gl2NlkB3CQlkizAbOkeBs=
-github.com/shirou/gopsutil/v3 v3.21.4 h1:XB/+p+kVnyYLuPHCfa99lxz2aJyvVhnyd+FxZqH/k7M=
-github.com/shirou/gopsutil/v3 v3.21.4/go.mod h1:ghfMypLDrFSWN2c9cDYFLHyynQ+QUht0cv/18ZqVczw=
 github.com/shirou/gopsutil/v3 v3.21.5 h1:YUBf0w/KPLk7w1803AYBnH7BmA+1Z/Q5MEZxpREUaB4=
 github.com/shirou/gopsutil/v3 v3.21.5/go.mod h1:ghfMypLDrFSWN2c9cDYFLHyynQ+QUht0cv/18ZqVczw=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -200,6 +200,7 @@ type GocognitSettings struct {
 }
 
 type GoConstSettings struct {
+	IgnoreTests         bool `mapstructure:"ignore-tests"`
 	MatchWithConstants  bool `mapstructure:"match-constant"`
 	MinStringLen        int  `mapstructure:"min-len"`
 	MinOccurrencesCount int  `mapstructure:"min-occurrences"`

--- a/pkg/golinters/goconst.go
+++ b/pkg/golinters/goconst.go
@@ -47,6 +47,7 @@ func NewGoconst() *goanalysis.Linter {
 
 func checkConstants(pass *analysis.Pass, lintCtx *linter.Context) ([]goanalysis.Issue, error) {
 	cfg := goconstAPI.Config{
+		IgnoreTests:        lintCtx.Settings().Goconst.IgnoreTests,
 		MatchWithConstants: lintCtx.Settings().Goconst.MatchWithConstants,
 		MinStringLength:    lintCtx.Settings().Goconst.MinStringLen,
 		MinOccurrences:     lintCtx.Settings().Goconst.MinOccurrencesCount,

--- a/test/testdata/goconst_dont_ignore_test.go
+++ b/test/testdata/goconst_dont_ignore_test.go
@@ -1,0 +1,36 @@
+//args: -Egoconst
+//config: linters-settings.goconst.ignore-tests=false
+package testdata
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGoConstA(t *testing.T) {
+	a := "needconst" // ERROR "string `needconst` has 5 occurrences, make it a constant"
+	fmt.Print(a)
+	b := "needconst"
+	fmt.Print(b)
+	c := "needconst"
+	fmt.Print(c)
+}
+
+func TestGoConstB(t *testing.T) {
+	a := "needconst"
+	fmt.Print(a)
+	b := "needconst"
+	fmt.Print(b)
+}
+
+const AlreadyHasConst = "alreadyhasconst"
+
+func TestGoConstC(t *testing.T) {
+	a := "alreadyhasconst" // ERROR "string `alreadyhasconst` has 3 occurrences, but such constant `AlreadyHasConst` already exists"
+	fmt.Print(a)
+	b := "alreadyhasconst"
+	fmt.Print(b)
+	c := "alreadyhasconst"
+	fmt.Print(c)
+	fmt.Print("alreadyhasconst")
+}

--- a/test/testdata/goconst_ignore_test.go
+++ b/test/testdata/goconst_ignore_test.go
@@ -1,0 +1,36 @@
+//args: -Egoconst
+//config: linters-settings.goconst.ignore-tests=true
+package testdata
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGoConstA(t *testing.T) {
+	a := "needconst"
+	fmt.Print(a)
+	b := "needconst"
+	fmt.Print(b)
+	c := "needconst"
+	fmt.Print(c)
+}
+
+func TestGoConstB(t *testing.T) {
+	a := "needconst"
+	fmt.Print(a)
+	b := "needconst"
+	fmt.Print(b)
+}
+
+const AlreadyHasConst = "alreadyhasconst"
+
+func TestGoConstC(t *testing.T) {
+	a := "alreadyhasconst"
+	fmt.Print(a)
+	b := "alreadyhasconst"
+	fmt.Print(b)
+	c := "alreadyhasconst"
+	fmt.Print(c)
+	fmt.Print("alreadyhasconst")
+}


### PR DESCRIPTION
- Updates goconst to v1.5.1.
- Plumbs IgnoreTests through from the backend, and tests new configuration.

https://github.com/jgautheron/goconst/compare/v1.4.0...v1.5.1