### PR TITLE
revive: fix exclude comment rule for const block.

### DIFF
--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -79,7 +79,7 @@ var DefaultExcludePatterns = []ExcludePattern{
 	},
 	{
 		ID:      "EXC0012",
-		Pattern: `exported (.+) should have comment or be unexported`,
+		Pattern: `exported (.+) should have comment( \(or a comment on this block\))? or be unexported`,
 		Linter:  "revive",
 		Why:     "Annoying issue about not having a comment. The rare codebase has such comments",
 	},


### PR DESCRIPTION
related to https://github.com/golangci/golangci-lint/pull/2005#discussion_r654075262

Details:
https://github.com/mgechev/revive/blob/8586baacbfaed0d70b319f1cdf2df91997b5fcdc/rule/exported.go#L196-L205