### PR TITLE
gofumpt: Add lang-version option

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -259,6 +259,9 @@ linters-settings:
     simplify: true
 
   gofumpt:
+    # Select the Go language version to target. The default is `1.15`.
+    lang-version: "1.15"
+
     # Choose whether or not to use the extra rules that are disabled
     # by default
     extra-rules: false

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -259,7 +259,7 @@ linters-settings:
     simplify: true
 
   gofumpt:
-    # Select the Go language version to target. The default is `1.15`.
+    # Select the Go version to target. The default is `1.15`.
     lang-version: "1.15"
 
     # Choose whether or not to use the extra rules that are disabled

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -59,7 +59,8 @@ var defaultLintersSettings = LintersSettings{
 		DefaultSignifiesExhaustive: false,
 	},
 	Gofumpt: GofumptSettings{
-		ExtraRules: false,
+		LangVersion: "",
+		ExtraRules:  false,
 	},
 	ErrorLint: ErrorLintSettings{
 		Errorf:     true,
@@ -232,7 +233,8 @@ type GoFmtSettings struct {
 }
 
 type GofumptSettings struct {
-	ExtraRules bool `mapstructure:"extra-rules"`
+	LangVersion string `mapstructure:"lang-version"`
+	ExtraRules  bool   `mapstructure:"extra-rules"`
 }
 
 type GoHeaderSettings struct {

--- a/pkg/golinters/gofumpt.go
+++ b/pkg/golinters/gofumpt.go
@@ -34,9 +34,9 @@ func NewGofumpt() *goanalysis.Linter {
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		settings := lintCtx.Settings().Gofumpt
-		langVersion := getLangVersion(settings)
+
 		options := format.Options{
-			LangVersion: langVersion,
+			LangVersion: getLangVersion(settings),
 			ExtraRules:  settings.ExtraRules,
 		}
 
@@ -100,12 +100,9 @@ func NewGofumpt() *goanalysis.Linter {
 }
 
 func getLangVersion(settings config.GofumptSettings) string {
-	langVersion := settings.LangVersion
-
-	if langVersion != "" {
-		return langVersion
+	if settings.LangVersion == "" {
+		// TODO: defaults to "1.15", in the future (v2) must be set by using build.Default.ReleaseTags like staticcheck.
+		return "1.15"
 	}
-
-	// TODO: defaults to "1.15", in the future (v2) must be set by using build.Default.ReleaseTags like staticcheck.
-	return "1.15"
+	return settings.LangVersion
 }

--- a/pkg/golinters/gofumpt.go
+++ b/pkg/golinters/gofumpt.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"mvdan.cc/gofumpt/format"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 )
@@ -32,6 +33,13 @@ func NewGofumpt() *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
+		settings := lintCtx.Settings().Gofumpt
+		langVersion := getLangVersion(settings)
+		options := format.Options{
+			LangVersion: langVersion,
+			ExtraRules:  settings.ExtraRules,
+		}
+
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
 			var fileNames []string
 			for _, f := range pass.Files {
@@ -46,12 +54,12 @@ func NewGofumpt() *goanalysis.Linter {
 				if err != nil {
 					return nil, fmt.Errorf("unable to open file %s: %w", f, err)
 				}
-				output, err := format.Source(input, format.Options{
-					ExtraRules: lintCtx.Settings().Gofumpt.ExtraRules,
-				})
+
+				output, err := format.Source(input, options)
 				if err != nil {
 					return nil, fmt.Errorf("error while running gofumpt: %w", err)
 				}
+
 				if !bytes.Equal(input, output) {
 					out := bytes.Buffer{}
 					_, err = out.WriteString(fmt.Sprintf("--- %[1]s\n+++ %[1]s\n", f))
@@ -89,4 +97,15 @@ func NewGofumpt() *goanalysis.Linter {
 	}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
 		return resIssues
 	}).WithLoadMode(goanalysis.LoadModeSyntax)
+}
+
+func getLangVersion(settings config.GofumptSettings) string {
+	langVersion := settings.LangVersion
+
+	if langVersion != "" {
+		return langVersion
+	}
+
+	// TODO: defaults to "1.15", in the future (v2) must be set by using build.Default.ReleaseTags like staticcheck.
+	return "1.15"
 }


### PR DESCRIPTION
Without the Go language version input, `gofumpt` cannot apply some rules
which are version dependent.

Defaulting `lang-version` to the Go version of the running environment
if not specified.

Signed-off-by: Kailun Qin <kailun.qin@intel.com>