### PR TITLE
dev: fix interface implement check for "SkipDirs"

### DIFF
--- a/pkg/result/processors/skip_dirs.go
+++ b/pkg/result/processors/skip_dirs.go
@@ -24,7 +24,7 @@ type SkipDirs struct {
 	skippedDirsCache map[string]bool
 }
 
-var _ Processor = SkipFiles{}
+var _ Processor = (*SkipDirs)(nil)
 
 const goFileSuffix = ".go"
 

--- a/pkg/result/processors/skip_files.go
+++ b/pkg/result/processors/skip_files.go
@@ -11,7 +11,7 @@ type SkipFiles struct {
 	patterns []*regexp.Regexp
 }
 
-var _ Processor = SkipFiles{}
+var _ Processor = (*SkipFiles)(nil)
 
 func NewSkipFiles(patterns []string) (*SkipFiles, error) {
 	var patternsRe []*regexp.Regexp


### PR DESCRIPTION
For every processor, there's a compile-time check for processors to check if they implement the `Processor` interface:
```
type Processor interface {
	Process(issues []result.Issue) ([]result.Issue, error)
	Name() string
	Finish()
}
```

But there's a typo: `SkipFiles` is getting checked instead of `SkipDirs` 

Fix:
```
var _ Processor = (*SkipDirs)(nil)
```
(or)
```
var _ Processor = &SkipDirs
```

The former is more idiomatic; so I did that.