### PR TITLE
docs: not show the number of linters

### DIFF
--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -23,7 +23,7 @@ Follow the news and releases on our twitter <IconContainer color="#1DA1F2"><FaTw
 - ⚡ [Very fast](/usage/performance): runs linters in parallel, reuses Go build cache and caches analysis results.
 - ⚙️ Yaml-based [configuration](/usage/configuration).
 - 🖥 [integrations](/usage/integrations) with VS Code, Sublime Text, GoLand, GNU Emacs, Vim, Atom, GitHub Actions.
-- 🥇 [48 linters](/usage/linters) included, no need to install them.
+- 🥇 [A lot of linters](/usage/linters) included, no need to install them.
 - 📈 Minimum number of [false positives](/usage/false-positives) because of tuned default settings.
 - 🔥nice output with colors, source code lines and marked `identifiers`.
 


### PR DESCRIPTION
Currently more than 48 linter can be used with golangci-lint, so, the number of linters on docs is wrong.
It would be hard to change this number every time, maybe 🤔 

This PR changed to not show the number of linters.