### PR TITLE
errcheck: allow exclude config without extra file

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -117,6 +117,14 @@ linters-settings:
     # see https://github.com/kisielk/errcheck#excluding-functions for details
     exclude: /path/to/file.txt
 
+    # list of functions to exclude from checking, where each entry is a single
+    # function to exclude.
+    # see https://github.com/kisielk/errcheck#excluding-functions for details
+    exclude-functions:
+      - io/ioutil.ReadFile
+      - io.Copy(*bytes.Buffer)
+      - io.Copy(os.Stdout)
+
   errorlint:
     # Check whether fmt.Errorf uses the %w verb for formatting errors. See the readme for caveats
     errorf: true

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -113,12 +113,12 @@ linters-settings:
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
     ignore: fmt:.*,io/ioutil:^Read.*
 
+    # [deprecated] use exclude-functions instead.
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details
     exclude: /path/to/file.txt
 
-    # list of functions to exclude from checking, where each entry is a single
-    # function to exclude.
+    # list of functions to exclude from checking, where each entry is a single function to exclude.
     # see https://github.com/kisielk/errcheck#excluding-functions for details
     exclude-functions:
       - io/ioutil.ReadFile

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,12 @@ issues:
     - path: _test\.go
       linters:
         - gomnd
+
+    - path: pkg/golinters/errcheck.go
+      text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
+    - path: pkg/commands/run.go
+      text: "SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead"
+
     # TODO must be removed after the release of the next version (v1.41.0)
     - path: pkg/commands/run.go
       linters:

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -133,9 +133,6 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.StringVar(&lsc.Errcheck.Exclude, "errcheck.exclude", "",
 		"Path to a file containing a list of functions to exclude from checking")
 	hideFlag("errcheck.exclude")
-	fs.StringSliceVar(&lsc.Errcheck.ExcludeFunctions, "errcheck.exclude-functions", nil,
-		"List of functions to exclude from checking")
-	hideFlag("errcheck.exclude-functions")
 	fs.StringVar(&lsc.Errcheck.Ignore, "errcheck.ignore", "fmt:.*",
 		`Comma-separated list of pairs of the form pkg:regex. The regex is used to ignore names within pkg`)
 	hideFlag("errcheck.ignore")

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -133,6 +133,9 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.StringVar(&lsc.Errcheck.Exclude, "errcheck.exclude", "",
 		"Path to a file containing a list of functions to exclude from checking")
 	hideFlag("errcheck.exclude")
+	fs.StringSliceVar(&lsc.Errcheck.ExcludeFunctions, "errcheck.exclude-functions", nil,
+		"List of functions to exclude from checking")
+	hideFlag("errcheck.exclude-functions")
 	fs.StringVar(&lsc.Errcheck.Ignore, "errcheck.ignore", "fmt:.*",
 		`Comma-separated list of pairs of the form pkg:regex. The regex is used to ignore names within pkg`)
 	hideFlag("errcheck.ignore")

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -164,8 +164,10 @@ type ErrcheckSettings struct {
 	CheckTypeAssertions bool     `mapstructure:"check-type-assertions"`
 	CheckAssignToBlank  bool     `mapstructure:"check-blank"`
 	Ignore              string   `mapstructure:"ignore"`
-	Exclude             string   `mapstructure:"exclude"`
 	ExcludeFunctions    []string `mapstructure:"exclude-functions"`
+
+	// Deprecated: use ExcludeFunctions instead
+	Exclude string `mapstructure:"exclude"`
 }
 
 type ErrorLintSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -161,10 +161,11 @@ type DuplSettings struct {
 }
 
 type ErrcheckSettings struct {
-	CheckTypeAssertions bool   `mapstructure:"check-type-assertions"`
-	CheckAssignToBlank  bool   `mapstructure:"check-blank"`
-	Ignore              string `mapstructure:"ignore"`
-	Exclude             string `mapstructure:"exclude"`
+	CheckTypeAssertions bool     `mapstructure:"check-type-assertions"`
+	CheckAssignToBlank  bool     `mapstructure:"check-blank"`
+	Ignore              string   `mapstructure:"ignore"`
+	Exclude             string   `mapstructure:"exclude"`
+	ExcludeFunctions    []string `mapstructure:"exclude-functions"`
 }
 
 type ErrorLintSettings struct {

--- a/pkg/golinters/errcheck.go
+++ b/pkg/golinters/errcheck.go
@@ -152,6 +152,8 @@ func getChecker(errCfg *config.ErrcheckSettings) (*errcheck.Checker, error) {
 		checker.Exclusions.Symbols = append(checker.Exclusions.Symbols, exclude...)
 	}
 
+	checker.Exclusions.Symbols = append(checker.Exclusions.Symbols, errCfg.ExcludeFunctions...)
+
 	return &checker, nil
 }
 

--- a/test/testdata/errcheck/exclude_functions.yml
+++ b/test/testdata/errcheck/exclude_functions.yml
@@ -1,0 +1,6 @@
+linters-settings:
+  errcheck:
+    check-blank: true
+    exclude-functions:
+      - io/ioutil.ReadFile
+      - io/ioutil.ReadDir

--- a/test/testdata/errcheck_exclude_functions.go
+++ b/test/testdata/errcheck_exclude_functions.go
@@ -1,0 +1,19 @@
+//args: -Eerrcheck
+//config: linters-settings.errcheck.check-blank=true
+//config: linters-settings.errcheck.exclude-functions=io/ioutil.ReadFile,io/ioutil.ReadDir
+package testdata
+
+import (
+	"io/ioutil"
+)
+
+func TestErrcheckExclude() []byte {
+	ret, _ := ioutil.ReadFile("f.txt")
+	_, _ = ioutil.ReadDir("dir")
+	return ret
+}
+
+func TestErrcheckNoExclude() []byte {
+	ret, _ := ioutil.ReadAll(nil) // ERROR "Error return value of `ioutil.ReadAll` is not checked"
+	return ret
+}

--- a/test/testdata/errcheck_exclude_functions.go
+++ b/test/testdata/errcheck_exclude_functions.go
@@ -1,19 +1,18 @@
 //args: -Eerrcheck
-//config: linters-settings.errcheck.check-blank=true
-//config: linters-settings.errcheck.exclude-functions=io/ioutil.ReadFile,io/ioutil.ReadDir
+//config_path: testdata/errcheck/exclude_functions.yml
 package testdata
 
 import (
 	"io/ioutil"
 )
 
-func TestErrcheckExclude() []byte {
+func TestErrcheckExcludeFunctions() []byte {
 	ret, _ := ioutil.ReadFile("f.txt")
-	_, _ = ioutil.ReadDir("dir")
+	ioutil.ReadDir("dir")
 	return ret
 }
 
-func TestErrcheckNoExclude() []byte {
+func TestErrcheckNoExcludeFunctions() []byte {
 	ret, _ := ioutil.ReadAll(nil) // ERROR "Error return value of `ioutil.ReadAll` is not checked"
 	return ret
 }


### PR DESCRIPTION
One of the challenges in standardizing on a golangci-lint configuration is that if we want to configure `errcheck`, it requires two separate files to configure: the golangci config file, plus a separate errcheck excludes file.
In particular, copying golangci-lint configs across projects often fails, as a reference to an exclude file at a particular file will not resolve.

While this config does not add any new functionality, it allows the entirety of the errcheck configuration to be done inside the
golangci-lint config file itself.


https://github.com/kisielk/errcheck#excluding-functions