### PR TITLE
suggest golangci-lint help linters

### DIFF
--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -30,7 +30,7 @@ func (v Validator) validateLintersNames(cfg *config.Linters) error {
 	}
 
 	if len(unknownNames) > 0 {
-		return fmt.Errorf("unknown linters: '%v', run 'golangci-lint linters' to see the list of supported linters",
+		return fmt.Errorf("unknown linters: '%v', run 'golangci-lint help linters' to see the list of supported linters",
 			strings.Join(unknownNames, ","))
 	}
 


### PR DESCRIPTION
`golangci-lint linters` wont run when you have an unknown linter. `golangci-lint help linters` works. 