### PR TITLE
fix(runner): add suggested edit text from linter in display issue text

### DIFF
--- a/pkg/golinters/goanalysis/issue.go
+++ b/pkg/golinters/goanalysis/issue.go
@@ -23,6 +23,7 @@ func NewIssue(i *result.Issue, pass *analysis.Pass) Issue {
 type EncodingIssue struct {
 	FromLinter           string
 	Text                 string
+	SuggestedFixes       []result.SuggestedFix
 	Pos                  token.Position
 	LineRange            *result.Range
 	Replacement          *result.Replacement

--- a/pkg/golinters/goanalysis/runners.go
+++ b/pkg/golinters/goanalysis/runners.go
@@ -98,10 +98,11 @@ func buildIssues(diags []Diagnostic, linterNameBuilder func(diag *Diagnostic) st
 		}
 
 		issues = append(issues, result.Issue{
-			FromLinter: linterName,
-			Text:       text,
-			Pos:        diag.Position,
-			Pkg:        diag.Pkg,
+			FromLinter:     linterName,
+			Text:           text,
+			SuggestedFixes: result.BuildSuggestedFixes(diag.SuggestedFixes),
+			Pos:            diag.Position,
+			Pkg:            diag.Pkg,
 		})
 
 		if len(diag.Related) > 0 {
@@ -150,6 +151,7 @@ func saveIssuesToCache(allPkgs []*packages.Package, pkgsFromCache map[*packages.
 					encodedIssues = append(encodedIssues, EncodingIssue{
 						FromLinter:           i.FromLinter,
 						Text:                 i.Text,
+						SuggestedFixes:       i.SuggestedFixes,
 						Pos:                  i.Pos,
 						LineRange:            i.LineRange,
 						Replacement:          i.Replacement,
@@ -221,6 +223,7 @@ func loadIssuesFromCache(pkgs []*packages.Package, lintCtx *linter.Context,
 					issues = append(issues, result.Issue{
 						FromLinter:           i.FromLinter,
 						Text:                 i.Text,
+						SuggestedFixes:       i.SuggestedFixes,
 						Pos:                  i.Pos,
 						LineRange:            i.LineRange,
 						Replacement:          i.Replacement,

--- a/pkg/printers/tab.go
+++ b/pkg/printers/tab.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/fatih/color"
@@ -34,6 +35,7 @@ func (p *Tab) Print(ctx context.Context, issues []result.Issue) error {
 
 	for i := range issues {
 		p.printIssue(&issues[i], w)
+		p.printSuggestedEdits(&issues[i], w)
 	}
 
 	if err := w.Flush(); err != nil {
@@ -55,4 +57,20 @@ func (p Tab) printIssue(i *result.Issue, w io.Writer) {
 	}
 
 	fmt.Fprintf(w, "%s\t%s\n", pos, text)
+}
+
+func (p Tab) printSuggestedEdits(i *result.Issue, w io.Writer) {
+	var text string
+	if len(i.SuggestedFixes) > 0 {
+		for _, fix := range i.SuggestedFixes {
+			text += p.SprintfColored(color.FgRed, "%s\n", strings.TrimSpace(fix.Message))
+			var suggestedEdits []string
+			for _, textEdit := range fix.TextEdits {
+				suggestedEdits = append(suggestedEdits, strings.TrimSpace(textEdit.NewText))
+			}
+			text += strings.Join(suggestedEdits, "\n") + "\n"
+		}
+	}
+
+	fmt.Fprintln(w, text)
 }

--- a/pkg/printers/text.go
+++ b/pkg/printers/text.go
@@ -47,6 +47,7 @@ func (p *Text) Print(ctx context.Context, issues []result.Issue) error {
 
 		p.printSourceCode(&issues[i])
 		p.printUnderLinePointer(&issues[i])
+		p.printSuggestedEdits(&issues[i])
 	}
 
 	return nil
@@ -88,4 +89,20 @@ func (p Text) printUnderLinePointer(i *result.Issue) {
 	}
 
 	fmt.Fprintf(logutils.StdOut, "%s%s\n", string(prefixRunes), p.SprintfColored(color.FgYellow, "^"))
+}
+
+func (p Text) printSuggestedEdits(i *result.Issue) {
+	var text string
+	if len(i.SuggestedFixes) > 0 {
+		for _, fix := range i.SuggestedFixes {
+			text += p.SprintfColored(color.FgRed, "%s\n", strings.TrimSpace(fix.Message))
+			var suggestedEdits []string
+			for _, textEdit := range fix.TextEdits {
+				suggestedEdits = append(suggestedEdits, strings.TrimSpace(textEdit.NewText))
+			}
+			text += strings.Join(suggestedEdits, "\n") + "\n"
+		}
+	}
+
+	fmt.Fprintln(logutils.StdOut, text)
 }


### PR DESCRIPTION
The tool did not print suggested edits by the linter when displaying
the issues. If there is suggested edits by the linter, it should
be displayed along with the issue.

Closes #2134