### PR TITLE
feat: Add support for remote config file

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -51,7 +51,10 @@ func wh(text string) string {
 	return color.GreenString(text)
 }
 
-const defaultTimeout = time.Minute
+const (
+	defaultTimeout                     = time.Minute
+	defaultRemoteConfigDownloadTimeout = 10 * time.Second
+)
 
 //nolint:funlen
 func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, isFinalInit bool) {
@@ -104,7 +107,9 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.BoolVar(&rc.AnalyzeTests, "tests", true, wh("Analyze tests (*_test.go)"))
 	fs.BoolVar(&rc.PrintResourcesUsage, "print-resources-usage", false,
 		wh("Print avg and max memory usage of golangci-lint and total time"))
-	fs.StringVarP(&rc.Config, "config", "c", "", wh("Read config from file path `PATH`"))
+	fs.StringVarP(&rc.Config, "config", "c", "", wh("Read config from file path `PATH` or remote using (should start with http or https)"))
+	fs.DurationVar(&rc.RemoteConfigDownloadTimeout, "config-download-timeout", defaultRemoteConfigDownloadTimeout,
+		wh("Timeout for the remote config file download"))
 	fs.BoolVar(&rc.NoConfig, "no-config", false, wh("Don't read config"))
 	fs.StringSliceVar(&rc.SkipDirs, "skip-dirs", nil, wh("Regexps of directories to skip"))
 	fs.BoolVar(&rc.UseDefaultSkipDirs, "skip-dirs-use-default", true, getDefaultDirectoryExcludeHelp())

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRemoteFile(t *testing.T) {
+	r := NewFileReader(nil, nil, nil)
+	tests := []struct {
+		ConfigFile string
+		IsRemote   bool
+	}{
+		{
+			ConfigFile: "~/config/.golangcilint.yaml",
+			IsRemote:   false,
+		},
+		{
+			ConfigFile: "~/http/config/.golangcilint.yaml",
+			IsRemote:   false,
+		},
+		{
+			ConfigFile: ".golangcilint.yaml",
+			IsRemote:   false,
+		},
+		{
+			ConfigFile: ".golangcilint.yaml",
+			IsRemote:   false,
+		},
+		{
+			ConfigFile: "localhost:8080/.golangci.example.yml",
+			IsRemote:   false, // Scheme is mandatory to determine if this is a remote file
+		},
+		{
+			ConfigFile: "https://raw.githubusercontent.com/golangci/golangci-lint/master/.golangci.example.yml",
+			IsRemote:   true,
+		},
+		{
+			ConfigFile: "http://localhost:8080/.golangci.example.yml",
+			IsRemote:   true,
+		},
+	}
+
+	for _, test := range tests {
+		result := r.isRemoteFile(test.ConfigFile)
+		assert.Equal(t, test.IsRemote, result)
+	}
+}

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -11,8 +11,9 @@ type Run struct {
 	Concurrency         int
 	PrintResourcesUsage bool `mapstructure:"print-resources-usage"`
 
-	Config   string
-	NoConfig bool
+	Config                      string
+	RemoteConfigDownloadTimeout time.Duration `mapstructure:"config-download-timeout"`
+	NoConfig                    bool
 
 	Args []string
 


### PR DESCRIPTION
Enforcing the same lint configuration for many projects and making updates for it can become a bit time consuming.
This is why I purpose you to add support for remote config file in golangci-lint. It allows teams to maintain only one global configuration file for all their projects.

I'll be happy to discuss with you if the implementation does not match your coding style/rules.