### PR TITLE
Update Go versions used by the CI

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Check go mod
@@ -45,7 +45,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16 # test only the latest go version to speed up CI
+          go-version: 1.17 # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
         continue-on-error: true
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16 # test only the latest go version to speed up CI
+          go-version: 1.17 # test only the latest go version to speed up CI
       - name: Run tests
         run: make test
   tests-on-unix:
@@ -68,6 +68,7 @@ jobs:
         golang:
           - 1.15
           - 1.16
+          - 1.17
     steps:
       - uses: actions/checkout@v2
       - name: Install Go
@@ -95,6 +96,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Check generated files are up to date
         run: make fast_check_generated

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Unshallow
         run: git fetch --prune --unshallow


### PR DESCRIPTION
The binaries for the releases should be built with Go1.17.

For now, the min Go version will stay on go1.15 but we will upgrade to go1.16 in few weeks.