### PR TITLE
docs: fix link to `Spacemacs`

### DIFF
--- a/docs/src/docs/usage/integrations.mdx
+++ b/docs/src/docs/usage/integrations.mdx
@@ -23,7 +23,7 @@ title: Integrations
    - Add [File Watcher](https://www.jetbrains.com/help/go/settings-tools-file-watchers.html) using existing `golangci-lint` template.
    - If your version of GoLand does not have the `golangci-lint` [File Watcher](https://www.jetbrains.com/help/go/settings-tools-file-watchers.html) template you can configure your own and use arguments `run --disable=typecheck $FileDir$`.
 4. GNU Emacs
-   - [Spacemacs](https://github.com/syl20bnr/spacemacs/blob/develop/layers/+lang/go/README.org#pre-requisites)
+   - [Spacemacs](https://github.com/syl20bnr/spacemacs/blob/develop/layers/+lang/go/README.org#linting)
    - [flycheck checker](https://github.com/weijiangan/flycheck-golangci-lint).
 5. Vim
    - [vim-go](https://github.com/fatih/vim-go)


### PR DESCRIPTION
Noted the format of the target project `README.org` had changed - link within page was no longer valid. Have corrected.