### PR TITLE
Build docker images with go1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ fast_generate: assets/github-action-config.json
 
 fast_check_generated:
 	$(MAKE) --always-make fast_generate
-	git checkout -- go.mod go.sum # can differ between go1.15 and go1.16
+	git checkout -- go.mod go.sum # can differ between go1.16 and go1.17
 	git diff --exit-code # check no changes
 
 release: .goreleaser.yml tools/goreleaser

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -10,7 +10,7 @@ WORKDIR /golangci
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.16
+FROM golang:1.17
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/Dockerfile.alpine
+++ b/build/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.16-alpine as builder
+FROM golang:1.17-alpine as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -15,7 +15,7 @@ RUN apk --no-cache add gcc musl-dev git mercurial
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.16-alpine
+FROM golang:1.17-alpine
 # gcc is required to support cgo;
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80


### PR DESCRIPTION
Move docker images onto go1.17 base images.
All base images were released https://github.com/docker-library/golang/pull/381