### PR TITLE
gci: Parse the settings more similarly to the cli

### DIFF
--- a/pkg/golinters/gci.go
+++ b/pkg/golinters/gci.go
@@ -47,9 +47,8 @@ func NewGci() *goanalysis.Linter {
 
 			var issues []goanalysis.Issue
 
-			flagSet := gci.FlagSet{}
-			if localFlag != "" {
-				flagSet.LocalFlag = strings.Split(localFlag, ",")
+			flagSet := gci.FlagSet{
+				LocalFlag: gci.ParseLocalFlag(localFlag),
 			}
 
 			for _, f := range fileNames {

--- a/pkg/golinters/gci.go
+++ b/pkg/golinters/gci.go
@@ -3,7 +3,6 @@ package golinters
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/daixiang0/gci/pkg/gci"


### PR DESCRIPTION
The gci command line parses the -local flag using the `gci.ParseLocalFlag` helper function,
which is different than `strings.Split` (which golangci-lint uses) in that it handles the empty string (which golangci-lint separately handles)
and that it handles empty entries in the list (which golangci-lint does not handle).

For example, the gci command line parses `"-local foo,,bar"` as the list `["foo", "bar"]`, but golangci-lint parses the YAML `"local-prefixes: foo,,bar"` as the list `["foo", "", "bar"]`.

This is a silly discrepancy to have; just use the `gci.ParseLocalFlag` helper function!