### PR TITLE
new-linter: ireturn (checks for function return type)

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -447,6 +447,27 @@ linters-settings:
       - pkg: knative.dev/serving/pkg/apis/(\w+)/(v[\w\d]+)
         alias: $1$2
 
+  ireturn:
+    # ireturn allows to use either `allow` or `reject` settings at the same time.
+    # both settings are a lists of the keywords (`empty` for interface{}`,
+    # `error` for errors, `stdlib` for standard library, `anon` for anonymouse
+    # interfaces ) and reglar expresssions matched to interfaces or packages.
+
+    allow:
+    # default settings are allow to use errors, empty interfaces, anonymouse
+    # interfaces, and interfaces provided by standard library.
+    - anon
+    - error
+    - empty
+    - stdlib
+    # You can specify idiomatic endings for interface
+    - (or|er)$
+
+
+    # or you can specify reject patterns
+    reject:
+    - github.com\/user\/package\/v4\.Type
+
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -448,14 +448,14 @@ linters-settings:
         alias: $1$2
 
   ireturn:
-    # ireturn allows to use either `allow` or `reject` settings at the same time.
-    # both settings are a lists of the keywords (`empty` for interface{}`,
-    # `error` for errors, `stdlib` for standard library, `anon` for anonymouse
-    # interfaces ) and reglar expresssions matched to interfaces or packages.
+    # ireturn allows using either `allow` or `reject` settings at the same time.
+    # both settings are lists of the keywords (`empty` for interface{}`,
+    # `error` for errors, `stdlib` for standard library, `anon` for anonymous
+    # interfaces ) and regular expressions matched to interfaces or packages.
 
     allow:
-    # default settings are allow to use errors, empty interfaces, anonymouse
-    # interfaces, and interfaces provided by standard library.
+    # default settings are allowed to use errors, empty interfaces, anonymous
+    # interfaces, and interfaces provided by the standard library.
     - anon
     - error
     - empty

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -448,14 +448,17 @@ linters-settings:
         alias: $1$2
 
   ireturn:
-    # ireturn allows using either `allow` or `reject` settings at the same time.
-    # both settings are lists of the keywords (`empty` for interface{}`,
-    # `error` for errors, `stdlib` for standard library, `anon` for anonymous
-    # interfaces ) and regular expressions matched to interfaces or packages.
+    # ireturn allows using `allow` and `reject` settings at the same time.
+    # Both settings are lists of the keywords and regular expressions matched to interface or package names.
+    # keywords:
+    # - `empty` for `interface{}`
+    # - `error` for errors
+    # - `stdlib` for standard library
+    # - `anon` for anonymous interfaces
 
+    # By default, it allows using errors, empty interfaces, anonymous interfaces,
+    # and interfaces provided by the standard library.
     allow:
-    # default settings are allowed to use errors, empty interfaces, anonymous
-    # interfaces, and interfaces provided by the standard library.
     - anon
     - error
     - empty
@@ -463,8 +466,7 @@ linters-settings:
     # You can specify idiomatic endings for interface
     - (or|er)$
 
-
-    # or you can specify reject patterns
+    # Reject patterns
     reject:
     - github.com\/user\/package\/v4\.Type
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ashanbrown/makezero v0.0.0-20210520155254-b6261585ddde
 	github.com/bkielbasa/cyclop v1.2.0
 	github.com/bombsimon/wsl/v3 v3.3.0
+	github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd // indirect
 	github.com/charithe/durationcheck v0.0.8
 	github.com/daixiang0/gci v0.2.9
 	github.com/denis-tingajkin/go-header v0.4.2
@@ -92,3 +93,5 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20210104141923-aac4ce9116a7
 )
+
+replace github.com/butuzov/ireturn => ../ireturn

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ashanbrown/makezero v0.0.0-20210520155254-b6261585ddde
 	github.com/bkielbasa/cyclop v1.2.0
 	github.com/bombsimon/wsl/v3 v3.3.0
-	github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd
+	github.com/butuzov/ireturn v0.1.0
 	github.com/charithe/durationcheck v0.0.8
 	github.com/daixiang0/gci v0.2.9
 	github.com/denis-tingajkin/go-header v0.4.2

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ashanbrown/makezero v0.0.0-20210520155254-b6261585ddde
 	github.com/bkielbasa/cyclop v1.2.0
 	github.com/bombsimon/wsl/v3 v3.3.0
-	github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd // indirect
+	github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd
 	github.com/charithe/durationcheck v0.0.8
 	github.com/daixiang0/gci v0.2.9
 	github.com/denis-tingajkin/go-header v0.4.2

--- a/go.mod
+++ b/go.mod
@@ -93,5 +93,3 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20210104141923-aac4ce9116a7
 )
-
-replace github.com/butuzov/ireturn => ../ireturn

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/bkielbasa/cyclop v1.2.0 h1:7Jmnh0yL2DjKfw28p86YTd/B4lRGcNuu12sKE35sM7
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxjM=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
-github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd h1:FCBvjaeDPGFMZpUeUrEikCrhL/Bp9UOUfhRTSBrkcgA=
-github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd/go.mod h1:pxsIfiT9YhERToguQDHMdthS36WZBCltDcoh5dpbd2M=
+github.com/butuzov/ireturn v0.1.0 h1:fMNgwuKMwsV9qtPNFgI7/NUOF3+CfbdLPGX6ZhDaMgA=
+github.com/butuzov/ireturn v0.1.0/go.mod h1:Wh6Zl3IMtTpaIKbmwzqi6olnM9ptYQxxVacMsOEFPoc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -280,9 +280,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/go.sum
+++ b/go.sum
@@ -280,7 +280,6 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/bkielbasa/cyclop v1.2.0 h1:7Jmnh0yL2DjKfw28p86YTd/B4lRGcNuu12sKE35sM7
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxjM=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
+github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd h1:FCBvjaeDPGFMZpUeUrEikCrhL/Bp9UOUfhRTSBrkcgA=
+github.com/butuzov/ireturn v0.0.0-20210903145654-645c1cbdbffd/go.mod h1:pxsIfiT9YhERToguQDHMdthS36WZBCltDcoh5dpbd2M=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -280,6 +282,8 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -110,6 +110,7 @@ type LintersSettings struct {
 	Gosimple         StaticCheckSettings
 	Govet            GovetSettings
 	Ifshort          IfshortSettings
+	Ireturn          IreturnSettings
 	ImportAs         ImportAsSettings
 	Lll              LllSettings
 	Makezero         MakezeroSettings
@@ -184,6 +185,11 @@ type ExhaustiveSettings struct {
 
 type ExhaustiveStructSettings struct {
 	StructPatterns []string `mapstructure:"struct-patterns"`
+}
+
+type IreturnSettings struct {
+	Allow  []string `mapstructure:"allow"`
+	Reject []string `mapstructure:"return"`
 }
 
 type ForbidigoSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -189,7 +189,7 @@ type ExhaustiveStructSettings struct {
 
 type IreturnSettings struct {
 	Allow  []string `mapstructure:"allow"`
-	Reject []string `mapstructure:"return"`
+	Reject []string `mapstructure:"reject"`
 }
 
 type ForbidigoSettings struct {

--- a/pkg/golinters/ireturn.go
+++ b/pkg/golinters/ireturn.go
@@ -1,0 +1,35 @@
+package golinters
+
+import (
+	"strings"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+
+	"github.com/butuzov/ireturn/analyzer"
+	"golang.org/x/tools/go/analysis"
+)
+
+func NewIreturn(settings *config.IreturnSettings) *goanalysis.Linter {
+	a := analyzer.NewAnalyzer()
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		ireturnSettings(a.Name, settings),
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}
+
+func ireturnSettings(name string, s *config.IreturnSettings) map[string]map[string]interface{} {
+	if s == nil {
+		return nil
+	}
+
+	return map[string]map[string]interface{}{
+		name: {
+			"allow":  strings.Join(s.Allow, ","),
+			"reject": strings.Join(s.Reject, ","),
+		},
+	}
+}

--- a/pkg/golinters/ireturn.go
+++ b/pkg/golinters/ireturn.go
@@ -13,23 +13,18 @@ import (
 func NewIreturn(settings *config.IreturnSettings) *goanalysis.Linter {
 	a := analyzer.NewAnalyzer()
 
+	cfg := map[string]map[string]interface{}{}
+	if settings != nil {
+		cfg[a.Name] = map[string]interface{}{
+			"allow":  strings.Join(settings.Allow, ","),
+			"reject": strings.Join(settings.Reject, ","),
+		}
+	}
+
 	return goanalysis.NewLinter(
 		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
-		ireturnSettings(a.Name, settings),
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
-}
-
-func ireturnSettings(name string, s *config.IreturnSettings) map[string]map[string]interface{} {
-	if s == nil {
-		return nil
-	}
-
-	return map[string]map[string]interface{}{
-		name: {
-			"allow":  strings.Join(s.Allow, ","),
-			"reject": strings.Join(s.Reject, ","),
-		},
-	}
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -511,6 +511,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
 			WithSince("v1.43.0").
 			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
 			WithURL("https://github.com/butuzov/ireturn"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -458,12 +458,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.36.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/esimonov/ifshort"),
-
-		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
-			WithSince("v1.43.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/butuzov/ireturn"),
-
 		linter.NewConfig(golinters.NewPredeclared(predeclaredCfg)).
 			WithSince("v1.35.0").
 			WithPresets(linter.PresetStyle).
@@ -514,6 +508,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/Antonboom/errname").
 			WithSince("v1.42.0"),
+		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
+			WithSince("v1.43.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/butuzov/ireturn"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint()).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -110,6 +110,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var reviveCfg *config.ReviveSettings
 	var cyclopCfg *config.Cyclop
 	var importAsCfg *config.ImportAsSettings
+	var ireturnCfg *config.IreturnSettings
 	var goModDirectivesCfg *config.GoModDirectivesSettings
 	var tagliatelleCfg *config.TagliatelleSettings
 	var gosecCfg *config.GoSecSettings
@@ -131,6 +132,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		reviveCfg = &m.cfg.LintersSettings.Revive
 		cyclopCfg = &m.cfg.LintersSettings.Cyclop
 		importAsCfg = &m.cfg.LintersSettings.ImportAs
+		ireturnCfg = &m.cfg.LintersSettings.Ireturn
 		goModDirectivesCfg = &m.cfg.LintersSettings.GoModDirectives
 		tagliatelleCfg = &m.cfg.LintersSettings.Tagliatelle
 		gosecCfg = &m.cfg.LintersSettings.Gosec
@@ -456,6 +458,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.36.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/esimonov/ifshort"),
+
+		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
+			WithSince("v1.43.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/butuzov/ireturn"),
+
 		linter.NewConfig(golinters.NewPredeclared(predeclaredCfg)).
 			WithSince("v1.35.0").
 			WithPresets(linter.PresetStyle).

--- a/test/testdata/configs/ireturn.yml
+++ b/test/testdata/configs/ireturn.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  ireturn:
+    allow:
+    - IreturnAllowDoer

--- a/test/testdata/configs/ireturn_stdlib_reject.yml
+++ b/test/testdata/configs/ireturn_stdlib_reject.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  ireturn:
+    reject:
+    - stdlib

--- a/test/testdata/ireturn_allow.go
+++ b/test/testdata/ireturn_allow.go
@@ -1,5 +1,5 @@
 // args: -Eireturn
-// config: linters-settings.ireturn.allow=["IreturnAllowDoer"]
+// config_path: testdata/configs/ireturn.yml
 package testdata
 
 type (

--- a/test/testdata/ireturn_allow.go
+++ b/test/testdata/ireturn_allow.go
@@ -1,0 +1,13 @@
+// args: -Eireturn
+// config: linters-settings.ireturn.allow=["IreturnAllowDoer"]
+package testdata
+
+type (
+	IreturnAllowDoer interface{ Do() }
+	ireturnAllowDoer struct{}
+)
+
+func NewAllowDoer() IreturnAllowDoer { return new(ireturnAllowDoer) }
+func (d *ireturnAllowDoer) Do()      { /*...*/ }
+
+func NewerAllowDoer() *ireturnAllowDoer { return new(ireturnAllowDoer) }

--- a/test/testdata/ireturn_default.go
+++ b/test/testdata/ireturn_default.go
@@ -1,0 +1,12 @@
+// args: -Eireturn
+package testdata
+
+type (
+	IreturnDoer interface{ Do() }
+	ireturnDoer struct{}
+)
+
+func New() IreturnDoer     { return new(ireturnDoer) } // ERROR `New returns interface \(command-line-arguments.IreturnDoer\)`
+func (d *ireturnDoer) Do() { /*...*/ }
+
+func Newer() *ireturnDoer { return new(ireturnDoer) }

--- a/test/testdata/ireturn_reject_stdlib.go
+++ b/test/testdata/ireturn_reject_stdlib.go
@@ -7,7 +7,22 @@ import (
 	"io"
 )
 
-func NewAllowDoer() io.Writer {
+func NewWriter() io.Writer { // ERROR `NewWriter returns interface \(io.Writer\)`
 	var buf bytes.Buffer
 	return &buf
+}
+
+func TestError() error {
+	return nil
+}
+
+type Foo interface {
+	Foo()
+}
+type foo int
+
+func (f foo) Foo() {}
+
+func NewFoo() Foo {
+	return foo(1)
 }

--- a/test/testdata/ireturn_reject_stdlib.go
+++ b/test/testdata/ireturn_reject_stdlib.go
@@ -1,0 +1,13 @@
+// args: -Eireturn
+// config_path: testdata/configs/ireturn_stdlib_reject.yml
+package testdata
+
+import (
+	"bytes"
+	"io"
+)
+
+func NewAllowDoer() io.Writer {
+	var buf bytes.Buffer
+	return &buf
+}


### PR DESCRIPTION
This PR introduces a new linter `ireturn` that checks for function's returned types and adds the possibility to reject or allow specific types of interfaces.

https://github.com/butuzov/ireturn

TL/DR
_Accept Interfaces, Return Concrete Types_

