### PR TITLE
docs: Update docs of installation with go

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -106,7 +106,11 @@ Note: such `go get` installation aren't guaranteed to work. We recommend using b
 <div style="margin-top: 2em;">
 
 ```sh
-go get github.com/golangci/golangci-lint/cmd/golangci-lint@{.LatestVersion}
+# Go 1.16+
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@{.LatestVersion}
+
+# Go version < 1.16
+go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@{.LatestVersion}
 ```
 
 </div>


### PR DESCRIPTION
> installing executables with 'go get' in module mode is deprecated.

So, we have to use `go install` on golang v1.16+

```
$ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

```