### PR TITLE
feat: sharable config presets

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -1,6 +1,11 @@
 # This file contains all available configuration options
 # with their default values.
 
+# configuration presets to use, each can be:
+# - a file path beginning with '.', which will be resolved relative to this config file
+# - a go module path, which will be searched for .golangci.yaml, .golangci.json etc
+presets: []
+
 # options for analysis running
 run:
   # default concurrency is a available CPU number

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b
 	github.com/tetafro/godot v1.4.10
+	github.com/thepwagner/golangci-lint-yaml v0.0.1 // indirect
 	github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94
 	github.com/tomarrell/wrapcheck/v2 v2.3.0
 	github.com/tommy-muehle/go-mnd/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -675,6 +675,8 @@ github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b h1:HxLVTlqcHhF
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tetafro/godot v1.4.10 h1:BqGslJVcVV7coRukPF104O3AUXVJIS606l2KB7vo6Bc=
 github.com/tetafro/godot v1.4.10/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
+github.com/thepwagner/golangci-lint-yaml v0.0.1 h1:s2ZttSkIY02e+cK8WsH1TJhJu/1Jxs9FV+/5rBN6Qlw=
+github.com/thepwagner/golangci-lint-yaml v0.0.1/go.mod h1:1Rq4ptw08Ta2vbxiM9wTdPWXdEmBawsj4xIiXAyaajo=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94 h1:ig99OeTyDwQWhPe2iw9lwfQVF1KB3Q4fpP3X7/2VBG8=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,8 @@
 package config
 
 type Config struct {
-	Run Run
+	Run     Run
+	Presets []string
 
 	Output Output
 

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/golangci/golangci-lint/pkg/logutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileReader_Read(t *testing.T) {
+	cases := map[string]Config{
+		"preset_parent.yml": {
+			Linters: Linters{
+				EnableAll: true,
+				Fast:      true,
+				Enable:    []string{"deadcode", "errcheck", "gosimple"},
+			},
+		},
+		"preset_single.yml": {
+			Linters: Linters{
+				Fast:    true,
+				Enable:  []string{"errcheck", "gosimple", "govet"},
+				Disable: []string{"deadcode"},
+			},
+			Presets: []string{"./preset_parent.yml"},
+		},
+		"preset_double.yml": {
+			Linters: Linters{
+				Enable:  []string{"errcheck", "gosimple", "govet"},
+				Disable: []string{"deadcode"},
+			},
+			Output: Output{
+				PrintIssuedLine: true,
+			},
+			Presets: []string{"./preset_parent.yml", "./preset_single.yml"},
+		},
+		"preset_order.yml": {
+			Linters: Linters{
+				Fast:    true,
+				Disable: []string{"deadcode", "errcheck", "gosimple", "govet"},
+			},
+			Presets: []string{"./preset_parent.yml", "./preset_single.yml", "./disable_all.yml"},
+		},
+	}
+
+	for cfgFile, expected := range cases {
+		t.Run(cfgFile, func(t *testing.T) {
+			cfg := readConfig(t, cfgFile)
+			assert.Equal(t, expected, cfg)
+		})
+	}
+}
+
+func TestFileReader_Read_Module(t *testing.T) {
+	cfg := readConfig(t, "preset_module.yml")
+	assert.NotEmpty(t, cfg.Linters.Enable)
+}
+
+func readConfig(t *testing.T, fn string) Config {
+	var cfg, cmdCfg Config
+	cmdCfg.Run.Config = filepath.Join("..", "..", "test", "testdata", "configs", fn)
+	log := logutils.NewMockLog()
+	log.On("Infof", mock.Anything, mock.Anything).Maybe()
+
+	r := NewFileReader(&cfg, &cmdCfg, log)
+	err := r.Read()
+	require.NoError(t, err)
+	return cfg
+}

--- a/test/testdata/configs/disable_all.yml
+++ b/test/testdata/configs/disable_all.yml
@@ -1,0 +1,6 @@
+linters:
+  disable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet

--- a/test/testdata/configs/preset_double.yml
+++ b/test/testdata/configs/preset_double.yml
@@ -1,0 +1,11 @@
+linters:
+  # overwrite the value in preset_single.yml
+  fast: false
+
+# add a new value
+output:
+  print-issued-lines: true
+
+presets:
+  - ./preset_parent.yml
+  - ./preset_single.yml

--- a/test/testdata/configs/preset_module.yml
+++ b/test/testdata/configs/preset_module.yml
@@ -1,0 +1,3 @@
+# TODO: host a preset in the golangci org?
+presets:
+ - github.com/thepwagner/golangci-lint-yaml

--- a/test/testdata/configs/preset_order.yml
+++ b/test/testdata/configs/preset_order.yml
@@ -1,0 +1,5 @@
+presets:
+ - ./preset_parent.yml
+ - ./preset_single.yml
+ # appears last, overwriting previously enabled checks
+ - ./disable_all.yml

--- a/test/testdata/configs/preset_parent.yml
+++ b/test/testdata/configs/preset_parent.yml
@@ -1,0 +1,7 @@
+linters:
+   enable-all: true
+   fast: true
+   enable:
+      - deadcode
+      - errcheck
+      - gosimple

--- a/test/testdata/configs/preset_single.yml
+++ b/test/testdata/configs/preset_single.yml
@@ -1,0 +1,11 @@
+linters:
+  # overwrite a value in preset_parent.yml
+  enable-all: false
+  # enable and disable a linter
+  enable:
+    - govet
+  disable:
+    - deadcode
+
+presets:
+ - ./preset_parent.yml


### PR DESCRIPTION
Add an implementation of "shareable presets", as discussed by https://github.com/golangci/golangci-lint/issues/1141 .

This is configured by a new root element, like:

```yaml
presets:
- ./.golangci.myorg.yml  # an additional configuration file on disk, maybe maintained via curl
- github.com/thepwagner/golangci-lint-yaml # a go module, which must contain a configuration file
```

That feature set is aiming to align with the opinions in https://github.com/golangci/golangci-lint/issues/2137 - minimize additional remote access by delegating to the go module system. Presets can be pinned in `go.sum`, fetched with `go mod download`, vendored, change-managed by Dependabot, etc. This mirrors alternatives like [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb). Authentication is delegated to go modules: I've tested using `ssh` and a private repo.

Presets are not loaded recursively, to limit overhead and complexity.

Preset configurations are merged rather ungracefully: viper does the heavy lifting. The exception is the `.linters.enabled` and `.linters.disabled` lists, which are hand-merged to avoid the most expected repetition. This merge operation is the biggest area for improvements.

The included test references a public repo that worksonmymachine(TM), this is just for a demo and should be replaced with something embedded or controlled by this org.
https://github.com/thepwagner/archivist/pull/130 is a standalone sample of the changes required to a project to adopt a shared preset. The ugly bit is treating the lint configuration as a Go dependency.