### PR TITLE
add support for finding issues in entire files in a diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
 	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
 	github.com/golangci/misspell v0.3.5
-	github.com/golangci/revgrep v0.0.0-20210208091834-cd28932614b5
+	github.com/golangci/revgrep v0.0.0-20210930125155-c22e5001d4f2
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4
 	github.com/gordonklaus/ineffassign v0.0.0-20210225214923-2e10b2664254
 	github.com/gostaticanalysis/forcetypeassert v0.0.0-20200621232751-01d4955beaa5

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29M
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca/go.mod h1:tvlJhZqDe4LMs4ZHD0oMUlt9G2LWuDGoisJTBzLMV9o=
 github.com/golangci/misspell v0.3.5 h1:pLzmVdl3VxTOncgzHcvLOKirdvcx/TydsClUQXTehjo=
 github.com/golangci/misspell v0.3.5/go.mod h1:dEbvlSfYbMQDtrpRMQU675gSDLDNa8sCPPChZ7PhiVA=
-github.com/golangci/revgrep v0.0.0-20210208091834-cd28932614b5 h1:c9Mqqrm/Clj5biNaG7rABrmwUq88nHh0uABo2b/WYmc=
-github.com/golangci/revgrep v0.0.0-20210208091834-cd28932614b5/go.mod h1:LK+zW4MpyytAWQRz0M4xnzEk50lSvqDQKfx304apFkY=
+github.com/golangci/revgrep v0.0.0-20210930125155-c22e5001d4f2 h1:SgM7GDZTxtTTQPU84heOxy34iG5Du7F2jcoZnvp+fXI=
+github.com/golangci/revgrep v0.0.0-20210930125155-c22e5001d4f2/go.mod h1:LK+zW4MpyytAWQRz0M4xnzEk50lSvqDQKfx304apFkY=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -233,7 +233,7 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 		wh("Show only new issues created after git revision `REV`"))
 	fs.StringVar(&ic.DiffPatchFilePath, "new-from-patch", "",
 		wh("Show only new issues created in git patch with file path `PATH`"))
-	fs.BoolVar(&ic.DiffWholeFiles, "whole-files", false,
+	fs.BoolVar(&ic.WholeFiles, "whole-files", false,
 		wh("Show issues in any part of update files (requires new-from-rev or new-from-patch)"))
 	fs.BoolVar(&ic.NeedFix, "fix", false, "Fix found issues (if it's supported by the linter)")
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -233,6 +233,8 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 		wh("Show only new issues created after git revision `REV`"))
 	fs.StringVar(&ic.DiffPatchFilePath, "new-from-patch", "",
 		wh("Show only new issues created in git patch with file path `PATH`"))
+	fs.BoolVar(&ic.DiffWholeFiles, "whole-files", false,
+		wh("Show issues in any part of update files (requires new-from-rev or new-from-patch)"))
 	fs.BoolVar(&ic.NeedFix, "fix", false, "Fix found issues (if it's supported by the linter)")
 }
 

--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -115,6 +115,7 @@ type Issues struct {
 
 	DiffFromRevision  string `mapstructure:"new-from-rev"`
 	DiffPatchFilePath string `mapstructure:"new-from-patch"`
+	WholeFiles        bool   `mapstructure:"whole-files"`
 	Diff              bool   `mapstructure:"new"`
 
 	NeedFix bool `mapstructure:"fix"`

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -86,7 +86,7 @@ func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env, es *lint
 			processors.NewNolint(log.Child("nolint"), dbManager, enabledLinters),
 
 			processors.NewUniqByLine(cfg),
-			processors.NewDiff(cfg.Issues.Diff, cfg.Issues.DiffFromRevision, cfg.Issues.DiffPatchFilePath, cfg.Issues.DiffWholeFiles),
+			processors.NewDiff(cfg.Issues.Diff, cfg.Issues.DiffFromRevision, cfg.Issues.DiffPatchFilePath, cfg.Issues.WholeFiles),
 			processors.NewMaxPerFileFromLinter(cfg),
 			processors.NewMaxSameIssues(cfg.Issues.MaxSameIssues, log.Child("max_same_issues"), cfg),
 			processors.NewMaxFromLinter(cfg.Issues.MaxIssuesPerLinter, log.Child("max_from_linter"), cfg),

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -86,7 +86,7 @@ func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env, es *lint
 			processors.NewNolint(log.Child("nolint"), dbManager, enabledLinters),
 
 			processors.NewUniqByLine(cfg),
-			processors.NewDiff(cfg.Issues.Diff, cfg.Issues.DiffFromRevision, cfg.Issues.DiffPatchFilePath),
+			processors.NewDiff(cfg.Issues.Diff, cfg.Issues.DiffFromRevision, cfg.Issues.DiffPatchFilePath, cfg.Issues.DiffWholeFiles),
 			processors.NewMaxPerFileFromLinter(cfg),
 			processors.NewMaxSameIssues(cfg.Issues.MaxSameIssues, log.Child("max_same_issues"), cfg),
 			processors.NewMaxFromLinter(cfg.Issues.MaxIssuesPerLinter, log.Child("max_from_linter"), cfg),

--- a/pkg/result/processors/diff.go
+++ b/pkg/result/processors/diff.go
@@ -17,16 +17,18 @@ type Diff struct {
 	onlyNew       bool
 	fromRev       string
 	patchFilePath string
+	wholeFiles    bool
 	patch         string
 }
 
 var _ Processor = Diff{}
 
-func NewDiff(onlyNew bool, fromRev, patchFilePath string) *Diff {
+func NewDiff(onlyNew bool, fromRev, patchFilePath string, wholeFiles bool) *Diff {
 	return &Diff{
 		onlyNew:       onlyNew,
 		fromRev:       fromRev,
 		patchFilePath: patchFilePath,
+		wholeFiles:    wholeFiles,
 		patch:         os.Getenv("GOLANGCI_DIFF_PROCESSOR_PATCH"),
 	}
 }
@@ -54,6 +56,7 @@ func (p Diff) Process(issues []result.Issue) ([]result.Issue, error) {
 	c := revgrep.Checker{
 		Patch:        patchReader,
 		RevisionFrom: p.fromRev,
+		WholeFiles:   p.wholeFiles,
 	}
 	if err := c.Prepare(); err != nil {
 		return nil, fmt.Errorf("can't prepare diff by revgrep: %s", err)


### PR DESCRIPTION
This implements #2261 

It adds a flag called "whole-files" which changes the behavior of new-from-rev and new-from-patch so they report all issues in a file that has been changed, not just on the exact lines that have been updated.

Requires https://github.com/golangci/revgrep/pull/6. (and I'll need to update that import version after that PR is merged)