### PR TITLE
Add govarpkg linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/OpenPeeDeeP/depguard v1.0.1
+	github.com/alexal/govarpkg v0.0.0-20211004180800-c75d2e224459
 	github.com/alexkohler/prealloc v1.0.0
 	github.com/ashanbrown/forbidigo v1.2.0
 	github.com/ashanbrown/makezero v0.0.0-20210520155254-b6261585ddde

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexal/govarpkg v0.0.0-20211004180800-c75d2e224459 h1:HFZUeifnsi9oxrcEVTcYuqe9iCG1r9+llnfBiCVLuB4=
+github.com/alexal/govarpkg v0.0.0-20211004180800-c75d2e224459/go.mod h1:LX6RekCGQ1W+JqFrzJAqo62DwX8M8ug/EqAOPXYPlA4=
 github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pOcUuw=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=

--- a/pkg/golinters/govarpkg.go
+++ b/pkg/golinters/govarpkg.go
@@ -1,0 +1,16 @@
+package golinters
+
+import (
+	"github.com/alexal/govarpkg/pkg/analyzer"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"golang.org/x/tools/go/analysis"
+)
+
+func NewGoVarPkg() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		"govarpkg",
+		"Finds variables that collide with imported package names.",
+		[]*analysis.Analyzer{analyzer.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -529,6 +529,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/sivchari/tenv"),
+		linter.NewConfig(golinters.NewGoVarPkg()).
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/alexal/govarpkg"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint()).

--- a/test/testdata/govarpkg.go
+++ b/test/testdata/govarpkg.go
@@ -1,0 +1,13 @@
+package testdata
+
+import (
+	"fmt"
+	"github.com/alexal/govarpkg/pkg/tst"
+)
+
+func test() {
+	a := "test"
+	fmt.Println(a)
+	tst := tst.Name{}
+	tst.New("Alex")
+}


### PR DESCRIPTION
Finds variables that collide with imported package names. Inspired by built-in linter in IntelliJ.

https://github.com/alexal/govarpkg