### PR TITLE
Allow custom linters to auto-fix suggested fixes

### DIFF
--- a/pkg/golinters/goanalysis/linter.go
+++ b/pkg/golinters/goanalysis/linter.go
@@ -51,7 +51,11 @@ type Linter struct {
 	needUseOriginalPackages bool
 }
 
-func NewLinter(name, desc string, analyzers []*analysis.Analyzer, cfg map[string]map[string]interface{}) *Linter {
+func NewLinter(
+	name, desc string,
+	analyzers []*analysis.Analyzer,
+	cfg map[string]map[string]interface{},
+) *Linter {
 	return &Linter{name: name, desc: desc, analyzers: analyzers, cfg: cfg}
 }
 

--- a/pkg/golinters/goanalysis/runners_test.go
+++ b/pkg/golinters/goanalysis/runners_test.go
@@ -1,0 +1,245 @@
+package goanalysis
+
+import (
+	"go/token"
+	"reflect"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/golangci/golangci-lint/pkg/result"
+)
+
+const someLinterName = "some-linter"
+
+func Test_buildIssues(t *testing.T) {
+	type args struct {
+		diags             []Diagnostic
+		linterNameBuilder func(diag *Diagnostic) string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []result.Issue
+	}{
+		{
+			name: "No Diagnostics",
+			args: args{
+				diags: []Diagnostic{},
+				linterNameBuilder: func(*Diagnostic) string {
+					return someLinterName
+				},
+			},
+			want: []result.Issue(nil),
+		},
+		{
+			name: "Linter Name is Analyzer Name",
+			args: args{
+				diags: []Diagnostic{
+					{
+						Diagnostic: analysis.Diagnostic{
+							Message: "failure message",
+						},
+						Analyzer: &analysis.Analyzer{
+							Name: someLinterName,
+						},
+						Position: token.Position{},
+						Pkg:      nil,
+					},
+				},
+				linterNameBuilder: func(*Diagnostic) string {
+					return someLinterName
+				},
+			},
+			want: []result.Issue{
+				{
+					FromLinter: someLinterName,
+					Text:       "failure message",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildIssues(tt.args.diags, tt.args.linterNameBuilder); !reflect.DeepEqual(
+				got,
+				tt.want,
+			) {
+				t.Errorf("buildIssues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildSingleIssue(t *testing.T) { //nolint:funlen
+	type args struct {
+		diag       *Diagnostic
+		linterName string
+	}
+	fakePkg := packages.Package{
+		Fset: makeFakeFileSet(),
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantIssue result.Issue
+	}{
+		{
+			name: "Linter Name is Analyzer Name",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: someLinterName,
+					},
+					Position: token.Position{},
+					Pkg:      nil,
+				},
+
+				linterName: someLinterName,
+			},
+			wantIssue: result.Issue{
+				FromLinter: someLinterName,
+				Text:       "failure message",
+			},
+		},
+		{
+			name: "Linter Name is NOT Analyzer Name",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: "some-analyzer",
+					},
+					Position: token.Position{},
+					Pkg:      nil,
+				},
+				linterName: someLinterName,
+			},
+			wantIssue: result.Issue{
+				FromLinter: someLinterName,
+				Text:       "some-analyzer: failure message",
+			},
+		},
+		{
+			name: "Shows issue when suggested edits exist but has no TextEdits",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message:   "fix something",
+								TextEdits: []analysis.TextEdit{},
+							},
+						},
+					},
+					Analyzer: &analysis.Analyzer{Name: "some-analyzer"},
+					Position: token.Position{},
+					Pkg:      nil,
+				},
+				linterName: someLinterName,
+			},
+			wantIssue: result.Issue{
+				FromLinter: someLinterName,
+				Text:       "some-analyzer: failure message",
+			},
+		},
+		{
+			name: "Replace Whole Line",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message: "fix something",
+								TextEdits: []analysis.TextEdit{
+									{
+										Pos:     101,
+										End:     201,
+										NewText: []byte("// Some comment to fix\n"),
+									},
+								},
+							},
+						},
+					},
+					Analyzer: &analysis.Analyzer{Name: "some-analyzer"},
+					Position: token.Position{},
+					Pkg:      &fakePkg,
+				},
+				linterName: someLinterName,
+			},
+			wantIssue: result.Issue{
+				FromLinter: someLinterName,
+				Text:       "some-analyzer: failure message",
+				LineRange: &result.Range{
+					From: 2,
+					To:   2,
+				},
+				Replacement: &result.Replacement{
+					NeedOnlyDelete: false,
+					NewLines: []string{
+						"// Some comment to fix",
+					},
+				},
+				Pkg: &fakePkg,
+			},
+		},
+		{
+			name: "Excludes Replacement if TextEdit doesn't modify only whole lines",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message: "fix something",
+								TextEdits: []analysis.TextEdit{
+									{
+										Pos:     101,
+										End:     151,
+										NewText: []byte("// Some comment to fix\n"),
+									},
+								},
+							},
+						},
+					},
+					Analyzer: &analysis.Analyzer{Name: "some-analyzer"},
+					Position: token.Position{},
+					Pkg:      &fakePkg,
+				},
+				linterName: someLinterName,
+			},
+			wantIssue: result.Issue{
+				FromLinter: someLinterName,
+				Text:       "some-analyzer: failure message",
+				Pkg:        &fakePkg,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotIssues := buildSingleIssue(tt.args.diag, tt.args.linterName); !reflect.DeepEqual(
+				gotIssues,
+				tt.wantIssue,
+			) {
+				t.Errorf("buildSingleIssue() = %v, want %v", gotIssues, tt.wantIssue)
+			}
+		})
+	}
+}
+
+func makeFakeFileSet() *token.FileSet {
+	fSet := token.NewFileSet()
+	file := fSet.AddFile("fake.go", 1, 1000)
+	for i := 100; i < 1000; i += 100 {
+		file.AddLine(i)
+	}
+	return fSet
+}

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -116,7 +116,7 @@ func configureCheckerInfo(info *gocriticlinter.CheckerInfo, allParams map[string
 // but the file parsers (TOML, YAML, JSON) don't create the same representation for raw type.
 // then we have to convert value types into the expected value types.
 // Maybe in the future, this kind of conversion will be done in go-critic itself.
-//nolint:exhaustive // only 3 types (int, bool, and string) are supported by CheckerParam.Value
+//nolint:exhaustive,nolintlint // only 3 types (int, bool, and string) are supported by CheckerParam.Value
 func normalizeCheckerParamsValue(p interface{}) interface{} {
 	rv := reflect.ValueOf(p)
 	switch rv.Type().Kind() {


### PR DESCRIPTION
This allows custom linters hook into the `--fix` functionality to resolve #1728
Custom linters specify the fixes using the Go analysis structures,
which allow for arbitrary char offsets for fixes; they get converted
into golangci structures, which are line-based. If the conversion is
not possible, the fix is dropped on the floor.

This also potentially *partially* addresses #1779 for those fixes that can be converted to line-based. For those that cannot, a modification to golangci structures is still necessary.

Current linters that support `SuggestedFixes`:
- `goerr113`
- `ruleguard`
- `staticcheck`
- `nlreturn`
- `exportloopref`
- `exhaustive`
- `govet`

This work is a cherry-pick of https://github.com/Khan/golangci-lint/commit/b48d22023ce565946a3c180ca3a1dec7275c4713 by @dbraley and @csilvers
Signed-off-by: Steve Coffman <steve@khanacademy.org>