### PR TITLE
Add documentation for go-critic and ruleguard settings

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -236,8 +236,26 @@ linters-settings:
         # whether to check test functions (default true)
         skipTestFuncs: true
       ruleguard:
+        # Enable debug for the specified named ruleguard rule group.
+        # When debug is enabled, ruleguard provides an explanation on why a rule
+        # is rejected (e.g. which Where() condition failed).
+        debug: 'm.Match(`!($x != $y)`)'
+        # Deprecated, use failOn param
+        # If set to true, identical to failOn='all', otherwise failOn=''
+        failOnError: false
+        # Determines the behavior when an error occurs while parsing ruleguard files.
+    	  # If flag is not set, log error and skip rule files that contain an error.
+    	  # If flag is set, the value must be a comma-separated list of error conditions.
+    	  # * 'import': rule refers to a package that cannot be loaded.
+    	  # * 'dsl':    gorule file does not comply with the ruleguard DSL.
+        failOn: dsl
+        # Comma-separated list of gorule file paths.
+        # Glob patterns such as 'rules-*.go' may be specified
         # path to a gorules file for the ruleguard checker
-        rules: ''
+        rules: 'rules-*.go,myrule1.go,myrules/rule1.go'
+      tooManyResultsChecker:
+    	  # maximum number of results (default 5)
+        maxResults: 10
       truncateCmp:
         # whether to skip int/uint/uintptr types (default true)
         skipArchDependent: true

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -240,21 +240,22 @@ linters-settings:
         # When debug is enabled, ruleguard provides an explanation on why a rule
         # is rejected (e.g. which Where() condition failed).
         debug: 'm.Match(`!($x != $y)`)'
-        # Deprecated, use failOn param
+        # Deprecated, use 'failOn' param.
         # If set to true, identical to failOn='all', otherwise failOn=''
         failOnError: false
         # Determines the behavior when an error occurs while parsing ruleguard files.
-    	  # If flag is not set, log error and skip rule files that contain an error.
-    	  # If flag is set, the value must be a comma-separated list of error conditions.
-    	  # * 'import': rule refers to a package that cannot be loaded.
-    	  # * 'dsl':    gorule file does not comply with the ruleguard DSL.
+        # If flag is not set, log error and skip rule files that contain an error.
+        # If flag is set, the value must be a comma-separated list of error conditions.
+        # * 'all':    fail on all errors.
+        # * 'import': rule refers to a package that cannot be loaded.
+        # * 'dsl':    gorule file does not comply with the ruleguard DSL.
         failOn: dsl
         # Comma-separated list of gorule file paths.
         # Glob patterns such as 'rules-*.go' may be specified
         # path to a gorules file for the ruleguard checker
         rules: 'rules-*.go,myrule1.go,myrules/rule1.go'
       tooManyResultsChecker:
-    	  # maximum number of results (default 5)
+        # maximum number of results (default 5)
         maxResults: 10
       truncateCmp:
         # whether to skip int/uint/uintptr types (default true)

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -246,9 +246,9 @@ linters-settings:
         # Determines the behavior when an error occurs while parsing ruleguard files.
         # If flag is not set, log error and skip rule files that contain an error.
         # If flag is set, the value must be a comma-separated list of error conditions.
-        # * 'all':    fail on all errors.
-        # * 'import': rule refers to a package that cannot be loaded.
-        # * 'dsl':    gorule file does not comply with the ruleguard DSL.
+        # - 'all':    fail on all errors.
+        # - 'import': ruleguard rule imports a package that cannot be found.
+        # - 'dsl':    gorule file does not comply with the ruleguard DSL.
         failOn: dsl
         # Comma-separated list of gorule file paths.
         # Glob patterns such as 'rules-*.go' may be specified

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -262,7 +262,7 @@ linters-settings:
         # If a path is relative, it is relative to the directory where the golangci-lint command is executed.
         # The special '${configDir}' variable is substituted with the absolute directory containing the golangci config file.
         # Glob patterns such as 'rules-*.go' may be specified.
-        rules: 'rules-*.go,myrule1.go,myrules/rule1.go'
+        rules: '${configDir}/ruleguard/rules-*.go,${configDir}/myrule1.go'
       tooManyResultsChecker:
         # maximum number of results (default 5)
         maxResults: 10

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -259,7 +259,7 @@ linters-settings:
         # - 'dsl':    gorule file does not comply with the ruleguard DSL.
         failOn: dsl
         # Comma-separated list of gorule file paths.
-        # Glob patterns such as 'rules-*.go' may be specified
+        # Glob patterns such as 'rules-*.go' may be specified.
         # path to a gorules file for the ruleguard checker
         rules: 'rules-*.go,myrule1.go,myrules/rule1.go'
       tooManyResultsChecker:

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -236,10 +236,18 @@ linters-settings:
         # whether to check test functions (default true)
         skipTestFuncs: true
       ruleguard:
-        # Enable debug for the specified named ruleguard rule group.
-        # When debug is enabled, ruleguard provides an explanation on why a rule
-        # is rejected (e.g. which Where() condition failed).
-        debug: 'm.Match(`!($x != $y)`)'
+        # Enable debug to identify which 'Where' condition was rejected.
+        # The value of the parameter is the name of a function in a ruleguard file.
+        #
+        # When a rule is evaluated:
+        # If:
+        #   The Match() clause is accepted; and
+        #   One of the conditions in the Where() clause is rejected,
+        # Then:
+        #   ruleguard prints the specific Where() condition that was rejected.
+        #
+        # The flag is passed to the ruleguard 'debug-group' argument.
+        debug: 'emptyDecl'
         # Deprecated, use 'failOn' param.
         # If set to true, identical to failOn='all', otherwise failOn=''
         failOnError: false

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -258,7 +258,9 @@ linters-settings:
         # - 'import': ruleguard rule imports a package that cannot be found.
         # - 'dsl':    gorule file does not comply with the ruleguard DSL.
         failOn: dsl
-        # Comma-separated list of gorule file paths.
+        # Comma-separated list of file paths containing ruleguard rules.
+        # If a path is relative, it is relative to the directory where the golangci-lint command is executed.
+        # The special '${configDir}' variable is substituted with the absolute directory containing the golangci config file.
         # Glob patterns such as 'rules-*.go' may be specified.
         rules: 'rules-*.go,myrule1.go,myrules/rule1.go'
       tooManyResultsChecker:

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -260,7 +260,6 @@ linters-settings:
         failOn: dsl
         # Comma-separated list of gorule file paths.
         # Glob patterns such as 'rules-*.go' may be specified.
-        # path to a gorules file for the ruleguard checker
         rules: 'rules-*.go,myrule1.go,myrules/rule1.go'
       tooManyResultsChecker:
         # maximum number of results (default 5)


### PR DESCRIPTION
Add examples for `gocritic` and `ruleguard` settings.
This documents the settings for `go-critic` which has been upgraded to `0.6.1`.

Depends on #2308 