### PR TITLE
fix: Add missing space in "disabled by config" warning

### DIFF
--- a/pkg/config/linters_settings_gocritic.go
+++ b/pkg/config/linters_settings_gocritic.go
@@ -156,7 +156,7 @@ func (s *GocriticSettings) InferEnabledChecks(log logutils.Log) {
 		enabledChecksSet := stringsSliceToSet(enabledChecks)
 		for _, disabledCheck := range s.DisabledChecks {
 			if !enabledChecksSet[disabledCheck] {
-				log.Warnf("Gocritic check %q was explicitly disabled via config. However, as this check"+
+				log.Warnf("Gocritic check %q was explicitly disabled via config. However, as this check "+
 					"is disabled by default, there is no need to explicitly disable it via config.", disabledCheck)
 				continue
 			}


### PR DESCRIPTION
Before this change, the message said "However, as this checkis disabled by default".