### PR TITLE
Bump gochecknoglobals to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/golangci/golangci-lint
 go 1.16
 
 require (
-	4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a
+	4d63.com/gochecknoglobals v0.1.0
 	github.com/Antonboom/errname v0.1.5
 	github.com/Antonboom/nilnil v0.1.0
 	github.com/BurntSushi/toml v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a h1:wFEQiK85fRsEVF0CRrPAos5LoAryUsIX1kPW/WrIqFw=
-4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a/go.mod h1:wfdC5ZjKSPr7CybKEcgJhUOgeAQW1+7WcyK8OvUilfo=
+4d63.com/gochecknoglobals v0.1.0 h1:zeZSRqj5yCg28tCkIV/z/lWbwvNm5qnKVS15PI8nhD0=
+4d63.com/gochecknoglobals v0.1.0/go.mod h1:wfdC5ZjKSPr7CybKEcgJhUOgeAQW1+7WcyK8OvUilfo=
 bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=


### PR DESCRIPTION
As it's the first tagged version, we have to update the linter manually.

Fixes #1727