### PR TITLE
.golangci.example.yml: clarify nolintlint.allow-unused

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -518,7 +518,7 @@ linters-settings:
     block-size: 1
 
   nolintlint:
-    # Enable to ensure that nolint directives are all used. Default is true.
+    # Disable to ensure that all nolint directives actually have an effect. Default is true.
     allow-unused: false
     # Disable to ensure that nolint directives don't have a leading space. Default is true.
     allow-leading-space: true


### PR DESCRIPTION
nolintlint's allow-usued option comment is misleading: use of "enable" suggests that setting the value to true will ensure all directives are used. Further, it's unclear what "used" means in this context (it could be misread that every possible linter must be specified in at least one nolint directive).