### PR TITLE
Add github.com/breml/bidichk linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/bkielbasa/cyclop v1.2.0
 	github.com/blizzy78/varnamelen v0.3.0
 	github.com/bombsimon/wsl/v3 v3.3.0
+	github.com/breml/bidichk v0.1.0
 	github.com/butuzov/ireturn v0.1.1
 	github.com/charithe/durationcheck v0.0.9
 	github.com/daixiang0/gci v0.2.9

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/bkielbasa/cyclop v1.2.0
 	github.com/blizzy78/varnamelen v0.3.0
 	github.com/bombsimon/wsl/v3 v3.3.0
-	github.com/breml/bidichk v0.1.0
+	github.com/breml/bidichk v0.1.1
 	github.com/butuzov/ireturn v0.1.1
 	github.com/charithe/durationcheck v0.0.9
 	github.com/daixiang0/gci v0.2.9

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,12 @@ github.com/blizzy78/varnamelen v0.3.0 h1:80mYO7Y5ppeEefg1Jzu+NBg16iwToOQVnDnNIoW
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
 github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxjM=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
+github.com/breml/bidichk v0.0.0-20211101211321-e7013e04fb35 h1:gVuw76onitoSg977sQ5CEK87U5sV17UHhtn0VmBaW3g=
+github.com/breml/bidichk v0.0.0-20211101211321-e7013e04fb35/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
+github.com/breml/bidichk v0.0.0-20211101215529-9b68d04c240e h1:vYW6FE3czRa1PWZHaarmH+rXqjxAxl5+4Cbda3793S4=
+github.com/breml/bidichk v0.0.0-20211101215529-9b68d04c240e/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
+github.com/breml/bidichk v0.1.0 h1:YwtIcBAwRYE9vIoBvnNTv0JB7nNYgYtxA0Kfa5KbyDM=
+github.com/breml/bidichk v0.1.0/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
 github.com/butuzov/ireturn v0.1.1 h1:QvrO2QF2+/Cx1WA/vETCIYBKtRjc30vesdoPUNo1EbY=
 github.com/butuzov/ireturn v0.1.1/go.mod h1:Wh6Zl3IMtTpaIKbmwzqi6olnM9ptYQxxVacMsOEFPoc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -106,12 +106,8 @@ github.com/blizzy78/varnamelen v0.3.0 h1:80mYO7Y5ppeEefg1Jzu+NBg16iwToOQVnDnNIoW
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
 github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxjM=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
-github.com/breml/bidichk v0.0.0-20211101211321-e7013e04fb35 h1:gVuw76onitoSg977sQ5CEK87U5sV17UHhtn0VmBaW3g=
-github.com/breml/bidichk v0.0.0-20211101211321-e7013e04fb35/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
-github.com/breml/bidichk v0.0.0-20211101215529-9b68d04c240e h1:vYW6FE3czRa1PWZHaarmH+rXqjxAxl5+4Cbda3793S4=
-github.com/breml/bidichk v0.0.0-20211101215529-9b68d04c240e/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
-github.com/breml/bidichk v0.1.0 h1:YwtIcBAwRYE9vIoBvnNTv0JB7nNYgYtxA0Kfa5KbyDM=
-github.com/breml/bidichk v0.1.0/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
+github.com/breml/bidichk v0.1.1 h1:Qpy8Rmgos9qdJxhka0K7ADEE5bQZX9PQUthkgggHpFM=
+github.com/breml/bidichk v0.1.1/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
 github.com/butuzov/ireturn v0.1.1 h1:QvrO2QF2+/Cx1WA/vETCIYBKtRjc30vesdoPUNo1EbY=
 github.com/butuzov/ireturn v0.1.1/go.mod h1:Wh6Zl3IMtTpaIKbmwzqi6olnM9ptYQxxVacMsOEFPoc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/golinters/bidichk.go
+++ b/pkg/golinters/bidichk.go
@@ -2,8 +2,9 @@ package golinters
 
 import (
 	"github.com/breml/bidichk/pkg/bidichk"
-	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
 func NewBiDiChkFuncName() *goanalysis.Linter {

--- a/pkg/golinters/bidichk.go
+++ b/pkg/golinters/bidichk.go
@@ -1,0 +1,16 @@
+package golinters
+
+import (
+	"github.com/breml/bidichk/pkg/bidichk"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"golang.org/x/tools/go/analysis"
+)
+
+func NewBiDiChkFuncName() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		"bidichk",
+		"Checks for dangerous unicode character sequences",
+		[]*analysis.Analyzer{bidichk.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -542,6 +542,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/blizzy78/varnamelen"),
+		linter.NewConfig(golinters.NewBiDiChkFuncName()).
+			WithSince("1.43.0").
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/breml/bidichk"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint()).

--- a/test/testdata/bidichk.go
+++ b/test/testdata/bidichk.go
@@ -1,0 +1,8 @@
+//args: -Ebidichk
+package testdata
+
+import "fmt"
+
+func main() {
+	fmt.Println("LEFT-TO-RIGHT-OVERRIDE: '‭', it is between the single quotes, but it is not visible with a regular editor") // ERROR "found dangerous unicode character sequence LEFT-TO-RIGHT-OVERRIDE"
+}


### PR DESCRIPTION
[bidichk](https://github.com/breml/bidichk) checks for dangerous unicode character sequences

The following unicode characters are considered dangerous:

* U+202A: LEFT-TO-RIGHT-EMBEDDING
* U+202B: RIGHT-TO-LEFT-EMBEDDING
* U+202C: POP-DIRECTIONAL-FORMATTING
* U+202D: LEFT-TO-RIGHT-OVERRIDE
* U+202E: RIGHT-TO-LEFT-OVERRIDE
* U+2066: LEFT-TO-RIGHT-ISOLATE
* U+2067: RIGHT-TO-LEFT-ISOLATE
* U+2068: FIRST-STRONG-ISOLATE
* U+2069: POP-DIRECTIONAL-ISOLATE

See following links for background:

* ['Trojan Source' Bug Threatens the Security of All Code](https://krebsonsecurity.com/2021/11/trojan-source-bug-threatens-the-security-of-all-code/)
* [Trojan Source - Proofs-of-Concept](https://github.com/nickboucher/trojan-source)
* [Go proposal: disallow LTR/RTL characters in string literals?](https://github.com/golang/go/issues/20209)
* [cockroachdb/cockroach - PR: lint: add linter for unicode directional formatting characters](https://github.com/cockroachdb/cockroach/pull/72287)
