### PR TITLE
preallocate slices

### DIFF
--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -80,7 +80,7 @@ func (e *Executor) executeLintersHelp(_ *cobra.Command, args []string) {
 	color.Green("\nLinters presets:")
 	for _, p := range e.DBManager.AllPresets() {
 		linters := e.DBManager.GetAllLinterConfigsForPreset(p)
-		linterNames := []string{}
+		linterNames := make([]string, 0, len(linters))
 		for _, lc := range linters {
 			linterNames = append(linterNames, lc.Name())
 		}

--- a/pkg/golinters/wsl.go
+++ b/pkg/golinters/wsl.go
@@ -34,7 +34,7 @@ func NewWSL() *goanalysis.Linter {
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
 			var (
-				files        = []string{}
+				files        = make([]string, 0, len(pass.Files))
 				linterCfg    = lintCtx.Cfg.LintersSettings.WSL
 				processorCfg = wsl.Configuration{
 					StrictAppend:                     linterCfg.StrictAppend,

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -31,7 +31,7 @@ func NewCodeClimate() *CodeClimate {
 }
 
 func (p CodeClimate) Print(ctx context.Context, issues []result.Issue) error {
-	codeClimateIssues := []CodeClimateIssue{}
+	codeClimateIssues := make([]CodeClimateIssue, 0, len(issues))
 	for i := range issues {
 		issue := &issues[i]
 		codeClimateIssue := CodeClimateIssue{}

--- a/pkg/result/processors/nolint.go
+++ b/pkg/result/processors/nolint.go
@@ -284,7 +284,7 @@ func (p Nolint) Finish() {
 		return
 	}
 
-	unknownLinters := []string{}
+	unknownLinters := make([]string, 0, len(p.unknownLintersSet))
 	for name := range p.unknownLintersSet {
 		unknownLinters = append(unknownLinters, name)
 	}

--- a/pkg/timeutils/stopwatch.go
+++ b/pkg/timeutils/stopwatch.go
@@ -36,7 +36,7 @@ type stageDuration struct {
 }
 
 func (s *Stopwatch) stageDurationsSorted() []stageDuration {
-	stageDurations := []stageDuration{}
+	stageDurations := make([]stageDuration, 0, len(s.stages))
 	for n, d := range s.stages {
 		stageDurations = append(stageDurations, stageDuration{
 			name: n,
@@ -56,7 +56,7 @@ func (s *Stopwatch) sprintStages() string {
 
 	stageDurations := s.stageDurationsSorted()
 
-	stagesStrings := []string{}
+	stagesStrings := make([]string, 0, len(stageDurations))
 	for _, s := range stageDurations {
 		stagesStrings = append(stagesStrings, fmt.Sprintf("%s: %s", s.name, s.d))
 	}


### PR DESCRIPTION
This PR refactors some slice declarations. It's better to preallocate memory when declaring a slice.