### PR TITLE
Change Github to GitHub in comments and docs

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -807,7 +807,7 @@ severity:
   # selected out format.
   # - Code climate: https://docs.codeclimate.com/docs/issues#issue-severity
   # -   Checkstyle: https://checkstyle.sourceforge.io/property_types.html#severity
-  # -       Github: https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+  # -       GitHub: https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
   default-severity: error
 
   # The default value is false.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Documentation is hosted at https://golangci-lint.run.
 [![License](https://img.shields.io/github/license/golangci/golangci-lint)](/LICENSE)
 [![Release](https://img.shields.io/github/release/golangci/golangci-lint.svg)](https://github.com/golangci/golangci-lint/releases/latest)
 [![Docker](https://img.shields.io/docker/pulls/golangci/golangci-lint)](https://hub.docker.com/r/golangci/golangci-lint)
-[![Github Releases Stats of golangci-lint](https://img.shields.io/github/downloads/golangci/golangci-lint/total.svg?logo=github)](https://somsubhra.github.io/github-release-stats/?username=golangci&repository=golangci-lint)
+[![GitHub Releases Stats of golangci-lint](https://img.shields.io/github/downloads/golangci/golangci-lint/total.svg?logo=github)](https://somsubhra.github.io/github-release-stats/?username=golangci&repository=golangci-lint)
 
 ## Contributors
 

--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -9,7 +9,7 @@ import { IconContainer } from "lib/icons";
 [![License](https://img.shields.io/github/license/golangci/golangci-lint)](/LICENSE)
 [![Release](https://img.shields.io/github/release/golangci/golangci-lint.svg)](https://github.com/golangci/golangci-lint/releases/latest)
 [![Docker](https://img.shields.io/docker/pulls/golangci/golangci-lint)](https://hub.docker.com/r/golangci/golangci-lint)
-[![Github Releases Stats of golangci-lint](https://img.shields.io/github/downloads/golangci/golangci-lint/total.svg?logo=github)](https://somsubhra.com/github-release-stats/?username=golangci&repository=golangci-lint)
+[![GitHub Releases Stats of golangci-lint](https://img.shields.io/github/downloads/golangci/golangci-lint/total.svg?logo=github)](https://somsubhra.com/github-release-stats/?username=golangci&repository=golangci-lint)
 
 `golangci-lint` is a Go linters aggregator.
 

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -13,7 +13,7 @@ type github struct {
 
 const defaultGithubSeverity = "error"
 
-// NewGithub output format outputs issues according to Github actions format:
+// NewGithub output format outputs issues according to GitHub actions format:
 // https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
 func NewGithub() Printer {
 	return &github{}


### PR DESCRIPTION
The official spelling for "GitHub" is [GitHub](https://github.com/about) (with "H" uppercased).
The PR changes  "Github" to "GitHub" in the comments, README, docs, and example.yml.