### PR TITLE
bump bidichk from v0.1.1 to v0.2.0

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -82,6 +82,18 @@ output:
 
 # all available settings of specific linters
 linters-settings:
+  bidichk:
+    # The following configurations check for all mentioned invisible unicode
+    # runes. It can be omitted because all runes are enabled by default.
+    left-to-right-embedding: true
+    right-to-left-embedding: true
+    pop-directional-formatting: true
+    left-to-right-override: true
+    right-to-left-override: true
+    left-to-right-isolate: true
+    right-to-left-isolate: true
+    first-strong-isolate: true
+    pop-directional-isolate: true
 
   cyclop:
     # the maximal code complexity to report

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/bkielbasa/cyclop v1.2.0
 	github.com/blizzy78/varnamelen v0.3.0
 	github.com/bombsimon/wsl/v3 v3.3.0
-	github.com/breml/bidichk v0.1.1
+	github.com/breml/bidichk v0.2.0
 	github.com/butuzov/ireturn v0.1.1
 	github.com/charithe/durationcheck v0.0.9
 	github.com/daixiang0/gci v0.2.9

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxj
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/breml/bidichk v0.1.1 h1:Qpy8Rmgos9qdJxhka0K7ADEE5bQZX9PQUthkgggHpFM=
 github.com/breml/bidichk v0.1.1/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
+github.com/breml/bidichk v0.2.0 h1:kBrsPFWq0GTrExB4G55zd1fCiw+0XN4o505lMx9XnFM=
+github.com/breml/bidichk v0.2.0/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
 github.com/butuzov/ireturn v0.1.1 h1:QvrO2QF2+/Cx1WA/vETCIYBKtRjc30vesdoPUNo1EbY=
 github.com/butuzov/ireturn v0.1.1/go.mod h1:Wh6Zl3IMtTpaIKbmwzqi6olnM9ptYQxxVacMsOEFPoc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/blizzy78/varnamelen v0.3.0 h1:80mYO7Y5ppeEefg1Jzu+NBg16iwToOQVnDnNIoW
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
 github.com/bombsimon/wsl/v3 v3.3.0 h1:Mka/+kRLoQJq7g2rggtgQsjuI/K5Efd87WX96EWFxjM=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
-github.com/breml/bidichk v0.1.1 h1:Qpy8Rmgos9qdJxhka0K7ADEE5bQZX9PQUthkgggHpFM=
-github.com/breml/bidichk v0.1.1/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
 github.com/breml/bidichk v0.2.0 h1:kBrsPFWq0GTrExB4G55zd1fCiw+0XN4o505lMx9XnFM=
 github.com/breml/bidichk v0.2.0/go.mod h1:zbfeitpevDUGI7V91Uzzuwrn4Vls8MoBMrwtt78jmso=
 github.com/butuzov/ireturn v0.1.1 h1:QvrO2QF2+/Cx1WA/vETCIYBKtRjc30vesdoPUNo1EbY=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -83,6 +83,7 @@ var defaultLintersSettings = LintersSettings{
 }
 
 type LintersSettings struct {
+	BiDiChk          BiDiChkSettings
 	Cyclop           Cyclop
 	Depguard         DepGuardSettings
 	Dogsled          DogsledSettings
@@ -144,6 +145,18 @@ type LintersSettings struct {
 	WSL              WSLSettings
 
 	Custom map[string]CustomLinterSettings
+}
+
+type BiDiChkSettings struct {
+	LeftToRightEmbedding     bool `mapstructure:"left-to-right-embedding"`
+	RightToLeftEmbedding     bool `mapstructure:"right-to-left-embedding"`
+	PopDirectionalFormatting bool `mapstructure:"pop-directional-formatting"`
+	LeftToRightOverride      bool `mapstructure:"left-to-right-override"`
+	RightToLeftOverride      bool `mapstructure:"right-to-left-override"`
+	LeftToRightIsolate       bool `mapstructure:"left-to-right-isolate"`
+	RightToLeftIsolate       bool `mapstructure:"right-to-left-isolate"`
+	FirstStrongIsolate       bool `mapstructure:"first-strong-isolate"`
+	PopDirectionalIsolate    bool `mapstructure:"pop-directional-isolate"`
 }
 
 type Cyclop struct {

--- a/pkg/golinters/bidichk.go
+++ b/pkg/golinters/bidichk.go
@@ -1,17 +1,60 @@
 package golinters
 
 import (
-	"github.com/breml/bidichk/pkg/bidichk"
+	"strings"
+
 	"golang.org/x/tools/go/analysis"
 
+	"github.com/breml/bidichk/pkg/bidichk"
+
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-func NewBiDiChkFuncName() *goanalysis.Linter {
+func NewBiDiChkFuncName(cfg *config.BiDiChkSettings) *goanalysis.Linter {
+	a := bidichk.NewAnalyzer()
+
+	cfgMap := map[string]map[string]interface{}{}
+	if cfg != nil {
+		var opts []string
+
+		if cfg.LeftToRightEmbedding {
+			opts = append(opts, "LEFT-TO-RIGHT-EMBEDDING")
+		}
+		if cfg.RightToLeftEmbedding {
+			opts = append(opts, "RIGHT-TO-LEFT-EMBEDDING")
+		}
+		if cfg.PopDirectionalFormatting {
+			opts = append(opts, "POP-DIRECTIONAL-FORMATTING")
+		}
+		if cfg.LeftToRightOverride {
+			opts = append(opts, "LEFT-TO-RIGHT-OVERRIDE")
+		}
+		if cfg.RightToLeftOverride {
+			opts = append(opts, "RIGHT-TO-LEFT-OVERRIDE")
+		}
+		if cfg.LeftToRightIsolate {
+			opts = append(opts, "LEFT-TO-RIGHT-ISOLATE")
+		}
+		if cfg.RightToLeftIsolate {
+			opts = append(opts, "RIGHT-TO-LEFT-ISOLATE")
+		}
+		if cfg.FirstStrongIsolate {
+			opts = append(opts, "FIRST-STRONG-ISOLATE")
+		}
+		if cfg.PopDirectionalIsolate {
+			opts = append(opts, "POP-DIRECTIONAL-ISOLATE")
+		}
+
+		cfgMap[a.Name] = map[string]interface{}{
+			"disallowed-runes": strings.Join(opts, ","),
+		}
+	}
+
 	return goanalysis.NewLinter(
 		"bidichk",
 		"Checks for dangerous unicode character sequences",
-		[]*analysis.Analyzer{bidichk.Analyzer},
-		nil,
+		[]*analysis.Analyzer{a},
+		cfgMap,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/bidichk.go
+++ b/pkg/golinters/bidichk.go
@@ -3,9 +3,8 @@ package golinters
 import (
 	"strings"
 
-	"golang.org/x/tools/go/analysis"
-
 	"github.com/breml/bidichk/pkg/bidichk"
+	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -100,6 +100,7 @@ func enableLinterConfigs(lcs []*linter.Config, isEnabled func(lc *linter.Config)
 
 //nolint:funlen
 func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
+	var bidichkCfg *config.BiDiChkSettings
 	var cyclopCfg *config.Cyclop
 	var errorlintCfg *config.ErrorLintSettings
 	var exhaustiveCfg *config.ExhaustiveSettings
@@ -126,6 +127,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var nlreturnCfg *config.NlreturnSettings
 
 	if m.cfg != nil {
+		bidichkCfg = &m.cfg.LintersSettings.BiDiChk
 		cyclopCfg = &m.cfg.LintersSettings.Cyclop
 		errorlintCfg = &m.cfg.LintersSettings.ErrorLint
 		exhaustiveCfg = &m.cfg.LintersSettings.Exhaustive
@@ -542,7 +544,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/blizzy78/varnamelen"),
-		linter.NewConfig(golinters.NewBiDiChkFuncName()).
+		linter.NewConfig(golinters.NewBiDiChkFuncName(bidichkCfg)).
 			WithSince("1.43.0").
 			WithPresets(linter.PresetBugs).
 			WithURL("https://github.com/breml/bidichk"),


### PR DESCRIPTION
Address proposal in https://github.com/golangci/golangci-lint/pull/2330#issuecomment-956738417

Make disallowed unicode runes configurable.


https://github.com/breml/bidichk/compare/v0.1.1...v0.2.0