### PR TITLE
Ensure that the Issues key in JSON format is a list

### DIFF
--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -30,6 +30,9 @@ func (p JSON) Print(ctx context.Context, issues []result.Issue) error {
 		Issues: issues,
 		Report: p.rd,
 	}
+	if res.Issues == nil {
+		res.Issues = []result.Issue{}
+	}
 
 	outputJSON, err := json.Marshal(res)
 	if err != nil {


### PR DESCRIPTION
This makes the data more consistent and easier to use with other tools. For example, a third-party tool can iterate over `Issues` without having to make a preliminary null check.

Before:
```console
$ golangci-lint run --out-format=json | jq
{
  "Issues": null,
  "Report": {
    "Linters": [...]
  }
}
```

After:
```console
$ golangci-lint run --out-format=json | jq
{
  "Issues": [],
  "Report": {
    "Linters": [...]
  }
}
```