### PR TITLE
fix: reduce flaky in the CI and clean the .golangci.yml of the project

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,9 @@ linters-settings:
       mnd:
         # don't include the "operation" and "assign"
         checks: argument,case,condition,return
+        ignored-numbers: 0,1,2,3
+        ignored-functions: strings.SplitN
+
   govet:
     check-shadowing: true
     settings:
@@ -115,9 +118,6 @@ linters:
   # - wsl
 
 issues:
-  exclude:
-    # disable this rule for go1.15 compatibility
-    - 'ioutilDeprecated:'
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: _test\.go
@@ -128,19 +128,8 @@ issues:
       text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
     - path: pkg/commands/run.go
       text: "SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead"
-
-    # TODO must be removed after the release of the next version (v1.41.0)
     - path: pkg/commands/run.go
-      linters:
-        - gomnd
-    # TODO must be removed after the release of the next version (v1.41.0)
-    - path: pkg/golinters/nolintlint/nolintlint.go
-      linters:
-        - gomnd
-    # TODO must be removed after the release of the next version (v1.41.0)
-    - path: pkg/printers/tab.go
-      linters:
-        - gomnd
+      text: "SA1019: e.cfg.Run.Deadline is deprecated: Deadline exists for historical compatibility and should not be used."
 
 run:
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,7 @@ issues:
       text: "SA1019: e.cfg.Run.Deadline is deprecated: Deadline exists for historical compatibility and should not be used."
 
 run:
+  timeout: 5m
   skip-dirs:
     - test/testdata_etc
     - internal/cache

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -53,7 +53,7 @@ func wh(text string) string {
 
 const defaultTimeout = time.Minute
 
-//nolint:funlen
+//nolint:funlen,gomnd
 func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, isFinalInit bool) {
 	hideFlag := func(name string) {
 		if err := fs.MarkHidden(name); err != nil {
@@ -479,7 +479,6 @@ func (e *Executor) executeRun(_ *cobra.Command, args []string) {
 
 // to be removed when deadline is finally decommissioned
 func (e *Executor) setTimeoutToDeadlineIfOnlyDeadlineIsSet() {
-	// nolint:staticcheck
 	deadlineValue := e.cfg.Run.Deadline
 	if deadlineValue != 0 && e.cfg.Run.Timeout == defaultTimeout {
 		e.cfg.Run.Timeout = deadlineValue

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -496,7 +496,7 @@ func (e *Executor) setupExitCode(ctx context.Context) {
 		return
 	}
 
-	needFailOnWarnings := (os.Getenv("GL_TEST_RUN") == "1" || os.Getenv("FAIL_ON_WARNINGS") == "1")
+	needFailOnWarnings := os.Getenv("GL_TEST_RUN") == "1" || os.Getenv("FAIL_ON_WARNINGS") == "1"
 	if needFailOnWarnings && len(e.reportData.Warnings) != 0 {
 		e.exitCode = exitcodes.WarningInTest
 		return

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	InternalTest    bool // Option is used only for testing golangci-lint code, don't use it
 }
 
-// getConfigDir returns the directory that contains golangci config file.
+// GetConfigDir returns the directory that contains golangci config file.
 func (c *Config) GetConfigDir() string {
 	return c.cfgDir
 }

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -119,9 +119,9 @@ func configureCheckerInfo(
 // but the file parsers (TOML, YAML, JSON) don't create the same representation for raw type.
 // then we have to convert value types into the expected value types.
 // Maybe in the future, this kind of conversion will be done in go-critic itself.
-//nolint:exhaustive // only 3 types (int, bool, and string) are supported by CheckerParam.Value
 func normalizeCheckerParamsValue(lintCtx *linter.Context, p interface{}) interface{} {
 	rv := reflect.ValueOf(p)
+	//nolint:exhaustive // only 3 types (int, bool, and string) are supported by CheckerParam.Value
 	switch rv.Type().Kind() {
 	case reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int:
 		return int(rv.Int())

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -21,7 +21,7 @@ func (v Validator) validateLintersNames(cfg *config.Linters) error {
 	allNames := append([]string{}, cfg.Enable...)
 	allNames = append(allNames, cfg.Disable...)
 
-	unknownNames := []string{}
+	var unknownNames []string
 
 	for _, name := range allNames {
 		if v.m.GetLinterConfigs(name) == nil {

--- a/pkg/packages/errors.go
+++ b/pkg/packages/errors.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-//nolint:gomnd
 func ParseErrorPosition(pos string) (*token.Position, error) {
 	// file:line(<optional>:colon)
 	parts := strings.Split(pos, ":")

--- a/pkg/timeutils/stopwatch.go
+++ b/pkg/timeutils/stopwatch.go
@@ -71,7 +71,7 @@ func (s *Stopwatch) sprintTopStages(n int) string {
 
 	stageDurations := s.stageDurationsSorted()
 
-	stagesStrings := []string{}
+	var stagesStrings []string
 	for i := 0; i < len(stageDurations) && i < n; i++ {
 		s := stageDurations[i]
 		stagesStrings = append(stagesStrings, fmt.Sprintf("%s: %s", s.name, s.d))

--- a/test/bench/bench_test.go
+++ b/test/bench/bench_test.go
@@ -71,7 +71,7 @@ func printCommand(cmd string, args ...string) {
 	if os.Getenv("PRINT_CMD") != "1" {
 		return
 	}
-	quotedArgs := []string{}
+	var quotedArgs []string
 	for _, a := range args {
 		quotedArgs = append(quotedArgs, strconv.Quote(a))
 	}


### PR DESCRIPTION
- transforms one`//nolint` comment to an `exclude-rules` (less flaky)
- clean `.golangci.yml` (remove obsolete stuff, and change `gomnd` config)
- minor changes (slice init and godoc comment)

Note: I think that `nolintlint` have a concurrency/cache problem, it needs to be fixed in another PR.
