### PR TITLE
chore: fix wrong default value in comment

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -565,7 +565,7 @@ linters-settings:
     block-size: 1
 
   nolintlint:
-    # Disable to ensure that all nolint directives actually have an effect. Default is true.
+    # Disable to ensure that all nolint directives actually have an effect. Default is false.
     allow-unused: false
     # Disable to ensure that nolint directives don't have a leading space. Default is true.
     allow-leading-space: true


### PR DESCRIPTION
* The default value for `allow-unused` is false
  * https://github.com/golangci/golangci-lint/blob/ecbb9c475ffb689c0d7d35ed84e385c5d9905f5f/pkg/config/linters_settings.go#L49