### PR TITLE
bump github.com/ryanrolds/sqlclosecheck from 0.3.0 to 0.3.1-0.20200727151525-d07596347ac2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/quasilyte/go-ruleguard/dsl v0.3.10
 	github.com/ryancurrah/gomodguard v1.2.3
-	github.com/ryanrolds/sqlclosecheck v0.3.0
+	github.com/ryanrolds/sqlclosecheck v0.3.1-0.20200727151525-d07596347ac2
 	github.com/sanposhiho/wastedassign/v2 v2.0.6
 	github.com/securego/gosec/v2 v2.9.1
 	github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c

--- a/go.sum
+++ b/go.sum
@@ -641,6 +641,8 @@ github.com/ryancurrah/gomodguard v1.2.3 h1:ww2fsjqocGCAFamzvv/b8IsRduuHHeK2MHTcT
 github.com/ryancurrah/gomodguard v1.2.3/go.mod h1:rYbA/4Tg5c54mV1sv4sQTP5WOPBcoLtnBZ7/TEhXAbg=
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
+github.com/ryanrolds/sqlclosecheck v0.3.1-0.20200727151525-d07596347ac2 h1:KkZMl19HKTaeZJgTtSiAsfcX0WK1tWW/l/TGLWyLIVg=
+github.com/ryanrolds/sqlclosecheck v0.3.1-0.20200727151525-d07596347ac2/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.1.0/go.mod h1:B/mN0msZuINBtQ1zZLEQcegFJJf9vnYIR88KRMEuODE=
 github.com/sanposhiho/wastedassign/v2 v2.0.6 h1:+6/hQIHKNJAUixEj6EmOngGIisyeI+T3335lYTyxRoA=


### PR DESCRIPTION
Upstream hasn't tagged a new release for a while (see https://github.com/ryanrolds/sqlclosecheck/issues/10), but their current `main` branch has a couple of fixes for panics.