### PR TITLE
Automatically detect local prefixes

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -226,7 +226,8 @@ type FunlenSettings struct {
 }
 
 type GciSettings struct {
-	LocalPrefixes string `mapstructure:"local-prefixes"`
+	LocalPrefixes     string `mapstructure:"local-prefixes"`
+	LocalPrefixModule bool   `mapstructure:"local-prefix-module"`
 }
 
 type GocognitSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -277,7 +277,8 @@ type GoHeaderSettings struct {
 }
 
 type GoImportsSettings struct {
-	LocalPrefixes string `mapstructure:"local-prefixes"`
+	LocalPrefixes     string `mapstructure:"local-prefixes"`
+	LocalPrefixModule bool   `mapstructure:"local-prefix-module"`
 }
 
 type GoLintSettings struct {

--- a/pkg/golinters/gci.go
+++ b/pkg/golinters/gci.go
@@ -3,6 +3,7 @@ package golinters
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/daixiang0/gci/pkg/gci"
@@ -32,9 +33,30 @@ func NewGci() *goanalysis.Linter {
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		localFlag := lintCtx.Settings().Gci.LocalPrefixes
+
+		if localFlag == "" && lintCtx.Settings().Gci.LocalPrefixModule {
+			var modules []string
+
+			for _, module := range lintCtx.Modules {
+				modules = append(modules, module.Path)
+			}
+
+			localFlag = strings.Join(modules, ",")
+		}
+
 		goimportsFlag := lintCtx.Settings().Goimports.LocalPrefixes
 		if localFlag == "" && goimportsFlag != "" {
 			localFlag = goimportsFlag
+		}
+
+		if localFlag == "" && lintCtx.Settings().Goimports.LocalPrefixModule {
+			var modules []string
+
+			for _, module := range lintCtx.Modules {
+				modules = append(modules, module.Path)
+			}
+
+			localFlag = strings.Join(modules, ",")
 		}
 
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {

--- a/pkg/golinters/goimports.go
+++ b/pkg/golinters/goimports.go
@@ -1,6 +1,7 @@
 package golinters
 
 import (
+	"strings"
 	"sync"
 
 	goimportsAPI "github.com/golangci/gofmt/goimports"
@@ -29,6 +30,17 @@ func NewGoimports() *goanalysis.Linter {
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		imports.LocalPrefix = lintCtx.Settings().Goimports.LocalPrefixes
+
+		if imports.LocalPrefix == "" && lintCtx.Settings().Goimports.LocalPrefixModule {
+			var modules []string
+
+			for _, module := range lintCtx.Modules {
+				modules = append(modules, module.Path)
+			}
+
+			imports.LocalPrefix = strings.Join(modules, ",")
+		}
+
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
 			var fileNames []string
 			for _, f := range pass.Files {

--- a/pkg/lint/linter/context.go
+++ b/pkg/lint/linter/context.go
@@ -20,6 +20,8 @@ type Context struct {
 	// version for each of packages
 	OriginalPackages []*packages.Package
 
+	Modules []*packages.Module
+
 	Cfg       *config.Config
 	FileCache *fsutils.FileCache
 	LineCache *fsutils.LineCache


### PR DESCRIPTION
This PR is an attempt to automatically detect local prefixes from module paths.
The rationale behind this feature is making config files less verbose/redundant and a little bit more portable.

It is not perfect, but it's working.

More specifically, I'm not sure if loading module information for every linter is a good idea, so module information loading should be incorporated into the LoadMode, but I'm not sure how since it's a string.

I'm also not sure if the gci -> goimports fallback is necessary.

Last, but not least the config option name feels a bit weird, but I couldn't come up with a better one.

Any feedback would be highly appreciated.

Fixes #931