### PR TITLE
Update wrapcheck configuration to include ignoreSignRegexps

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -744,9 +744,11 @@ linters-settings:
       - .WithMessage(
       - .WithMessagef(
       - .WithStack(
+    ignoreSigRegexps:
+      - \.New.*Error\(
     ignorePackageGlobs:
-        - encoding/*
-        - github.com/pkg/*
+      - encoding/*
+      - github.com/pkg/*
 
   wsl:
     # See https://github.com/bombsimon/wsl/blob/master/doc/configuration.md for

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -519,6 +519,7 @@ type WhitespaceSettings struct {
 
 type WrapcheckSettings struct {
 	IgnoreSigs         []string `mapstructure:"ignoreSigs"`
+	IgnoreSigRegexps   []string `mapstructure:"ignoreSigRegexps"`
 	IgnorePackageGlobs []string `mapstructure:"ignorePackageGlobs"`
 }
 

--- a/pkg/golinters/wrapcheck.go
+++ b/pkg/golinters/wrapcheck.go
@@ -16,6 +16,9 @@ func NewWrapcheck(settings *config.WrapcheckSettings) *goanalysis.Linter {
 		if len(settings.IgnoreSigs) != 0 {
 			cfg.IgnoreSigs = settings.IgnoreSigs
 		}
+		if len(settings.IgnoreSigRegexps) != 0 {
+			cfg.IgnoreSigRegexps = settings.IgnoreSigRegexps
+		}
 		if len(settings.IgnorePackageGlobs) != 0 {
 			cfg.IgnorePackageGlobs = settings.IgnorePackageGlobs
 		}


### PR DESCRIPTION
This provides an update to the `wrapcheck` linter configuration to account for a change introduced here - https://github.com/tomarrell/wrapcheck/pull/21

cc: @tomarrell 