### PR TITLE
Normalize exclude-rules paths for Windows

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2080,6 +2080,7 @@ issues:
 
     # Exclude known linters from partially hard-vendored code,
     # which is impossible to exclude via `nolint` comments.
+    # `/` will be replaced by current OS file path separator to properly work on Windows.
     - path: internal/hmac/
       text: "weak cryptographic primitive"
       linters:

--- a/pkg/result/processors/exclude_rules.go
+++ b/pkg/result/processors/exclude_rules.go
@@ -44,7 +44,8 @@ func createRules(rules []ExcludeRule, prefix string) []excludeRule {
 			parsedRule.source = regexp.MustCompile(prefix + rule.Source)
 		}
 		if rule.Path != "" {
-			parsedRule.path = regexp.MustCompile(rule.Path)
+			path := normalizePathInRegex(rule.Path)
+			parsedRule.path = regexp.MustCompile(path)
 		}
 		parsedRules = append(parsedRules, parsedRule)
 	}


### PR DESCRIPTION
Minor change to normalize the paths in `exclude-rules`. This re-uses the same logic that is already in place for `skip-dirs`.


Fixes  #1398