### PR TITLE
fix: update uname_os from shlib in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,9 +194,10 @@ log_crit() {
 uname_os() {
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   case "$os" in
-    cygwin_nt*) os="windows" ;;
+    msys*) os="windows" ;;
     mingw*) os="windows" ;;
-    msys_nt*) os="windows" ;;
+    cygwin*) os="windows" ;;
+    win*) os="windows" ;;
   esac
   echo "$os"
 }


### PR DESCRIPTION
`uname_os` function in install.sh, which is from [client9/shlib](https://github.com/client9/shlib), behaved incorrectly in certain Windows environment.
The issue was fixed in https://github.com/client9/shlib/pull/23, so opening PR to apply the updated function body.

Fixes #1944