### PR TITLE
Add multiimport linter

### DIFF
--- a/pkg/golinters/multiimport.go
+++ b/pkg/golinters/multiimport.go
@@ -1,0 +1,45 @@
+package golinters
+
+import (
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+const (
+	multiImportName = `multiimport`
+	multiImportDesc = `Finds files where packages are imported more than once under different aliases.`
+)
+
+func NewMultiImport() *goanalysis.Linter {
+	a := &analysis.Analyzer{
+		Name: multiImportName,
+		Doc:  multiImportDesc,
+		Run:  runMultiImport,
+	}
+	return goanalysis.
+		NewLinter(multiImportName, multiImportDesc, []*analysis.Analyzer{a}, nil).
+		WithLoadMode(goanalysis.LoadModeSyntax)
+}
+
+func runMultiImport(pass *analysis.Pass) (interface{}, error) {
+	for _, f := range pass.Files {
+		importToPathPos := make(map[string][]token.Pos, len(f.Imports))
+
+		for _, decl := range f.Imports {
+			importToPathPos[decl.Path.Value] = append(importToPathPos[decl.Path.Value], decl.Path.ValuePos)
+		}
+
+		for _, positions := range importToPathPos {
+			if len(positions) <= 1 {
+				continue
+			}
+			for _, pos := range positions {
+				pass.Reportf(pos, `import appears multiple times under different aliases (%s)`, multiImportName)
+			}
+		}
+	}
+	return nil, nil
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -555,6 +555,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetBugs).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/breml/errchkjson"),
+		linter.NewConfig(golinters.NewMultiImport()).
+			WithSince("1.44.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis(),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint()).

--- a/test/testdata/multiimport.go
+++ b/test/testdata/multiimport.go
@@ -1,0 +1,12 @@
+//args: -Emultiimport
+package testdata
+
+import (
+	"fmt"      // ERROR "import appears multiple times under different aliases"
+	blah "fmt" // ERROR "import appears multiple times under different aliases"
+)
+
+func MultiImportIssue() {
+	fmt.Println(`a`)
+	blah.Println(`a`)
+}

--- a/test/testdata/multiimport.go
+++ b/test/testdata/multiimport.go
@@ -4,9 +4,11 @@ package testdata
 import (
 	"fmt"      // ERROR "import appears multiple times under different aliases"
 	blah "fmt" // ERROR "import appears multiple times under different aliases"
+	blah2 "log"
 )
 
 func MultiImportIssue() {
 	fmt.Println(`a`)
 	blah.Println(`a`)
+	blah2.Print(`hi`)
 }


### PR DESCRIPTION
It's possible to import the same package under different aliases in a go file. This is often unintentional (as a result of `goimports` autoimporting something, for example). This linter warns when this happens.