### PR TITLE
runner: exit with non-zero code when linter fails

### DIFF
--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -198,7 +198,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 		sw.TrackStage(lc.Name(), func() {
 			linterIssues, err := r.runLinterSafe(ctx, lintCtx, lc)
 			if err != nil {
-				r.Log.Warnf("Can't run linter %s: %v", lc.Linter.Name(), err)
+				r.Log.Errorf("Can't run linter %s: %v", lc.Linter.Name(), err)
 				return
 			}
 			issues = append(issues, linterIssues...)


### PR DESCRIPTION
I think this problem was introduced when `runErr` was removed [here](https://github.com/golangci/golangci-lint/pull/1911/commits/78826cacdade100cec6bb66fe93b25631ea90389#diff-9eb8763cc52a311ebb1b71eab153215b1ca033a31b071347c39b2ff09f2f529aL206)

Fixes #2357