### PR TITLE
dev: sorting linters by alphabet (ascending order)

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -3,20 +3,25 @@ package config
 import "github.com/pkg/errors"
 
 var defaultLintersSettings = LintersSettings{
-	Lll: LllSettings{
-		LineLength: 120,
-		TabWidth:   1,
+	Dogsled: DogsledSettings{
+		MaxBlankIdentifiers: 2,
 	},
-	Unparam: UnparamSettings{
-		Algo: "cha",
+	ErrorLint: ErrorLintSettings{
+		Errorf:     true,
+		Asserts:    true,
+		Comparison: true,
 	},
-	Nakedret: NakedretSettings{
-		MaxFuncLines: 30,
+	Exhaustive: ExhaustiveSettings{
+		CheckGenerated:             false,
+		DefaultSignifiesExhaustive: false,
+		IgnoreEnumMembers:          "",
+		CheckingStrategy:           "value",
 	},
-	Prealloc: PreallocSettings{
-		Simple:     true,
-		RangeLoops: true,
-		ForLoops:   false,
+	Forbidigo: ForbidigoSettings{
+		ExcludeGodocExamples: true,
+	},
+	Gocognit: GocognitSettings{
+		MinComplexity: 30,
 	},
 	Gocritic: GocriticSettings{
 		SettingsPerCheck: map[string]GocriticCheckSettings{},
@@ -24,11 +29,44 @@ var defaultLintersSettings = LintersSettings{
 	Godox: GodoxSettings{
 		Keywords: []string{},
 	},
-	Dogsled: DogsledSettings{
-		MaxBlankIdentifiers: 2,
+	Gofumpt: GofumptSettings{
+		LangVersion: "",
+		ExtraRules:  false,
 	},
-	Gocognit: GocognitSettings{
-		MinComplexity: 30,
+	Ifshort: IfshortSettings{
+		MaxDeclLines: 1,
+		MaxDeclChars: 30,
+	},
+	Lll: LllSettings{
+		LineLength: 120,
+		TabWidth:   1,
+	},
+	Nakedret: NakedretSettings{
+		MaxFuncLines: 30,
+	},
+	Nestif: NestifSettings{
+		MinComplexity: 5,
+	},
+	NoLintLint: NoLintLintSettings{
+		RequireExplanation: false,
+		AllowLeadingSpace:  true,
+		RequireSpecific:    false,
+		AllowUnused:        false,
+	},
+	Prealloc: PreallocSettings{
+		Simple:     true,
+		RangeLoops: true,
+		ForLoops:   false,
+	},
+	Predeclared: PredeclaredSettings{
+		Ignore:    "",
+		Qualified: false,
+	},
+	Testpackage: TestpackageSettings{
+		SkipRegexp: `(export|internal)_test\.go`,
+	},
+	Unparam: UnparamSettings{
+		Algo: "cha",
 	},
 	WSL: WSLSettings{
 		StrictAppend:                     true,
@@ -41,44 +79,6 @@ var defaultLintersSettings = LintersSettings{
 		ForceCuddleErrCheckAndAssign:     false,
 		ForceExclusiveShortDeclarations:  false,
 		ForceCaseTrailingWhitespaceLimit: 0,
-	},
-	NoLintLint: NoLintLintSettings{
-		RequireExplanation: false,
-		AllowLeadingSpace:  true,
-		RequireSpecific:    false,
-		AllowUnused:        false,
-	},
-	Testpackage: TestpackageSettings{
-		SkipRegexp: `(export|internal)_test\.go`,
-	},
-	Nestif: NestifSettings{
-		MinComplexity: 5,
-	},
-	Exhaustive: ExhaustiveSettings{
-		CheckGenerated:             false,
-		DefaultSignifiesExhaustive: false,
-		IgnoreEnumMembers:          "",
-		CheckingStrategy:           "value",
-	},
-	Gofumpt: GofumptSettings{
-		LangVersion: "",
-		ExtraRules:  false,
-	},
-	ErrorLint: ErrorLintSettings{
-		Errorf:     true,
-		Asserts:    true,
-		Comparison: true,
-	},
-	Ifshort: IfshortSettings{
-		MaxDeclLines: 1,
-		MaxDeclChars: 30,
-	},
-	Predeclared: PredeclaredSettings{
-		Ignore:    "",
-		Qualified: false,
-	},
-	Forbidigo: ForbidigoSettings{
-		ExcludeGodocExamples: true,
 	},
 }
 
@@ -114,8 +114,8 @@ type LintersSettings struct {
 	Gosimple         StaticCheckSettings
 	Govet            GovetSettings
 	Ifshort          IfshortSettings
-	Ireturn          IreturnSettings
 	ImportAs         ImportAsSettings
+	Ireturn          IreturnSettings
 	Lll              LllSettings
 	Makezero         MakezeroSettings
 	Maligned         MalignedSettings
@@ -134,9 +134,9 @@ type LintersSettings struct {
 	Structcheck      StructCheckSettings
 	Stylecheck       StaticCheckSettings
 	Tagliatelle      TagliatelleSettings
+	Tenv             TenvSettings
 	Testpackage      TestpackageSettings
 	Thelper          ThelperSettings
-	Tenv             TenvSettings
 	Unparam          UnparamSettings
 	Unused           StaticCheckSettings
 	Varcheck         VarCheckSettings
@@ -166,11 +166,6 @@ type Cyclop struct {
 	SkipTests      bool    `mapstructure:"skip-tests"`
 }
 
-type ErrChkJSONSettings struct {
-	CheckErrorFreeEncoding bool `mapstructure:"check-error-free-encoding"`
-	ReportNoExported       bool `mapstructure:"report-no-exported"`
-}
-
 type DepGuardSettings struct {
 	ListType                 string `mapstructure:"list-type"`
 	Packages                 []string
@@ -196,6 +191,11 @@ type ErrcheckSettings struct {
 	Exclude string `mapstructure:"exclude"`
 }
 
+type ErrChkJSONSettings struct {
+	CheckErrorFreeEncoding bool `mapstructure:"check-error-free-encoding"`
+	ReportNoExported       bool `mapstructure:"report-no-exported"`
+}
+
 type ErrorLintSettings struct {
 	Errorf     bool `mapstructure:"errorf"`
 	Asserts    bool `mapstructure:"asserts"`
@@ -214,11 +214,6 @@ type ExhaustiveSettings struct {
 
 type ExhaustiveStructSettings struct {
 	StructPatterns []string `mapstructure:"struct-patterns"`
-}
-
-type IreturnSettings struct {
-	Allow  []string `mapstructure:"allow"`
-	Reject []string `mapstructure:"reject"`
 }
 
 type ForbidigoSettings struct {
@@ -364,6 +359,11 @@ type ImportAsSettings struct {
 type ImportAsAlias struct {
 	Pkg   string
 	Alias string
+}
+
+type IreturnSettings struct {
+	Allow  []string `mapstructure:"allow"`
+	Reject []string `mapstructure:"reject"`
 }
 
 type LllSettings struct {

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -158,6 +158,8 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 
 	const megacheckName = "megacheck"
 
+	// The linters are in the alphabetical order (case-insensitive).
+	// When a new linter is added the version in `WithSince(...)` must be the next version of golangci-lint.
 	lcs := []*linter.Config{
 		linter.NewConfig(golinters.NewAsciicheck()).
 			WithSince("v1.26.0").
@@ -233,6 +235,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/Antonboom/errname"),
 
+		linter.NewConfig(golinters.NewErrorLint(errorlintCfg)).
+			WithSince("v1.32.0").
+			WithPresets(linter.PresetBugs, linter.PresetError).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/polyfloyd/go-errorlint"),
+
 		linter.NewConfig(golinters.NewExhaustive(exhaustiveCfg)).
 			WithSince(" v1.28.0").
 			WithPresets(linter.PresetBugs).
@@ -272,39 +280,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithAutoFix().
 			WithURL("https://github.com/daixiang0/gci"),
 
-		linter.NewConfig(golinters.NewGocritic()).
-			WithSince("v1.12.0").
-			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/go-critic/go-critic"),
-
-		linter.NewConfig(golinters.NewGoerr113()).
-			WithSince("v1.26.0").
-			WithPresets(linter.PresetStyle, linter.PresetError).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/Djarvur/go-err113"),
-
-		linter.NewConfig(golinters.NewErrorLint(errorlintCfg)).
-			WithSince("v1.32.0").
-			WithPresets(linter.PresetBugs, linter.PresetError).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/polyfloyd/go-errorlint"),
-
-		linter.NewConfig(golinters.NewGoHeader()).
-			WithSince("v1.28.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/denis-tingajkin/go-header"),
-
-		linter.NewConfig(golinters.NewGoMND(m.cfg)).
-			WithSince("v1.22.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/tommy-muehle/go-mnd"),
-
-		linter.NewConfig(golinters.NewGoPrintfFuncName()).
-			WithSince("v1.23.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/jirfag/go-printf-func-name"),
-
 		linter.NewConfig(golinters.NewGochecknoglobals()).
 			WithSince("v1.12.0").
 			WithPresets(linter.PresetStyle).
@@ -325,6 +300,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/jgautheron/goconst"),
 
+		linter.NewConfig(golinters.NewGocritic()).
+			WithSince("v1.12.0").
+			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/go-critic/go-critic"),
+
 		linter.NewConfig(golinters.NewGocyclo()).
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetComplexity).
@@ -341,6 +322,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle, linter.PresetComment).
 			WithURL("https://github.com/matoous/godox"),
 
+		linter.NewConfig(golinters.NewGoerr113()).
+			WithSince("v1.26.0").
+			WithPresets(linter.PresetStyle, linter.PresetError).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/Djarvur/go-err113"),
+
 		linter.NewConfig(golinters.NewGofmt()).
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetFormatting).
@@ -353,11 +340,28 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithAutoFix().
 			WithURL("https://github.com/mvdan/gofumpt"),
 
+		linter.NewConfig(golinters.NewGoHeader()).
+			WithSince("v1.28.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/denis-tingajkin/go-header"),
+
 		linter.NewConfig(golinters.NewGoimports()).
 			WithSince("v1.20.0").
 			WithPresets(linter.PresetFormatting, linter.PresetImport).
 			WithAutoFix().
 			WithURL("https://godoc.org/golang.org/x/tools/cmd/goimports"),
+
+		linter.NewConfig(golinters.NewGolint()).
+			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/golang/lint").
+			Deprecated("The repository of the linter has been archived by the owner.", "v1.41.0", "revive"),
+
+		linter.NewConfig(golinters.NewGoMND(m.cfg)).
+			WithSince("v1.22.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/tommy-muehle/go-mnd"),
 
 		linter.NewConfig(golinters.NewGoModDirectives(goModDirectivesCfg)).
 			WithSince("v1.39.0").
@@ -368,6 +372,11 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.25.0").
 			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
 			WithURL("https://github.com/ryancurrah/gomodguard"),
+
+		linter.NewConfig(golinters.NewGoPrintfFuncName()).
+			WithSince("v1.23.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/jirfag/go-printf-func-name"),
 
 		linter.NewConfig(golinters.NewGosec(gosecCfg)).
 			WithSince("v1.0.0").
@@ -418,13 +427,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/butuzov/ireturn"),
-
-		linter.NewConfig(golinters.NewGolint()).
-			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/golang/lint").
-			Deprecated("The repository of the linter has been archived by the owner.", "v1.41.0", "revive"),
 
 		linter.NewConfig(golinters.NewLLL()).
 			WithSince("v1.8.0").
@@ -624,16 +626,16 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithAutoFix().
 			WithURL("https://github.com/ultraware/whitespace"),
 
-		linter.NewConfig(golinters.NewWSL()).
-			WithSince("v1.20.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/bombsimon/wsl"),
-
 		linter.NewConfig(golinters.NewWrapcheck(wrapcheckCfg)).
 			WithSince("v1.32.0").
 			WithPresets(linter.PresetStyle, linter.PresetError).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/tomarrell/wrapcheck"),
+
+		linter.NewConfig(golinters.NewWSL()).
+			WithSince("v1.20.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/bombsimon/wsl"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint()).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -114,6 +114,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var importAsCfg *config.ImportAsSettings
 	var ireturnCfg *config.IreturnSettings
 	var nilNilCfg *config.NilNilSettings
+	var nlreturnCfg *config.NlreturnSettings
 	var predeclaredCfg *config.PredeclaredSettings
 	var reviveCfg *config.ReviveSettings
 	var staticcheckCfg *config.StaticCheckSettings
@@ -125,7 +126,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var unusedCfg *config.StaticCheckSettings
 	var varnamelenCfg *config.VarnamelenSettings
 	var wrapcheckCfg *config.WrapcheckSettings
-	var nlreturnCfg *config.NlreturnSettings
 
 	if m.cfg != nil {
 		bidichkCfg = &m.cfg.LintersSettings.BiDiChk
@@ -142,6 +142,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		importAsCfg = &m.cfg.LintersSettings.ImportAs
 		ireturnCfg = &m.cfg.LintersSettings.Ireturn
 		nilNilCfg = &m.cfg.LintersSettings.NilNil
+		nlreturnCfg = &m.cfg.LintersSettings.Nlreturn
 		predeclaredCfg = &m.cfg.LintersSettings.Predeclared
 		reviveCfg = &m.cfg.LintersSettings.Revive
 		staticcheckCfg = &m.cfg.LintersSettings.Staticcheck
@@ -153,44 +154,377 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		unusedCfg = &m.cfg.LintersSettings.Unused
 		varnamelenCfg = &m.cfg.LintersSettings.Varnamelen
 		wrapcheckCfg = &m.cfg.LintersSettings.Wrapcheck
-		nlreturnCfg = &m.cfg.LintersSettings.Nlreturn
 	}
 
 	const megacheckName = "megacheck"
 
 	lcs := []*linter.Config{
+		linter.NewConfig(golinters.NewAsciicheck()).
+			WithSince("v1.26.0").
+			WithPresets(linter.PresetBugs, linter.PresetStyle).
+			WithURL("https://github.com/tdakkota/asciicheck"),
+
+		linter.NewConfig(golinters.NewBiDiChkFuncName(bidichkCfg)).
+			WithSince("1.43.0").
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/breml/bidichk"),
+
+		linter.NewConfig(golinters.NewBodyclose()).
+			WithSince("v1.18.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetPerformance, linter.PresetBugs).
+			WithURL("https://github.com/timakin/bodyclose"),
+
+		linter.NewConfig(golinters.NewContextCheck()).
+			WithSince("v1.43.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/sylvia7788/contextcheck"),
+
+		linter.NewConfig(golinters.NewCyclop(cyclopCfg)).
+			WithSince("v1.37.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetComplexity).
+			WithURL("https://github.com/bkielbasa/cyclop"),
+
+		linter.NewConfig(golinters.NewDeadcode()).
+			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetUnused).
+			WithURL("https://github.com/remyoudompheng/go-misc/tree/master/deadcode"),
+
+		linter.NewConfig(golinters.NewDepguard()).
+			WithSince("v1.4.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
+			WithURL("https://github.com/OpenPeeDeeP/depguard"),
+
+		linter.NewConfig(golinters.NewDogsled()).
+			WithSince("v1.19.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/alexkohler/dogsled"),
+
+		linter.NewConfig(golinters.NewDupl()).
+			WithSince("v1.0.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/mibk/dupl"),
+
+		linter.NewConfig(golinters.NewDurationCheck()).
+			WithSince("v1.37.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/charithe/durationcheck"),
+
+		linter.NewConfig(golinters.NewErrcheck()).
+			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetBugs, linter.PresetError).
+			WithURL("https://github.com/kisielk/errcheck"),
+
+		linter.NewConfig(golinters.NewErrChkJSONFuncName(errchkjsonCfg)).
+			WithSince("1.44.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/breml/errchkjson"),
+
+		linter.NewConfig(golinters.NewErrName()).
+			WithSince("v1.42.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/Antonboom/errname"),
+
+		linter.NewConfig(golinters.NewExhaustive(exhaustiveCfg)).
+			WithSince(" v1.28.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/nishanths/exhaustive"),
+
+		linter.NewConfig(golinters.NewExhaustiveStruct(exhaustiveStructCfg)).
+			WithSince("v1.32.0").
+			WithPresets(linter.PresetStyle, linter.PresetTest).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/mbilski/exhaustivestruct"),
+
+		linter.NewConfig(golinters.NewExportLoopRef()).
+			WithSince("v1.28.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/kyoh86/exportloopref"),
+
+		linter.NewConfig(golinters.NewForbidigo()).
+			WithSince("v1.34.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/ashanbrown/forbidigo"),
+
+		linter.NewConfig(golinters.NewForceTypeAssert()).
+			WithSince("v1.38.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/gostaticanalysis/forcetypeassert"),
+
+		linter.NewConfig(golinters.NewFunlen()).
+			WithSince("v1.18.0").
+			WithPresets(linter.PresetComplexity).
+			WithURL("https://github.com/ultraware/funlen"),
+
+		linter.NewConfig(golinters.NewGci()).
+			WithSince("v1.30.0").
+			WithPresets(linter.PresetFormatting, linter.PresetImport).
+			WithAutoFix().
+			WithURL("https://github.com/daixiang0/gci"),
+
+		linter.NewConfig(golinters.NewGocritic()).
+			WithSince("v1.12.0").
+			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/go-critic/go-critic"),
+
+		linter.NewConfig(golinters.NewGoerr113()).
+			WithSince("v1.26.0").
+			WithPresets(linter.PresetStyle, linter.PresetError).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/Djarvur/go-err113"),
+
+		linter.NewConfig(golinters.NewErrorLint(errorlintCfg)).
+			WithSince("v1.32.0").
+			WithPresets(linter.PresetBugs, linter.PresetError).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/polyfloyd/go-errorlint"),
+
+		linter.NewConfig(golinters.NewGoHeader()).
+			WithSince("v1.28.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/denis-tingajkin/go-header"),
+
+		linter.NewConfig(golinters.NewGoMND(m.cfg)).
+			WithSince("v1.22.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/tommy-muehle/go-mnd"),
+
+		linter.NewConfig(golinters.NewGoPrintfFuncName()).
+			WithSince("v1.23.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/jirfag/go-printf-func-name"),
+
+		linter.NewConfig(golinters.NewGochecknoglobals()).
+			WithSince("v1.12.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/leighmcculloch/gochecknoglobals"),
+
+		linter.NewConfig(golinters.NewGochecknoinits()).
+			WithSince("v1.12.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/leighmcculloch/gochecknoinits"),
+
+		linter.NewConfig(golinters.NewGocognit()).
+			WithSince("v1.20.0").
+			WithPresets(linter.PresetComplexity).
+			WithURL("https://github.com/uudashr/gocognit"),
+
+		linter.NewConfig(golinters.NewGoconst()).
+			WithSince("v1.0.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/jgautheron/goconst"),
+
+		linter.NewConfig(golinters.NewGocyclo()).
+			WithSince("v1.0.0").
+			WithPresets(linter.PresetComplexity).
+			WithURL("https://github.com/fzipp/gocyclo"),
+
+		linter.NewConfig(golinters.NewGodot()).
+			WithSince("v1.25.0").
+			WithPresets(linter.PresetStyle, linter.PresetComment).
+			WithAutoFix().
+			WithURL("https://github.com/tetafro/godot"),
+
+		linter.NewConfig(golinters.NewGodox()).
+			WithSince("v1.19.0").
+			WithPresets(linter.PresetStyle, linter.PresetComment).
+			WithURL("https://github.com/matoous/godox"),
+
+		linter.NewConfig(golinters.NewGofmt()).
+			WithSince("v1.0.0").
+			WithPresets(linter.PresetFormatting).
+			WithAutoFix().
+			WithURL("https://golang.org/cmd/gofmt/"),
+
+		linter.NewConfig(golinters.NewGofumpt()).
+			WithSince("v1.28.0").
+			WithPresets(linter.PresetFormatting).
+			WithAutoFix().
+			WithURL("https://github.com/mvdan/gofumpt"),
+
+		linter.NewConfig(golinters.NewGoimports()).
+			WithSince("v1.20.0").
+			WithPresets(linter.PresetFormatting, linter.PresetImport).
+			WithAutoFix().
+			WithURL("https://godoc.org/golang.org/x/tools/cmd/goimports"),
+
+		linter.NewConfig(golinters.NewGoModDirectives(goModDirectivesCfg)).
+			WithSince("v1.39.0").
+			WithPresets(linter.PresetStyle, linter.PresetModule).
+			WithURL("https://github.com/ldez/gomoddirectives"),
+
+		linter.NewConfig(golinters.NewGomodguard()).
+			WithSince("v1.25.0").
+			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
+			WithURL("https://github.com/ryancurrah/gomodguard"),
+
+		linter.NewConfig(golinters.NewGosec(gosecCfg)).
+			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/securego/gosec").
+			WithAlternativeNames("gas"),
+
+		linter.NewConfig(golinters.NewGosimple(gosimpleCfg)).
+			WithSince("v1.20.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithAlternativeNames(megacheckName).
+			WithURL("https://github.com/dominikh/go-tools/tree/master/simple"),
+
 		linter.NewConfig(golinters.NewGovet(govetCfg)).
 			WithSince("v1.0.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetBugs, linter.PresetMetaLinter).
 			WithAlternativeNames("vet", "vetshadow").
 			WithURL("https://golang.org/cmd/vet/"),
-		linter.NewConfig(golinters.NewBodyclose()).
-			WithSince("v1.18.0").
+
+		linter.NewConfig(golinters.NewIfshort(ifshortCfg)).
+			WithSince("v1.36.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/esimonov/ifshort"),
+
+		linter.NewConfig(golinters.NewImportAs(importAsCfg)).
+			WithSince("v1.38.0").
+			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetPerformance, linter.PresetBugs).
-			WithURL("https://github.com/timakin/bodyclose"),
-		linter.NewConfig(golinters.NewNoctx()).
-			WithSince("v1.28.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetPerformance, linter.PresetBugs).
-			WithURL("https://github.com/sonatard/noctx"),
-		linter.NewConfig(golinters.NewErrcheck()).
+			WithURL("https://github.com/julz/importas"),
+
+		linter.NewConfig(golinters.NewIneffassign()).
+			WithSince("v1.0.0").
+			WithPresets(linter.PresetUnused).
+			WithURL("https://github.com/gordonklaus/ineffassign"),
+
+		linter.NewConfig(golinters.NewInterfacer()).
 			WithSince("v1.0.0").
 			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs, linter.PresetError).
-			WithURL("https://github.com/kisielk/errcheck"),
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/mvdan/interfacer").
+			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", ""),
+
+		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
+			WithSince("v1.43.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/butuzov/ireturn"),
+
 		linter.NewConfig(golinters.NewGolint()).
 			WithSince("v1.0.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/golang/lint").
 			Deprecated("The repository of the linter has been archived by the owner.", "v1.41.0", "revive"),
+
+		linter.NewConfig(golinters.NewLLL()).
+			WithSince("v1.8.0").
+			WithPresets(linter.PresetStyle),
+
+		linter.NewConfig(golinters.NewMakezero()).
+			WithSince("v1.34.0").
+			WithPresets(linter.PresetStyle, linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/ashanbrown/makezero"),
+
+		linter.NewConfig(golinters.NewMaligned()).
+			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetPerformance).
+			WithURL("https://github.com/mdempsky/maligned").
+			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", "govet 'fieldalignment'"),
+
+		linter.NewConfig(golinters.NewMisspell()).
+			WithSince("v1.8.0").
+			WithPresets(linter.PresetStyle, linter.PresetComment).
+			WithAutoFix().
+			WithURL("https://github.com/client9/misspell"),
+
+		linter.NewConfig(golinters.NewNakedret()).
+			WithSince("v1.19.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/alexkohler/nakedret"),
+
+		linter.NewConfig(golinters.NewNestif()).
+			WithSince("v1.25.0").
+			WithPresets(linter.PresetComplexity).
+			WithURL("https://github.com/nakabonne/nestif"),
+
+		linter.NewConfig(golinters.NewNilErr()).
+			WithSince("v1.38.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/gostaticanalysis/nilerr"),
+
+		linter.NewConfig(golinters.NewNilNil(nilNilCfg)).
+			WithSince("v1.43.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/Antonboom/nilnil"),
+
+		linter.NewConfig(golinters.NewNLReturn(nlreturnCfg)).
+			WithSince("v1.30.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/ssgreg/nlreturn"),
+
+		linter.NewConfig(golinters.NewNoctx()).
+			WithSince("v1.28.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetPerformance, linter.PresetBugs).
+			WithURL("https://github.com/sonatard/noctx"),
+
+		linter.NewConfig(golinters.NewParallelTest()).
+			WithSince("v1.33.0").
+			WithPresets(linter.PresetStyle, linter.PresetTest).
+			WithURL("https://github.com/kunwardeep/paralleltest"),
+
+		linter.NewConfig(golinters.NewPrealloc()).
+			WithSince("v1.19.0").
+			WithPresets(linter.PresetPerformance).
+			WithURL("https://github.com/alexkohler/prealloc"),
+
+		linter.NewConfig(golinters.NewPredeclared(predeclaredCfg)).
+			WithSince("v1.35.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/nishanths/predeclared"),
+
+		linter.NewConfig(golinters.NewPromlinter()).
+			WithSince("v1.40.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/yeya24/promlinter"),
+
+		linter.NewConfig(golinters.NewRevive(reviveCfg)).
+			WithSince("v1.37.0").
+			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
+			ConsiderSlow().
+			WithURL("https://github.com/mgechev/revive"),
+
 		linter.NewConfig(golinters.NewRowsErrCheck()).
 			WithSince("v1.23.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetBugs, linter.PresetSQL).
 			WithURL("https://github.com/jingyugao/rowserrcheck"),
+
+		linter.NewConfig(golinters.NewScopelint()).
+			WithSince("v1.12.0").
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/kyoh86/scopelint").
+			Deprecated("The repository of the linter has been deprecated by the owner.", "v1.39.0", "exportloopref"),
+
+		linter.NewConfig(golinters.NewSQLCloseCheck()).
+			WithSince("v1.28.0").
+			WithPresets(linter.PresetBugs, linter.PresetSQL).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/ryanrolds/sqlclosecheck"),
 
 		linter.NewConfig(golinters.NewStaticcheck(staticcheckCfg)).
 			WithSince("v1.0.0").
@@ -198,6 +532,65 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetBugs, linter.PresetMetaLinter).
 			WithAlternativeNames(megacheckName).
 			WithURL("https://staticcheck.io/"),
+
+		linter.NewConfig(golinters.NewStructcheck()).
+			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetUnused).
+			WithURL("https://github.com/opennota/check"),
+
+		linter.NewConfig(golinters.NewStylecheck(stylecheckCfg)).
+			WithSince("v1.20.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/dominikh/go-tools/tree/master/stylecheck"),
+
+		linter.NewConfig(golinters.NewTagliatelle(tagliatelleCfg)).
+			WithSince("v1.40.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/ldez/tagliatelle"),
+
+		linter.NewConfig(golinters.NewTenv(tenvCfg)).
+			WithSince("v1.43.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/sivchari/tenv"),
+
+		linter.NewConfig(golinters.NewTestpackage(testpackageCfg)).
+			WithSince("v1.25.0").
+			WithPresets(linter.PresetStyle, linter.PresetTest).
+			WithURL("https://github.com/maratori/testpackage"),
+
+		linter.NewConfig(golinters.NewThelper(thelperCfg)).
+			WithSince("v1.34.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/kulti/thelper"),
+
+		linter.NewConfig(golinters.NewTparallel()).
+			WithSince("v1.32.0").
+			WithPresets(linter.PresetStyle, linter.PresetTest).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/moricho/tparallel"),
+
+		linter.NewConfig(golinters.NewTypecheck()).
+			WithSince("v1.3.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetBugs).
+			WithURL(""),
+
+		linter.NewConfig(golinters.NewUnconvert()).
+			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/mdempsky/unconvert"),
+
+		linter.NewConfig(golinters.NewUnparam()).
+			WithSince("v1.9.0").
+			WithPresets(linter.PresetUnused).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/mvdan/unparam"),
+
 		linter.NewConfig(golinters.NewUnused(unusedCfg)).
 			WithSince("v1.20.0").
 			WithLoadForGoAnalysis().
@@ -206,355 +599,41 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			ConsiderSlow().
 			WithChangeTypes().
 			WithURL("https://github.com/dominikh/go-tools/tree/master/unused"),
-		linter.NewConfig(golinters.NewGosimple(gosimpleCfg)).
-			WithSince("v1.20.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetStyle).
-			WithAlternativeNames(megacheckName).
-			WithURL("https://github.com/dominikh/go-tools/tree/master/simple"),
 
-		linter.NewConfig(golinters.NewStylecheck(stylecheckCfg)).
-			WithSince("v1.20.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/dominikh/go-tools/tree/master/stylecheck"),
-		linter.NewConfig(golinters.NewGosec(gosecCfg)).
-			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs).
-			WithURL("https://github.com/securego/gosec").
-			WithAlternativeNames("gas"),
-		linter.NewConfig(golinters.NewStructcheck()).
-			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetUnused).
-			WithURL("https://github.com/opennota/check"),
 		linter.NewConfig(golinters.NewVarcheck()).
 			WithSince("v1.0.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetUnused).
 			WithURL("https://github.com/opennota/check"),
-		linter.NewConfig(golinters.NewInterfacer()).
-			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/mvdan/interfacer").
-			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", ""),
-		linter.NewConfig(golinters.NewUnconvert()).
-			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/mdempsky/unconvert"),
-		linter.NewConfig(golinters.NewIneffassign()).
-			WithSince("v1.0.0").
-			WithPresets(linter.PresetUnused).
-			WithURL("https://github.com/gordonklaus/ineffassign"),
-		linter.NewConfig(golinters.NewDupl()).
-			WithSince("v1.0.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/mibk/dupl"),
-		linter.NewConfig(golinters.NewGoconst()).
-			WithSince("v1.0.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/jgautheron/goconst"),
-		linter.NewConfig(golinters.NewDeadcode()).
-			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetUnused).
-			WithURL("https://github.com/remyoudompheng/go-misc/tree/master/deadcode"),
-		linter.NewConfig(golinters.NewGocyclo()).
-			WithSince("v1.0.0").
-			WithPresets(linter.PresetComplexity).
-			WithURL("https://github.com/fzipp/gocyclo"),
-		linter.NewConfig(golinters.NewCyclop(cyclopCfg)).
-			WithSince("v1.37.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetComplexity).
-			WithURL("https://github.com/bkielbasa/cyclop"),
-		linter.NewConfig(golinters.NewGocognit()).
-			WithSince("v1.20.0").
-			WithPresets(linter.PresetComplexity).
-			WithURL("https://github.com/uudashr/gocognit"),
-		linter.NewConfig(golinters.NewTypecheck()).
-			WithSince("v1.3.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs).
-			WithURL(""),
-		linter.NewConfig(golinters.NewAsciicheck()).
-			WithSince("v1.26.0").
-			WithPresets(linter.PresetBugs, linter.PresetStyle).
-			WithURL("https://github.com/tdakkota/asciicheck"),
 
-		linter.NewConfig(golinters.NewGofmt()).
-			WithSince("v1.0.0").
-			WithPresets(linter.PresetFormatting).
-			WithAutoFix().
-			WithURL("https://golang.org/cmd/gofmt/"),
-		linter.NewConfig(golinters.NewGofumpt()).
-			WithSince("v1.28.0").
-			WithPresets(linter.PresetFormatting).
-			WithAutoFix().
-			WithURL("https://github.com/mvdan/gofumpt"),
-		linter.NewConfig(golinters.NewGoimports()).
-			WithSince("v1.20.0").
-			WithPresets(linter.PresetFormatting, linter.PresetImport).
-			WithAutoFix().
-			WithURL("https://godoc.org/golang.org/x/tools/cmd/goimports"),
-		linter.NewConfig(golinters.NewGoHeader()).
-			WithSince("v1.28.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/denis-tingajkin/go-header"),
-		linter.NewConfig(golinters.NewGci()).
-			WithSince("v1.30.0").
-			WithPresets(linter.PresetFormatting, linter.PresetImport).
-			WithAutoFix().
-			WithURL("https://github.com/daixiang0/gci"),
-		linter.NewConfig(golinters.NewMaligned()).
-			WithSince("v1.0.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetPerformance).
-			WithURL("https://github.com/mdempsky/maligned").
-			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", "govet 'fieldalignment'"),
-		linter.NewConfig(golinters.NewDepguard()).
-			WithSince("v1.4.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
-			WithURL("https://github.com/OpenPeeDeeP/depguard"),
-		linter.NewConfig(golinters.NewMisspell()).
-			WithSince("v1.8.0").
-			WithPresets(linter.PresetStyle, linter.PresetComment).
-			WithAutoFix().
-			WithURL("https://github.com/client9/misspell"),
-		linter.NewConfig(golinters.NewLLL()).
-			WithSince("v1.8.0").
-			WithPresets(linter.PresetStyle),
-		linter.NewConfig(golinters.NewUnparam()).
-			WithSince("v1.9.0").
-			WithPresets(linter.PresetUnused).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/mvdan/unparam"),
-		linter.NewConfig(golinters.NewDogsled()).
-			WithSince("v1.19.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/alexkohler/dogsled"),
-		linter.NewConfig(golinters.NewNakedret()).
-			WithSince("v1.19.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/alexkohler/nakedret"),
-		linter.NewConfig(golinters.NewPrealloc()).
-			WithSince("v1.19.0").
-			WithPresets(linter.PresetPerformance).
-			WithURL("https://github.com/alexkohler/prealloc"),
-		linter.NewConfig(golinters.NewScopelint()).
-			WithSince("v1.12.0").
-			WithPresets(linter.PresetBugs).
-			WithURL("https://github.com/kyoh86/scopelint").
-			Deprecated("The repository of the linter has been deprecated by the owner.", "v1.39.0", "exportloopref"),
-		linter.NewConfig(golinters.NewGocritic()).
-			WithSince("v1.12.0").
-			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/go-critic/go-critic"),
-		linter.NewConfig(golinters.NewGochecknoinits()).
-			WithSince("v1.12.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/leighmcculloch/gochecknoinits"),
-		linter.NewConfig(golinters.NewGochecknoglobals()).
-			WithSince("v1.12.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/leighmcculloch/gochecknoglobals"),
-		linter.NewConfig(golinters.NewGodox()).
-			WithSince("v1.19.0").
-			WithPresets(linter.PresetStyle, linter.PresetComment).
-			WithURL("https://github.com/matoous/godox"),
-		linter.NewConfig(golinters.NewFunlen()).
-			WithSince("v1.18.0").
-			WithPresets(linter.PresetComplexity).
-			WithURL("https://github.com/ultraware/funlen"),
-		linter.NewConfig(golinters.NewWhitespace()).
-			WithSince("v1.19.0").
-			WithPresets(linter.PresetStyle).
-			WithAutoFix().
-			WithURL("https://github.com/ultraware/whitespace"),
-		linter.NewConfig(golinters.NewWSL()).
-			WithSince("v1.20.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/bombsimon/wsl"),
-		linter.NewConfig(golinters.NewGoPrintfFuncName()).
-			WithSince("v1.23.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/jirfag/go-printf-func-name"),
-		linter.NewConfig(golinters.NewGoMND(m.cfg)).
-			WithSince("v1.22.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/tommy-muehle/go-mnd"),
-		linter.NewConfig(golinters.NewGoerr113()).
-			WithSince("v1.26.0").
-			WithPresets(linter.PresetStyle, linter.PresetError).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/Djarvur/go-err113"),
-		linter.NewConfig(golinters.NewGomodguard()).
-			WithSince("v1.25.0").
-			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
-			WithURL("https://github.com/ryancurrah/gomodguard"),
-		linter.NewConfig(golinters.NewGodot()).
-			WithSince("v1.25.0").
-			WithPresets(linter.PresetStyle, linter.PresetComment).
-			WithAutoFix().
-			WithURL("https://github.com/tetafro/godot"),
-		linter.NewConfig(golinters.NewTestpackage(testpackageCfg)).
-			WithSince("v1.25.0").
-			WithPresets(linter.PresetStyle, linter.PresetTest).
-			WithURL("https://github.com/maratori/testpackage"),
-		linter.NewConfig(golinters.NewNestif()).
-			WithSince("v1.25.0").
-			WithPresets(linter.PresetComplexity).
-			WithURL("https://github.com/nakabonne/nestif"),
-		linter.NewConfig(golinters.NewExportLoopRef()).
-			WithSince("v1.28.0").
-			WithPresets(linter.PresetBugs).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/kyoh86/exportloopref"),
-		linter.NewConfig(golinters.NewExhaustive(exhaustiveCfg)).
-			WithSince(" v1.28.0").
-			WithPresets(linter.PresetBugs).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/nishanths/exhaustive"),
-		linter.NewConfig(golinters.NewSQLCloseCheck()).
-			WithSince("v1.28.0").
-			WithPresets(linter.PresetBugs, linter.PresetSQL).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/ryanrolds/sqlclosecheck"),
-		linter.NewConfig(golinters.NewNLReturn(nlreturnCfg)).
-			WithSince("v1.30.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/ssgreg/nlreturn"),
-		linter.NewConfig(golinters.NewWrapcheck(wrapcheckCfg)).
-			WithSince("v1.32.0").
-			WithPresets(linter.PresetStyle, linter.PresetError).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/tomarrell/wrapcheck"),
-		linter.NewConfig(golinters.NewThelper(thelperCfg)).
-			WithSince("v1.34.0").
-			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/kulti/thelper"),
-		linter.NewConfig(golinters.NewTparallel()).
-			WithSince("v1.32.0").
-			WithPresets(linter.PresetStyle, linter.PresetTest).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/moricho/tparallel"),
-		linter.NewConfig(golinters.NewExhaustiveStruct(exhaustiveStructCfg)).
-			WithSince("v1.32.0").
-			WithPresets(linter.PresetStyle, linter.PresetTest).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/mbilski/exhaustivestruct"),
-		linter.NewConfig(golinters.NewErrorLint(errorlintCfg)).
-			WithSince("v1.32.0").
-			WithPresets(linter.PresetBugs, linter.PresetError).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/polyfloyd/go-errorlint"),
-		linter.NewConfig(golinters.NewParallelTest()).
-			WithSince("v1.33.0").
-			WithPresets(linter.PresetStyle, linter.PresetTest).
-			WithURL("https://github.com/kunwardeep/paralleltest"),
-		linter.NewConfig(golinters.NewMakezero()).
-			WithSince("v1.34.0").
-			WithPresets(linter.PresetStyle, linter.PresetBugs).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/ashanbrown/makezero"),
-		linter.NewConfig(golinters.NewForbidigo()).
-			WithSince("v1.34.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/ashanbrown/forbidigo"),
-		linter.NewConfig(golinters.NewIfshort(ifshortCfg)).
-			WithSince("v1.36.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/esimonov/ifshort"),
-		linter.NewConfig(golinters.NewPredeclared(predeclaredCfg)).
-			WithSince("v1.35.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/nishanths/predeclared"),
-		linter.NewConfig(golinters.NewRevive(reviveCfg)).
-			WithSince("v1.37.0").
-			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
-			ConsiderSlow().
-			WithURL("https://github.com/mgechev/revive"),
-		linter.NewConfig(golinters.NewDurationCheck()).
-			WithSince("v1.37.0").
-			WithPresets(linter.PresetBugs).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/charithe/durationcheck"),
-		linter.NewConfig(golinters.NewWastedAssign()).
-			WithSince("v1.38.0").
-			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/sanposhiho/wastedassign"),
-		linter.NewConfig(golinters.NewImportAs(importAsCfg)).
-			WithSince("v1.38.0").
-			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/julz/importas"),
-		linter.NewConfig(golinters.NewNilErr()).
-			WithSince("v1.38.0").
-			WithLoadForGoAnalysis().
-			WithPresets(linter.PresetBugs).
-			WithURL("https://github.com/gostaticanalysis/nilerr"),
-		linter.NewConfig(golinters.NewForceTypeAssert()).
-			WithSince("v1.38.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/gostaticanalysis/forcetypeassert"),
-		linter.NewConfig(golinters.NewGoModDirectives(goModDirectivesCfg)).
-			WithSince("v1.39.0").
-			WithPresets(linter.PresetStyle, linter.PresetModule).
-			WithURL("https://github.com/ldez/gomoddirectives"),
-		linter.NewConfig(golinters.NewPromlinter()).
-			WithSince("v1.40.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/yeya24/promlinter"),
-		linter.NewConfig(golinters.NewTagliatelle(tagliatelleCfg)).
-			WithSince("v1.40.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/ldez/tagliatelle"),
-		linter.NewConfig(golinters.NewErrName()).
-			WithSince("v1.42.0").
-			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/Antonboom/errname"),
-		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
-			WithSince("v1.43.0").
-			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/butuzov/ireturn"),
-		linter.NewConfig(golinters.NewNilNil(nilNilCfg)).
-			WithSince("v1.43.0").
-			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/Antonboom/nilnil"),
-		linter.NewConfig(golinters.NewTenv(tenvCfg)).
-			WithSince("v1.43.0").
-			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/sivchari/tenv"),
-		linter.NewConfig(golinters.NewContextCheck()).
-			WithSince("v1.43.0").
-			WithPresets(linter.PresetBugs).
-			WithLoadForGoAnalysis().
-			WithURL("https://github.com/sylvia7788/contextcheck"),
 		linter.NewConfig(golinters.NewVarnamelen(varnamelenCfg)).
 			WithSince("v1.43.0").
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/blizzy78/varnamelen"),
-		linter.NewConfig(golinters.NewBiDiChkFuncName(bidichkCfg)).
-			WithSince("1.43.0").
-			WithPresets(linter.PresetBugs).
-			WithURL("https://github.com/breml/bidichk"),
-		linter.NewConfig(golinters.NewErrChkJSONFuncName(errchkjsonCfg)).
-			WithSince("1.44.0").
-			WithPresets(linter.PresetBugs).
+
+		linter.NewConfig(golinters.NewWastedAssign()).
+			WithSince("v1.38.0").
+			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/breml/errchkjson"),
+			WithURL("https://github.com/sanposhiho/wastedassign"),
+
+		linter.NewConfig(golinters.NewWhitespace()).
+			WithSince("v1.19.0").
+			WithPresets(linter.PresetStyle).
+			WithAutoFix().
+			WithURL("https://github.com/ultraware/whitespace"),
+
+		linter.NewConfig(golinters.NewWSL()).
+			WithSince("v1.20.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/bombsimon/wsl"),
+
+		linter.NewConfig(golinters.NewWrapcheck(wrapcheckCfg)).
+			WithSince("v1.32.0").
+			WithPresets(linter.PresetStyle, linter.PresetError).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/tomarrell/wrapcheck"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint()).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -158,8 +158,8 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 
 	const megacheckName = "megacheck"
 
-	// The linters are in the alphabetical order (case-insensitive).
-	// When a new linter is added the version in `WithSince(...)` must be the next version of golangci-lint.
+	// The linters are sorted in the alphabetical order (case-insensitive).
+	// When a new linter is added the version in `WithSince(...)` must be the next minor version of golangci-lint.
 	lcs := []*linter.Config{
 		linter.NewConfig(golinters.NewAsciicheck()).
 			WithSince("v1.26.0").


### PR DESCRIPTION
This change will help to :
- keep linters db in the consistent view
- keep new unmerged linters in conflict-free mode until merge time comes
  (assuming new linters will be placed in the correct position, instead
   settings to the end of the list)