### PR TITLE
dev: improve and clean fix_test

### DIFF
--- a/test/testdata/configs/gocritic-fix.yml
+++ b/test/testdata/configs/gocritic-fix.yml
@@ -1,0 +1,8 @@
+linters-settings:
+  gocritic:
+    enabled-checks:
+      - ruleguard
+    settings:
+      ruleguard:
+        rules: 'ruleguard/rangeExprCopy.go,ruleguard/strings_simplify.go'
+

--- a/test/testdata/fix/in/gocritic.go
+++ b/test/testdata/fix/in/gocritic.go
@@ -1,6 +1,5 @@
-//args: -Egocritic
-//config: linters-settings.gocritic.enabled-checks=ruleguard
-//config: linters-settings.gocritic.settings.ruleguard.rules=ruleguard/rangeExprCopy.go,ruleguard/strings_simplify.go
+// args: -Egocritic
+// config_path: testdata/configs/gocritic-fix.yml
 package p
 
 import (

--- a/test/testdata/fix/in/unused.go
+++ b/test/testdata/fix/in/unused.go
@@ -1,8 +1,0 @@
-//args: -Eunused
-package p
-
-type (
-	unused struct{}
-)
-
-func X() {}

--- a/test/testdata/fix/out/gocritic.go
+++ b/test/testdata/fix/out/gocritic.go
@@ -1,6 +1,5 @@
-//args: -Egocritic
-//config: linters-settings.gocritic.enabled-checks=ruleguard
-//config: linters-settings.gocritic.settings.ruleguard.rules=ruleguard/rangeExprCopy.go,ruleguard/strings_simplify.go
+// args: -Egocritic
+// config_path: testdata/configs/gocritic-fix.yml
 package p
 
 import (

--- a/test/testdata/fix/out/unused.go
+++ b/test/testdata/fix/out/unused.go
@@ -1,8 +1,0 @@
-//args: -Eunused
-package p
-
-type (
-	unused struct{}
-)
-
-func X() {}


### PR DESCRIPTION
- allows `config_path`
- removes `unused.go` (because it doesn't support autofix)
- check the exit code of the running command