### PR TITLE
Print error text in <failure> tag content for more readable junit report

### DIFF
--- a/pkg/printers/junitxml.go
+++ b/pkg/printers/junitxml.go
@@ -57,8 +57,8 @@ func (p JunitXML) Print(ctx context.Context, issues []result.Issue) error {
 			Name:      i.FromLinter,
 			ClassName: i.Pos.String(),
 			Failure: failureXML{
-				Message: i.Text,
-				Content: i.Text + ":\n" + strings.Join(i.SourceLines, "\n"),
+				Message: i.Pos.String() + ": " + i.Text,
+				Content: i.Pos.String() + ": " + i.Text + "\n" + strings.Join(i.SourceLines, "\n"),
 			},
 		}
 

--- a/pkg/printers/junitxml.go
+++ b/pkg/printers/junitxml.go
@@ -3,6 +3,7 @@ package printers
 import (
 	"context"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"strings"
 
@@ -31,6 +32,7 @@ type testCaseXML struct {
 
 type failureXML struct {
 	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
 	Content string `xml:",cdata"`
 }
 
@@ -57,8 +59,10 @@ func (p JunitXML) Print(ctx context.Context, issues []result.Issue) error {
 			Name:      i.FromLinter,
 			ClassName: i.Pos.String(),
 			Failure: failureXML{
+				Type:    i.Severity,
 				Message: i.Pos.String() + ": " + i.Text,
-				Content: i.Pos.String() + ": " + i.Text + "\n" + strings.Join(i.SourceLines, "\n"),
+				Content: fmt.Sprintf("%s: %s\nCategory: %s\nFile: %s\nLine: %d\nDetails: %s",
+					i.Severity, i.Text, i.FromLinter, i.Pos.Filename, i.Pos.Line, strings.Join(i.SourceLines, "\n")),
 			},
 		}
 

--- a/pkg/printers/junitxml.go
+++ b/pkg/printers/junitxml.go
@@ -58,7 +58,7 @@ func (p JunitXML) Print(ctx context.Context, issues []result.Issue) error {
 			ClassName: i.Pos.String(),
 			Failure: failureXML{
 				Message: i.Text,
-				Content: strings.Join(i.SourceLines, "\n"),
+				Content: i.Text + ":\n" + strings.Join(i.SourceLines, "\n"),
 			},
 		}
 


### PR DESCRIPTION
Just adds the actual lint error text that is currently only in the `message` attribute, into the content of the `<failure>` tag.
Fixes #2452