### PR TITLE
pkg/result/processors: compile nolint regexp only once

### DIFF
--- a/pkg/result/processors/nolint.go
+++ b/pkg/result/processors/nolint.go
@@ -17,6 +17,7 @@ import (
 )
 
 var nolintDebugf = logutils.Debug("nolint")
+var nolintRe = regexp.MustCompile(`^nolint( |:|$)`)
 
 type ignoredRange struct {
 	linters                []string
@@ -234,7 +235,7 @@ func (p *Nolint) extractFileCommentsInlineRanges(fset *token.FileSet, comments .
 
 func (p *Nolint) extractInlineRangeFromComment(text string, g ast.Node, fset *token.FileSet) *ignoredRange {
 	text = strings.TrimLeft(text, "/ ")
-	if ok, _ := regexp.MatchString(`^nolint( |:|$)`, text); !ok {
+	if !nolintRe.MatchString(text) {
 		return nil
 	}
 


### PR DESCRIPTION
`regexp.MatchString` compiles regexp for every invocation,
there is no pattern caching there.

This change introduces a precompiled regexp to save some time
while checking comments for nolint directives.

Found using go-perfguard with cpu profile collected while
running golangci-lint on itself.