### PR TITLE
Return error if any linter fails to run

### DIFF
--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -213,10 +213,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 	}
 
 	if len(failedLinters) > 0 {
-		linterErr = fmt.Errorf(
-			"one or more linters failed to run: %s",
-			strings.Join(failedLinters, ", "),
-		)
+		linterErr = errors.New("one or more linters failed to run: " + strings.Join(failedLinters, ", "))
 	}
 
 	return r.processLintResults(issues), linterErr


### PR DESCRIPTION
If a linter fails, store its name and use that to create a list of all linters that failed to run.
This will make `golangci-lint` exit with a non-zero exit code if one or more linters fails but still ensure all linters are run before exiting.

Fixes #2357 