### PR TITLE
revive: adding missing lint rules

### DIFF
--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -305,6 +305,8 @@ var allRules = append([]lint.Rule{
 	&rule.NestedStructs{},
 	&rule.IfReturnRule{},
 	&rule.UselessBreak{},
+	&rule.OptimizeOperandsOrderRule{},
+	&rule.TimeEqualRule{},
 }, defaultRules...)
 
 // This element is not exported by revive, so we need copy the code.


### PR DESCRIPTION
This PR adds a couple of rules that are currently not present on the revive linter. These rules are available as of the current revive version