### PR TITLE
exhaustive: drop deprecated/unused settings

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -15,7 +15,7 @@ var defaultLintersSettings = LintersSettings{
 		CheckGenerated:             false,
 		DefaultSignifiesExhaustive: false,
 		IgnoreEnumMembers:          "",
-		CheckingStrategy:           "value",
+		PackageScopeOnly:           false,
 	},
 	Forbidigo: ForbidigoSettings{
 		ExcludeGodocExamples: true,
@@ -207,9 +207,6 @@ type ExhaustiveSettings struct {
 	DefaultSignifiesExhaustive bool   `mapstructure:"default-signifies-exhaustive"`
 	IgnoreEnumMembers          string `mapstructure:"ignore-enum-members"`
 	PackageScopeOnly           bool   `mapstructure:"package-scope-only"`
-
-	IgnorePattern    string `mapstructure:"ignore-pattern"`    // Deprecated: this setting has no effect; see IgnoreEnumMembers instead.
-	CheckingStrategy string `mapstructure:"checking-strategy"` // Deprecated.
 }
 
 type ExhaustiveStructSettings struct {

--- a/pkg/golinters/exhaustive.go
+++ b/pkg/golinters/exhaustive.go
@@ -19,9 +19,6 @@ func NewExhaustive(settings *config.ExhaustiveSettings) *goanalysis.Linter {
 				exhaustive.DefaultSignifiesExhaustiveFlag: settings.DefaultSignifiesExhaustive,
 				exhaustive.IgnoreEnumMembersFlag:          settings.IgnoreEnumMembers,
 				exhaustive.PackageScopeOnlyFlag:           settings.PackageScopeOnly,
-
-				exhaustive.IgnorePatternFlag:    settings.IgnorePattern,
-				exhaustive.CheckingStrategyFlag: settings.CheckingStrategy,
 			},
 		}
 	}


### PR DESCRIPTION
Both settings are no more used by `exhaustive` linter:
- `ignore-pattern`
- `checking-strategy`

See https://github.com/nishanths/exhaustive/blob/v0.7.11/exhaustive.go#L203-L205