### PR TITLE
docs: split configuration page into multiple sections

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters-settings:
     local-prefixes: github.com/golangci/golangci-lint
   goconst:
     min-len: 2
-    min-occurrences: 2
+    min-occurrences: 3
   gocritic:
     enabled-tags:
       - diagnostic

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -24195,6 +24195,7 @@
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.27.1.tgz",
       "integrity": "sha512-IQNXWdspb4nZcJemXa6cfgz+JvKONsuqP8Mwi1Oti23Uo7+J+UF2jihJDf6I1BQbrmhcZ0lagH/1WYG+ReAzyQ==",
+      "hasInstallScript": true,
       "dependencies": {
         "array-flatten": "^3.0.0",
         "color": "^3.1.3",

--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -44,9 +44,7 @@ You can configure specific linters' options only within the config file (not the
 There is a [`.golangci.example.yml`](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml) example
 config file with all supported options, their description and default value:
 
-```yaml
-{ .GolangciYamlExample }
-```
+{ .ConfigurationExample }
 
 ## Cache
 

--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -12,19 +12,6 @@ To see a list of enabled by your configuration linters:
 golangci-lint linters
 ```
 
-## Command-Line Options
-
-```sh
-golangci-lint run -h
-{.RunHelpText}
-```
-
-When the `--cpu-profile-path` or `--mem-profile-path` arguments are specified, `golangci-lint` writes runtime profiling data
-in the format expected by the [pprof](https://github.com/google/pprof) visualization tool.
-
-When the `--trace-path` argument is specified, `golangci-lint` writes runtime tracing data in the format expected by
-the `go tool trace` command and visualization tool.
-
 ## Config File
 
 GolangCI-Lint looks for config files in the following paths from the current working directory:
@@ -41,10 +28,23 @@ To see which config file is being used and where it was sourced from run golangc
 Config options inside the file are identical to command-line options.
 You can configure specific linters' options only within the config file (not the command-line).
 
-There is a [`.golangci.example.yml`](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml) example
-config file with all supported options, their description and default value:
+There is a [`.golangci.example.yml`](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml) file with all supported options, their description, and default values.
+This file is a neither a working example nor recommended configuration, it's just a reference to display all the configuration options.
 
 { .ConfigurationExample }
+
+## Command-Line Options
+
+```sh
+golangci-lint run -h
+{.RunHelpText}
+```
+
+When the `--cpu-profile-path` or `--mem-profile-path` arguments are specified, `golangci-lint` writes runtime profiling data
+in the format expected by the [pprof](https://github.com/google/pprof) visualization tool.
+
+When the `--trace-path` argument is specified, `golangci-lint` writes runtime tracing data in the format expected by
+the `go tool trace` command and visualization tool.
 
 ## Cache
 

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -347,7 +347,7 @@ func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 
 	snippets := SettingSnippets{}
 
-	buffer := bytes.NewBufferString("")
+	builder := strings.Builder{}
 
 	for j, node := range root.Content {
 		switch node.Value {
@@ -385,7 +385,7 @@ func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 				return nil, err
 			}
 
-			_, _ = buffer.WriteString(
+			_, _ = builder.WriteString(
 				fmt.Sprintf(
 					"### `%s` configuration\n\nSee the dedicated [linters-settings](/usage/linters) documentation section.\n\n",
 					node.Value,
@@ -407,7 +407,7 @@ func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 			return nil, errSnip
 		}
 
-		_, _ = buffer.WriteString(fmt.Sprintf("### `%s` configuration\n\n%s", node.Value, snippet))
+		_, _ = builder.WriteString(fmt.Sprintf("### `%s` configuration\n\n%s", node.Value, snippet))
 	}
 
 	overview, err := marshallSnippet(globalNode)
@@ -415,7 +415,7 @@ func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 		return nil, err
 	}
 
-	snippets.ConfigurationFile = overview + buffer.String()
+	snippets.ConfigurationFile = overview + builder.String()
 
 	return &snippets, nil
 }
@@ -444,9 +444,8 @@ func getLintersSettingSnippets(node, nextNode *yaml.Node) (string, error) {
 		_, _ = fmt.Fprintf(builder, "### %s\n\n", nextNode.Content[i].Value)
 		_, _ = fmt.Fprintln(builder, "```yaml")
 
-		const ident = 2
 		encoder := yaml.NewEncoder(builder)
-		encoder.SetIndent(ident)
+		encoder.SetIndent(2)
 
 		err := encoder.Encode(r)
 		if err != nil {
@@ -468,9 +467,8 @@ func marshallSnippet(node *yaml.Node) (string, error) {
 	}
 	_, _ = fmt.Fprintln(builder, "```yaml")
 
-	const ident = 2
 	encoder := yaml.NewEncoder(builder)
-	encoder.SetIndent(ident)
+	encoder.SetIndent(2)
 
 	err := encoder.Encode(node)
 	if err != nil {

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -165,7 +165,7 @@ func buildTemplateContext() (map[string]string, error) {
 		return nil, fmt.Errorf("can't read .golangci.example.yml: %s", err)
 	}
 
-	lintersCfg, err := getLintersConfiguration(golangciYamlExample)
+	snippets, err := extractExampleSnippets(golangciYamlExample)
 	if err != nil {
 		return nil, fmt.Errorf("can't read .golangci.example.yml: %s", err)
 	}
@@ -202,8 +202,8 @@ func buildTemplateContext() (map[string]string, error) {
 	}
 
 	return map[string]string{
-		"LintersExample":                   lintersCfg,
-		"GolangciYamlExample":              strings.TrimSpace(string(golangciYamlExample)),
+		"LintersExample":                   snippets.LintersSettings,
+		"ConfigurationExample":             snippets.ConfigurationFile,
 		"LintersCommandOutputEnabledOnly":  string(lintersOutParts[0]),
 		"LintersCommandOutputDisabledOnly": string(lintersOutParts[1]),
 		"EnabledByDefaultLinters":          getLintersListMarkdown(true),
@@ -317,58 +317,168 @@ func getThanksList() string {
 	return strings.Join(lines, "\n")
 }
 
-func getLintersConfiguration(example []byte) (string, error) {
-	builder := &strings.Builder{}
+type SettingSnippets struct {
+	ConfigurationFile string
+	LintersSettings   string
+}
 
+func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 	var data yaml.Node
 	err := yaml.Unmarshal(example, &data)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	root := data.Content[0]
 
+	globalNode := &yaml.Node{
+		Kind:        root.Kind,
+		Style:       root.Style,
+		Tag:         root.Tag,
+		Value:       root.Value,
+		Anchor:      root.Anchor,
+		Alias:       root.Alias,
+		HeadComment: root.HeadComment,
+		LineComment: root.LineComment,
+		FootComment: root.FootComment,
+		Line:        root.Line,
+		Column:      root.Column,
+	}
+
+	snippets := SettingSnippets{}
+
+	buffer := bytes.NewBufferString("")
+
 	for j, node := range root.Content {
-		if node.Value != "linters-settings" {
+		switch node.Value {
+		case "run", "output", "linters", "linters-settings", "issues", "severity":
+		default:
 			continue
 		}
 
-		nodes := root.Content[j+1]
+		nextNode := root.Content[j+1]
 
-		for i := 0; i < len(nodes.Content); i += 2 {
-			r := &yaml.Node{
-				Kind:  nodes.Kind,
-				Style: nodes.Style,
-				Tag:   nodes.Tag,
-				Value: node.Value,
-				Content: []*yaml.Node{
-					{
-						Kind:  root.Content[j].Kind,
-						Value: root.Content[j].Value,
-					},
-					{
-						Kind:    nodes.Kind,
-						Content: []*yaml.Node{nodes.Content[i], nodes.Content[i+1]},
-					},
+		newNode := &yaml.Node{
+			Kind: nextNode.Kind,
+			Content: []*yaml.Node{
+				{
+					HeadComment: fmt.Sprintf("See the dedicated %q documentation section.", node.Value),
+					Kind:        node.Kind,
+					Style:       node.Style,
+					Tag:         node.Tag,
+					Value:       "option",
 				},
-			}
-
-			_, _ = fmt.Fprintf(builder, "### %s\n\n", nodes.Content[i].Value)
-			_, _ = fmt.Fprintln(builder, "```yaml")
-
-			const ident = 2
-			encoder := yaml.NewEncoder(builder)
-			encoder.SetIndent(ident)
-
-			err = encoder.Encode(r)
-			if err != nil {
-				return "", err
-			}
-
-			_, _ = fmt.Fprintln(builder, "```")
-			_, _ = fmt.Fprintln(builder)
+				{
+					Kind:  node.Kind,
+					Style: node.Style,
+					Tag:   node.Tag,
+					Value: "value",
+				},
+			},
 		}
+
+		globalNode.Content = append(globalNode.Content, node, newNode)
+
+		if node.Value == "linters-settings" {
+			snippets.LintersSettings, err = getLintersSettingSnippets(node, nextNode)
+			if err != nil {
+				return nil, err
+			}
+
+			_, _ = buffer.WriteString(
+				fmt.Sprintf(
+					"### `%s` configuration\n\nSee the dedicated [linters-settings](/usage/linters) documentation section.\n\n",
+					node.Value,
+				),
+			)
+			continue
+		}
+
+		nodeSection := &yaml.Node{
+			Kind:    root.Kind,
+			Style:   root.Style,
+			Tag:     root.Tag,
+			Value:   root.Value,
+			Content: []*yaml.Node{node, nextNode},
+		}
+
+		snippet, errSnip := marshallSnippet(nodeSection)
+		if errSnip != nil {
+			return nil, errSnip
+		}
+
+		_, _ = buffer.WriteString(fmt.Sprintf("### `%s` configuration\n\n%s", node.Value, snippet))
 	}
+
+	overview, err := marshallSnippet(globalNode)
+	if err != nil {
+		return nil, err
+	}
+
+	snippets.ConfigurationFile = overview + buffer.String()
+
+	return &snippets, nil
+}
+
+func getLintersSettingSnippets(node, nextNode *yaml.Node) (string, error) {
+	builder := &strings.Builder{}
+
+	for i := 0; i < len(nextNode.Content); i += 2 {
+		r := &yaml.Node{
+			Kind:  nextNode.Kind,
+			Style: nextNode.Style,
+			Tag:   nextNode.Tag,
+			Value: node.Value,
+			Content: []*yaml.Node{
+				{
+					Kind:  node.Kind,
+					Value: node.Value,
+				},
+				{
+					Kind:    nextNode.Kind,
+					Content: []*yaml.Node{nextNode.Content[i], nextNode.Content[i+1]},
+				},
+			},
+		}
+
+		_, _ = fmt.Fprintf(builder, "### %s\n\n", nextNode.Content[i].Value)
+		_, _ = fmt.Fprintln(builder, "```yaml")
+
+		const ident = 2
+		encoder := yaml.NewEncoder(builder)
+		encoder.SetIndent(ident)
+
+		err := encoder.Encode(r)
+		if err != nil {
+			return "", err
+		}
+
+		_, _ = fmt.Fprintln(builder, "```")
+		_, _ = fmt.Fprintln(builder)
+	}
+
+	return builder.String(), nil
+}
+
+func marshallSnippet(node *yaml.Node) (string, error) {
+	builder := &strings.Builder{}
+
+	if node.Value != "" {
+		_, _ = fmt.Fprintf(builder, "### %s\n\n", node.Value)
+	}
+	_, _ = fmt.Fprintln(builder, "```yaml")
+
+	const ident = 2
+	encoder := yaml.NewEncoder(builder)
+	encoder.SetIndent(ident)
+
+	err := encoder.Encode(node)
+	if err != nil {
+		return "", err
+	}
+
+	_, _ = fmt.Fprintln(builder, "```")
+	_, _ = fmt.Fprintln(builder)
 
 	return builder.String(), nil
 }

--- a/scripts/expand_website_templates/main_test.go
+++ b/scripts/expand_website_templates/main_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractExampleSnippets(t *testing.T) {
+	t.Skip("only for debugging purpose")
+
+	example, err := os.ReadFile("../../../golangci-lint/.golangci.example.yml")
+	require.NoError(t, err)
+
+	m, err := extractExampleSnippets(example)
+	require.NoError(t, err)
+
+	t.Log(m)
+}


### PR DESCRIPTION
Split the integration of `.golangci.example.yml` into multiple sections.
Switch the CLI section and the file section: put the file section first because it's the main use case.

<details>
<summary>before the PR</summary>

There is a small bug at the end of the capture (the black background disappears), but it's just a capture artifact. (the real current render [configuration](https://golangci-lint.run/usage/configuration/))

![Screenshot 2022-01-15 at 12-01-14 Configuration golangci-lint](https://user-images.githubusercontent.com/5674651/149619372-b6db79c6-a692-4d2a-8cdc-d9825cded556.png)

</details>


<details>
<summary>with the PR</summary>

![Screenshot 2022-01-19 at 13-00-19 Configuration golangci-lint](https://user-images.githubusercontent.com/5674651/150125652-1e5236da-34e7-4401-af75-337cf1bf81ed.png)

</details>
