### PR TITLE
importas: new option `no-extra-aliases`

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -498,8 +498,10 @@ linters-settings:
     max-decl-chars: 30
 
   importas:
-    # if set to `true`, force to use alias.
+    # Do not allow unaliased imports of aliased packages.
     no-unaliased: true
+    # Do not allow non-required aliases.
+    no-extra-aliases: true
     # List of aliases
     alias:
       # using `servingv1` alias for `knative.dev/serving/pkg/apis/serving/v1` package

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/jgautheron/goconst v1.5.1
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
-	github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d
+	github.com/julz/importas v0.0.0-20210922140945-27e0a5d4dee2
 	github.com/kisielk/errcheck v1.6.0
 	github.com/kulti/thelper v0.4.0
 	github.com/kunwardeep/paralleltest v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/jgautheron/goconst v1.5.1
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
-	github.com/julz/importas v0.0.0-20210922140945-27e0a5d4dee2
+	github.com/julz/importas v0.1.0
 	github.com/kisielk/errcheck v1.6.0
 	github.com/kulti/thelper v0.4.0
 	github.com/kunwardeep/paralleltest v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,8 @@ github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d h1:XeSMXURZPtUffuWAa
 github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/julz/importas v0.0.0-20210922140945-27e0a5d4dee2 h1:3sSu9gZvOTazWE4B4wsND7ofCsn75BD8Iz1OCBUZISs=
 github.com/julz/importas v0.0.0-20210922140945-27e0a5d4dee2/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
+github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
+github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/go.sum
+++ b/go.sum
@@ -456,6 +456,8 @@ github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSg
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d h1:XeSMXURZPtUffuWAaq90o6kLgZdgu+QA8wk4MPC8ikI=
 github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
+github.com/julz/importas v0.0.0-20210922140945-27e0a5d4dee2 h1:3sSu9gZvOTazWE4B4wsND7ofCsn75BD8Iz1OCBUZISs=
+github.com/julz/importas v0.0.0-20210922140945-27e0a5d4dee2/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -352,8 +352,9 @@ type IfshortSettings struct {
 }
 
 type ImportAsSettings struct {
-	Alias       []ImportAsAlias
-	NoUnaliased bool `mapstructure:"no-unaliased"`
+	Alias          []ImportAsAlias
+	NoUnaliased    bool `mapstructure:"no-unaliased"`
+	NoExtraAliases bool `mapstructure:"no-extra-aliases"`
 }
 
 type ImportAsAlias struct {

--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -28,8 +28,11 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			lintCtx.Log.Infof("importas settings found, but no aliases listed. List aliases under alias: key.") // nolint: misspell
 		}
 
-		err := analyzer.Flags.Set("no-unaliased", strconv.FormatBool(settings.NoUnaliased))
-		if err != nil {
+		if err := analyzer.Flags.Set("no-unaliased", strconv.FormatBool(settings.NoUnaliased)); err != nil {
+			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
+		}
+
+		if err := analyzer.Flags.Set("no-extra-aliases", strconv.FormatBool(settings.NoUnaliased)); err != nil {
 			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 		}
 


### PR DESCRIPTION
Adds `no-extra-aliases` option to `importas` linter. (added in (https://github.com/julz/importas/commit/27e0a5d4dee270c88e73ce808fce24fad723ed30))