### PR TITLE
varnamelen: explicit default values

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -1057,19 +1057,19 @@ linters-settings:
   varnamelen:
     # The longest distance, in source lines, that is being considered a "small scope." (defaults to 5)
     # Variables used in at most this many lines will be ignored.
-    max-distance: 5
+    max-distance: 6
     # The minimum length of a variable's name that is considered "long." (defaults to 3)
     # Variable names that are at least this long will be ignored.
-    min-name-length: 3
+    min-name-length: 2
     # Check method receiver names. (defaults to false)
     check-receiver: false
     # Check named return values. (defaults to false)
     check-return: false
-    # Ignore "ok" variables that hold the bool return value of a type assertion. (defaults to false)
+    # Ignore "ok" variables that hold the bool return value of a type assertion. (defaults to true)
     ignore-type-assert-ok: false
-    # Ignore "ok" variables that hold the bool return value of a map index. (defaults to false)
+    # Ignore "ok" variables that hold the bool return value of a map index. (defaults to true)
     ignore-map-index-ok: false
-    # Ignore "ok" variables that hold the bool return value of a channel receive. (defaults to false)
+    # Ignore "ok" variables that hold the bool return value of a channel receive. (defaults to true)
     ignore-chan-recv-ok: false
     # Optional list of variable names that should be ignored completely. (defaults to empty list)
     ignore-names:

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -1065,11 +1065,11 @@ linters-settings:
     check-receiver: false
     # Check named return values. (defaults to false)
     check-return: false
-    # Ignore "ok" variables that hold the bool return value of a type assertion. (defaults to true)
+    # Ignore "ok" variables that hold the bool return value of a type assertion. (defaults to false)
     ignore-type-assert-ok: false
-    # Ignore "ok" variables that hold the bool return value of a map index. (defaults to true)
+    # Ignore "ok" variables that hold the bool return value of a map index. (defaults to false)
     ignore-map-index-ok: false
-    # Ignore "ok" variables that hold the bool return value of a channel receive. (defaults to true)
+    # Ignore "ok" variables that hold the bool return value of a channel receive. (defaults to false)
     ignore-chan-recv-ok: false
     # Optional list of variable names that should be ignored completely. (defaults to empty list)
     ignore-names:

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -81,6 +81,13 @@ var defaultLintersSettings = LintersSettings{
 	Unparam: UnparamSettings{
 		Algo: "cha",
 	},
+	Varnamelen: VarnamelenSettings{
+		MaxDistance:        5,
+		MinNameLength:      3,
+		IgnoreTypeAssertOk: true,
+		IgnoreMapIndexOk:   true,
+		IgnoreChanRecvOk:   true,
+	},
 	WSL: WSLSettings{
 		StrictAppend:                     true,
 		AllowAssignAndCallCuddle:         true,

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -82,11 +82,8 @@ var defaultLintersSettings = LintersSettings{
 		Algo: "cha",
 	},
 	Varnamelen: VarnamelenSettings{
-		MaxDistance:        5,
-		MinNameLength:      3,
-		IgnoreTypeAssertOk: true,
-		IgnoreMapIndexOk:   true,
-		IgnoreChanRecvOk:   true,
+		MaxDistance:   5,
+		MinNameLength: 3,
 	},
 	WSL: WSLSettings{
 		StrictAppend:                     true,


### PR DESCRIPTION
adds explicit default values 

(defined in varnamelen linter)
- `MaxDistance` (int:5)
- `MinNameLength` (int:3)