### PR TITLE
gomnd: new configuration

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -414,20 +414,30 @@ linters-settings:
     min-confidence: 0.8
 
   gomnd:
-    settings:
-      mnd:
-        # the list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
-        checks:
-        - argument
-        - case
-        - condition
-        - operation
-        - return
-        - assign
-        # Next settings are expecting comma separated string values
-        ignored-numbers: "0666,0755,42"                   # values always ignored: 1, 1.0, 0 and 0.0
-        ignored-files: "magic1_.*.go"                     # values always ignored:_test.go
-        ignored-functions: "math.*,http.StatusText,make"  # values always ignored: time.Time
+    # List of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
+    checks:
+      - argument
+      - case
+      - condition
+      - operation
+      - return
+      - assign
+    # List of numbers to exclude from analysis.
+    # The numbers should be written as string.
+    # Values always ignored: "1", "1.0", "0" and "0.0"
+    ignored-numbers:
+      - '0666'
+      - '0755'
+      - '42'
+    # List of file patterns to exclude from analysis.
+    # Values always ignored: `.+_test.go`
+    ignored-files:
+      - 'magic1_.*.go'
+    # List of function patterns to exclude from analysis.
+    # Values always ignored: `time.Time`
+    ignored-functions:
+      - 'math.*'
+      - 'http.StatusText'
 
   gomoddirectives:
     # Allow local `replace` directives. Default is false.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
   gomnd:
+    # TODO(ldez) must be rewritten after the v1.44.0 release.
     settings:
       mnd:
         # don't include the "operation" and "assign"

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -304,7 +304,11 @@ type GoLintSettings struct {
 }
 
 type GoMndSettings struct {
-	Settings map[string]map[string]interface{}
+	Settings         map[string]map[string]interface{} // Deprecated
+	Checks           []string                          `mapstructure:"checks"`
+	IgnoredNumbers   []string                          `mapstructure:"ignored-numbers"`
+	IgnoredFiles     []string                          `mapstructure:"ignored-files"`
+	IgnoredFunctions []string                          `mapstructure:"ignored-functions"`
 }
 
 type GoModDirectivesSettings struct {

--- a/pkg/golinters/gomnd.go
+++ b/pkg/golinters/gomnd.go
@@ -8,20 +8,29 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-func NewGoMND(cfg *config.Config) *goanalysis.Linter {
-	analyzers := []*analysis.Analyzer{
-		mnd.Analyzer,
-	}
-
+func NewGoMND(settings *config.GoMndSettings) *goanalysis.Linter {
 	var linterCfg map[string]map[string]interface{}
-	if cfg != nil {
-		linterCfg = cfg.LintersSettings.Gomnd.Settings
+
+	if settings != nil {
+		// TODO(ldez) For compatibility only, must be drop in v2.
+		if len(settings.Settings) > 0 {
+			linterCfg = settings.Settings
+		} else {
+			linterCfg = map[string]map[string]interface{}{
+				"mnd": {
+					"checks":            settings.Checks,
+					"ignored-numbers":   settings.IgnoredNumbers,
+					"ignored-files":     settings.IgnoredFiles,
+					"ignored-functions": settings.IgnoredFunctions,
+				},
+			}
+		}
 	}
 
 	return goanalysis.NewLinter(
 		"gomnd",
 		"An analyzer to detect magic numbers.",
-		analyzers,
+		[]*analysis.Analyzer{mnd.Analyzer},
 		linterCfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/gomnd.go
+++ b/pkg/golinters/gomnd.go
@@ -16,13 +16,22 @@ func NewGoMND(settings *config.GoMndSettings) *goanalysis.Linter {
 		if len(settings.Settings) > 0 {
 			linterCfg = settings.Settings
 		} else {
+			cfg := make(map[string]interface{})
+			if len(settings.Checks) > 0 {
+				cfg["checks"] = settings.Checks
+			}
+			if len(settings.IgnoredNumbers) > 0 {
+				cfg["ignored-numbers"] = settings.IgnoredNumbers
+			}
+			if len(settings.IgnoredFiles) > 0 {
+				cfg["ignored-files"] = settings.IgnoredFiles
+			}
+			if len(settings.IgnoredFunctions) > 0 {
+				cfg["ignored-functions"] = settings.IgnoredFunctions
+			}
+
 			linterCfg = map[string]map[string]interface{}{
-				"mnd": {
-					"checks":            settings.Checks,
-					"ignored-numbers":   settings.IgnoredNumbers,
-					"ignored-files":     settings.IgnoredFiles,
-					"ignored-functions": settings.IgnoredFunctions,
-				},
+				"mnd": cfg,
 			}
 		}
 	}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -108,6 +108,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var exhaustiveCfg *config.ExhaustiveSettings
 	var exhaustiveStructCfg *config.ExhaustiveStructSettings
 	var goModDirectivesCfg *config.GoModDirectivesSettings
+	var goMndCfg *config.GoMndSettings
 	var gosecCfg *config.GoSecSettings
 	var gosimpleCfg *config.StaticCheckSettings
 	var govetCfg *config.GovetSettings
@@ -137,6 +138,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		exhaustiveCfg = &m.cfg.LintersSettings.Exhaustive
 		exhaustiveStructCfg = &m.cfg.LintersSettings.ExhaustiveStruct
 		goModDirectivesCfg = &m.cfg.LintersSettings.GoModDirectives
+		goMndCfg = &m.cfg.LintersSettings.Gomnd
 		gosecCfg = &m.cfg.LintersSettings.Gosec
 		gosimpleCfg = &m.cfg.LintersSettings.Gosimple
 		govetCfg = &m.cfg.LintersSettings.Govet
@@ -365,7 +367,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/golang/lint").
 			Deprecated("The repository of the linter has been archived by the owner.", "v1.41.0", "revive"),
 
-		linter.NewConfig(golinters.NewGoMND(m.cfg)).
+		linter.NewConfig(golinters.NewGoMND(goMndCfg)).
 			WithSince("v1.22.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/tommy-muehle/go-mnd"),


### PR DESCRIPTION
I rewrote the `gomnd` configuration to be like the other linters configuration.
I added a compatibility section, so no breaking changes.

The old configuration and the new configuration cannot be used at the same time: if the old configuration is defined, only this configuration will be used.