### PR TITLE
contextcheck: bump to v1.0.5 && add noCache flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/ssgreg/nlreturn/v2 v2.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/sylvia7788/contextcheck v1.0.4
+	github.com/sylvia7788/contextcheck v1.0.5
 	github.com/tdakkota/asciicheck v0.1.1
 	github.com/tetafro/godot v1.4.11
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/sylvia7788/contextcheck v1.0.4 h1:MsiVqROAdr0efZc/fOCt0c235qm9XJqHtWwM+2h2B04=
-github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
+github.com/sylvia7788/contextcheck v1.0.5 h1:sIC4UT2ffb4XfcBB6YxFNhdyZVpblh4kc3R8FMnRq4c=
+github.com/sylvia7788/contextcheck v1.0.5/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
 github.com/tdakkota/asciicheck v0.1.1 h1:PKzG7JUTUmVspQTDqtkX9eSiLGossXTybutHwTXuO0A=
 github.com/tdakkota/asciicheck v0.1.1/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tenntenn/modver v1.0.1 h1:2klLppGhDgzJrScMpkj9Ujy3rXPUspSjAcev9tSEBgA=

--- a/pkg/golinters/contextcheck.go
+++ b/pkg/golinters/contextcheck.go
@@ -5,6 +5,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/lint/linter"
 )
 
 func NewContextCheck() *goanalysis.Linter {
@@ -14,5 +15,8 @@ func NewContextCheck() *goanalysis.Linter {
 		"check the function whether use a non-inherited context",
 		[]*analysis.Analyzer{analyzer},
 		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeTypesInfo).WithNoCache().
+		WithContextSetter(func(lintCtx *linter.Context) {
+			analyzer.Run = contextcheck.NewRun(lintCtx.Packages)
+		})
 }

--- a/pkg/golinters/goanalysis/linter.go
+++ b/pkg/golinters/goanalysis/linter.go
@@ -49,6 +49,7 @@ type Linter struct {
 	contextSetter           func(*linter.Context)
 	loadMode                LoadMode
 	needUseOriginalPackages bool
+	noCache                 bool
 }
 
 func NewLinter(name, desc string, analyzers []*analysis.Analyzer, cfg map[string]map[string]interface{}) *Linter {
@@ -83,6 +84,11 @@ func (lnt *Linter) WithIssuesReporter(r func(*linter.Context) []Issue) *Linter {
 
 func (lnt *Linter) WithContextSetter(cs func(*linter.Context)) *Linter {
 	lnt.contextSetter = cs
+	return lnt
+}
+
+func (lnt *Linter) WithNoCache() *Linter {
+	lnt.noCache = true
 	return lnt
 }
 
@@ -185,6 +191,10 @@ func (lnt *Linter) reportIssues(lintCtx *linter.Context) []Issue {
 
 func (lnt *Linter) getLoadMode() LoadMode {
 	return lnt.loadMode
+}
+
+func (lnt *Linter) withoutCache() bool {
+	return lnt.noCache
 }
 
 func allFlagNames(fs *flag.FlagSet) []string {

--- a/pkg/golinters/goanalysis/metalinter.go
+++ b/pkg/golinters/goanalysis/metalinter.go
@@ -88,3 +88,12 @@ func (ml MetaLinter) getAnalyzerToLinterNameMapping() map[*analysis.Analyzer]str
 	}
 	return analyzerToLinterName
 }
+
+func (ml MetaLinter) withoutCache() bool {
+	for _, l := range ml.linters {
+		if l.withoutCache() {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The pkg that the current buildssa.SSA.Pkg depends on cannot be built because its info is nil. 
https://github.com/golang/tools/blob/0f0bbfd77bf2de5c3a4bc5cc6126522f42ef47c7/go/analysis/passes/buildssa/buildssa.go#L55-L68
If you want to get a function with Block, you can only get it from the analysis results of the previous dependent packages, but the cache will cause the analysis of the dependent packages to be skipped, so nocache is added.
https://github.com/sylvia7788/contextcheck/compare/v1.0.4...v1.0.5