### PR TITLE
gocritic: fix debug output

### DIFF
--- a/pkg/config/linters_settings_gocritic.go
+++ b/pkg/config/linters_settings_gocritic.go
@@ -355,8 +355,9 @@ func filterByDisableTags(enabledChecks, disableTags []string, log logutils.Log) 
 		if len(hitTags) != 0 {
 			delete(enabledChecksSet, enabledCheck)
 		}
-		debugChecksListf(enabledChecks, "Disabled by config tags %s", sprintStrings(disableTags))
 	}
+	debugChecksListf(enabledChecks, "Disabled by config tags %s", sprintStrings(disableTags))
+
 	enabledChecks = nil
 	for enabledCheck := range enabledChecksSet {
 		enabledChecks = append(enabledChecks, enabledCheck)


### PR DESCRIPTION
PR related to: https://github.com/go-critic/go-critic/issues/1199

now if we use debug mode for gocritic like this:
```
GL_DEBUG=gocritic golangci-lint run --config=.golangci.yml -v ./...
```
we get over ~136 repeated messages like this:
```
DEBU [gocritic] Disabled by config tags [experimental] checks (136): [appendAssign appendAssign appendCombine argOrder argOrder assignOp assignOp badCall badCall badCond badCond badLock badRegexp badSorting boolExprSimplify builtinShadow builtinShadowDecl captLocal captLocal caseOrder caseOrder codegenComment codegenComment commentFormatting commentFormatting commentedOutCode commentedOutImport defaultCaseOrder defaultCaseOrder deferInLoop deferUnlambda deprecatedComment deprecatedComment docStub dupArg dupArg dupBranchBody dupBranchBody dupCase dupCase dupImport dupSubExpr dupSubExpr dynamicFmtString elseif elseif emptyDecl emptyFallthrough emptyStringTest equalFold evalOrder exitAfterDefer exitAfterDefer exposedSyncMutex externalErrorReassign filepathJoin flagDeref flagDeref flagName flagName hexLiteral httpNoBody hugeParam ifElseChain ifElseChain importShadow indexAlloc initClause ioutilDeprecated mapKey mapKey methodExprCall nestingReduce newDeref newDeref nilValReturn octalLiteral offBy1 offBy1 paramTypeCombine preferDecodeRune preferFilepathJoin preferFprint preferStringWriter preferWriteByte ptrToRefParam rangeExprCopy rangeValCopy redundantSprint regexpMust regexpMust regexpPattern regexpSimplify returnAfterHttpError ruleguard singleCaseSwitch singleCaseSwitch sliceClear sloppyLen sloppyLen sloppyReassign sloppyTypeAssert sloppyTypeAssert sortSlice sprintfQuotedString sqlQuery stringConcatSimplify stringXbytes switchTrue switchTrue syncMapLoadAndDelete timeExprSimplify tooManyResultsChecker truncateCmp typeAssertChain typeDefFirst typeSwitchVar typeSwitchVar typeUnparen underef underef unlabelStmt unlambda unlambda unnamedResult unnecessaryBlock unnecessaryDefer unslice unslice valSwap valSwap weakCond whyNoLint wrapperFunc wrapperFunc yodaStyleExpr]
```

test yml config:
```yml
linters:
  disable:
    - typecheck
  enable:
    - gocritic
linters-settings:
  gocritic:
    enabled-tags:
      - style
      - diagnostic
      - performance
    disabled-tags:
      - experimental
```