### PR TITLE
Updating tagliatelle to 0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/kunwardeep/paralleltest v1.0.3
 	github.com/kyoh86/exportloopref v0.1.8
 	github.com/ldez/gomoddirectives v0.2.2
-	github.com/ldez/tagliatelle v0.3.0
+	github.com/ldez/tagliatelle v0.3.1
 	github.com/leonklingele/grouper v1.1.0
 	github.com/maratori/testpackage v1.0.1
 	github.com/matoous/godox v0.0.0-20210227103229-6504466cf951 // v1.0

--- a/go.sum
+++ b/go.sum
@@ -489,6 +489,8 @@ github.com/ldez/gomoddirectives v0.2.2 h1:p9/sXuNFArS2RLc+UpYZSI4KQwGMEDWC/LbtF5
 github.com/ldez/gomoddirectives v0.2.2/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdBr6g8G04uz6d0=
 github.com/ldez/tagliatelle v0.3.0 h1:Aubm2ZsrsjIGFvdxemMPJaXrSJ5Cys6VWyTQFt9k2dI=
 github.com/ldez/tagliatelle v0.3.0/go.mod h1:8s6WJQwEYHbKZDsp/LjArytKOG8qaMrKQQ3mFukHs88=
+github.com/ldez/tagliatelle v0.3.1 h1:3BqVVlReVUZwafJUwQ+oxbx2BEX2vUG4Yu/NOfMiKiM=
+github.com/ldez/tagliatelle v0.3.1/go.mod h1:8s6WJQwEYHbKZDsp/LjArytKOG8qaMrKQQ3mFukHs88=
 github.com/leonklingele/grouper v1.1.0 h1:tC2y/ygPbMFSBOs3DcyaEMKnnwH7eYKzohOtRrf0SAg=
 github.com/leonklingele/grouper v1.1.0/go.mod h1:uk3I3uDfi9B6PeUjsCKi6ndcf63Uy7snXgR4yDYQVDY=
 github.com/letsencrypt/pkcs11key/v4 v4.0.0/go.mod h1:EFUvBDay26dErnNb70Nd0/VW3tJiIbETBPTl9ATXQag=


### PR DESCRIPTION
There is a bug making tags like `json:",inline"` failing. It was fixed in `0.3.1` release of tagliatelle (https://github.com/ldez/tagliatelle/commit/c13286cdb4c6fd98c732a65bb0505247ab9a8363), hence PR with version update.

Example:
<img width="664" alt="Screenshot 2022-02-05 at 09 41 26" src="https://user-images.githubusercontent.com/9121459/152634909-771bf89c-4483-4cb4-8829-de2e691a6a51.png">

Note: It was working just fine before upgraded to `golangci-lint` 1.44.0