### PR TITLE
bump github.com/mgechev/revive from v1.1.3 to v1.1.4

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -1042,6 +1042,11 @@ linters-settings:
             allowInts: "0,1,2"
             allowFloats: "0.0,0.,1.0,1.,2.0,2."
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
+      - name: argument-limit
+        severity: warning
+        disabled: false
+        arguments: [4]
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
       - name: atomic
         severity: warning
         disabled: false

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -1024,6 +1024,10 @@ linters-settings:
      - UnitAbbreviations
 
   revive:
+    # Maximum number of open files at the same time.
+    # https://github.com/mgechev/revive#command-line-flags
+    # Defaults to unlimited.
+    max-open-files: 2048
     # See https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: true
     severity: warning

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mbilski/exhaustivestruct v1.2.0
 	github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517
-	github.com/mgechev/revive v1.1.3
+	github.com/mgechev/revive v1.1.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/moricho/tparallel v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/mbilski/exhaustivestruct v1.2.0 h1:wCBmUnSYufAHO6J4AVWY6ff+oxWxsVFrwg
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517 h1:zpIH83+oKzcpryru8ceC6BxnoG8TBrhgAvRg8obzup0=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
-github.com/mgechev/revive v1.1.3 h1:6tBZacs2/uv9UOpkBQhCtXh2NGgu2Ry97ZyjcN6uDCM=
-github.com/mgechev/revive v1.1.3/go.mod h1:jMzDa13teAuv/KLeqgJw79NDe+1IT0ZO3Mht0vN1Yls=
+github.com/mgechev/revive v1.1.4 h1:sZOjY6GU35Kr9jKa/wsKSHgrFz8eASIB5i3tqWZMp0A=
+github.com/mgechev/revive v1.1.4/go.mod h1:ZZq2bmyssGh8MSPz3VVziqRNIMYTJXzP8MUKG90vZ9A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -480,6 +480,7 @@ type PromlinterSettings struct {
 }
 
 type ReviveSettings struct {
+	MaxOpenFiles          int  `mapstructure:"max-open-files"`
 	IgnoreGeneratedHeader bool `mapstructure:"ignore-generated-header"`
 	Confidence            float64
 	Severity              string

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -148,7 +148,7 @@ func reviveToIssue(pass *analysis.Pass, object *jsonObject) goanalysis.Issue {
 // This function mimics the GetConfig function of revive.
 // This allows to get default values and right types.
 // https://github.com/golangci/golangci-lint/issues/1745
-// https://github.com/mgechev/revive/blob/389ba853b0b3587f0c3b71b5f0c61ea4e23928ec/config/config.go#L155
+// https://github.com/mgechev/revive/blob/v1.1.4/config/config.go#L182
 func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
 	conf := defaultConfig()
 
@@ -235,7 +235,7 @@ func safeTomlSlice(r []interface{}) []interface{} {
 }
 
 // This element is not exported by revive, so we need copy the code.
-// Extracted from https://github.com/mgechev/revive/blob/111721be475b73b5a2304dd01ccbcab587357fca/config/config.go#L15
+// Extracted from https://github.com/mgechev/revive/blob/v1.1.4/config/config.go#L15
 var defaultRules = []lint.Rule{
 	&rule.VarDeclarationsRule{},
 	&rule.PackageCommentsRule{},
@@ -310,14 +310,11 @@ var allRules = append([]lint.Rule{
 	&rule.OptimizeOperandsOrderRule{},
 }, defaultRules...)
 
-// This element is not exported by revive, so we need copy the code.
-// Extracted from https://github.com/mgechev/revive/blob/111721be475b73b5a2304dd01ccbcab587357fca/config/config.go#L143
-func normalizeConfig(cfg *lint.Config) {
-	const defaultConfidence = 0.8
-	if cfg.Confidence == 0 {
-		cfg.Confidence = defaultConfidence
-	}
+const defaultConfidence = 0.8
 
+// This element is not exported by revive, so we need copy the code.
+// Extracted from https://github.com/mgechev/revive/blob/v1.1.4/config/config.go#L145
+func normalizeConfig(cfg *lint.Config) {
 	if len(cfg.Rules) == 0 {
 		cfg.Rules = map[string]lint.RuleConfig{}
 	}
@@ -352,10 +349,10 @@ func normalizeConfig(cfg *lint.Config) {
 }
 
 // This element is not exported by revive, so we need copy the code.
-// Extracted from https://github.com/mgechev/revive/blob/111721be475b73b5a2304dd01ccbcab587357fca/config/config.go#L210
+// Extracted from https://github.com/mgechev/revive/blob/v1.1.4/config/config.go#L214
 func defaultConfig() *lint.Config {
 	defaultConfig := lint.Config{
-		Confidence: 0.0,
+		Confidence: defaultConfidence,
 		Severity:   lint.SeverityWarning,
 		Rules:      map[string]lint.RuleConfig{},
 	}

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -65,7 +65,7 @@ func NewRevive(cfg *config.ReviveSettings) *goanalysis.Linter {
 				return nil, err
 			}
 
-			revive := lint.New(os.ReadFile)
+			revive := lint.New(os.ReadFile, cfg.MaxOpenFiles)
 
 			lintingRules, err := reviveConfig.GetLintingRules(conf)
 			if err != nil {


### PR DESCRIPTION
https://github.com/mgechev/revive/compare/8aab7c6...v1.1.4

Fixes #2575

related to https://github.com/mgechev/revive/issues/634#issuecomment-1040881748

This update is performed by hand because of the rewrite of v1.1.3 tag and the change related to that.