### PR TITLE
gci: fix configuration naming

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -300,11 +300,11 @@ linters-settings:
 
     # Checks that no inline Comments are present.
     # Default: false
-    no-inlineComments: true
+    no-inline-comments: true
 
     # Checks that no prefix Comments(comment lines above an import) are present.
     # Default: false
-    no-prefixComments: true
+    no-prefix-comments: true
 
     # Section configuration to compare against.
     # Section names are case-insensitive and may contain parameters in ().
@@ -318,7 +318,7 @@ linters-settings:
 
     # Separators that should be present between sections.
     # Default: ["newLine"]
-    sectionSeparators:
+    section-separators:
       - newLine
 
   gocognit:

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -258,10 +258,10 @@ type FunlenSettings struct {
 
 type GciSettings struct {
 	LocalPrefixes    string   `mapstructure:"local-prefixes"` // Deprecated
-	NoInlineComments bool     `mapstructure:"no-inlineComments"`
-	NoPrefixComments bool     `mapstructure:"no-prefixComments"`
+	NoInlineComments bool     `mapstructure:"no-inline-comments"`
+	NoPrefixComments bool     `mapstructure:"no-prefix-comments"`
 	Sections         []string `mapstructure:"sections"`
-	SectionSeparator []string `mapstructure:"sectionSeparators"`
+	SectionSeparator []string `mapstructure:"section-separators"`
 }
 
 type GocognitSettings struct {


### PR DESCRIPTION
Follow the golangci-lint convention.
It's not breaking because those elements have been added after v1.44.0.
