### PR TITLE
docs: add link to configuration in the linters list

### DIFF
--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -13,12 +13,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/golangci/golangci-lint/internal/renameio"
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 )
@@ -251,7 +253,11 @@ func getName(lc *linter.Config) string {
 	name := lc.Name()
 
 	if lc.OriginalURL != "" {
-		name = fmt.Sprintf("[%s](%s)", lc.Name(), lc.OriginalURL)
+		name = fmt.Sprintf("[%s](%s)", name, lc.OriginalURL)
+	}
+
+	if hasSettings(lc.Name()) {
+		name = fmt.Sprintf("%s [%s](#%s)", name, span("Configuration", "⚙️"), lc.Name())
 	}
 
 	if !lc.IsDeprecated() {
@@ -283,6 +289,18 @@ func check(b bool, title string) string {
 		return span(title, "✔")
 	}
 	return ""
+}
+
+func hasSettings(name string) bool {
+	tp := reflect.TypeOf(config.LintersSettings{})
+
+	for i := 0; i < tp.NumField(); i++ {
+		if strings.EqualFold(name, tp.Field(i).Name) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func span(title, icon string) string {


### PR DESCRIPTION
Add a link (⚙️) to the linter configuration in the list of "Enabled By Default Linters" and "Disabled By Default Linters".

<details>
<summary>before the PR</summary>

![Screenshot 2022-02-17 at 14-44-03 Linters golangci-lint](https://user-images.githubusercontent.com/5674651/154495753-8716b4c3-af69-41c2-bad3-60ff5b10c434.png)

</details>

It can be tested here: https://deploy-preview-2587--unruffled-torvalds-a209db.netlify.app/usage/linters/