### PR TITLE
gci: restore defaults for sections

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -27,7 +27,7 @@ var defaultLintersSettings = LintersSettings{
 		ExcludeGodocExamples: true,
 	},
 	Gci: GciSettings{
-		Sections:         []string{"default", "standard"},
+		Sections:         []string{"standard", "default"},
 		SectionSeparator: []string{"newline"},
 	},
 	Gocognit: GocognitSettings{


### PR DESCRIPTION
Fixes #2588

 - :bug: restore default for sections setting of gci linter