### PR TITLE
feat(severity): color warning severity, non-zero exit when issue != default severity

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -378,8 +378,13 @@ func (e *Executor) setOutputToDevNull() (savedStdout, savedStderr *os.File) {
 }
 
 func (e *Executor) setExitCodeIfIssuesFound(issues []result.Issue) {
-	if len(issues) != 0 {
-		e.exitCode = e.cfg.Run.ExitCodeIfIssuesFound
+	for i := range issues {
+		// If we find an issue with a severity equal to the default (non-modified)
+		// then we exit with the normal issues exit code.
+		if issues[i].Severity == e.cfg.Severity.Default {
+			e.exitCode = e.cfg.Run.ExitCodeIfIssuesFound
+			break
+		}
 	}
 }
 
@@ -471,7 +476,7 @@ func (e *Executor) createPrinter(format string, w io.Writer) (printers.Printer, 
 		p = printers.NewJSON(&e.reportData, w)
 	case config.OutFormatColoredLineNumber, config.OutFormatLineNumber:
 		p = printers.NewText(e.cfg.Output.PrintIssuedLine,
-			format == config.OutFormatColoredLineNumber, e.cfg.Output.PrintLinterName,
+			format == config.OutFormatColoredLineNumber, e.cfg.Output.PrintLinterName, e.cfg.Output.PrintSeverity,
 			e.log.Child("text_printer"), w)
 	case config.OutFormatTab:
 		p = printers.NewTab(e.cfg.Output.PrintLinterName, e.log.Child("tab_printer"), w)

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -29,6 +29,7 @@ type Output struct {
 	Color               string
 	PrintIssuedLine     bool   `mapstructure:"print-issued-lines"`
 	PrintLinterName     bool   `mapstructure:"print-linter-name"`
+	PrintSeverity       bool   `mapstructure:"print-severity"`
 	UniqByLine          bool   `mapstructure:"uniq-by-line"`
 	SortResults         bool   `mapstructure:"sort-results"`
 	PrintWelcomeMessage bool   `mapstructure:"print-welcome"`

--- a/pkg/printers/text.go
+++ b/pkg/printers/text.go
@@ -14,6 +14,7 @@ import (
 
 type Text struct {
 	printIssuedLine bool
+	printSeverity   bool
 	useColors       bool
 	printLinterName bool
 
@@ -21,9 +22,10 @@ type Text struct {
 	w   io.Writer
 }
 
-func NewText(printIssuedLine, useColors, printLinterName bool, log logutils.Log, w io.Writer) *Text {
+func NewText(printIssuedLine, useColors, printLinterName, printSeverity bool, log logutils.Log, w io.Writer) *Text {
 	return &Text{
 		printIssuedLine: printIssuedLine,
+		printSeverity:   printSeverity,
 		useColors:       useColors,
 		printLinterName: printLinterName,
 		log:             log,
@@ -56,9 +58,17 @@ func (p *Text) Print(ctx context.Context, issues []result.Issue) error {
 }
 
 func (p Text) printIssue(i *result.Issue) {
-	text := p.SprintfColored(color.FgRed, "%s", strings.TrimSpace(i.Text))
+	issueColor := color.FgRed
+	if i.Severity == "warning" {
+		issueColor = color.FgYellow
+	}
+
+	text := p.SprintfColored(issueColor, "%s", strings.TrimSpace(i.Text))
 	if p.printLinterName {
 		text += fmt.Sprintf(" (%s)", i.FromLinter)
+	}
+	if p.printSeverity {
+		text += fmt.Sprintf(" %s", i.Severity)
 	}
 	pos := p.SprintfColored(color.Bold, "%s:%d", i.FilePath(), i.Line())
 	if i.Pos.Column != 0 {

--- a/pkg/printers/text_test.go
+++ b/pkg/printers/text_test.go
@@ -46,7 +46,7 @@ func TestText_Print(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 
-	printer := NewText(true, false, true, logutils.NewStderrLog(""), buf)
+	printer := NewText(true, false, true, false, logutils.NewStderrLog(""), buf)
 
 	err := printer.Print(context.Background(), issues)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**: This PR adds a new `print-severity` field that toggles printing severity information on the `text` printer. By default, we now change the color of the error if the severity is set to `warning`. Also changed is when issues are discovered, we only return a non-zero exit code if it's equal to the default severity (e.g. `error`). If it's a non-default severity, e.g. `warning`, we return a zero exit code.

**Imporant Note**: I know this is super opinionated, so let me know if there's a different direction we want to take this. I'm not attached to this implementation at all! Also happy to split this into multiple PRs 😄 