### PR TITLE
forbidigo: add example that uses comments

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -280,6 +280,9 @@ linters-settings:
     forbid:
       - ^print.*$
       - 'fmt\.Print.*'
+      # Optionally put comments at the end of the regex, surrounded by `(# )?`
+      # Escape any special characters.
+      - 'fmt\.Print.*(# Do not commit print statements\.)?'
     # Exclude godoc examples from forbidigo checks.
     # Default: true
     exclude_godoc_examples: false


### PR DESCRIPTION
Add an example of a recently-added forbidigo feature, comments (https://github.com/ashanbrown/forbidigo/pull/11).

Is the docs site (https://golangci-lint.run/usage/linters/#forbidigo) generated from this file?