### PR TITLE
docs: add "back to the top" button

### DIFF
--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 )
 
+const listItemPrefix = "list-item-"
+
 var stateFilePath = filepath.Join("docs", "template_data.state")
 
 func main() {
@@ -257,7 +259,7 @@ func getName(lc *linter.Config) string {
 	}
 
 	if hasSettings(lc.Name()) {
-		name = fmt.Sprintf("%s&nbsp;[%s](#%s)", name, span("Configuration", "⚙️"), lc.Name())
+		name = fmt.Sprintf("%s&nbsp;[%s](#%s)", name, spanWithID(listItemPrefix+lc.Name(), "Configuration", "⚙️"), lc.Name())
 	}
 
 	if !lc.IsDeprecated() {
@@ -305,6 +307,10 @@ func hasSettings(name string) bool {
 
 func span(title, icon string) string {
 	return fmt.Sprintf(`<span title=%q>%s</span>`, title, icon)
+}
+
+func spanWithID(id, title, icon string) string {
+	return fmt.Sprintf(`<span id=%q title=%q>%s</span>`, id, title, icon)
 }
 
 func getThanksList() string {
@@ -471,6 +477,8 @@ func getLintersSettingSnippets(node, nextNode *yaml.Node) (string, error) {
 		}
 
 		_, _ = fmt.Fprintln(builder, "```")
+		_, _ = fmt.Fprintln(builder)
+		_, _ = fmt.Fprintf(builder, "[%s](#%s)\n\n", span("Back to the top", "🔼"), listItemPrefix+nextNode.Content[i].Value)
 		_, _ = fmt.Fprintln(builder)
 	}
 


### PR DESCRIPTION
- use non-breaking space
  <details>
  <summary>before the PR</summary>
  
  ![Screen Shot 2022-02-18 at 17 26 16](https://user-images.githubusercontent.com/5674651/154723179-707cfc48-d4c4-462a-9dda-401ff9b2e507.png)
  
  </details>
  <details>
  <summary>After the PR</summary>
  
  ![Screen Shot 2022-02-18 at 17 26 38](https://user-images.githubusercontent.com/5674651/154723188-42f95421-52cc-4564-a940-16055bef4bc9.png)
  
  </details>

- add "back to the top" button
  <details>
  <summary>example</summary>

  ![Screenshot 2022-02-18 at 17-27-10 Linters golangci-lint](https://user-images.githubusercontent.com/5674651/154723202-43ac2c31-6783-462e-8bd7-0f8a4e1e1e2c.png)

  </details>


It can be tested here: https://deploy-preview-2602--unruffled-torvalds-a209db.netlify.app/usage/linters/