### PR TITLE
Default to YAML when config file has no extension

### DIFF
--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -46,6 +46,11 @@ func (r *FileReader) Read() error {
 
 	if configFile != "" {
 		viper.SetConfigFile(configFile)
+
+		// Assume YAML if the file has no extension.
+		if filepath.Ext(configFile) == "" {
+			viper.SetConfigType("yaml")
+		}
 	} else {
 		r.setupConfigFileSearch()
 	}


### PR DESCRIPTION
With this, it is possible to use process substitution so that there's no need to frequently download new rules.

```bash
golangci-lint run -c <(curl https://some-site.com/golangci-rules.yaml)
```