### PR TITLE
Add module-path setting to gofumpt

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -511,6 +511,10 @@ linters-settings:
     # Default: 1.15
     lang-version: "1.17"
 
+    # Module path which contains the source code being formatted.
+    # Default: empty string
+    module-path: "github.com/golangci/golangci-lint"
+
     # Choose whether to use the extra rules.
     # Default: false
     extra-rules: true

--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -513,7 +513,7 @@ linters-settings:
 
     # Module path which contains the source code being formatted.
     # Default: empty string
-    module-path: "github.com/golangci/golangci-lint"
+    module-path: github.com/org/project
 
     # Choose whether to use the extra rules.
     # Default: false

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -49,6 +49,7 @@ var defaultLintersSettings = LintersSettings{
 	},
 	Gofumpt: GofumptSettings{
 		LangVersion: "",
+		ModulePath:  "",
 		ExtraRules:  false,
 	},
 	Gosec: GoSecSettings{
@@ -311,6 +312,7 @@ type GoFmtSettings struct {
 
 type GofumptSettings struct {
 	LangVersion string `mapstructure:"lang-version"`
+	ModulePath  string `mapstructure:"module-path"`
 	ExtraRules  bool   `mapstructure:"extra-rules"`
 }
 

--- a/pkg/golinters/gofumpt.go
+++ b/pkg/golinters/gofumpt.go
@@ -37,6 +37,7 @@ func NewGofumpt() *goanalysis.Linter {
 
 		options := format.Options{
 			LangVersion: getLangVersion(settings),
+			ModulePath:  settings.ModulePath,
 			ExtraRules:  settings.ExtraRules,
 		}
 


### PR DESCRIPTION
`gofumpt` v0.3.0 changed how imports are arranged, and added a `ModulePath` configuration option to control that behavior. Imports with the defined module path are no longer grouped with the standard library (https://github.com/mvdan/gofumpt/commit/487b40bce0289dc24fad95233b57828a4cd56943)

When using the `gofumpt` binary, it will actually exec out to the `go` binary in an attempt to get the module path from the `go.mod` file: https://github.com/mvdan/gofumpt/blob/master/gofmt.go#L289

This causes a conflict between the two formatters as the `gofumpt` binary will be clever and find the module path, but `golangci-lint` (currently) has no way of specifying this value.