### PR TITLE
feat: enable override coloring based on CLICOLOR and CLICOLOR_FORCE

### DIFF
--- a/pkg/logutils/stderr_log.go
+++ b/pkg/logutils/stderr_log.go
@@ -38,7 +38,8 @@ func NewStderrLog(name string) *StderrLog {
 
 	sl.logger.Out = StdErr
 	formatter := &logrus.TextFormatter{
-		DisableTimestamp: true, // `INFO[0007] msg` -> `INFO msg`
+		DisableTimestamp:          true, // `INFO[0007] msg` -> `INFO msg`
+		EnvironmentOverrideColors: true,
 	}
 	if os.Getenv("LOG_TIMESTAMP") == "1" {
 		formatter.DisableTimestamp = false


### PR DESCRIPTION
some CI runners does not support TTY, like gitlab runner.

related issue https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2115
https://gitlab.com/gitlab-org/gitlab/-/issues/28598

even with `golangci-lint run -v --color always`, we can not make **the log level** support color.

with this option, one can set env var `CLICOLOR_FORCE=1` to skip the tty check and print colored log level.

and set env var `CLICOLOR_FORCE=0` and  `CLICOLOR=0` to disable colored log level.

see https://github.com/sirupsen/logrus/blob/85981c045988a3ebe607e2f5b8a6499d86e0ddac/text_formatter.go#L120