### PR TITLE
feat: automatic Go version detection

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -66,8 +66,8 @@ run:
 
   # Define the Go version limit.
   # Mainly related to generics support in go1.18.
-  # Default: 1.17
-  go: 1.18
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
+  go: '1.18'
 
 
 # output configuration options

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,7 @@ issues:
 
 run:
   timeout: 5m
+  go: '1.17' # TODO(ldez): we force to use an old version of Go for the CI and the tests.
   skip-dirs:
     - test/testdata_etc
     - internal/cache

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -110,6 +110,10 @@ func NewExecutor(version, commit, date string) *Executor {
 		e.log.Fatalf("Can't read config: %s", err)
 	}
 
+	if commandLineCfg.Run.Go == "" && e.cfg.Run.Go == "" {
+		e.cfg.Run.Go = config.DetectGoVersion()
+	}
+
 	// recreate after getting config
 	e.DBManager = lintersdb.NewManager(e.cfg, e.log).WithCustomLinters()
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -95,7 +95,7 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 		"Modules download mode. If not empty, passed as -mod=<mode> to go tools")
 	fs.IntVar(&rc.ExitCodeIfIssuesFound, "issues-exit-code",
 		exitcodes.IssuesFound, wh("Exit code when issues were found"))
-	fs.StringVar(&rc.Go, "go", "1.17", wh("Targeted Go version"))
+	fs.StringVar(&rc.Go, "go", "", wh("Targeted Go version"))
 	fs.StringSliceVar(&rc.BuildTags, "build-tags", nil, wh("Build tags"))
 
 	fs.DurationVar(&rc.Timeout, "deadline", defaultTimeout, wh("Deadline for total work"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"github.com/ldez/gomoddirectives"
+)
+
 // Config encapsulates the config data specified in the golangci yaml config file.
 type Config struct {
 	cfgDir string // The directory containing the golangci config file.
@@ -30,4 +34,19 @@ func NewDefault() *Config {
 
 type Version struct {
 	Format string `mapstructure:"format"`
+}
+
+func DetectGoVersion() string {
+	const defaultGo = "1.17"
+
+	file, err := gomoddirectives.GetModuleFile()
+	if err != nil {
+		return defaultGo
+	}
+
+	if file != nil && file.Go != nil {
+		return file.Go.Version
+	}
+
+	return defaultGo
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"strings"
 
 	hcversion "github.com/hashicorp/go-version"
@@ -54,16 +55,16 @@ func IsGreaterThanOrEqualGo118(v string) bool {
 }
 
 func DetectGoVersion() string {
-	const defaultGo = "1.17"
-
-	file, err := gomoddirectives.GetModuleFile()
-	if err != nil {
-		return defaultGo
-	}
+	file, _ := gomoddirectives.GetModuleFile()
 
 	if file != nil && file.Go != nil {
 		return file.Go.Version
 	}
 
-	return defaultGo
+	v := os.Getenv("GOVERSION")
+	if v != "" {
+		return v
+	}
+
+	return "1.17"
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,7 +57,7 @@ func IsGreaterThanOrEqualGo118(v string) bool {
 func DetectGoVersion() string {
 	file, _ := gomoddirectives.GetModuleFile()
 
-	if file != nil && file.Go != nil {
+	if file != nil && file.Go != nil && file.Go.Version != "" {
 		return file.Go.Version
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"strings"
+
+	hcversion "github.com/hashicorp/go-version"
 	"github.com/ldez/gomoddirectives"
 )
 
@@ -34,6 +37,20 @@ func NewDefault() *Config {
 
 type Version struct {
 	Format string `mapstructure:"format"`
+}
+
+func IsGreaterThanOrEqualGo118(v string) bool {
+	v1, err := hcversion.NewVersion(strings.TrimPrefix(v, "go"))
+	if err != nil {
+		return false
+	}
+
+	limit, err := hcversion.NewVersion("1.18")
+	if err != nil {
+		return false
+	}
+
+	return v1.GreaterThanOrEqual(limit)
 }
 
 func DetectGoVersion() string {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -374,7 +374,8 @@ type GoSecSettings struct {
 }
 
 type GovetSettings struct {
-	CheckShadowing bool `mapstructure:"check-shadowing"`
+	Go             string `mapstructure:"-"`
+	CheckShadowing bool   `mapstructure:"check-shadowing"`
 	Settings       map[string]map[string]interface{}
 
 	Enable     []string
@@ -383,7 +384,7 @@ type GovetSettings struct {
 	DisableAll bool `mapstructure:"disable-all"`
 }
 
-func (cfg GovetSettings) Validate() error {
+func (cfg *GovetSettings) Validate() error {
 	if cfg.EnableAll && cfg.DisableAll {
 		return errors.New("enable-all and disable-all can't be combined")
 	}

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -1,9 +1,6 @@
 package linter
 
 import (
-	"strings"
-
-	hcversion "github.com/hashicorp/go-version"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/packages"
 
@@ -126,7 +123,7 @@ func (lc *Config) Name() string {
 }
 
 func (lc *Config) WithNoopFallback(cfg *config.Config) *Config {
-	if isGreaterThanOrEqualGo118(cfg) {
+	if cfg != nil && config.IsGreaterThanOrEqualGo118(cfg.Run.Go) {
 		lc.Linter = &Noop{
 			name: lc.Linter.Name(),
 			desc: lc.Linter.Desc(),
@@ -147,22 +144,4 @@ func NewConfig(linter Linter) *Config {
 		Linter: linter,
 	}
 	return lc.WithLoadFiles()
-}
-
-func isGreaterThanOrEqualGo118(cfg *config.Config) bool {
-	if cfg == nil {
-		return false
-	}
-
-	v1, err := hcversion.NewVersion(strings.TrimPrefix(cfg.Run.Go, "go"))
-	if err != nil {
-		return false
-	}
-
-	limit, err := hcversion.NewVersion("1.18")
-	if err != nil {
-		return false
-	}
-
-	return v1.GreaterThanOrEqual(limit)
 }

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -134,6 +134,9 @@ func (lc *Config) WithNoopFallback(cfg *config.Config) *Config {
 				return nil, nil
 			},
 		}
+
+		lc.LoadMode = 0
+		return lc.WithLoadFiles()
 	}
 
 	return lc

--- a/pkg/lint/linter/linter.go
+++ b/pkg/lint/linter/linter.go
@@ -22,7 +22,6 @@ type Noop struct {
 
 func (n Noop) Run(_ context.Context, lintCtx *Context) ([]result.Issue, error) {
 	lintCtx.Log.Warnf("%s is disabled because of go1.18."+
-		" If you are not using go1.18, you can set `go: go1.17` in the `run` section."+
 		" You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.", n.name)
 	return nil, nil
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -164,6 +164,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		unusedCfg = &m.cfg.LintersSettings.Unused
 		varnamelenCfg = &m.cfg.LintersSettings.Varnamelen
 		wrapcheckCfg = &m.cfg.LintersSettings.Wrapcheck
+
+		if govetCfg != nil {
+			govetCfg.Go = m.cfg.Run.Go
+		}
 	}
 
 	const megacheckName = "megacheck"

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -450,7 +450,8 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/mvdan/interfacer").
-			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", ""),
+			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", "").
+			WithNoopFallback(m.cfg),
 
 		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
 			WithSince("v1.43.0").

--- a/test/fix_test.go
+++ b/test/fix_test.go
@@ -43,6 +43,7 @@ func TestFix(t *testing.T) {
 			t.Parallel()
 
 			args := []string{
+				"--go=1.17", //  TODO(ldez): we force to use an old version of Go for the CI and the tests.
 				"--disable-all", "--print-issued-lines=false", "--print-linter-name=false", "--out-format=line-number",
 				"--allow-parallel-runners", "--fix",
 				input,

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -179,6 +179,7 @@ func saveConfig(t *testing.T, cfg map[string]interface{}) (cfgPath string, finis
 func testOneSource(t *testing.T, sourcePath string) {
 	args := []string{
 		"run",
+		"--go=1.17", //  TODO(ldez): we force to use an old version of Go for the CI and the tests.
 		"--allow-parallel-runners",
 		"--disable-all",
 		"--print-issued-lines=false",

--- a/test/testshared/testshared.go
+++ b/test/testshared/testshared.go
@@ -98,7 +98,10 @@ func (r *LintRunner) Run(args ...string) *RunResult {
 func (r *LintRunner) RunCommand(command string, args ...string) *RunResult {
 	r.Install()
 
-	runArgs := append([]string{command}, "--internal-cmd-test")
+	runArgs := append([]string{command},
+		"--go=1.17", //  TODO(ldez): we force to use an old version of Go for the CI and the tests.
+		"--internal-cmd-test",
+	)
 	runArgs = append(runArgs, args...)
 
 	defer func(startedAt time.Time) {


### PR DESCRIPTION
The Go version will be detected from the `go.mod` file.

The autodetection can be overridden by defining the configuration option.

### How it works

golangci-lint will use, in order:
- the Go version defined by the CLI flag, ex: `--go=1.18`
- then the Go version defined in the configuration file, ex:
  ```
  run:
    go: '1.18'
  ```
- the Go version defined in the `go.mod`, ex;
  ```
  module github.com/org/my-project

  go 1.18
  ```
- the Go version defined by the env var `GOVERSION`
- fallback on go1.17.

### Additionals

- The govet analyzers `nilness` and `unusedwrite` will be inactivated when using go1.18
- `interfacer` will be inactivated with go1.18

Related to #2649