### PR TITLE
dev: remove some TODO

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,9 +34,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17 # TODO(ldez) the binary compiled with go1.17 doesn't work on go1.18
           # stable: 'false'  # Keep this line to be able to use rc and beta version of Go (ex: 1.18.0-rc1).
-          # go-version: ${{ env.GO_VERSION }} # TODO(ldez) the binary compiled with go1.17 doesn't work on go1.18
+          go-version: ${{ env.GO_VERSION }}
       - name: lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,13 +33,19 @@ linters-settings:
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
   gomnd:
-    # TODO(ldez) must be rewritten after the v1.44.0 release.
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
-        ignored-numbers: 0,1,2,3
-        ignored-functions: strings.SplitN
+    # don't include the "operation" and "assign"
+    checks:
+      - argument
+      - case
+      - condition
+      - return
+    ignored-numbers:
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+    ignored-functions:
+      - strings.SplitN
 
   govet:
     check-shadowing: true


### PR DESCRIPTION
- use go1.18 to test the previous version of golangci-lint
- update gomnd configuration