### PR TITLE
dev: support build tags about go version in linter tests

### DIFF
--- a/test/fix_test.go
+++ b/test/fix_test.go
@@ -49,6 +49,11 @@ func TestFix(t *testing.T) {
 				input,
 			}
 			rc := extractRunContextFromComments(t, input)
+			if rc == nil {
+				t.Logf("Skipped: %s", input)
+				return
+			}
+
 			args = append(args, rc.args...)
 
 			cfg, err := yaml.Marshal(rc.config)

--- a/test/testdata/tenv_go118.go
+++ b/test/testdata/tenv_go118.go
@@ -1,0 +1,19 @@
+//go:build go1.18
+// +build go1.18
+
+// args: -Etenv
+package testdata
+
+import (
+	"os"
+	"testing"
+)
+
+func FuzzF(f *testing.F) {
+	os.Setenv("a", "b")        // ERROR "os\\.Setenv\\(\\) can be replaced by `f\\.Setenv\\(\\)` in FuzzF"
+	err := os.Setenv("a", "b") // ERROR "os\\.Setenv\\(\\) can be replaced by `f\\.Setenv\\(\\)` in FuzzF"
+	_ = err
+	if err := os.Setenv("a", "b"); err != nil { // ERROR "os\\.Setenv\\(\\) can be replaced by `f\\.Setenv\\(\\)` in FuzzF"
+		_ = err
+	}
+}


### PR DESCRIPTION
Skip linter tests about go1.18 when using go1.17.

Allows using go1.17 and go1.18 in CI.