### PR TITLE
pkg/lint: added cleanSkipped func

### DIFF
--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -30,7 +30,7 @@ type Runner struct {
 
 func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env, es *lintersdb.EnabledSet,
 	lineCache *fsutils.LineCache, dbManager *lintersdb.Manager, pkgs []*gopackages.Package) (*Runner, error) {
-	skipFilesProcessor, err := processors.NewSkipFiles(cfg.Run.SkipFiles)
+	skipFilesProcessor, err := processors.NewSkipFiles(cfg.Run.SkipFiles, pkgs)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env, es *lint
 	if cfg.Run.UseDefaultSkipDirs {
 		skipDirs = append(skipDirs, packages.StdExcludeDirRegexps...)
 	}
-	skipDirsProcessor, err := processors.NewSkipDirs(skipDirs, log.Child("skip dirs"), cfg.Run.Args)
+	skipDirsProcessor, err := processors.NewSkipDirs(skipDirs, log.Child("skip dirs"), cfg.Run.Args, pkgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/result/processors/skip_files_test.go
+++ b/pkg/result/processors/skip_files_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/tools/go/packages"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -18,7 +19,7 @@ func newFileIssue(file string) result.Issue {
 }
 
 func newTestSkipFiles(t *testing.T, patterns ...string) *SkipFiles {
-	p, err := NewSkipFiles(patterns)
+	p, err := NewSkipFiles(patterns, []*packages.Package{})
 	assert.NoError(t, err)
 	return p
 }
@@ -44,7 +45,7 @@ func TestSkipFiles(t *testing.T) {
 }
 
 func TestSkipFilesInvalidPattern(t *testing.T) {
-	p, err := NewSkipFiles([]string{"\\o"})
+	p, err := NewSkipFiles([]string{"\\o"}, []*packages.Package{})
 	assert.Error(t, err)
 	assert.Nil(t, p)
 }

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -195,11 +195,9 @@ func TestLintFilesWithLineDirective(t *testing.T) {
 
 func TestSkippedDirsNoMatchArg(t *testing.T) {
 	dir := getTestDataDir("skipdirs", "skip_me", "nested")
-	res := testshared.NewLintRunner(t).Run("--print-issued-lines=false", "--no-config", "--skip-dirs", dir, "-Egolint", dir)
-
-	res.ExpectExitCode(exitcodes.IssuesFound).
-		ExpectOutputEq("testdata/skipdirs/skip_me/nested/with_issue.go:8:9: `if` block ends with " +
-			"a `return` statement, so drop this `else` and outdent its block (golint)\n")
+	testshared.NewLintRunner(t).Run("--print-issued-lines=false", "--no-config", "--skip-dirs", dir, "-Egolint", dir).
+		ExpectExitCode(exitcodes.NoGoFiles).
+		ExpectOutputContains(": no go files to analyze")
 }
 
 func TestSkippedDirsTestdata(t *testing.T) {


### PR DESCRIPTION
The cleanSkiped func cleans the files and directories passed
via `skipDirs` and `skipFiles` for the pkgs slice. This way,
we could skip analyzing them. This way, it's easy for the user
to avoid panics/errs when analyzing excluded files and/or
folders.

Closes https://github.com/golangci/golangci-lint/issues/2784