### PR TITLE
Add typenaming linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144
 	github.com/tomarrell/wrapcheck/v2 v2.6.0
 	github.com/tommy-muehle/go-mnd/v2 v2.5.0
+	github.com/typenaming/typenaming v1.1.1
 	github.com/ultraware/funlen v0.0.3
 	github.com/ultraware/whitespace v0.0.5
 	github.com/uudashr/gocognit v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -767,6 +767,8 @@ github.com/tomarrell/wrapcheck/v2 v2.6.0/go.mod h1:68bQ/eJg55BROaRTbMjC7vuhL2Ogf
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tommy-muehle/go-mnd/v2 v2.5.0 h1:iAj0a8e6+dXSL7Liq0aXPox36FiN1dBbjA6lt9fl65s=
 github.com/tommy-muehle/go-mnd/v2 v2.5.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
+github.com/typenaming/typenaming v1.1.1 h1:a825wSpl7LpFLTX1Xv7rd4ZjxJKK9Pxmy7tEFAHCIxI=
+github.com/typenaming/typenaming v1.1.1/go.mod h1:mMIHMtUDlrXGi4aN9XuAcdjJWbGSUwgAYDnYsVv9YiM=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ultraware/funlen v0.0.3 h1:5ylVWm8wsNwH5aWo9438pwvsK0QiqVuUrt9bn7S/iLA=
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=

--- a/pkg/golinters/typenaming.go
+++ b/pkg/golinters/typenaming.go
@@ -1,0 +1,16 @@
+package golinters
+
+import (
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	typenaming "github.com/typenaming/typenaming/pkg/analyzer"
+	"golang.org/x/tools/go/analysis"
+)
+
+func NewTypenaming() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		typenaming.Analyzer.Name,
+		typenaming.Analyzer.Doc,
+		[]*analysis.Analyzer{typenaming.Analyzer},
+		nil,
+	)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -704,6 +704,11 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/bombsimon/wsl"),
 
+		linter.NewConfig(golinters.NewTypenaming()).
+			WithSince("v1.46.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/typenaming/typenaming"),
+
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint()).
 			WithSince("v1.26.0").

--- a/test/testdata/typenaming.go
+++ b/test/testdata/typenaming.go
@@ -1,0 +1,6 @@
+// args: -Etypenaming
+package testdata
+
+type UserType struct{} // ERROR "trim suffix `Type` from type name"
+
+type userType string // ERROR "trim suffix `Type` from type name"


### PR DESCRIPTION
typenaming linter will prevent gophers from using the ugly "Type" suffix in type names.

_Bad_
```golang
type UserType struct {}
```

_Good_
```golang
type User struct {}
```
Github repo: https://github.com/typenaming/typenaming