### PR TITLE
Fix install instructions to point at tag

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -28,13 +28,13 @@ Here is the recommended way to install golangci-lint {.LatestVersion}:
 
 ```sh
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/{.LatestVersion}/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
 
 # or install it into ./bin/
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/{.LatestVersion}/install.sh | sh -s {.LatestVersion}
 
 # In alpine linux (as it does not come with curl by default)
-wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s {.LatestVersion}
+wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/{.LatestVersion}/install.sh | sh -s {.LatestVersion}
 
 golangci-lint --version
 ```
@@ -79,7 +79,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} g
 
 ```sh
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/{.LatestVersion}/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
 
 golangci-lint --version
 ```
@@ -96,7 +96,7 @@ Note: such `go install`/`go get` installation aren't guaranteed to work. We reco
 `go install`/`go get` installation isn't recommended because of the following points:
 
 1. some users use `-u` flag for `go get`, which upgrades our dependencies. Resulting configuration wasn't tested and isn't guaranteed to work.
-2. [`go.mod`](https://github.com/golangci/golangci-lint/blob/master/go.mod) replacement directive doesn't apply. It means a user will be using patched version of `golangci-lint` if we use such replacements.
+2. [`go.mod`](https://github.com/golangci/golangci-lint/blob/{.LatestVersion}/go.mod) replacement directive doesn't apply. It means a user will be using patched version of `golangci-lint` if we use such replacements.
 3. it's stability depends on a user's Go version (e.g. on [this compiler Go <= 1.12 bug](https://github.com/golang/go/issues/29612)).
 4. we've encountered a lot of issues with Go modules hashes.
 5. it allows installation from `master` branch which can't be considered stable.


### PR DESCRIPTION
The `install.sh` script at `master` is not guaranteed to be compatible with the latest tagged release.