### PR TITLE
docs: update "Shell Completion" instruction on Linux

### DIFF
--- a/docs/src/docs/usage/integrations.mdx
+++ b/docs/src/docs/usage/integrations.mdx
@@ -33,7 +33,7 @@ title: Integrations
 
 ## Shell Completion
 
-`golangci-lint` can generate bash completion file.
+`golangci-lint` can generate bash, fish, powershell, and zsh completion files.
 
 ### macOS
 
@@ -58,7 +58,7 @@ source ~/.bashrc
 
 ### Linux
 
-See [kubectl instructions](https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion) and don't forget to replace `kubectl` with `golangci-lint`.
+See the instructions on `golangci-lint completion <YOUR_SHELL> --help` (replace `<YOUR_SHELL>` with your favorite one).
 
 ## CI Integration
 


### PR DESCRIPTION
When I tried to enable shell autocompletion reading the website, noticed the content on kubernetes.io had been moved. After some playing, I also noticed the `golangci-lint completion $SHELL --help` command exists and it has a straightforward instruction.
This replaces that link with the command above. I'm open to update the link to https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#enable-shell-autocompletion, which is the new location of kubectl's instruction, if you'd like.

(I haven't removed the macOS's instruction in case it's still useful.)