### PR TITLE
unparam: re-enable for go1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	honnef.co/go/tools v0.3.1
 	mvdan.cc/gofumpt v0.3.1
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed
-	mvdan.cc/unparam v0.0.0-20211214103731-d0ef000c54e5
+	mvdan.cc/unparam v0.0.0-20220316160445-06cc5682983b
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1446,6 +1446,8 @@ mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b h1:DxJ5nJdkhDlLok9K6qO+5290kphD
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20211214103731-d0ef000c54e5 h1:Jh3LAeMt1eGpxomyu3jVkmVZWW2MxZ1qIIV2TZ/nRio=
 mvdan.cc/unparam v0.0.0-20211214103731-d0ef000c54e5/go.mod h1:b8RRCBm0eeiWR8cfN88xeq2G5SG3VKGO+5UPWi5FSOY=
+mvdan.cc/unparam v0.0.0-20220316160445-06cc5682983b h1:C8Pi6noat8BcrL9WnSRYeQ63fpkJk3hKVHtF5731kIw=
+mvdan.cc/unparam v0.0.0-20220316160445-06cc5682983b/go.mod h1:WqFWCt8MGPoFSYGsQSiIORRlYVhkJsIk+n2MY6rhNbA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -656,8 +656,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.9.0").
 			WithPresets(linter.PresetUnused).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/mvdan/unparam").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/mvdan/unparam"),
 
 		linter.NewConfig(golinters.NewUnused(unusedCfg)).
 			WithSince("v1.20.0").


### PR DESCRIPTION
Fixes #2649

Using golangci-lint 1.45.2:
```
% golangci-lint version                     
golangci-lint has version 1.45.2 built from 8bdc4d3f on 2022-03-24T11:51:26Z
% golangci-lint run --disable-all -E unparam
WARN [linters context] unparam is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649. 
```

Using this PR:
```
% golangci-lint version                     
golangci-lint has version (devel) built from (unknown, mod sum: "") on (unknown)
% golangci-lint run --disable-all -E unparam
request.go:779:79: `(RequestForwarder).forwardRequest` - `method` always receives `http.MethodPost` (`"POST"`) (unparam)
func (service RequestForwarder) forwardRequest(ctx context.Context, endpoint, method string, data interface{}, headers map[string]string) ([]byte, int, errors.IRichErrorComponent) {
                                                                              ^
```