### PR TITLE
fix panic caused by lufeee/execinquery v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/ldez/gomoddirectives v0.2.3
 	github.com/ldez/tagliatelle v0.3.1
 	github.com/leonklingele/grouper v1.1.0
-	github.com/lufeee/execinquery v1.0.0
+	github.com/lufeee/execinquery v1.1.0
 	github.com/maratori/testpackage v1.0.1
 	github.com/matoous/godox v0.0.0-20210227103229-6504466cf951 // v1.0
 	github.com/mattn/go-colorable v0.1.12


### PR DESCRIPTION
This PR bumps github.com/lufeee/execinquery v1.1.0 to fix a panic case in v1.0.0.