### PR TITLE
docs: add containedctx linter to the list of available linters

### DIFF
--- a/.golangci.example.yml
+++ b/.golangci.example.yml
@@ -1635,6 +1635,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - cyclop
     - deadcode
@@ -1726,6 +1727,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - containedctx
     - contextcheck
     - cyclop
     - deadcode


### PR DESCRIPTION
I forgot to add the linter to the list of available linters, so I added it.