### PR TITLE
thelper: allow to disable one option

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -550,26 +550,16 @@ type TestpackageSettings struct {
 }
 
 type ThelperSettings struct {
-	Test struct {
-		First bool `mapstructure:"first"`
-		Name  bool `mapstructure:"name"`
-		Begin bool `mapstructure:"begin"`
-	} `mapstructure:"test"`
-	Fuzz struct {
-		First bool `mapstructure:"first"`
-		Name  bool `mapstructure:"name"`
-		Begin bool `mapstructure:"begin"`
-	} `mapstructure:"fuzz"`
-	Benchmark struct {
-		First bool `mapstructure:"first"`
-		Name  bool `mapstructure:"name"`
-		Begin bool `mapstructure:"begin"`
-	} `mapstructure:"benchmark"`
-	TB struct {
-		First bool `mapstructure:"first"`
-		Name  bool `mapstructure:"name"`
-		Begin bool `mapstructure:"begin"`
-	} `mapstructure:"tb"`
+	Test      ThelperOptions `mapstructure:"test"`
+	Fuzz      ThelperOptions `mapstructure:"fuzz"`
+	Benchmark ThelperOptions `mapstructure:"benchmark"`
+	TB        ThelperOptions `mapstructure:"tb"`
+}
+
+type ThelperOptions struct {
+	First *bool `mapstructure:"first"`
+	Name  *bool `mapstructure:"name"`
+	Begin *bool `mapstructure:"begin"`
 }
 
 type TenvSettings struct {

--- a/test/testdata/configs/thelper.yml
+++ b/test/testdata/configs/thelper.yml
@@ -1,0 +1,5 @@
+linters-settings:
+  thelper:
+    test:
+      name: false
+      begin: true

--- a/test/testdata/thelper_with_options.go
+++ b/test/testdata/thelper_with_options.go
@@ -1,0 +1,18 @@
+// args: -Ethelper
+// config_path: testdata/configs/thelper.yml
+package testdata
+
+import "testing"
+
+func thelperWithHelperAfterAssignmentWO(t *testing.T) { // ERROR "test helper function should start from t.Helper()"
+	_ = 0
+	t.Helper()
+}
+
+func thelperWithNotFirstWO(s string, t *testing.T, i int) { // ERROR `parameter \*testing.T should be the first`
+	t.Helper()
+}
+
+func thelperWithIncorrectNameWO(o *testing.T) {
+	o.Helper()
+}


### PR DESCRIPTION
Fixes #2848

Note:
Currently, `thelper` doesn't work on projects that use go1.17 even if golangci-lint is compiled with go1.18.
To fix this behavior the PR https://github.com/kulti/thelper/pull/38 must be merged.


ping @kulti 