### PR TITLE
docs: rename .golangci.example.yml to .golangci.reference.yml

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1,5 +1,8 @@
 # This file contains all available configuration options
 # with their default values (in comments).
+#
+# This file is not a configuration example,
+# it contains the exhaustive configuration with explanations of the options.
 
 # Options for analysis running.
 run:

--- a/docs/src/docs/contributing/faq.mdx
+++ b/docs/src/docs/contributing/faq.mdx
@@ -21,7 +21,7 @@ Just update it's version in `go.mod`.
 ## How to add configuration option to existing linter
 
 Add a new field to a [config struct](https://github.com/golangci/golangci-lint/blob/master/pkg/config/config.go).
-Document it in [.golangci.example.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml).
+Document it in [.golangci.reference.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml).
 Pass it to a linter.
 
 ## How to see `INFO` or `DEBUG` logs

--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -26,9 +26,9 @@ After that:
    to the function `GetAllSupportedLinterConfigs`.
     - Add `WithSince("next_version")`, where `next_version` must be replaced by the next minor version. (ex: v1.2.0 if the current version is v1.1.0)
 4. Find out what options do you need to configure for the linter.
-   For example, `nakedret` has only 1 option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml).
+   For example, `nakedret` has only 1 option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml).
    Choose default values to not being annoying for users of golangci-lint. Add configuration options to:
-    - [.golangci.example.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml) - the example of a configuration file.
+    - [.golangci.reference.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml) - the example of a configuration file.
       You can also add them to [.golangci.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.yml)
       if you think that this project needs not default values.
     - [config struct](https://github.com/golangci/golangci-lint/blob/master/pkg/config/config.go) -

--- a/docs/src/docs/contributing/workflow.mdx
+++ b/docs/src/docs/contributing/workflow.mdx
@@ -37,7 +37,7 @@ Which runs all the linters and tests.
 
 ## Create or update parameters for docs
 
-Add your new or updated parameters to `.golangci.example.yml` so they will be shown in the docs
+Add your new or updated parameters to `.golangci.reference.yml` so they will be shown in the docs
 
 ## Submit a pull request
 

--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -28,7 +28,7 @@ To see which config file is being used and where it was sourced from run golangc
 Config options inside the file are identical to command-line options.
 You can configure specific linters' options only within the config file (not the command-line).
 
-There is a [`.golangci.example.yml`](https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml) file with all supported options, their description, and default values.
+There is a [`.golangci.reference.yml`](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml) file with all supported options, their description, and default values.
 This file is a neither a working example nor recommended configuration, it's just a reference to display all the configuration options.
 
 { .ConfigurationExample }

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -164,14 +164,14 @@ func getLatestVersion() (string, error) {
 }
 
 func buildTemplateContext() (map[string]string, error) {
-	golangciYamlExample, err := os.ReadFile(".golangci.example.yml")
+	golangciYamlExample, err := os.ReadFile(".golangci.reference.yml")
 	if err != nil {
-		return nil, fmt.Errorf("can't read .golangci.example.yml: %w", err)
+		return nil, fmt.Errorf("can't read .golangci.reference.yml: %w", err)
 	}
 
 	snippets, err := extractExampleSnippets(golangciYamlExample)
 	if err != nil {
-		return nil, fmt.Errorf("can't read .golangci.example.yml: %w", err)
+		return nil, fmt.Errorf("can't read .golangci.reference.yml: %w", err)
 	}
 
 	if err = exec.Command("make", "build").Run(); err != nil {

--- a/scripts/expand_website_templates/main_test.go
+++ b/scripts/expand_website_templates/main_test.go
@@ -10,7 +10,7 @@ import (
 func Test_extractExampleSnippets(t *testing.T) {
 	t.Skip("only for debugging purpose")
 
-	example, err := os.ReadFile("../../../golangci-lint/.golangci.example.yml")
+	example, err := os.ReadFile("../../../golangci-lint/.golangci.reference.yml")
 	require.NoError(t, err)
 
 	m, err := extractExampleSnippets(example)


### PR DESCRIPTION
The name of this file leads many people to think that this file is a configuration example.

This file is a configuration reference: it contains the exhaustive configuration with explanations of the options.

This is not a configuration example.