### PR TITLE
docs(gocritic): add `enable` and `disable` ruleguard settings

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -457,6 +457,7 @@ linters-settings:
         #   ruleguard prints the specific Where() condition that was rejected.
         #
         # The flag is passed to the ruleguard 'debug-group' argument.
+        # Default: ""
         debug: 'emptyDecl'
         # Deprecated, use 'failOn' param.
         # If set to true, identical to failOn='all', otherwise failOn=''
@@ -467,12 +468,22 @@ linters-settings:
         # - 'all':    fail on all errors.
         # - 'import': ruleguard rule imports a package that cannot be found.
         # - 'dsl':    gorule file does not comply with the ruleguard DSL.
+        # Default: ""
         failOn: dsl
         # Comma-separated list of file paths containing ruleguard rules.
         # If a path is relative, it is relative to the directory where the golangci-lint command is executed.
         # The special '${configDir}' variable is substituted with the absolute directory containing the golangci config file.
         # Glob patterns such as 'rules-*.go' may be specified.
+        # Default: ""
         rules: '${configDir}/ruleguard/rules-*.go,${configDir}/myrule1.go'
+        # Comma-separated list of enabled groups or skip empty to enable everything.
+        # Tags can be defined with # character prefix.
+        # Default: "<all>"
+        enable: "badLock,httpNoBody,#experimental,#style"
+        # Comma-separated list of disabled groups or skip empty to enable everything.
+        # Tags can be defined with # character prefix.
+        # Default: ""
+        disable: "badLock,httpNoBody,#experimental,#style"
       tooManyResultsChecker:
         # Maximum number of results.
         # Default: 5

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -479,11 +479,11 @@ linters-settings:
         # Comma-separated list of enabled groups or skip empty to enable everything.
         # Tags can be defined with # character prefix.
         # Default: "<all>"
-        enable: "badLock,httpNoBody,#experimental,#style"
+        enable: "myGroupName,#myTagName"
         # Comma-separated list of disabled groups or skip empty to enable everything.
         # Tags can be defined with # character prefix.
         # Default: ""
-        disable: "badLock,httpNoBody,#experimental,#style"
+        disable: "myGroupName,#myTagName"
       tooManyResultsChecker:
         # Maximum number of results.
         # Default: 5


### PR DESCRIPTION
Add missing `enable` and `disable` settings of `ruleguard` to `.golangci.reference.yml`.

See:
https://github.com/go-critic/go-critic/blob/498eef8a04d52f25a7f3718211a46a55e0ae73f0/checkers/ruleguard_checker.go#L45-L52