### PR TITLE
docs: add thanks page

### DIFF
--- a/docs/src/config/sidebar.yml
+++ b/docs/src/config/sidebar.yml
@@ -24,6 +24,8 @@
   items:
     - label: "Roadmap"
       link: "/product/roadmap/"
+    - label: "Thanks"
+      link: "/product/thanks/"
     - label: "Trusted By"
       link: "/product/trusted-by/"
     - label: "GitHub"

--- a/docs/src/docs/product/roadmap.mdx
+++ b/docs/src/docs/product/roadmap.mdx
@@ -14,15 +14,6 @@ Please file an issue for bugs, missing documentation, or unexpected behavior.
 
 [See Bugs](https://github.com/golangci/golangci-lint/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22bug%22+sort%3Acreated-desc)
 
-## Thanks
-
-Thanks to all [contributors](https://github.com/golangci/golangci-lint/graphs/contributors)!
-Thanks to [alecthomas/gometalinter](https://github.com/alecthomas/gometalinter) for inspiration and amazing work.
-Thanks to [bradleyfalzon/revgrep](https://github.com/bradleyfalzon/revgrep) for cool diff tool.
-
-Thanks to developers and authors of used linters:
-{.ThanksList}
-
 ## Changelog
 
 {.ChangeLog}

--- a/docs/src/docs/product/thanks.mdx
+++ b/docs/src/docs/product/thanks.mdx
@@ -2,7 +2,7 @@
 title: Thanks
 ---
 
-## ❤️ Thanks
+## ❤️
 
 Thanks to all [contributors](https://github.com/golangci/golangci-lint/graphs/contributors)!
 
@@ -10,4 +10,5 @@ Thanks to [alecthomas/gometalinter](https://github.com/alecthomas/gometalinter) 
 Thanks to [bradleyfalzon/revgrep](https://github.com/bradleyfalzon/revgrep) for cool diff tool.
 
 Thanks to developers and authors of used linters:
+
 {.ThanksList}

--- a/docs/src/docs/product/thanks.mdx
+++ b/docs/src/docs/product/thanks.mdx
@@ -1,0 +1,13 @@
+---
+title: Thanks
+---
+
+## ❤️ Thanks
+
+Thanks to all [contributors](https://github.com/golangci/golangci-lint/graphs/contributors)!
+
+Thanks to [alecthomas/gometalinter](https://github.com/alecthomas/gometalinter) for inspiration and amazing work.
+Thanks to [bradleyfalzon/revgrep](https://github.com/bradleyfalzon/revgrep) for cool diff tool.
+
+Thanks to developers and authors of used linters:
+{.ThanksList}

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -314,35 +314,42 @@ func spanWithID(id, title, icon string) string {
 }
 
 func getThanksList() string {
-	addedLines := map[string]bool{}
+	addedAuthors := map[string]string{}
 
-	var lines []string
 	for _, lc := range lintersdb.NewManager(nil, nil).GetAllSupportedLinterConfigs() {
 		if lc.OriginalURL == "" {
 			continue
 		}
 
-		var line string
-		if author := extractAuthor(lc.OriginalURL, "https://github.com/"); author != "" && author != "golangci" {
-			line = fmt.Sprintf("- [%[1]s](https://github.com/sponsors/%[1]s)", author)
-		} else if author := extractAuthor(lc.OriginalURL, "https://gitlab.com/"); author != "" {
+		var line, author string
+		if author = extractAuthor(lc.OriginalURL, "https://github.com/"); author != "" && author != "golangci" {
+			line = fmt.Sprintf(`- <img src="https://github.com/%[1]s.png" alt="%[1]s" style="max-width: 20%%;" width="20px;"></img> <a href="https://github.com/sponsors/%[1]s">%[1]s</a>`, author)
+		} else if author = extractAuthor(lc.OriginalURL, "https://gitlab.com/"); author != "" {
 			line = fmt.Sprintf("- [%[1]s](https://gitlab.com/%[1]s)", author)
 		} else {
 			continue
 		}
 
-		if addedLines[line] {
+		if addedAuthors[author] != "" {
 			continue
 		}
 
-		addedLines[line] = true
-
-		lines = append(lines, line)
+		addedAuthors[author] = line
 	}
 
-	sort.Slice(lines, func(i, j int) bool {
-		return strings.ToLower(lines[i]) < strings.ToLower(lines[j])
+	var authors []string
+	for author := range addedAuthors {
+		authors = append(authors, author)
+	}
+
+	sort.Slice(authors, func(i, j int) bool {
+		return strings.ToLower(authors[i]) < strings.ToLower(authors[j])
 	})
+
+	var lines []string
+	for _, author := range authors {
+		lines = append(lines, addedAuthors[author])
+	}
 
 	return strings.Join(lines, "\n")
 }

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -333,8 +333,7 @@ func getThanksList() string {
 		}
 		addedAuthors[githubAuthor] = true
 
-		line := fmt.Sprintf("- [%s](https://github.com/%s)",
-			githubAuthor, githubAuthor)
+		line := fmt.Sprintf("- [%[1]s](https://github.com/sponsors/%[1]s)", githubAuthor)
 		lines = append(lines, line)
 	}
 


### PR DESCRIPTION
Golangi-lint is a wrapper around linters, so I think it's a good idea to have a dedicated page to promote linter authors.

- move the Thanks section to a dedicated page
- add authors from Gitlab
- use the sponsor link (GitHub only)

<details>

![Thanks golangci-lint](https://user-images.githubusercontent.com/5674651/171065637-425c6f0c-90ab-4a2e-a431-d9a690b42e2b.png)

</details>
