### PR TITLE
docs(gomnd): fix typo

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -641,7 +641,7 @@ linters-settings:
     ignored-files:
       - 'magic1_.*.go'
     # List of function patterns to exclude from analysis.
-    # Values always ignored: `time.Time`
+    # Values always ignored: `time.Date`
     # Default: []
     ignored-functions:
       - 'math.*'


### PR DESCRIPTION
See https://github.com/tommy-muehle/go-mnd/blob/10a50fc5abd6e8e49a713d0a96838d2d56eb54f2/config/config.go#L30