### PR TITLE
depguard: adjust phrasing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters-settings:
   depguard:
-    list-type: blacklist
+    list-type: denylist
     packages:
       # logging is allowed only by logutils.Log, logrus
       # is allowed to use only in logutils package

--- a/pkg/golinters/depguard.go
+++ b/pkg/golinters/depguard.go
@@ -122,7 +122,7 @@ func newGuardian(settings *config.DepGuardSettings) (*guardian, error) {
 		return nil, err
 	}
 
-	// if the list type was a blacklist the packages with error messages should be included in the blacklist package list
+	// if the list type was a denylist the packages with error messages should be included in the denylist package list
 	if dg.ListType == depguard.LTBlacklist {
 		noMessagePackages := make(map[string]bool)
 		for _, pkg := range dg.Packages {
@@ -164,9 +164,9 @@ func (g guardian) run(loadConfig *loader.Config, prog *loader.Program, pass *ana
 }
 
 func (g guardian) createMsg(pkgName string) string {
-	msgSuffix := "is in the blacklist"
+	msgSuffix := "is in the denylist"
 	if g.ListType == depguard.LTWhitelist {
-		msgSuffix = "is not in the whitelist"
+		msgSuffix = "is not in the allowlist"
 	}
 
 	var userSuppliedMsgSuffix string

--- a/test/testdata/depguard.go
+++ b/test/testdata/depguard.go
@@ -3,8 +3,8 @@
 package testdata
 
 import (
-	"compress/gzip" // ERROR "`compress/gzip` is in the blacklist"
-	"log"           // ERROR "`log` is in the blacklist: don't use log"
+	"compress/gzip" // ERROR "`compress/gzip` is in the denylist"
+	"log"           // ERROR "`log` is in the denylist: don't use log"
 )
 
 func SpewDebugInfo() {

--- a/test/testdata/depguard_additional_guards.go
+++ b/test/testdata/depguard_additional_guards.go
@@ -3,10 +3,10 @@
 package testdata
 
 import (
-	"compress/gzip" // ERROR "`compress/gzip` is in the blacklist"
-	"fmt"           // ERROR "`fmt` is in the blacklist"
-	"log"           // ERROR "`log` is in the blacklist: don't use log"
-	"strings"       // ERROR "`strings` is in the blacklist: disallowed in additional guard"
+	"compress/gzip" // ERROR "`compress/gzip` is in the denylist"
+	"fmt"           // ERROR "`fmt` is in the denylist"
+	"log"           // ERROR "`log` is in the denylist: don't use log"
+	"strings"       // ERROR "`strings` is in the denylist: disallowed in additional guard"
 )
 
 func SpewDebugInfo() {


### PR DESCRIPTION
Replaces `whitelist` and `blacklist` with `allowlist` and `blacklist` for depguard