### PR TITLE
Disable vcs stamping in go1.18

### DIFF
--- a/pkg/lint/load.go
+++ b/pkg/lint/load.go
@@ -75,6 +75,11 @@ func (cl *ContextLoader) findLoadMode(linters []*linter.Config) packages.LoadMod
 
 func (cl *ContextLoader) buildArgs() []string {
 	args := cl.cfg.Run.Args
+	// disable vcs stamping to avoid git exit status 128 errors
+	if cl.cfg.Run.Go == "1.18" && len(args) == 0 {
+		return []string{"-buildvcs=false", "./..."}
+	}
+
 	if len(args) == 0 {
 		return []string{"./..."}
 	}


### PR DESCRIPTION
This new go feature breaks `go list ./...` type commands that run in e.g. monorepos with several go modules but just one git repository. The fix is to run the command explicitly disabling vcs stamping with the flag `-buildvcs=false`. Since this wont have any effect on the output of the command it is fine to do it indiscriminately. 

Alternatively, a way of providing `go list` flags via the config yaml could be provided, but I dont think that is necessary.

Cheers!