### PR TITLE
Add linter `asasalint` to lint pass []any as any

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -109,12 +109,15 @@ output:
 linters-settings:
   asasalint:
     # Add FuncName to exclude for some bad case report.
+    # Default: []
     exclude:
       - Append
       - Log
     # ignore found case in *_test.go file
+    # Default: false
     ignore-in-test: false
     # if true, will disable the default exclude see https://github.com/alingse/asasalint/blob/main/asasalint.go#L15 like: Printf,Println,Errorf,Debugf ...
+    # Default: false
     no-default-exclude: false
   bidichk:
     # The following configurations check for all mentioned invisible unicode runes.

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -112,9 +112,10 @@ linters-settings:
     exclude:
       - Append
       - Log
+    # ignore found case in *_test.go file
+    ignore-in-test: false
     # if true, will disable the default exclude see https://github.com/alingse/asasalint/blob/main/asasalint.go#L15 like: Printf,Println,Errorf,Debugf ...
-    no_default_exclude: false
-    ignore_in_test: false
+    no-default-exclude: false
   bidichk:
     # The following configurations check for all mentioned invisible unicode runes.
     # All runes are enabled by default.

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -108,20 +108,20 @@ output:
 # All available settings of specific linters.
 linters-settings:
   asasalint:
-    # Add FuncName to exclude for avoid some bad case report.
-    # the asasalint has also some builtin exclude func names, not need to config here,
-    # and can disabled by `no-builtin-exclude` option.
-    # they are `Printf,Println,Fprintf,Fprintln,Fatal,Fatalf,Panic,Panicf,Panicln,Print,Printf,Println,Sprintf,Sprintln,Error,Errorf,Info,Infof,Warn,Warnf,Debug,Debugf`.
-    # Default: []
+    # To specify a set of function names to exclude.
+    # The values are merged with the builtin exclusions.
+    # The builtin exclusions can be disabled by setting `use-builtin-exclusions` to `false`.
+    # Default: ["^(fmt|log|logger)\.(Print|Fprint|Sprint|Fatal|Panic|Error|Warn|Warning|Info|Debug)(|f|ln)$"]
     exclude:
       - Append
-      - Log
-    # ignore found case in *_test.go file
+      - \.Wrapf
+    # To enable/disable the asasalint builtin exclusions of function names.
+    # See the default value of `exclude` to get the builtin exclusions.
+    # Default: true
+    use-builtin-exclusions: false
+    # Ignore *_test.go files.
     # Default: false
-    ignore-in-test: true
-    # if true, will disable the builtin exclude see https://github.com/alingse/asasalint/blob/main/asasalint.go#L15 like: Printf,Println,Errorf,Debugf ...
-    # Default: false
-    no-builtin-exclude: true
+    ignore-test: true
 
   bidichk:
     # The following configurations check for all mentioned invisible unicode runes.

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -108,17 +108,21 @@ output:
 # All available settings of specific linters.
 linters-settings:
   asasalint:
-    # Add FuncName to exclude for some bad case report.
+    # Add FuncName to exclude for avoid some bad case report.
+    # the asasalint has also some builtin exclude func names, not need to config here,
+    # and can disabled by `no-builtin-exclude` option.
+    # they are `Printf,Println,Fprintf,Fprintln,Fatal,Fatalf,Panic,Panicf,Panicln,Print,Printf,Println,Sprintf,Sprintln,Error,Errorf,Info,Infof,Warn,Warnf,Debug,Debugf`.
     # Default: []
     exclude:
       - Append
       - Log
     # ignore found case in *_test.go file
     # Default: false
-    ignore-in-test: false
-    # if true, will disable the default exclude see https://github.com/alingse/asasalint/blob/main/asasalint.go#L15 like: Printf,Println,Errorf,Debugf ...
+    ignore-in-test: true
+    # if true, will disable the builtin exclude see https://github.com/alingse/asasalint/blob/main/asasalint.go#L15 like: Printf,Println,Errorf,Debugf ...
     # Default: false
-    no-default-exclude: false
+    no-builtin-exclude: true
+
   bidichk:
     # The following configurations check for all mentioned invisible unicode runes.
     # All runes are enabled by default.

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -107,6 +107,14 @@ output:
 
 # All available settings of specific linters.
 linters-settings:
+  asasalint:
+    # Add FuncName to exclude for some bad case report.
+    exclude:
+      - Append
+      - Log
+    # if true, will disable the default exclude see https://github.com/alingse/asasalint/blob/main/asasalint.go#L15 like: Printf,Println,Errorf,Debugf ...
+    no_default_exclude: false
+    ignore_in_test: false
   bidichk:
     # The following configurations check for all mentioned invisible unicode runes.
     # All runes are enabled by default.
@@ -1823,6 +1831,7 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
   enable:
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose
@@ -1922,6 +1931,7 @@ linters:
   # Disable specific linter
   # https://golangci-lint.run/usage/linters/#disabled-by-default-linters--e--enable
   disable:
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0
 	github.com/OpenPeeDeeP/depguard v1.1.0
 	github.com/alexkohler/prealloc v1.0.0
-	github.com/alingse/asasalint v0.0.7
+	github.com/alingse/asasalint v0.0.8
 	github.com/ashanbrown/forbidigo v1.3.0
 	github.com/ashanbrown/makezero v1.1.1
 	github.com/bkielbasa/cyclop v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0
 	github.com/OpenPeeDeeP/depguard v1.1.0
 	github.com/alexkohler/prealloc v1.0.0
-	github.com/alingse/asasalint v0.0.5
+	github.com/alingse/asasalint v0.0.6
 	github.com/ashanbrown/forbidigo v1.3.0
 	github.com/ashanbrown/makezero v1.1.1
 	github.com/bkielbasa/cyclop v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0
 	github.com/OpenPeeDeeP/depguard v1.1.0
 	github.com/alexkohler/prealloc v1.0.0
-	github.com/alingse/asasalint v0.0.8
+	github.com/alingse/asasalint v0.0.10
 	github.com/ashanbrown/forbidigo v1.3.0
 	github.com/ashanbrown/makezero v1.1.1
 	github.com/bkielbasa/cyclop v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0
 	github.com/OpenPeeDeeP/depguard v1.1.0
 	github.com/alexkohler/prealloc v1.0.0
+	github.com/alingse/asasalint v0.0.5
 	github.com/ashanbrown/forbidigo v1.3.0
 	github.com/ashanbrown/makezero v1.1.1
 	github.com/bkielbasa/cyclop v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.2.0
 	github.com/OpenPeeDeeP/depguard v1.1.0
 	github.com/alexkohler/prealloc v1.0.0
-	github.com/alingse/asasalint v0.0.6
+	github.com/alingse/asasalint v0.0.7
 	github.com/ashanbrown/forbidigo v1.3.0
 	github.com/ashanbrown/makezero v1.1.1
 	github.com/bkielbasa/cyclop v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pOcUuw=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
-github.com/alingse/asasalint v0.0.7 h1:8DKtvyhyd6208936/2bFBFDNOuvzeXEkp7Cqj/i5f/A=
-github.com/alingse/asasalint v0.0.7/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
-github.com/alingse/asasalint v0.0.8 h1:yc4Gfk4SE5SW2fDDWdQJYS9+XXDA+DBzyRkaQktR/0g=
-github.com/alingse/asasalint v0.0.8/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
+github.com/alingse/asasalint v0.0.10 h1:qqGPDTV0ff0tWHN/nnIlSdjlU/EwRPaUY4SfpE1rnms=
+github.com/alingse/asasalint v0.0.10/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pO
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
 github.com/alingse/asasalint v0.0.5 h1:/U8o+wtkyc9wsmDiyvCAcGr5uskgM2tVLNlqZJouid0=
 github.com/alingse/asasalint v0.0.5/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
+github.com/alingse/asasalint v0.0.6 h1:UMyvWrkrDHm9y3MhC9sVxnTIY8MwxhgxSs6ZilB6Inc=
+github.com/alingse/asasalint v0.0.6/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pOcUuw=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
+github.com/alingse/asasalint v0.0.5 h1:/U8o+wtkyc9wsmDiyvCAcGr5uskgM2tVLNlqZJouid0=
+github.com/alingse/asasalint v0.0.5/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pOcUuw=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
-github.com/alingse/asasalint v0.0.5 h1:/U8o+wtkyc9wsmDiyvCAcGr5uskgM2tVLNlqZJouid0=
-github.com/alingse/asasalint v0.0.5/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
-github.com/alingse/asasalint v0.0.6 h1:UMyvWrkrDHm9y3MhC9sVxnTIY8MwxhgxSs6ZilB6Inc=
-github.com/alingse/asasalint v0.0.6/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
+github.com/alingse/asasalint v0.0.7 h1:8DKtvyhyd6208936/2bFBFDNOuvzeXEkp7Cqj/i5f/A=
+github.com/alingse/asasalint v0.0.7/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pO
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
 github.com/alingse/asasalint v0.0.7 h1:8DKtvyhyd6208936/2bFBFDNOuvzeXEkp7Cqj/i5f/A=
 github.com/alingse/asasalint v0.0.7/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
+github.com/alingse/asasalint v0.0.8 h1:yc4Gfk4SE5SW2fDDWdQJYS9+XXDA+DBzyRkaQktR/0g=
+github.com/alingse/asasalint v0.0.8/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -7,6 +7,9 @@ import (
 )
 
 var defaultLintersSettings = LintersSettings{
+	Asasalint: AsasalintSettings{
+		UseBuiltinExclusions: true,
+	},
 	Decorder: DecorderSettings{
 		DecOrder:                  []string{"type", "const", "var", "func"},
 		DisableDecNumCheck:        true,
@@ -186,9 +189,9 @@ type LintersSettings struct {
 }
 
 type AsasalintSettings struct {
-	Exclude          []string `mapstructure:"exclude"`
-	IgnoreInTest     bool     `mapstructure:"ignore-in-test"`
-	NoBuiltinExclude bool     `mapstructure:"no-builtin-exclude"`
+	Exclude              []string `mapstructure:"exclude"`
+	UseBuiltinExclusions bool     `mapstructure:"use-builtin-exclusions"`
+	IgnoreTest           bool     `mapstructure:"ignore-test"`
 }
 
 type BiDiChkSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -113,6 +113,7 @@ var defaultLintersSettings = LintersSettings{
 }
 
 type LintersSettings struct {
+	Asasalint        AsasalintSettings
 	BiDiChk          BiDiChkSettings
 	Cyclop           Cyclop
 	Decorder         DecorderSettings
@@ -182,6 +183,12 @@ type LintersSettings struct {
 	WSL              WSLSettings
 
 	Custom map[string]CustomLinterSettings
+}
+
+type AsasalintSettings struct {
+	Exclude          []string `mapstructure:"exclude"`
+	NoDefaultExclude bool     `mapstructure:"no_default_exclude"`
+	IgnoreInTest     bool     `mapstructure:"ignore_in_test"`
 }
 
 type BiDiChkSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -187,8 +187,8 @@ type LintersSettings struct {
 
 type AsasalintSettings struct {
 	Exclude          []string `mapstructure:"exclude"`
-	NoDefaultExclude bool     `mapstructure:"no_default_exclude"`
-	IgnoreInTest     bool     `mapstructure:"ignore_in_test"`
+	IgnoreInTest     bool     `mapstructure:"ignore-in-test"`
+	NoDefaultExclude bool     `mapstructure:"no-default-exclude"`
 }
 
 type BiDiChkSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -188,7 +188,7 @@ type LintersSettings struct {
 type AsasalintSettings struct {
 	Exclude          []string `mapstructure:"exclude"`
 	IgnoreInTest     bool     `mapstructure:"ignore-in-test"`
-	NoDefaultExclude bool     `mapstructure:"no-default-exclude"`
+	NoBuiltinExclude bool     `mapstructure:"no-builtin-exclude"`
 }
 
 type BiDiChkSettings struct {

--- a/pkg/golinters/asasalint.go
+++ b/pkg/golinters/asasalint.go
@@ -13,7 +13,7 @@ func NewAsasalint(setting *config.AsasalintSettings) *goanalysis.Linter {
 	if setting != nil {
 		cfg.Exclude = setting.Exclude
 		cfg.IgnoreInTest = setting.IgnoreInTest
-		cfg.NoDefaultExclude = setting.NoDefaultExclude
+		cfg.NoBuiltinExclude = setting.NoBuiltinExclude
 	}
 
 	a := asasalint.NewAnalyzer(cfg)

--- a/pkg/golinters/asasalint.go
+++ b/pkg/golinters/asasalint.go
@@ -18,7 +18,7 @@ func NewAsasalint(setting *config.AsasalintSettings) *goanalysis.Linter {
 
 	a, err := asasalint.NewAnalyzer(cfg)
 	if err != nil {
-		linterLogger.Fatalf("asasalint: create analyzer")
+		linterLogger.Fatalf("asasalint: create analyzer: %v", err)
 	}
 
 	return goanalysis.NewLinter(

--- a/pkg/golinters/asasalint.go
+++ b/pkg/golinters/asasalint.go
@@ -8,14 +8,15 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-func NewAsasalint(cfg *config.AsasalintSettings) *goanalysis.Linter {
-	setting := asasalint.LinterSetting{}
-	if cfg != nil {
-		setting.Exclude = cfg.Exclude
-		setting.NoDefaultExclude = cfg.NoDefaultExclude
-		setting.IgnoreInTest = cfg.IgnoreInTest
+func NewAsasalint(setting *config.AsasalintSettings) *goanalysis.Linter {
+	cfg := asasalint.LinterSetting{}
+	if setting != nil {
+		cfg.Exclude = setting.Exclude
+		cfg.IgnoreInTest = setting.IgnoreInTest
+		cfg.NoDefaultExclude = setting.NoDefaultExclude
 	}
-	a := asasalint.NewAnalyzer(setting)
+
+	a := asasalint.NewAnalyzer(cfg)
 
 	return goanalysis.NewLinter(
 		a.Name,

--- a/pkg/golinters/asasalint.go
+++ b/pkg/golinters/asasalint.go
@@ -1,0 +1,26 @@
+package golinters
+
+import (
+	"github.com/alingse/asasalint"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewAsasalint(cfg *config.AsasalintSettings) *goanalysis.Linter {
+	setting := asasalint.LinterSetting{}
+	if cfg != nil {
+		setting.Exclude = cfg.Exclude
+		setting.NoDefaultExclude = cfg.NoDefaultExclude
+		setting.IgnoreInTest = cfg.IgnoreInTest
+	}
+	a := asasalint.NewAnalyzer(setting)
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/asasalint.go
+++ b/pkg/golinters/asasalint.go
@@ -12,11 +12,14 @@ func NewAsasalint(setting *config.AsasalintSettings) *goanalysis.Linter {
 	cfg := asasalint.LinterSetting{}
 	if setting != nil {
 		cfg.Exclude = setting.Exclude
-		cfg.IgnoreInTest = setting.IgnoreInTest
-		cfg.NoBuiltinExclude = setting.NoBuiltinExclude
+		cfg.NoBuiltinExclusions = !setting.UseBuiltinExclusions
+		cfg.IgnoreTest = setting.IgnoreTest
 	}
 
-	a := asasalint.NewAnalyzer(cfg)
+	a, err := asasalint.NewAnalyzer(cfg)
+	if err != nil {
+		linterLogger.Fatalf("asasalint: create analyzer")
+	}
 
 	return goanalysis.NewLinter(
 		a.Name,

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -101,6 +101,7 @@ func enableLinterConfigs(lcs []*linter.Config, isEnabled func(lc *linter.Config)
 //nolint:funlen
 func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var (
+		asasalintCfg        *config.AsasalintSettings
 		bidichkCfg          *config.BiDiChkSettings
 		cyclopCfg           *config.Cyclop
 		decorderCfg         *config.DecorderSettings
@@ -171,6 +172,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	)
 
 	if m.cfg != nil {
+		asasalintCfg = &m.cfg.LintersSettings.Asasalint
 		bidichkCfg = &m.cfg.LintersSettings.BiDiChk
 		cyclopCfg = &m.cfg.LintersSettings.Cyclop
 		decorderCfg = &m.cfg.LintersSettings.Decorder
@@ -266,6 +268,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	// The linters are sorted in the alphabetical order (case-insensitive).
 	// When a new linter is added the version in `WithSince(...)` must be the next minor version of golangci-lint.
 	lcs := []*linter.Config{
+		linter.NewConfig(golinters.NewAsasalint(asasalintCfg)).
+			WithSince("1.47.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/alingse/asasalint"),
+
 		linter.NewConfig(golinters.NewAsciicheck()).
 			WithSince("v1.26.0").
 			WithPresets(linter.PresetBugs, linter.PresetStyle).

--- a/test/testdata/asasalint.go
+++ b/test/testdata/asasalint.go
@@ -1,0 +1,17 @@
+package testdata
+
+import "fmt"
+
+func getArgsLength(args ...any) int {
+	return len(args)
+}
+
+func checkArgsLength(args ...any) int {
+	return getArgsLength(args)
+}
+
+func someCall() {
+	var a = []any{1, 2, 3}
+	fmt.Println(checkArgsLength(a...) == getArgsLength(a))
+	fmt.Println(checkArgsLength(a...) == getArgsLength(a...))
+}

--- a/test/testdata/asasalint.go
+++ b/test/testdata/asasalint.go
@@ -1,17 +1,18 @@
+//args: -Easasalint
 package testdata
 
 import "fmt"
 
-func getArgsLength(args ...any) int {
+func getArgsLength(args ...interface{}) int {
 	return len(args)
 }
 
-func checkArgsLength(args ...any) int {
-	return getArgsLength(args)
+func checkArgsLength(args ...interface{}) int {
+	return getArgsLength(args) // ERROR `pass \[\]any as any to func getArgsLength func\(args \.\.\.interface\{\}\)`
 }
 
 func someCall() {
-	var a = []any{1, 2, 3}
-	fmt.Println(checkArgsLength(a...) == getArgsLength(a))
+	var a = []interface{}{1, 2, 3}
+	fmt.Println(checkArgsLength(a...) == getArgsLength(a)) // ERROR `pass \[\]any as any to func getArgsLength func\(args \.\.\.interface\{\}\)`
 	fmt.Println(checkArgsLength(a...) == getArgsLength(a...))
 }

--- a/test/testdata/asasalint.go
+++ b/test/testdata/asasalint.go
@@ -4,6 +4,8 @@ package testdata
 import "fmt"
 
 func getArgsLength(args ...interface{}) int {
+	// this line will not report as error
+	fmt.Println(args)
 	return len(args)
 }
 

--- a/test/testdata/asasalint.go
+++ b/test/testdata/asasalint.go
@@ -1,4 +1,4 @@
-//args: -Easasalint
+//golangcitest:args -Easasalint
 package testdata
 
 import "fmt"


### PR DESCRIPTION
## Linter
the linter [asasalint](https://github.com/alingse/asasalint) aim to lint bug about `pass []any as any in variadic function` 

i have check some top go repos in github, and the found bugs list in the issues: https://github.com/alingse/asasalint/issues/1

and more failed in check on [github actions](https://github.com/alingse/asasalint/actions?query=is%3Afailure) (some is not the bug) 

## User

the linter may wrong report some not bug lint,  

user can add `exclude` to avoid some wrong report
