### PR TITLE
dev: change err to nil

### DIFF
--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -73,11 +73,8 @@ func (e *Executor) executeCacheStatus(_ *cobra.Command, args []string) {
 func dirSizeBytes(path string) (int64, error) {
 	var size int64
 	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			size += info.Size()
+		if err == nil && !info.IsDir() {
+			size = info.Size()
 		}
 		return err
 	})


### PR DESCRIPTION
Added condition when err is nil and and file not dir instead of err handling, cuz err variable returned anyway. 
Changed operator for size variable. Because need assign only. 