### PR TITLE
staticcheck: fix generics

### DIFF
--- a/pkg/golinters/goanalysis/runner_loadingpackage.go
+++ b/pkg/golinters/goanalysis/runner_loadingpackage.go
@@ -123,6 +123,7 @@ func (lp *loadingPackage) loadFromSource(loadMode LoadMode) error {
 
 	pkg.TypesInfo = &types.Info{
 		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Instances:  make(map[*ast.Ident]types.Instance),
 		Defs:       make(map[*ast.Ident]types.Object),
 		Uses:       make(map[*ast.Ident]types.Object),
 		Implicits:  make(map[ast.Node]types.Object),

--- a/pkg/golinters/goanalysis/runner_loadingpackage.go
+++ b/pkg/golinters/goanalysis/runner_loadingpackage.go
@@ -121,15 +121,7 @@ func (lp *loadingPackage) loadFromSource(loadMode LoadMode) error {
 
 	pkg.IllTyped = true
 
-	pkg.TypesInfo = &types.Info{
-		Types:      make(map[ast.Expr]types.TypeAndValue),
-		Instances:  make(map[*ast.Ident]types.Instance),
-		Defs:       make(map[*ast.Ident]types.Object),
-		Uses:       make(map[*ast.Ident]types.Object),
-		Implicits:  make(map[ast.Node]types.Object),
-		Scopes:     make(map[ast.Node]*types.Scope),
-		Selections: make(map[*ast.SelectorExpr]*types.Selection),
-	}
+	pkg.TypesInfo = newTypesInfo()
 
 	importer := func(path string) (*types.Package, error) {
 		if path == unsafePkgName {

--- a/pkg/golinters/goanalysis/runner_loadingpackage_ti.go
+++ b/pkg/golinters/goanalysis/runner_loadingpackage_ti.go
@@ -1,0 +1,21 @@
+//go:build go1.18
+// +build go1.18
+
+package goanalysis
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+func newTypesInfo() *types.Info {
+	return &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Instances:  make(map[*ast.Ident]types.Instance),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+}

--- a/pkg/golinters/goanalysis/runner_loadingpackage_ti_go117.go
+++ b/pkg/golinters/goanalysis/runner_loadingpackage_ti_go117.go
@@ -1,0 +1,20 @@
+//go:build go1.17 && !go1.18
+// +build go1.17,!go1.18
+
+package goanalysis
+
+import (
+	"go/ast"
+	"go/types"
+)
+
+func newTypesInfo() *types.Info {
+	return &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+	}
+}


### PR DESCRIPTION
For staticcheck to work, `go/types.Info.Instances` must be populated. `go/types` will automatically populate the map as long as it's not nil, so the only change that has to be made is initializing that map.

Updates #2649
Closes #2859