### PR TITLE
gci: fix options display

### DIFF
--- a/pkg/golinters/gci.go
+++ b/pkg/golinters/gci.go
@@ -141,7 +141,7 @@ func getErrorTextForGci(settings config.GciSettings) string {
 	text += " with"
 
 	if settings.SkipGenerated {
-		text += " -skip-generated"
+		text += " --skip-generated"
 	}
 
 	if len(settings.Sections) > 0 {

--- a/test/testdata/gci.go
+++ b/test/testdata/gci.go
@@ -5,9 +5,9 @@ package testdata
 import (
 	"fmt"
 
-	"github.com/golangci/golangci-lint/pkg/config" // ERROR "File is not \\`gci\\`-ed with -skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
+	"github.com/golangci/golangci-lint/pkg/config" // ERROR "File is not \\`gci\\`-ed with --skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
 
-	"github.com/pkg/errors" // ERROR "File is not \\`gci\\`-ed with -skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
+	"github.com/pkg/errors" // ERROR "File is not \\`gci\\`-ed with --skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
 )
 
 func GoimportsLocalTest() {


### PR DESCRIPTION
While running the golangci-lint I got findings of the type: 

```
api/v1beta1/condition_types.go:93: File is not `gci`-ed with -skip-generated -s standard,default (gci)
```

However if you run `gci` with the provided output you will get the following error message:
```
./dist/gci write -skip-generated -s default main.go 
Error: invalid params: kip-generated
```

The correct format is `--skip-generated`. 

```
./dist/gci write --help
(...)
  -s, --section strings   Sections define how inputs will be processed. Section names are case-insensitive and may contain parameters in (). The section order is standard > default > custom. The default value is [standard,default].
                          standard - standard section that Golang provides officially, like "fmt"
                          Prefix(github.com/daixiang0) - custom section, groups all imports with the specified Prefix. Imports will be matched to the longest Prefix.
                          default - default section, contains all rest imports (default [standard,default])
      --skip-generated    Skip generated files
```