### PR TITLE
feat: sort the issue before print

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -403,6 +404,7 @@ func (e *Executor) runAndPrint(ctx context.Context, args []string) error {
 		return err // XXX: don't loose type
 	}
 
+	sort.Sort(result.Issues(issues))
 	formats := strings.Split(e.cfg.Output.Format, ",")
 	for _, format := range formats {
 		out := strings.SplitN(format, ":", 2)

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -96,3 +96,19 @@ func (i *Issue) Fingerprint() string {
 
 	return fmt.Sprintf("%X", hash.Sum(nil))
 }
+
+type Issues []Issue
+
+func (is Issues) Len() int {
+	return len(is)
+}
+
+func (is Issues) Less(i, j int) bool {
+	return !(is[i].Pos.Filename > is[j].Pos.Filename ||
+		is[i].Pos.Filename == is[j].Pos.Filename && is[i].Pos.Line > is[j].Pos.Line ||
+		is[i].Pos.Filename == is[j].Pos.Filename && is[i].Pos.Line == is[j].Pos.Line && is[i].Pos.Column > is[j].Pos.Column)
+}
+
+func (is Issues) Swap(i, j int) {
+	is[i], is[j] = is[j], is[i]
+}


### PR DESCRIPTION
i use golangci to check the project code, in some file, more then 2 linter report issue so before print the issues, sort the issues make sure same file issues in same area