### PR TITLE
feat: remove some go1.18 limitations

### DIFF
--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -155,11 +155,6 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 }
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
-	if (name == nilness.Analyzer.Name || name == unusedwrite.Analyzer.Name) &&
-		config.IsGreaterThanOrEqualGo118(cfg.Go) {
-		return false
-	}
-
 	if cfg.EnableAll {
 		for _, n := range cfg.Disable {
 			if n == name {

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -815,7 +815,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		golinters.NewStaticcheck(staticcheckCfg).Name(): true,
 		golinters.NewUnused(unusedCfg).Name():           true,
 		golinters.NewGosimple(gosimpleCfg).Name():       true,
-		golinters.NewStructcheck(structcheckCfg).Name(): true,
 		golinters.NewVarcheck(varcheckCfg).Name():       true,
 		golinters.NewIneffassign().Name():               true,
 		golinters.NewDeadcode().Name():                  true,

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -288,8 +288,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.18.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetPerformance, linter.PresetBugs).
-			WithURL("https://github.com/timakin/bodyclose").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/timakin/bodyclose"),
 
 		linter.NewConfig(golinters.NewContainedCtx()).
 			WithSince("1.44.0").
@@ -300,8 +299,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.43.0").
 			WithPresets(linter.PresetBugs).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/sylvia7788/contextcheck").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/sylvia7788/contextcheck"),
 
 		linter.NewConfig(golinters.NewCyclop(cyclopCfg)).
 			WithSince("v1.37.0").
@@ -561,8 +559,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/mvdan/interfacer").
-			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", "").
-			WithNoopFallback(m.cfg),
+			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", ""),
 
 		linter.NewConfig(golinters.NewIreturn(ireturnCfg)).
 			WithSince("v1.43.0").
@@ -612,8 +609,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.38.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetBugs).
-			WithURL("https://github.com/gostaticanalysis/nilerr").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/gostaticanalysis/nilerr"),
 
 		linter.NewConfig(golinters.NewNilNil(nilNilCfg)).
 			WithSince("v1.43.0").
@@ -630,8 +626,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.28.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetPerformance, linter.PresetBugs).
-			WithURL("https://github.com/sonatard/noctx").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/sonatard/noctx"),
 
 		linter.NewConfig(golinters.NewNoNamedReturns(noNamedReturnsCfg)).
 			WithSince("v1.46.0").
@@ -742,8 +737,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.32.0").
 			WithPresets(linter.PresetStyle, linter.PresetTest).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/moricho/tparallel").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/moricho/tparallel"),
 
 		linter.NewConfig(golinters.NewTypecheck()).
 			WithSince("v1.3.0").


### PR DESCRIPTION
Remove go1.18 limitations for:
- govet(nilness,unusedwrite)
- bodyclose
- contextcheck
- nilerr
- noctx
- tparallel
- unparam

Remove `structcheck` from the default linters.

Related to #2649
