### PR TITLE
doc: add Bytebase info the trusted-by page

### DIFF
--- a/docs/src/docs/product/trusted-by.mdx
+++ b/docs/src/docs/product/trusted-by.mdx
@@ -4,26 +4,26 @@ title: Trusted By
 
 The following companies/products use `golangci-lint`:
 
+- [Arduino](https://github.com/arduino/arduino-cli)
 - [AWS](https://github.com/aws/aws-xray-sdk-go)
+- [Baidu](https://github.com/baidu/bfe)
+- [Bytebase](https://github.com/bytebase/bytebase)
+- [Eclipse Foundation](https://github.com/eclipse/che-go-jsonrpc)
 - [Facebook](https://github.com/facebookincubator/fbender)
 - [Google](https://github.com/GoogleContainerTools/skaffold)
-- [Netflix](https://github.com/Netflix/titus-executor)
-- [Arduino](https://github.com/arduino/arduino-cli)
-- [Baidu](https://github.com/baidu/bfe)
-- [Eclipse Foundation](https://github.com/eclipse/che-go-jsonrpc)
 - [IBM](https://github.com/ibm-developer/ibm-cloud-env-golang)
 - [Istio](https://github.com/istio/istio)
+- [Netflix](https://github.com/Netflix/titus-executor)
 - [Percona](https://github.com/percona/pmm-managed)
 - [Red Hat OpenShift](https://github.com/openshift/telemeter)
 - [Samsung](https://github.com/samsung-cnct/cluster-api-provider-ssh)
-- [Serverless](https://github.com/serverless/event-gateway)
 - [ScyllaDB](https://github.com/scylladb/gocqlx)
+- [Serverless](https://github.com/serverless/event-gateway)
 - [SoundCloud](https://github.com/soundcloud/periskop)
 - [The New York Times](https://github.com/NYTimes/encoding-wrapper)
 - [WooCart](https://github.com/woocart/gsutil)
 - [Xiaomi](https://github.com/XiaoMi/soar)
 - [Yahoo](https://github.com/yahoo/yfuzz)
-- [Bytebase](https://github.com/bytebase/bytebase)
 
 And thousands of other great companies use `golangci-lint` too.
 You can find them by [this GitHub search query](https://github.com/search?q=golangci-lint&type=Code).

--- a/docs/src/docs/product/trusted-by.mdx
+++ b/docs/src/docs/product/trusted-by.mdx
@@ -23,6 +23,7 @@ The following companies/products use `golangci-lint`:
 - [WooCart](https://github.com/woocart/gsutil)
 - [Xiaomi](https://github.com/XiaoMi/soar)
 - [Yahoo](https://github.com/yahoo/yfuzz)
+- [Bytebase](https://github.com/bytebase/bytebase)
 
 And thousands of other great companies use `golangci-lint` too.
 You can find them by [this GitHub search query](https://github.com/search?q=golangci-lint&type=Code).


### PR DESCRIPTION
We at Bytebase are using golangci-lint extensively :smile::
https://github.com/bytebase/bytebase/blob/main/.golangci.yaml

We run golangci-lint for every commit in Github Actions:
https://github.com/bytebase/bytebase/blob/main/.github/workflows/tests.yml#L11-L31

We occasionally review the [linters page](https://golangci-lint.run/usage/linters/) to find new linters.
For example, in this PR we use all the revive linter checks by default and found a lot of warnings. So we split them up and will enable one linter at a time in a separate PR:
https://github.com/bytebase/bytebase/pull/1928