### PR TITLE
cgo: fix many linters ignoring Cgo files

### DIFF
--- a/pkg/golinters/dupl.go
+++ b/pkg/golinters/dupl.go
@@ -55,11 +55,7 @@ func NewDupl(settings *config.DuplSettings) *goanalysis.Linter {
 }
 
 func runDupl(pass *analysis.Pass, settings *config.DuplSettings) ([]goanalysis.Issue, error) {
-	var fileNames []string
-	for _, f := range pass.Files {
-		pos := pass.Fset.PositionFor(f.Pos(), false)
-		fileNames = append(fileNames, pos.Filename)
-	}
+	fileNames := getFileNames(pass)
 
 	issues, err := duplAPI.Run(fileNames, settings.Threshold)
 	if err != nil {

--- a/pkg/golinters/gci.go
+++ b/pkg/golinters/gci.go
@@ -83,11 +83,7 @@ func NewGci(settings *config.GciSettings) *goanalysis.Linter {
 }
 
 func runGci(pass *analysis.Pass, lintCtx *linter.Context, cfg *gcicfg.Config, lock *sync.Mutex) ([]goanalysis.Issue, error) {
-	var fileNames []string
-	for _, f := range pass.Files {
-		pos := pass.Fset.PositionFor(f.Pos(), false)
-		fileNames = append(fileNames, pos.Filename)
-	}
+	fileNames := getFileNames(pass)
 
 	var diffs []string
 	err := diffFormattedFilesToArray(fileNames, *cfg, &diffs, lock)

--- a/pkg/golinters/gofmt.go
+++ b/pkg/golinters/gofmt.go
@@ -53,11 +53,7 @@ func NewGofmt(settings *config.GoFmtSettings) *goanalysis.Linter {
 }
 
 func runGofmt(lintCtx *linter.Context, pass *analysis.Pass, settings *config.GoFmtSettings) ([]goanalysis.Issue, error) {
-	var fileNames []string
-	for _, f := range pass.Files {
-		pos := pass.Fset.PositionFor(f.Pos(), false)
-		fileNames = append(fileNames, pos.Filename)
-	}
+	fileNames := getFileNames(pass)
 
 	var issues []goanalysis.Issue
 

--- a/pkg/golinters/gofumpt.go
+++ b/pkg/golinters/gofumpt.go
@@ -73,11 +73,7 @@ func NewGofumpt(settings *config.GofumptSettings) *goanalysis.Linter {
 }
 
 func runGofumpt(lintCtx *linter.Context, pass *analysis.Pass, diff differ, options format.Options) ([]goanalysis.Issue, error) {
-	var fileNames []string
-	for _, f := range pass.Files {
-		pos := pass.Fset.PositionFor(f.Pos(), false)
-		fileNames = append(fileNames, pos.Filename)
-	}
+	fileNames := getFileNames(pass)
 
 	var issues []goanalysis.Issue
 

--- a/pkg/golinters/goimports.go
+++ b/pkg/golinters/goimports.go
@@ -55,11 +55,7 @@ func NewGoimports(settings *config.GoImportsSettings) *goanalysis.Linter {
 }
 
 func runGoiImports(lintCtx *linter.Context, pass *analysis.Pass) ([]goanalysis.Issue, error) {
-	var fileNames []string
-	for _, f := range pass.Files {
-		pos := pass.Fset.PositionFor(f.Pos(), false)
-		fileNames = append(fileNames, pos.Filename)
-	}
+	fileNames := getFileNames(pass)
 
 	var issues []goanalysis.Issue
 

--- a/pkg/golinters/gomodguard.go
+++ b/pkg/golinters/gomodguard.go
@@ -73,12 +73,7 @@ func NewGomodguard(settings *config.GoModGuardSettings) *goanalysis.Linter {
 		}
 
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
-			var files []string
-			for _, file := range pass.Files {
-				files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
-			}
-
-			gomodguardIssues := processor.ProcessFiles(files)
+			gomodguardIssues := processor.ProcessFiles(getFileNames(pass))
 
 			mu.Lock()
 			defer mu.Unlock()

--- a/pkg/golinters/lll.go
+++ b/pkg/golinters/lll.go
@@ -56,11 +56,7 @@ func NewLLL(settings *config.LllSettings) *goanalysis.Linter {
 }
 
 func runLll(pass *analysis.Pass, settings *config.LllSettings) ([]goanalysis.Issue, error) {
-	var fileNames []string
-	for _, f := range pass.Files {
-		pos := pass.Fset.PositionFor(f.Pos(), false)
-		fileNames = append(fileNames, pos.Filename)
-	}
+	fileNames := getFileNames(pass)
 
 	spaces := strings.Repeat(" ", settings.TabWidth)
 

--- a/pkg/golinters/misspell.go
+++ b/pkg/golinters/misspell.go
@@ -61,12 +61,7 @@ func NewMisspell(settings *config.MisspellSettings) *goanalysis.Linter {
 }
 
 func runMisspell(lintCtx *linter.Context, pass *analysis.Pass, replacer *misspell.Replacer) ([]goanalysis.Issue, error) {
-	var fileNames []string
-
-	for _, f := range pass.Files {
-		pos := pass.Fset.PositionFor(f.Pos(), false)
-		fileNames = append(fileNames, pos.Filename)
-	}
+	fileNames := getFileNames(pass)
 
 	var issues []goanalysis.Issue
 	for _, filename := range fileNames {

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -75,11 +75,7 @@ func NewRevive(settings *config.ReviveSettings) *goanalysis.Linter {
 }
 
 func runRevive(lintCtx *linter.Context, pass *analysis.Pass, settings *config.ReviveSettings) ([]goanalysis.Issue, error) {
-	var files []string
-	for _, file := range pass.Files {
-		files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
-	}
-	packages := [][]string{files}
+	packages := [][]string{getFileNames(pass)}
 
 	conf, err := getReviveConfig(settings)
 	if err != nil {

--- a/pkg/golinters/util.go
+++ b/pkg/golinters/util.go
@@ -2,7 +2,10 @@ package golinters
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
+
+	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 )
@@ -21,4 +24,18 @@ func formatCodeBlock(code string, _ *config.Config) string {
 	}
 
 	return fmt.Sprintf("```\n%s\n```", code)
+}
+
+func getFileNames(pass *analysis.Pass) []string {
+	var fileNames []string
+	for _, f := range pass.Files {
+		fileName := pass.Fset.PositionFor(f.Pos(), true).Filename
+		ext := filepath.Ext(fileName)
+		if ext != "" && ext != ".go" {
+			// position has been adjusted to a non-go file, revert to original file
+			fileName = pass.Fset.PositionFor(f.Pos(), false).Filename
+		}
+		fileNames = append(fileNames, fileName)
+	}
+	return fileNames
 }

--- a/pkg/golinters/wsl.go
+++ b/pkg/golinters/wsl.go
@@ -67,15 +67,11 @@ func NewWSL(settings *config.WSLSettings) *goanalysis.Linter {
 }
 
 func runWSL(pass *analysis.Pass, conf *wsl.Configuration) []goanalysis.Issue {
-	var files = make([]string, 0, len(pass.Files))
-	for _, file := range pass.Files {
-		files = append(files, pass.Fset.PositionFor(file.Pos(), false).Filename)
-	}
-
 	if conf == nil {
 		return nil
 	}
 
+	files := getFileNames(pass)
 	wslErrors, _ := wsl.NewProcessorWithConfig(*conf).ProcessFiles(files)
 	if len(wslErrors) == 0 {
 		return nil

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -104,6 +104,8 @@ func TestCgoWithIssues(t *testing.T) {
 		ExpectHasIssue("Printf format %t has arg cs of wrong type")
 	r.Run("--no-config", "--disable-all", "-Estaticcheck", getTestDataDir("cgo_with_issues")).
 		ExpectHasIssue("SA5009: Printf format %t has arg #1 of wrong type")
+	r.Run("--no-config", "--disable-all", "-Egofmt", getTestDataDir("cgo_with_issues")).
+		ExpectHasIssue("File is not `gofmt`-ed with `-s` (gofmt)")
 }
 
 func TestUnsafeOk(t *testing.T) {

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -106,6 +106,8 @@ func TestCgoWithIssues(t *testing.T) {
 		ExpectHasIssue("SA5009: Printf format %t has arg #1 of wrong type")
 	r.Run("--no-config", "--disable-all", "-Egofmt", getTestDataDir("cgo_with_issues")).
 		ExpectHasIssue("File is not `gofmt`-ed with `-s` (gofmt)")
+	r.Run("--no-config", "--disable-all", "-Erevive", getTestDataDir("cgo_with_issues")).
+		ExpectHasIssue("indent-error-flow: if block ends with a return statement")
 }
 
 func TestUnsafeOk(t *testing.T) {
@@ -129,7 +131,7 @@ func TestLineDirectiveProcessedFilesLiteLoading(t *testing.T) {
 }
 
 func TestSortedResults(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		opt  string
 		want string
 	}{

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -95,7 +95,7 @@ func TestTestsAreLintedByDefault(t *testing.T) {
 }
 
 func TestCgoOk(t *testing.T) {
-	testshared.NewLintRunner(t).Run("--no-config", "--enable-all", "-D", "nosnakecase", getTestDataDir("cgo")).ExpectNoIssues()
+	testshared.NewLintRunner(t).Run("--no-config", "--enable-all", "-D", "nosnakecase,gci", getTestDataDir("cgo")).ExpectNoIssues()
 }
 
 func TestCgoWithIssues(t *testing.T) {

--- a/test/testdata/cgo_with_issues/main.go
+++ b/test/testdata/cgo_with_issues/main.go
@@ -21,3 +21,15 @@ func Example() {
 	fmt.Printf("bad format %t", cs)
 	C.free(unsafe.Pointer(cs))
 }
+
+func notFormattedForGofmt()  {
+}
+
+func errorForRevive(p *int) error {
+	if p == nil {
+		return nil
+	} else {
+		return nil
+	}
+}
+


### PR DESCRIPTION
This change fixes a bug that caused that many linters ignored all files that are using Cgo. It was introduced by PR #1065, which assumed that all files referenced by `//line` directives are non-Go files, which is not true. In the case of Cgo they point to the original Go files which are used by Cgo as templates to generate other Go files.

The fix replaces all calls of `Pass.Fset.PositionFor` with a function `getFileNames()` that first calls `Pass.Fset.PositionFor` with adjustment, and only if it results in a non-Go file it calls `Pass.Fset.PositionFor` again without adjustment.

Fixes #1392
Fixes #2449
Fixes #2612
Fixes #2788
Fixes #2910

Signed-off-by: Sven Anderson <sven@anderson.de>
