### PR TITLE
docs(install): remove outdated info on source install

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -107,11 +107,7 @@ Note: such `go install`/`go get` installation aren't guaranteed to work. We reco
 <div style="margin-top: 2em;">
 
 ```sh
-# Go 1.16+
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@{.LatestVersion}
-
-# Go version < 1.16
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@{.LatestVersion}
 ```
 
 </div>


### PR DESCRIPTION
v1.47.3 no longer builds with 1.15 or 1.16, so remove related install instructions.