### PR TITLE
feat: add `explicitreturn` linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	mvdan.cc/gofumpt v0.3.1
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed
 	mvdan.cc/unparam v0.0.0-20220706161116-678bad134442
+	tildegit.org/indigo/explicitreturn v0.0.0-20220802220915-02f24a7ea1f1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1229,3 +1229,5 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+tildegit.org/indigo/explicitreturn v0.0.0-20220802220915-02f24a7ea1f1 h1:txaTJZML69O+uJ+89IWrMafAz/ZuNDJ0sYrF49qlZsE=
+tildegit.org/indigo/explicitreturn v0.0.0-20220802220915-02f24a7ea1f1/go.mod h1:qHM4k4m/KBwFptBEN7YV91OwxmrU9BAIMCK4UQoiKfI=

--- a/pkg/golinters/explicitreturn.go
+++ b/pkg/golinters/explicitreturn.go
@@ -1,0 +1,19 @@
+package golinters
+
+import (
+	"golang.org/x/tools/go/analysis"
+	"tildegit.org/indigo/explicitreturn/pkg/analyzer"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewExplicitReturn() *goanalysis.Linter {
+	a := analyzer.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -388,6 +388,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/GaijinEntertainment/go-exhaustruct"),
 
+		linter.NewConfig(golinters.NewExplicitReturn()).
+			WithSince("v1.48.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://tildegit.org/indigo/explicitreturn"),
+
 		linter.NewConfig(golinters.NewExportLoopRef()).
 			WithSince("v1.28.0").
 			WithPresets(linter.PresetBugs).

--- a/test/testdata/explicitreturn.go
+++ b/test/testdata/explicitreturn.go
@@ -1,0 +1,38 @@
+//golangcitest:args -Eexplicitreturn
+package testdata
+
+// This is the sort of thing we want to discourage because this will implicitly return x and y
+func SimpleNakedReturn() (x int, y string) {
+	return // ERROR `implicit return found in function SimpleNakedReturn`
+}
+
+// If your function doesn't return anything, the linter is happy to let you keep your naked return
+// ...even if it is redundant here
+func IgnorableProcedure() {
+	return
+}
+
+// Or even no return statement at all
+func AnotherIgnorableProcedure() {}
+
+// If you simply return the expected values in your return statement, everyone's happy
+func SimpleFunction() (x int, y string) {
+	return x, y // Return values are as foretold in the function signature
+}
+
+// If you have multiple return paths in your function, the linter will only catch the offensive ones
+func MultipleReturnPaths() (x int, y string) {
+	if true {
+		return x, y // All good here, but...
+	}
+	return // ERROR `implicit return found in function MultipleReturnPaths`
+}
+
+// Also works on anonymous functions!
+var x = func() (x int, y string) { return } // ERROR `implicit return found in anonymous function`
+
+// But we don't require the number of elements in the return statement to match the number in the function signature
+func NestedGoodAnonymousFunction() (x int, y string) {
+	var f = func() (x int, y string) { return x, y } // This is fine
+	return f()                                       // Your compiler will catch most of the stupid stuff you could try here
+}


### PR DESCRIPTION
Source: https://tildegit.org/indigo/explicitreturn

This adds a linter that requires functions to have explicit return statements. It's broadly similar to `nakedret`, but with a slightly different philosophy. 

For one thing, the size of the code doesn't matter. This will catch inline functions which I missed when I used `nakedret` (e.g. `var x` in my test). 

As well, I would not consider https://github.com/alexkohler/nakedret/issues/18 to be a bug because the function in that issue returns an error and a nil error is still a nil value so I would want to see that stated explicitly. The author of `nakedret` doesn't seem to take that view which is fine, but was part of what pushed me to writing this separately rather than working directly on `nakedret` as well as a PR that's been open for review on that project for quite a while now.