### PR TITLE
dev: remove stable from actions/setup-go

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -14,6 +14,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: 1.19
 
       - name: Update GitHub action config

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -14,9 +14,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: 1.19
 
       - name: Update GitHub action config

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -13,9 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: 1.19
       - name: Run go list
         run: go list -json -m all > go.list

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: 1.19
       - name: Run go list
         run: go list -json -m all > go.list

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v3
@@ -36,9 +33,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
 #          go-version: ${{ env.GO_VERSION }} # todo(ldez) uncomment after the next release v1.48.0
           go-version: 1.18
       - name: lint
@@ -57,9 +51,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
@@ -73,9 +64,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
       - name: Run tests
         run: make test
@@ -93,9 +81,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: ${{ matrix.golang }}
       - uses: actions/cache@v3
         with:
@@ -119,9 +104,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: ${{ env.GO_VERSION }}
       - name: Check generated files are up to date
         run: make fast_check_generated

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v3
@@ -33,6 +37,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
 #          go-version: ${{ env.GO_VERSION }} # todo(ldez) uncomment after the next release v1.48.0
           go-version: 1.18
       - name: lint
@@ -51,6 +59,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
@@ -64,6 +76,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
       - name: Run tests
         run: make test
@@ -81,6 +97,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ matrix.golang }}
       - uses: actions/cache@v3
         with:
@@ -104,6 +124,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }}
       - name: Check generated files are up to date
         run: make fast_check_generated

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,6 +14,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: 1.19
       - name: Unshallow
         run: git fetch --prune --unshallow
@@ -40,6 +44,10 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: 1.19
 
       - name: Unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,9 +14,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: 1.19
       - name: Unshallow
         run: git fetch --prune --unshallow
@@ -43,9 +40,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # Keep the following comment to be able to use rc and beta version of Go (ex: 1.18.0-rc.1).
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # stable: 'false'
           go-version: 1.19
 
       - name: Unshallow


### PR DESCRIPTION
Since actions/setup-go v3 `stable` parameter is no longer required
(see https://github.com/actions/setup-go/releases/tag/v3.0.0).