### PR TITLE
docs: remove allow-leading-space option

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1159,9 +1159,6 @@ linters-settings:
     # Disable to ensure that all nolint directives actually have an effect.
     # Default: false
     allow-unused: true
-    # Disable to ensure that nolint directives don't have a leading space.
-    # Default: true
-    allow-leading-space: false
     # Exclude following linters from requiring an explanation.
     # Default: []
     allow-no-explanation: [ ]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,7 +61,6 @@ linters-settings:
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: false
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped

--- a/test/testdata/fix/in/nolintlint.go
+++ b/test/testdata/fix/in/nolintlint.go
@@ -1,6 +1,5 @@
 //golangcitest:args -Enolintlint -Elll
 //golangcitest:expected_linter nolintlint
-//golangcitest:config linters-settings.nolintlint.allow-leading-space=false
 package p
 
 import "fmt"

--- a/test/testdata/fix/out/nolintlint.go
+++ b/test/testdata/fix/out/nolintlint.go
@@ -1,6 +1,5 @@
 //golangcitest:args -Enolintlint -Elll
 //golangcitest:expected_linter nolintlint
-//golangcitest:config linters-settings.nolintlint.allow-leading-space=false
 package p
 
 import "fmt"

--- a/test/testdata/nolintlint.go
+++ b/test/testdata/nolintlint.go
@@ -2,7 +2,6 @@
 //golangcitest:expected_linter nolintlint
 //golangcitest:config linters-settings.nolintlint.require-explanation=true
 //golangcitest:config linters-settings.nolintlint.require-specific=true
-//golangcitest:config linters-settings.nolintlint.allow-leading-space=false
 package testdata
 
 import "fmt"


### PR DESCRIPTION
The option `allow-leading-space` has been removed in #3002

These changes were to be made after the v1.48.0 release.