### PR TITLE
distinguish 32-bit or 64-bit under arch x86_x64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -213,6 +213,12 @@ uname_arch() {
     armv6*) arch="armv6" ;;
     armv7*) arch="armv7" ;;
   esac
+
+  longbit_arch="bit_$(getconf LONG_BIT)"
+  case $longbit_arch in
+    bit_32) arch="386" ;;
+  esac
+
   echo ${arch}
 }
 uname_os_check() {


### PR DESCRIPTION
fix: #3081 distinguish 32-bit or 64-bit under arch x86_x64