### PR TITLE
feat: Include custom linters in `enable-all`

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1692,7 +1692,7 @@ linters-settings:
     # Suggest the use of crypto.Hash
     # Default: false
     crypto-hash: true
-    # Suggest the use of pc.DefaultXXPath
+    # Suggest the use of rpc.DefaultXXPath
     # Default: false
     default-rpc-path: true
 


### PR DESCRIPTION
Related to https://github.com/golangci/golangci-lint/issues/3080

.golangci.yml
```
linters-settings:
  custom:
    example:
      path: ./example.so

linters:
  enable-all: true
```
Custom linters work for `enable-all`.

