### PR TITLE
dev: replace golangcitest:config by golangcitest:config_path

### DIFF
--- a/test/fix_test.go
+++ b/test/fix_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 
 	"github.com/golangci/golangci-lint/pkg/exitcodes"
 	"github.com/golangci/golangci-lint/test/testshared"
@@ -56,15 +55,12 @@ func TestFix(t *testing.T) {
 
 			args = append(args, rc.args...)
 
-			cfg, err := yaml.Marshal(rc.config)
-			require.NoError(t, err)
-
 			var runResult *testshared.RunResult
 			if rc.configPath != "" {
 				args = append(args, "-c", rc.configPath)
 				runResult = testshared.NewLintRunner(t).RunCommand("run", args...)
 			} else {
-				runResult = testshared.NewLintRunner(t).RunWithYamlConfig(string(cfg), args...)
+				runResult = testshared.NewLintRunner(t).RunWithYamlConfig("", args...)
 			}
 
 			// nolintlint test uses non existing linters (bob, alice)

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -82,7 +82,7 @@ func TestGoimportsLocal(t *testing.T) {
 
 	args = append(args, rc.args...)
 
-	cfg, err := yaml.Marshal(rc.config)
+	cfg, err := os.ReadFile(rc.configPath)
 	require.NoError(t, err)
 
 	testshared.NewLintRunner(t).RunWithYamlConfig(string(cfg), args...).

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -14,7 +14,6 @@ import (
 
 	hcversion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 
 	"github.com/golangci/golangci-lint/pkg/exitcodes"
 	"github.com/golangci/golangci-lint/test/testshared"
@@ -175,25 +174,6 @@ func TestFileOutput(t *testing.T) {
 	require.Contains(t, string(b), `"Issues":[`)
 }
 
-func saveConfig(t *testing.T, cfg map[string]interface{}) (cfgPath string, finishFunc func()) {
-	f, err := os.CreateTemp("", "golangci_lint_test")
-	require.NoError(t, err)
-
-	cfgPath = f.Name() + ".yml"
-	err = os.Rename(f.Name(), cfgPath)
-	require.NoError(t, err)
-
-	err = yaml.NewEncoder(f).Encode(cfg)
-	require.NoError(t, err)
-
-	return cfgPath, func() {
-		require.NoError(t, f.Close())
-		if os.Getenv("GL_KEEP_TEMP_FILES") != "1" {
-			require.NoError(t, os.Remove(cfgPath))
-		}
-	}
-}
-
 func testOneSource(t *testing.T, sourcePath string) {
 	args := []string{
 		"run",
@@ -210,25 +190,16 @@ func testOneSource(t *testing.T, sourcePath string) {
 		t.Skipf("Skipped: %s", sourcePath)
 	}
 
-	var cfgPath string
-	if rc.config != nil {
-		p, finish := saveConfig(t, rc.config)
-		defer finish()
-		cfgPath = p
-	} else if rc.configPath != "" {
-		cfgPath = rc.configPath
-	}
-
 	for _, addArg := range []string{"", "-Etypecheck"} {
 		caseArgs := append([]string{}, args...)
 		caseArgs = append(caseArgs, rc.args...)
 		if addArg != "" {
 			caseArgs = append(caseArgs, addArg)
 		}
-		if cfgPath == "" {
+		if rc.configPath == "" {
 			caseArgs = append(caseArgs, "--no-config")
 		} else {
-			caseArgs = append(caseArgs, "-c", cfgPath)
+			caseArgs = append(caseArgs, "-c", rc.configPath)
 		}
 
 		caseArgs = append(caseArgs, sourcePath)
@@ -241,32 +212,8 @@ func testOneSource(t *testing.T, sourcePath string) {
 
 type runContext struct {
 	args           []string
-	config         map[string]interface{}
 	configPath     string
 	expectedLinter string
-}
-
-func buildConfigFromShortRepr(t *testing.T, repr string, config map[string]interface{}) {
-	kv := strings.Split(repr, "=")
-	require.Len(t, kv, 2, "repr: %s", repr)
-
-	keyParts := strings.Split(kv[0], ".")
-	require.True(t, len(keyParts) >= 2, len(keyParts))
-
-	lastObj := config
-	for _, k := range keyParts[:len(keyParts)-1] {
-		var v map[string]interface{}
-		if lastObj[k] == nil {
-			v = map[string]interface{}{}
-		} else {
-			v = lastObj[k].(map[string]interface{})
-		}
-
-		lastObj[k] = v
-		lastObj = v
-	}
-
-	lastObj[keyParts[len(keyParts)-1]] = kv[1]
 }
 
 func skipMultilineComment(scanner *bufio.Scanner) {
@@ -275,7 +222,7 @@ func skipMultilineComment(scanner *bufio.Scanner) {
 	}
 }
 
-//nolint:gocyclo,funlen
+//nolint:gocyclo
 func extractRunContextFromComments(t *testing.T, sourcePath string) *runContext {
 	f, err := os.Open(sourcePath)
 	require.NoError(t, err)
@@ -322,14 +269,6 @@ func extractRunContextFromComments(t *testing.T, sourcePath string) *runContext 
 			require.Nil(t, rc.args)
 			require.NotEmpty(t, after)
 			rc.args = strings.Split(after, " ")
-			continue
-
-		case "//golangcitest:config":
-			require.NotEmpty(t, after)
-			if rc.config == nil {
-				rc.config = map[string]interface{}{}
-			}
-			buildConfigFromShortRepr(t, after, rc.config)
 			continue
 
 		case "//golangcitest:config_path":
@@ -394,10 +333,7 @@ func TestTparallel(t *testing.T) {
 
 		args = append(args, rc.args...)
 
-		cfg, err := yaml.Marshal(rc.config)
-		require.NoError(t, err)
-
-		testshared.NewLintRunner(t).RunWithYamlConfig(string(cfg), args...).
+		testshared.NewLintRunner(t).RunWithYamlConfig("", args...).
 			ExpectHasIssue(
 				"testdata/tparallel/missing_toplevel_test.go:7:6: TestTopLevel should call t.Parallel on the top level as well as its subtests\n",
 			)
@@ -416,10 +352,7 @@ func TestTparallel(t *testing.T) {
 
 		args = append(args, rc.args...)
 
-		cfg, err := yaml.Marshal(rc.config)
-		require.NoError(t, err)
-
-		testshared.NewLintRunner(t).RunWithYamlConfig(string(cfg), args...).
+		testshared.NewLintRunner(t).RunWithYamlConfig("", args...).
 			ExpectHasIssue(
 				"testdata/tparallel/missing_subtest_test.go:7:6: TestSubtests's subtests should call t.Parallel\n",
 			)
@@ -438,9 +371,6 @@ func TestTparallel(t *testing.T) {
 
 		args = append(args, rc.args...)
 
-		cfg, err := yaml.Marshal(rc.config)
-		require.NoError(t, err)
-
-		testshared.NewLintRunner(t).RunWithYamlConfig(string(cfg), args...).ExpectNoIssues()
+		testshared.NewLintRunner(t).RunWithYamlConfig("", args...).ExpectNoIssues()
 	})
 }

--- a/test/testdata/configs/cyclop.yml
+++ b/test/testdata/configs/cyclop.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  cyclop:
+    max-complexity: 15

--- a/test/testdata/configs/dupl.yml
+++ b/test/testdata/configs/dupl.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  dupl:
+    threshold: 20

--- a/test/testdata/configs/errcheck_exclude.yml
+++ b/test/testdata/configs/errcheck_exclude.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  errcheck:
+    check-blank: true
+    exclude: testdata/errcheck/exclude.txt

--- a/test/testdata/configs/errcheck_ignore_default.yml
+++ b/test/testdata/configs/errcheck_ignore_default.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  errcheck:
+    check-blank: true

--- a/test/testdata/configs/errcheck_type_assertions.yml
+++ b/test/testdata/configs/errcheck_type_assertions.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  errcheck:
+    check-type-assertions: true

--- a/test/testdata/configs/forbidigo_include_godoc_examples.yml
+++ b/test/testdata/configs/forbidigo_include_godoc_examples.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  forbidigo:
+   exclude-godoc-examples: false
+

--- a/test/testdata/configs/funlen.yml
+++ b/test/testdata/configs/funlen.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  funlen:
+    lines: 20
+    statements: 10

--- a/test/testdata/configs/gocognit.yml
+++ b/test/testdata/configs/gocognit.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  gocognit:
+    min-complexity: 2

--- a/test/testdata/configs/goconst_calls_enabled.yml
+++ b/test/testdata/configs/goconst_calls_enabled.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  goconst:
+    ignore-calls: false

--- a/test/testdata/configs/goconst_dont_ignore.yml
+++ b/test/testdata/configs/goconst_dont_ignore.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  goconst:
+    ignore-tests: false

--- a/test/testdata/configs/goconst_ignore.yml
+++ b/test/testdata/configs/goconst_ignore.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  goconst:
+    ignore-tests: true

--- a/test/testdata/configs/gocyclo.yml
+++ b/test/testdata/configs/gocyclo.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 20

--- a/test/testdata/configs/godox.yml
+++ b/test/testdata/configs/godox.yml
@@ -1,0 +1,5 @@
+linters-settings:
+  godox:
+    keywords:
+      - FIXME
+      - TODO

--- a/test/testdata/configs/gofmt_no_simplify.yml
+++ b/test/testdata/configs/gofmt_no_simplify.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  gofmt:
+    simplify: false

--- a/test/testdata/configs/gofumpt-fix.yml
+++ b/test/testdata/configs/gofumpt-fix.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  gofumpt:
+    extra-rules: true

--- a/test/testdata/configs/gofumpt_with_extra.yml
+++ b/test/testdata/configs/gofumpt_with_extra.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  gofumpt:
+    extra-rules: true

--- a/test/testdata/configs/goimports.yml
+++ b/test/testdata/configs/goimports.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint

--- a/test/testdata/configs/govet.yml
+++ b/test/testdata/configs/govet.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  govet:
+    check-shadowing: true

--- a/test/testdata/configs/govet_fieldalignment.yml
+++ b/test/testdata/configs/govet_fieldalignment.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  govet:
+    enable: fieldalignment

--- a/test/testdata/configs/govet_ifaceassert.yml
+++ b/test/testdata/configs/govet_ifaceassert.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  govet:
+    enable: ifaceassert

--- a/test/testdata/configs/lll.yml
+++ b/test/testdata/configs/lll.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  lll:
+    tab-width: 4

--- a/test/testdata/configs/makezero_always.yml
+++ b/test/testdata/configs/makezero_always.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  makezero:
+    always: true

--- a/test/testdata/configs/nestif.yml
+++ b/test/testdata/configs/nestif.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  nestif:
+    min-complexity: 1

--- a/test/testdata/configs/nolintlint.yml
+++ b/test/testdata/configs/nolintlint.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  nolintlint:
+    require-explanation: true
+    require-specific: true

--- a/test/testdata/configs/nolintlint_unused.yml
+++ b/test/testdata/configs/nolintlint_unused.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  nolintlint:
+    allow-unused: false

--- a/test/testdata/configs/whitespace-fix.yml
+++ b/test/testdata/configs/whitespace-fix.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  whitespace:
+    multi-if: true
+    multi-func: true

--- a/test/testdata/configs/wsl.yml
+++ b/test/testdata/configs/wsl.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  wsl:
+    tests: 1

--- a/test/testdata/configs/wsl.yml
+++ b/test/testdata/configs/wsl.yml
@@ -1,3 +1,3 @@
 linters-settings:
   wsl:
-    tests: 1
+    allow-cuddle-declarations: false

--- a/test/testdata/cyclop.go
+++ b/test/testdata/cyclop.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Ecyclop
-//golangcitest:config linters-settings.cyclop.max-complexity=15
+//golangcitest:config_path testdata/configs/cyclop.yml
 package testdata
 
 func cyclopComplexFunc(s string) { // ERROR "calculated cyclomatic complexity for function cyclopComplexFunc is 22, max is 15"

--- a/test/testdata/dupl.go
+++ b/test/testdata/dupl.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Edupl
-//golangcitest:config linters-settings.dupl.threshold=20
+//golangcitest:config_path testdata/configs/dupl.yml
 package testdata
 
 type DuplLogger struct{}

--- a/test/testdata/errcheck_exclude.go
+++ b/test/testdata/errcheck_exclude.go
@@ -1,6 +1,5 @@
 //golangcitest:args -Eerrcheck
-//golangcitest:config linters-settings.errcheck.check-blank=true
-//golangcitest:config linters-settings.errcheck.exclude=testdata/errcheck/exclude.txt
+//golangcitest:config_path testdata/configs/errcheck_exclude.yml
 package testdata
 
 import (

--- a/test/testdata/errcheck_ignore_default.go
+++ b/test/testdata/errcheck_ignore_default.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Eerrcheck
-//golangcitest:config linters-settings.errcheck.check-blank=true
+//golangcitest:config_path testdata/configs/errcheck_ignore_default.yml
 package testdata
 
 import (

--- a/test/testdata/errcheck_type_assertions.go
+++ b/test/testdata/errcheck_type_assertions.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Eerrcheck
-//golangcitest:config linters-settings.errcheck.check-type-assertions=true
+//golangcitest:config_path testdata/configs/errcheck_type_assertions.yml
 package testdata
 
 func ErrorTypeAssertion(filter map[string]interface{}) bool {

--- a/test/testdata/fix/in/gofumpt.go
+++ b/test/testdata/fix/in/gofumpt.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofumpt
-//golangcitest:config linters-settings.gofumpt.extra-rules=true
+//golangcitest:config_path testdata/configs/gofumpt-fix.yml
 package p
 
 import "fmt"

--- a/test/testdata/fix/in/whitespace.go
+++ b/test/testdata/fix/in/whitespace.go
@@ -1,6 +1,5 @@
 //golangcitest:args -Ewhitespace
-//golangcitest:config linters-settings.whitespace.multi-if=true
-//golangcitest:config linters-settings.whitespace.multi-func=true
+//golangcitest:config_path testdata/configs/whitespace-fix.yml
 package p
 
 import "fmt"

--- a/test/testdata/fix/out/gofumpt.go
+++ b/test/testdata/fix/out/gofumpt.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofumpt
-//golangcitest:config linters-settings.gofumpt.extra-rules=true
+//golangcitest:config_path testdata/configs/gofumpt-fix.yml
 package p
 
 import "fmt"

--- a/test/testdata/fix/out/whitespace.go
+++ b/test/testdata/fix/out/whitespace.go
@@ -1,6 +1,5 @@
 //golangcitest:args -Ewhitespace
-//golangcitest:config linters-settings.whitespace.multi-if=true
-//golangcitest:config linters-settings.whitespace.multi-func=true
+//golangcitest:config_path testdata/configs/whitespace-fix.yml
 package p
 
 import "fmt"

--- a/test/testdata/forbidigo_include_godoc_examples_test.go
+++ b/test/testdata/forbidigo_include_godoc_examples_test.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Eforbidigo
-//golangcitest:config linters-settings.forbidigo.exclude-godoc-examples=false
+//golangcitest:config_path testdata/configs/forbidigo_include_godoc_examples.yml
 package testdata
 
 import "fmt"

--- a/test/testdata/funlen.go
+++ b/test/testdata/funlen.go
@@ -1,6 +1,5 @@
 //golangcitest:args -Efunlen
-//golangcitest:config linters-settings.funlen.lines=20
-//golangcitest:config linters-settings.funlen.statements=10
+//golangcitest:config_path testdata/configs/funlen.yml
 package testdata
 
 func TooManyLines() { // ERROR `Function 'TooManyLines' is too long \(22 > 20\)`

--- a/test/testdata/gocognit.go
+++ b/test/testdata/gocognit.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egocognit
-//golangcitest:config linters-settings.gocognit.min-complexity=2
+//golangcitest:config_path testdata/configs/gocognit.yml
 package testdata
 
 func GoCognit_CC4_GetWords(number int) string { // ERROR "cognitive complexity 4 of func .* is high .*"

--- a/test/testdata/goconst_calls_enabled.go
+++ b/test/testdata/goconst_calls_enabled.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egoconst
-//golangcitest:config linters-settings.goconst.ignore-calls=false
+//golangcitest:config_path testdata/configs/goconst_calls_enabled.yml
 package testdata
 
 import "fmt"

--- a/test/testdata/goconst_dont_ignore_test.go
+++ b/test/testdata/goconst_dont_ignore_test.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egoconst
-//golangcitest:config linters-settings.goconst.ignore-tests=false
+//golangcitest:config_path testdata/configs/goconst_dont_ignore.yml
 package testdata
 
 import (

--- a/test/testdata/goconst_ignore_test.go
+++ b/test/testdata/goconst_ignore_test.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egoconst
-//golangcitest:config linters-settings.goconst.ignore-tests=true
+//golangcitest:config_path testdata/configs/goconst_ignore.yml
 package testdata
 
 import (

--- a/test/testdata/gocyclo.go
+++ b/test/testdata/gocyclo.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egocyclo
-//golangcitest:config linters-settings.gocyclo.min-complexity=20
+//golangcitest:config_path testdata/configs/gocyclo.yml
 package testdata
 
 import "net/http"

--- a/test/testdata/godox.go
+++ b/test/testdata/godox.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egodox
-//golangcitest:config linters-settings.godox.keywords=FIXME,TODO
+//golangcitest:config_path testdata/configs/godox.yml
 package testdata
 
 func todoLeftInCode() {

--- a/test/testdata/gofmt_no_simplify.go
+++ b/test/testdata/gofmt_no_simplify.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofmt
-//golangcitest:config linters-settings.gofmt.simplify=false
+//golangcitest:config_path testdata/configs/gofmt_no_simplify.yml
 package testdata
 
 import "fmt"

--- a/test/testdata/gofumpt_with_extra.go
+++ b/test/testdata/gofumpt_with_extra.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofumpt
-//golangcitest:config linters-settings.gofumpt.extra-rules=true
+//golangcitest:config_path testdata/configs/gofumpt_with_extra.yml
 package testdata
 
 import "fmt"

--- a/test/testdata/goimports/goimports.go
+++ b/test/testdata/goimports/goimports.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egoimports
-//golangcitest:config linters-settings.goimports.local-prefixes=github.com/golangci/golangci-lint
+//golangcitest:config_path testdata/configs/goimports.yml
 package goimports
 
 import (

--- a/test/testdata/govet.go
+++ b/test/testdata/govet.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egovet
-//golangcitest:config linters-settings.govet.check-shadowing=true
+//golangcitest:config_path testdata/configs/govet.yml
 package testdata
 
 import (

--- a/test/testdata/govet_fieldalignment.go
+++ b/test/testdata/govet_fieldalignment.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egovet
-//golangcitest:config linters-settings.govet.enable=fieldalignment
+//golangcitest:config_path testdata/configs/govet_fieldalignment.yml
 package testdata
 
 type gvfaGood struct {

--- a/test/testdata/govet_ifaceassert.go
+++ b/test/testdata/govet_ifaceassert.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egovet
-//golangcitest:config linters-settings.govet.enable=ifaceassert
+//golangcitest:config_path testdata/configs/govet_ifaceassert.yml
 package testdata
 
 import (

--- a/test/testdata/lll.go
+++ b/test/testdata/lll.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Elll
-//golangcitest:config linters-settings.lll.tab-width=4
+//golangcitest:config_path testdata/configs/lll.yml
 package testdata
 
 func Lll() {

--- a/test/testdata/makezero_always.go
+++ b/test/testdata/makezero_always.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Emakezero
-//golangcitest:config linters-settings.makezero.always=true
+//golangcitest:config_path testdata/configs/makezero_always.yml
 package testdata
 
 import "math"

--- a/test/testdata/nestif.go
+++ b/test/testdata/nestif.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Enestif
-//golangcitest:config linters-settings.nestif.min-complexity=1
+//golangcitest:config_path testdata/configs/nestif.yml
 package testdata
 
 func _() {

--- a/test/testdata/nolintlint.go
+++ b/test/testdata/nolintlint.go
@@ -1,7 +1,6 @@
 //golangcitest:args -Enolintlint -Emisspell
 //golangcitest:expected_linter nolintlint
-//golangcitest:config linters-settings.nolintlint.require-explanation=true
-//golangcitest:config linters-settings.nolintlint.require-specific=true
+//golangcitest:config_path testdata/configs/nolintlint.yml
 package testdata
 
 import "fmt"

--- a/test/testdata/nolintlint_unused.go
+++ b/test/testdata/nolintlint_unused.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Enolintlint -Evarcheck
-//golangcitest:config linters-settings.nolintlint.allow-unused=false
 //golangcitest:expected_linter nolintlint
+//golangcitest:config_path testdata/configs/nolintlint_unused.yml
 package testdata
 
 import "fmt"

--- a/test/testdata/wsl.go
+++ b/test/testdata/wsl.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Ewsl
-//golangcitest:config linters-settings.wsl.tests=1
+//golangcitest:config_path testdata/configs/wsl.yml
 package testdata
 
 import (

--- a/test/testshared/testshared.go
+++ b/test/testshared/testshared.go
@@ -153,8 +153,7 @@ func (r *LintRunner) RunCommandWithYamlConfig(cfg, command string, args ...strin
 		defer os.Remove(cfgPath)
 	}
 
-	cfg = strings.TrimSpace(cfg)
-	cfg = strings.ReplaceAll(cfg, "\t", " ")
+	cfg = strings.ReplaceAll(strings.TrimSpace(cfg), "\t", " ")
 
 	err = os.WriteFile(cfgPath, []byte(cfg), os.ModePerm)
 	assert.NoError(r.t, err)


### PR DESCRIPTION
Replacement of the directive `golangcitest:config` by `golangcitest:config_path`.

`golangcitest:config_path` already existed but we had a mix between the 2 directives.

The objective is to simplify maintenance and the contribution by having an identical approach for all tests.

This also simplifies the maintenance of test files which are corrected automatically by the IDEs as soon as the file is edited when you have to update the configuration.