### PR TITLE
dev: improve runner to run dir with go.mod

### DIFF
--- a/test/testshared/analysis.go
+++ b/test/testshared/analysis.go
@@ -6,7 +6,6 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -20,8 +19,6 @@ import (
 )
 
 const keyword = "want"
-
-const testdataDir = "testdata"
 
 type jsonResult struct {
 	Issues []*result.Issue
@@ -52,9 +49,6 @@ func Analyze(t *testing.T, sourcePath string, rawData []byte) {
 	require.NoError(t, err)
 
 	for _, issue := range reportData.Issues {
-		if !strings.HasPrefix(issue.Pos.Filename, testdataDir) {
-			issue.Pos.Filename = filepath.Join(testdataDir, issue.Pos.Filename)
-		}
 		checkMessage(t, want, issue.Pos, "diagnostic", issue.FromLinter, issue.Text)
 	}
 


### PR DESCRIPTION
Related to #3093 and https://github.com/golangci/golangci-lint/discussions/2969

Currently, we don't have any linter that required this approach, so I cannot add a test.

The test will look like that:

```go
func TestSourcesFromTestdataSubDir(t *testing.T) {
	subDirs := []string{
		"logrlint",
		"ginkgolinter",
	}

	for _, dir := range subDirs {
		t.Run(dir, func(t *testing.T) {
			testSourcesFromDir(t, filepath.Join(testdataDir, dir))
		})
	}
}
```