### PR TITLE
dev: fix: linter tests

### DIFF
--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -61,7 +61,7 @@ func testSourcesFromDir(t *testing.T, dir string) {
 		t.Run(filepath.Base(source), func(subTest *testing.T) {
 			subTest.Parallel()
 
-			rel, err := filepath.Rel(dir, sources[0])
+			rel, err := filepath.Rel(dir, source)
 			require.NoError(t, err)
 
 			testOneSource(subTest, log, binPath, rel)

--- a/test/testshared/runner.go
+++ b/test/testshared/runner.go
@@ -104,7 +104,17 @@ func (b *RunnerBuilder) WithRunContext(rc *RunContext) *RunnerBuilder {
 		return b
 	}
 
-	return b.WithConfigFile(rc.ConfigPath).WithArgs(rc.Args...)
+	dir, err := os.Getwd()
+	require.NoError(b.tb, err)
+
+	configPath := filepath.FromSlash(rc.ConfigPath)
+
+	base := filepath.Base(dir)
+	if strings.HasPrefix(configPath, base) {
+		configPath = strings.TrimPrefix(configPath, base+string(filepath.Separator))
+	}
+
+	return b.WithConfigFile(configPath).WithArgs(rc.Args...)
 }
 
 func (b *RunnerBuilder) WithDirectives(sourcePath string) *RunnerBuilder {


### PR DESCRIPTION
I made a mistake here: https://github.com/golangci/golangci-lint/pull/3124/files#diff-2d27f13815d27a52a927014f02a8d7545106cf3db781eb5de69e1f89ec689376R52

I just forget to remove my dev constraint.

only one linter test was running instead of all linter tests.