### PR TITLE
gofmt: support rewrite

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,6 @@ github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe h1:6RGUuS7EGotKx6J5HIP8ZtyMdiDscjMLfRBSPuzVVeo=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe/go.mod h1:gjqyPShc/m8pEMpk0a3SeagVb0kaqvhscv+i9jI5ZhQ=
-github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a h1:iR3fYXUjHCR97qWS8ch1y9zPNsgXThGwjKPrYfqMPks=
-github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29MYHubXix4aDDuE3RWHkPvopM/EDv/MA=

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -151,6 +151,9 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.BoolVar(&lsc.Gofmt.Simplify, "gofmt.simplify", true, "Gofmt: simplify code")
 	hideFlag("gofmt.simplify")
 
+	fs.StringVar(&lsc.Gofmt.Rewrite, "gofmt.rewrite", "", "Gofmt: rewrite code")
+	hideFlag("gofmt.rewrite")
+
 	fs.IntVar(&lsc.Gocyclo.MinComplexity, "gocyclo.min-complexity",
 		30, "Minimal complexity of function to report it")
 	hideFlag("gocyclo.min-complexity")

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -336,6 +336,7 @@ type GodoxSettings struct {
 
 type GoFmtSettings struct {
 	Simplify bool
+	Rewrite  string
 }
 
 type GofumptSettings struct {

--- a/pkg/golinters/gofmt.go
+++ b/pkg/golinters/gofmt.go
@@ -58,7 +58,7 @@ func runGofmt(lintCtx *linter.Context, pass *analysis.Pass, settings *config.GoF
 	var issues []goanalysis.Issue
 
 	for _, f := range fileNames {
-		diff, err := gofmtAPI.Run(f, settings.Simplify)
+		diff, err := gofmtAPI.RunRewrite(f, settings.Simplify, settings.Rewrite)
 		if err != nil { // TODO: skip
 			return nil, err
 		}

--- a/pkg/golinters/gofmt_common.go
+++ b/pkg/golinters/gofmt_common.go
@@ -223,6 +223,9 @@ func getErrorTextForLinter(settings *config.LintersSettings, linterName string) 
 		if settings.Gofmt.Simplify {
 			text += " with `-s`"
 		}
+		if settings.Gofmt.Rewrite != "" {
+			text += fmt.Sprintf(" `-r '%s'`", settings.Gofmt.Rewrite)
+		}
 	case goimportsName:
 		text = "File is not `goimports`-ed"
 		if settings.Goimports.LocalPrefixes != "" {


### PR DESCRIPTION
close https://github.com/golangci/golangci-lint/issues/3171

need to merge https://github.com/golangci/gofmt/pull/2 first and update gofmt in go.mod

example:

```text
$ go run .\cmd\golangci-lint\main.go run --disable-all -E=gofmt --gofmt.rewrite='interface{} -> any'
pkg\fsutils\filecache.go:59: File is not `gofmt`-ed with `-s -r "interface{} -> any"` (gofmt)
        fc.files.Range(func(_, fileBytes interface{}) bool {
internal\errorutil\errors.go:9: File is not `gofmt`-ed with `-s -r "interface{} -> any"` (gofmt)
        recovered interface{}
pkg\report\log.go:23: File is not `gofmt`-ed with `-s -r "interface{} -> any"` (gofmt)
func (lw LogWrapper) Fatalf(format string, args ...interface{}) {
exit status 1
```

golangci.yaml

```yaml
  gofmt:
    simplify: true
    rewrite: 'interface{} -> any'
```