### PR TITLE
fix: remove reference to non-working service

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -125,7 +125,7 @@ func (e *Executor) initRoot() {
 	rootCmd := &cobra.Command{
 		Use:   "golangci-lint",
 		Short: "golangci-lint is a smart linters runner.",
-		Long:  `Smart, fast linters runner. Run it in cloud for every GitHub pull request on https://golangci.com`,
+		Long:  `Smart, fast linters runner.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()


### PR DESCRIPTION
golangci.com has been shut down since April 2020, so can no longer be
used to run golangci-lint in the cloud.

See https://medium.com/golangci/golangci-com-is-closing-d1fc1bd30e0e