### PR TITLE
feat: update gofmt and goimports and add option "rewrite-rules"

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -567,6 +567,14 @@ linters-settings:
     # Simplify code: gofmt with `-s` option.
     # Default: true
     simplify: false
+    # Apply the rewrite rules to the source before reformatting.
+    # https://pkg.go.dev/cmd/gofmt
+    # Default: []
+    rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'
 
   gofumpt:
     # Select the Go version to target.

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
 	github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe
-	github.com/golangci/gofmt v0.0.0-20220901083514-bda9c14510ff
+	github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
 	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
 	github.com/golangci/misspell v0.3.5

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
 	github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe
-	github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a
+	github.com/golangci/gofmt v0.0.0-20220901083514-bda9c14510ff
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
 	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
 	github.com/golangci/misspell v0.3.5

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe h1:6RGUuS7EGotKx6J5HIP8ZtyMdiDscjMLfRBSPuzVVeo=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe/go.mod h1:gjqyPShc/m8pEMpk0a3SeagVb0kaqvhscv+i9jI5ZhQ=
-github.com/golangci/gofmt v0.0.0-20220901083514-bda9c14510ff h1:M3EIPyul/JVV3ynJJ2J3rfLJt0g3wHeHe1aHT90gAjE=
-github.com/golangci/gofmt v0.0.0-20220901083514-bda9c14510ff/go.mod h1:9wOXstvyDRshQ9LggQuzBCGysxs3b6Uo/1MvYCR2NMs=
+github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2 h1:amWTbTGqOZ71ruzrdA+Nx5WA3tV1N0goTspwmKCQvBY=
+github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2/go.mod h1:9wOXstvyDRshQ9LggQuzBCGysxs3b6Uo/1MvYCR2NMs=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29MYHubXix4aDDuE3RWHkPvopM/EDv/MA=

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe h1:6RGUuS7EGotKx6J5HIP8ZtyMdiDscjMLfRBSPuzVVeo=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe/go.mod h1:gjqyPShc/m8pEMpk0a3SeagVb0kaqvhscv+i9jI5ZhQ=
-github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a h1:iR3fYXUjHCR97qWS8ch1y9zPNsgXThGwjKPrYfqMPks=
-github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
+github.com/golangci/gofmt v0.0.0-20220901083514-bda9c14510ff h1:M3EIPyul/JVV3ynJJ2J3rfLJt0g3wHeHe1aHT90gAjE=
+github.com/golangci/gofmt v0.0.0-20220901083514-bda9c14510ff/go.mod h1:9wOXstvyDRshQ9LggQuzBCGysxs3b6Uo/1MvYCR2NMs=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29MYHubXix4aDDuE3RWHkPvopM/EDv/MA=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -337,7 +337,13 @@ type GodoxSettings struct {
 }
 
 type GoFmtSettings struct {
-	Simplify bool
+	Simplify     bool
+	RewriteRules []GoFmtRewriteRule `mapstructure:"rewrite-rules"`
+}
+
+type GoFmtRewriteRule struct {
+	Pattern     string
+	Replacement string
 }
 
 type GofumptSettings struct {

--- a/pkg/golinters/gofmt.go
+++ b/pkg/golinters/gofmt.go
@@ -55,10 +55,15 @@ func NewGofmt(settings *config.GoFmtSettings) *goanalysis.Linter {
 func runGofmt(lintCtx *linter.Context, pass *analysis.Pass, settings *config.GoFmtSettings) ([]goanalysis.Issue, error) {
 	fileNames := getFileNames(pass)
 
+	var rewriteRules []gofmtAPI.RewriteRule
+	for _, rule := range settings.RewriteRules {
+		rewriteRules = append(rewriteRules, gofmtAPI.RewriteRule(rule))
+	}
+
 	var issues []goanalysis.Issue
 
 	for _, f := range fileNames {
-		diff, err := gofmtAPI.Run(f, settings.Simplify)
+		diff, err := gofmtAPI.RunRewrite(f, settings.Simplify, rewriteRules)
 		if err != nil { // TODO: skip
 			return nil, err
 		}

--- a/pkg/golinters/gofmt_common.go
+++ b/pkg/golinters/gofmt_common.go
@@ -223,6 +223,9 @@ func getErrorTextForLinter(settings *config.LintersSettings, linterName string) 
 		if settings.Gofmt.Simplify {
 			text += " with `-s`"
 		}
+		for _, rule := range settings.Gofmt.RewriteRules {
+			text += fmt.Sprintf(" `-r '%s -> %s'`", rule.Pattern, rule.Replacement)
+		}
 	case goimportsName:
 		text = "File is not `goimports`-ed"
 		if settings.Goimports.LocalPrefixes != "" {

--- a/pkg/golinters/goimports.go
+++ b/pkg/golinters/goimports.go
@@ -34,7 +34,7 @@ func NewGoimports(settings *config.GoImportsSettings) *goanalysis.Linter {
 		imports.LocalPrefix = settings.LocalPrefixes
 
 		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
-			issues, err := runGoiImports(lintCtx, pass)
+			issues, err := runGoImports(lintCtx, pass)
 			if err != nil {
 				return nil, err
 			}
@@ -54,7 +54,7 @@ func NewGoimports(settings *config.GoImportsSettings) *goanalysis.Linter {
 	}).WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
-func runGoiImports(lintCtx *linter.Context, pass *analysis.Pass) ([]goanalysis.Issue, error) {
+func runGoImports(lintCtx *linter.Context, pass *analysis.Pass) ([]goanalysis.Issue, error) {
 	fileNames := getFileNames(pass)
 
 	var issues []goanalysis.Issue

--- a/test/testdata/configs/gofmt_rewrite_rules.yml
+++ b/test/testdata/configs/gofmt_rewrite_rules.yml
@@ -1,0 +1,5 @@
+linters-settings:
+  gofmt:
+    rewrite-rules:
+      - pattern: 'a[b:len(a)]'
+        replacement: 'a[b:]'

--- a/test/testdata/configs/gofmt_rewrite_rules.yml
+++ b/test/testdata/configs/gofmt_rewrite_rules.yml
@@ -1,5 +1,7 @@
 linters-settings:
   gofmt:
     rewrite-rules:
+      - pattern: 'interface{}'
+        replacement: 'any'
       - pattern: 'a[b:len(a)]'
         replacement: 'a[b:]'

--- a/test/testdata/fix/in/gofmt_rewrite_rules.go
+++ b/test/testdata/fix/in/gofmt_rewrite_rules.go
@@ -1,0 +1,24 @@
+//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/configs/gofmt_rewrite_rules.yml
+//golangcitest:expected_exitcode 0
+package p
+
+import "fmt"
+
+func GofmtRewriteRule() {
+	values := make([]int, 0)
+
+	values = append(values, 1)
+	values = append(values, 2)
+	values = append(values, 3)
+
+	slice := values[1:len(values)]
+
+	fmt.Println(slice)
+}
+
+func GofmtRewriteRule2() {
+	var to interface{}
+
+	fmt.Println(to)
+}

--- a/test/testdata/fix/out/gofmt_rewrite_rules.go
+++ b/test/testdata/fix/out/gofmt_rewrite_rules.go
@@ -1,0 +1,24 @@
+//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/configs/gofmt_rewrite_rules.yml
+//golangcitest:expected_exitcode 0
+package p
+
+import "fmt"
+
+func GofmtRewriteRule() {
+	values := make([]int, 0)
+
+	values = append(values, 1)
+	values = append(values, 2)
+	values = append(values, 3)
+
+	slice := values[1:]
+
+	fmt.Println(slice)
+}
+
+func GofmtRewriteRule2() {
+	var to any
+
+	fmt.Println(to)
+}

--- a/test/testdata/gofmt_rewrite_rules.go
+++ b/test/testdata/gofmt_rewrite_rules.go
@@ -1,0 +1,17 @@
+//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/configs/gofmt_rewrite_rules.yml
+package testdata
+
+import "fmt"
+
+func GofmtRewriteRule() {
+	vals := make([]int, 0)
+
+	vals = append(vals, 1)
+	vals = append(vals, 2)
+	vals = append(vals, 3)
+
+	slice := vals[1:len(vals)] // want "^File is not `gofmt`-ed"
+
+	fmt.Println(slice)
+}


### PR DESCRIPTION
Update gofmt and goimports.

Add the option `rewrite-rules`:
```yml
linters-settings:
  gofmt:
    rewrite-rules:
      - pattern: 'a[b:len(a)]'
        replacement: 'a[b:]'
```

https://github.com/golangci/gofmt/compare/244bba706f1af52a02a156282f7473162611fba1...f2edd75033f2ca22191625f8286bf50bca0d45ae

Fixes #3171