### PR TITLE
PoC: Add Severity Levels, use it to return zero exit code

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -380,7 +380,20 @@ func (e *Executor) setOutputToDevNull() (savedStdout, savedStderr *os.File) {
 }
 
 func (e *Executor) setExitCodeIfIssuesFound(issues []result.Issue) {
-	if len(issues) != 0 {
+	if len(issues) == 0 {
+		return
+	}
+
+	// Let's count how many Errors do we have overall?
+	errorsCount := 0
+	for _, i := range issues {
+		if i.Severity == config.SeverityErrorLevel {
+			errorsCount++
+		}
+	}
+
+	// Okay, we've got some errors, so we need to return some non-zero exit-code
+	if errorsCount > 0 {
 		e.exitCode = e.cfg.Run.ExitCodeIfIssuesFound
 	}
 }

--- a/pkg/config/severity.go
+++ b/pkg/config/severity.go
@@ -2,15 +2,24 @@ package config
 
 const severityRuleMinConditionsCount = 1
 
+type SeverityLevel string
+
+const (
+	SeverityDebugLevel   SeverityLevel = "debug"
+	SeverityInfoLevel    SeverityLevel = "info"
+	SeverityWarningLevel SeverityLevel = "warning"
+	SeverityErrorLevel   SeverityLevel = "error"
+)
+
 type Severity struct {
-	Default       string         `mapstructure:"default-severity"`
+	Default       SeverityLevel  `mapstructure:"default-severity"`
 	CaseSensitive bool           `mapstructure:"case-sensitive"`
 	Rules         []SeverityRule `mapstructure:"rules"`
 }
 
 type SeverityRule struct {
 	BaseRule `mapstructure:",squash"`
-	Severity string
+	Severity SeverityLevel
 }
 
 func (s *SeverityRule) Validate() error {

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -142,7 +142,7 @@ func reviveToIssue(pass *analysis.Pass, object *jsonObject) goanalysis.Issue {
 	}
 
 	return goanalysis.NewIssue(&result.Issue{
-		Severity: string(object.Severity),
+		Severity: config.SeverityLevel(object.Severity),
 		Text:     fmt.Sprintf("%s: %s", object.RuleName, object.Failure.Failure),
 		Pos: token.Position{
 			Filename: object.Position.Start.Filename,

--- a/pkg/printers/checkstyle.go
+++ b/pkg/printers/checkstyle.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-xmlfmt/xmlfmt"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
@@ -31,7 +32,7 @@ type checkstyleError struct {
 	Source   string `xml:"source,attr"`
 }
 
-const defaultCheckstyleSeverity = "error"
+const defaultCheckstyleSeverity config.SeverityLevel = config.SeverityErrorLevel
 
 type Checkstyle struct {
 	w io.Writer
@@ -69,7 +70,7 @@ func (p Checkstyle) Print(ctx context.Context, issues []result.Issue) error {
 			Line:     issue.Line(),
 			Message:  issue.Text,
 			Source:   issue.FromLinter,
-			Severity: severity,
+			Severity: string(severity),
 		}
 
 		file.Errors = append(file.Errors, newError)

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -42,7 +42,7 @@ func (p CodeClimate) Print(ctx context.Context, issues []result.Issue) error {
 		codeClimateIssue.Fingerprint = issue.Fingerprint()
 
 		if issue.Severity != "" {
-			codeClimateIssue.Severity = issue.Severity
+			codeClimateIssue.Severity = string(issue.Severity)
 		}
 
 		codeClimateIssues = append(codeClimateIssues, codeClimateIssue)

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
@@ -12,7 +13,7 @@ type github struct {
 	w io.Writer
 }
 
-const defaultGithubSeverity = "error"
+const defaultGithubSeverity config.SeverityLevel = config.SeverityErrorLevel
 
 // NewGithub output format outputs issues according to GitHub actions format:
 // https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message

--- a/pkg/printers/junitxml.go
+++ b/pkg/printers/junitxml.go
@@ -60,7 +60,7 @@ func (p JunitXML) Print(ctx context.Context, issues []result.Issue) error {
 			Name:      i.FromLinter,
 			ClassName: i.Pos.String(),
 			Failure: failureXML{
-				Type:    i.Severity,
+				Type:    string(i.Severity),
 				Message: i.Pos.String() + ": " + i.Text,
 				Content: fmt.Sprintf("%s: %s\nCategory: %s\nFile: %s\nLine: %d\nDetails: %s",
 					i.Severity, i.Text, i.FromLinter, i.Pos.Filename, i.Pos.Line, strings.Join(i.SourceLines, "\n")),

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -6,6 +6,8 @@ import (
 	"go/token"
 
 	"golang.org/x/tools/go/packages"
+
+	"github.com/golangci/golangci-lint/pkg/config"
 )
 
 type Range struct {
@@ -28,7 +30,7 @@ type Issue struct {
 	FromLinter string
 	Text       string
 
-	Severity string
+	Severity config.SeverityLevel
 
 	// Source lines of a code with the issue to show
 	SourceLines []string

--- a/pkg/result/processors/severity_rules.go
+++ b/pkg/result/processors/severity_rules.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"regexp"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
@@ -10,22 +11,27 @@ import (
 
 type severityRule struct {
 	baseRule
-	severity string
+	severity config.SeverityLevel
 }
 
 type SeverityRule struct {
 	BaseRule
-	Severity string
+	Severity config.SeverityLevel
 }
 
 type SeverityRules struct {
-	defaultSeverity string
+	defaultSeverity config.SeverityLevel
 	rules           []severityRule
 	lineCache       *fsutils.LineCache
 	log             logutils.Log
 }
 
-func NewSeverityRules(defaultSeverity string, rules []SeverityRule, lineCache *fsutils.LineCache, log logutils.Log) *SeverityRules {
+func NewSeverityRules(
+	defaultSeverity config.SeverityLevel,
+	rules []SeverityRule,
+	lineCache *fsutils.LineCache,
+	log logutils.Log,
+) *SeverityRules {
 	r := &SeverityRules{
 		lineCache:       lineCache,
 		log:             log,
@@ -89,7 +95,7 @@ type SeverityRulesCaseSensitive struct {
 	*SeverityRules
 }
 
-func NewSeverityRulesCaseSensitive(defaultSeverity string, rules []SeverityRule,
+func NewSeverityRulesCaseSensitive(defaultSeverity config.SeverityLevel, rules []SeverityRule,
 	lineCache *fsutils.LineCache, log logutils.Log) *SeverityRulesCaseSensitive {
 	r := &SeverityRules{
 		lineCache:       lineCache,

--- a/pkg/result/processors/severity_rules_test.go
+++ b/pkg/result/processors/severity_rules_test.go
@@ -88,7 +88,7 @@ func TestSeverityRulesMultiple(t *testing.T) {
 			Linter:   i.FromLinter,
 			Text:     i.Text,
 			Line:     i.Line(),
-			Severity: i.Severity,
+			Severity: string(i.Severity),
 		})
 	}
 	expectedCases := []issueTestCase{
@@ -153,7 +153,7 @@ func TestSeverityRulesOnlyDefault(t *testing.T) {
 			Linter:   i.FromLinter,
 			Text:     i.Text,
 			Line:     i.Line(),
-			Severity: i.Severity,
+			Severity: string(i.Severity),
 		})
 	}
 	expectedCases := []issueTestCase{
@@ -194,7 +194,7 @@ func TestSeverityRulesCaseSensitive(t *testing.T) {
 			Linter:   i.FromLinter,
 			Text:     i.Text,
 			Line:     i.Line(),
-			Severity: i.Severity,
+			Severity: string(i.Severity),
 		})
 	}
 	expectedCases := []issueTestCase{


### PR DESCRIPTION
Hi! 

This is my Proof-of-Concept of how it could be possible to approach problem with non-zero exit codes on issues with non-error level.

I've tested it on very simple severity config:

```yaml
severity:
  default-severity: error
  case-sensitive: true
  rules:
    - linters:
      - paralleltest
      - tparallel
      severity: warning
```  

Running with `golangci-lint run ./... && echo $?` in my project with several missing `t.Parallel()`.

I don't insist it is final or ideal, just my view on how it could be done.

What do you think, guys? 

Solves #1981 