### PR TITLE
feat: add linters onlyany, visibilityorder

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1997,6 +1997,7 @@ linters:
     - nonamedreturns
     - nosnakecase
     - nosprintfhostport
+    - onlyany
     - paralleltest
     - prealloc
     - predeclared
@@ -2022,6 +2023,7 @@ linters:
     - usestdlibvars
     - varcheck
     - varnamelen
+    - visibilityorder
     - wastedassign
     - whitespace
     - wrapcheck
@@ -2103,6 +2105,7 @@ linters:
     - nonamedreturns
     - nosnakecase
     - nosprintfhostport
+    - onlyany
     - paralleltest
     - prealloc
     - predeclared
@@ -2128,6 +2131,7 @@ linters:
     - usestdlibvars
     - varcheck
     - varnamelen
+    - visibilityorder
     - wastedassign
     - whitespace
     - wrapcheck

--- a/go.mod
+++ b/go.mod
@@ -120,6 +120,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chavacava/garif v0.0.0-20220630083739-93517212f375 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dorfire/go-analyzers v0.0.1
 	github.com/ettle/strcase v0.1.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
@@ -185,3 +186,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 )
+
+require github.com/samber/lo v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denis-tingaikin/go-header v0.4.3 h1:tEaZKAlqql6SKCY++utLmkPLd6K8IBM20Ha7UVm+mtU=
 github.com/denis-tingaikin/go-header v0.4.3/go.mod h1:0wOCWuN71D5qIgE2nz9KrKmuYBAC2Mra5RassOIQ2/c=
+github.com/dorfire/go-analyzers v0.0.1 h1:w2Pylz9NL+ptxTVDh2jflFhwMv3P8G3S/S9kvzAF8ag=
+github.com/dorfire/go-analyzers v0.0.1/go.mod h1:y0rhGvjpQ6A0S6+Cwy0rUz4wfTMkMb3W0cgG1F+z7Jg=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -460,6 +462,8 @@ github.com/ryancurrah/gomodguard v1.2.4 h1:CpMSDKan0LtNGGhPrvupAoLeObRFjND8/tU1r
 github.com/ryancurrah/gomodguard v1.2.4/go.mod h1:+Kem4VjWwvFpUJRJSwa16s1tBJe+vbv02+naTow2f6M=
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
+github.com/samber/lo v1.21.0 h1:FSby8pJQtX4KmyddTCCGhc3JvnnIVrDA+NW37rG+7G8=
+github.com/samber/lo v1.21.0/go.mod h1:2I7tgIv8Q1SG2xEIkRq0F2i2zgxVpnyPOP0d3Gj2r+A=
 github.com/sanposhiho/wastedassign/v2 v2.0.6 h1:+6/hQIHKNJAUixEj6EmOngGIisyeI+T3335lYTyxRoA=
 github.com/sanposhiho/wastedassign/v2 v2.0.6/go.mod h1:KyZ0MWTwxxBmfwn33zh3k1dmsbF2ud9pAAGfoLfjhtI=
 github.com/sashamelentyev/interfacebloat v1.1.0 h1:xdRdJp0irL086OyW1H/RTZTr1h/tMEOsumirXcOJqAw=
@@ -531,12 +535,9 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.4.11 h1:BVoBIqAf/2QdbFmSwAWnaIqDivZdOV0ZRwEm6jivLKw=
 github.com/tetafro/godot v1.4.11/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
+github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 h1:kl4KhGNsJIbDHS9/4U9yQo1UcPQM0kOMJHn29EoH/Ro=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
-github.com/timonwong/loggercheck v0.9.1 h1:7HrqjZzIWiSsAI1kO/LHqpEVHvBOOeiZ68XGQCU/WqY=
-github.com/timonwong/loggercheck v0.9.1/go.mod h1:wUqnk9yAOIKtGA39l1KLE9Iz0QiTocu/YZoOf+OzFdw=
-github.com/timonwong/loggercheck v0.9.2 h1:KrR/4yWGJcwulKPtlOyVCbgl/uckJMSMiCAzcv4OGx0=
-github.com/timonwong/loggercheck v0.9.2/go.mod h1:wUqnk9yAOIKtGA39l1KLE9Iz0QiTocu/YZoOf+OzFdw=
 github.com/timonwong/loggercheck v0.9.3 h1:ecACo9fNiHxX4/Bc02rW2+kaJIAMAes7qJ7JKxt0EZI=
 github.com/timonwong/loggercheck v0.9.3/go.mod h1:wUqnk9yAOIKtGA39l1KLE9Iz0QiTocu/YZoOf+OzFdw=
 github.com/tklauser/go-sysconf v0.3.10 h1:IJ1AZGZRWbY8T5Vfk04D9WOA5WSejdflXxP03OUqALw=

--- a/pkg/golinters/onlyany.go
+++ b/pkg/golinters/onlyany.go
@@ -1,0 +1,17 @@
+package golinters
+
+import (
+	"github.com/dorfire/go-analyzers/src/onlyany"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewOnlyAny() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		onlyany.Analyzer.Name,
+		onlyany.Analyzer.Doc,
+		[]*analysis.Analyzer{onlyany.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/visibilityorder.go
+++ b/pkg/golinters/visibilityorder.go
@@ -1,0 +1,17 @@
+package golinters
+
+import (
+	"github.com/dorfire/go-analyzers/src/visibilityorder"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewVisibilityOrder() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		visibilityorder.Analyzer.Name,
+		visibilityorder.Analyzer.Doc,
+		[]*analysis.Analyzer{visibilityorder.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -666,6 +666,11 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/stbenjam/no-sprintf-host-port"),
 
+		linter.NewConfig(golinters.NewOnlyAny()).
+			WithSince("v1.50.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/dorfire/go-analyzers"),
+
 		linter.NewConfig(golinters.NewParallelTest(parallelTestCfg)).
 			WithSince("v1.33.0").
 			WithLoadForGoAnalysis().
@@ -816,6 +821,11 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/blizzy78/varnamelen"),
+
+		linter.NewConfig(golinters.NewVisibilityOrder()).
+			WithSince("v1.50.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/dorfire/go-analyzers"),
 
 		linter.NewConfig(golinters.NewWastedAssign()).
 			WithSince("v1.38.0").

--- a/test/testdata/onlyany.go
+++ b/test/testdata/onlyany.go
@@ -1,0 +1,6 @@
+//golangcitest:args -Eonlyany
+package testdata
+
+func onlyanyTest() {
+	var a interface{}
+}

--- a/test/testdata/onlyany.go
+++ b/test/testdata/onlyany.go
@@ -1,6 +1,9 @@
 //golangcitest:args -Eonlyany
 package testdata
 
+import "fmt"
+
 func onlyanyTest() {
-	var a interface{}
+	var a interface{} // want `use any instead of an empty interface`
+	fmt.Print(a)
 }

--- a/test/testdata/visibilityorder.go
+++ b/test/testdata/visibilityorder.go
@@ -1,8 +1,8 @@
 //golangcitest:args -Evisibilityorder
 package testdata
 
-func visibilityorderTestunexported() { // ERROR
+func visibilityorderTest_UnexportedFunc() {
 }
 
-func visibilityorderTestExported() {
+func VisibilityorderTest_ExportedFunc() { // want `exported symbol VisibilityorderTest_ExportedFunc appears after unexported symbol visibilityorderTest_UnexportedFunc`
 }

--- a/test/testdata/visibilityorder.go
+++ b/test/testdata/visibilityorder.go
@@ -1,0 +1,8 @@
+//golangcitest:args -Evisibilityorder
+package testdata
+
+func visibilityorderTestunexported() { // ERROR
+}
+
+func visibilityorderTestExported() {
+}


### PR DESCRIPTION
onlyany: verifies only `any` is used (instead of `interface{}`).

visibilityorder: verifies exported symbols appear first.