### PR TITLE
exhaustive: add missing config

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -293,6 +293,11 @@ linters-settings:
     comparison: false
 
   exhaustive:
+    # Program elements to check for exhaustiveness.
+    # Default: [ switch ]
+    check:
+      - switch
+      - map
     # Check switch statements in generated files also.
     # Default: false
     check-generated: true
@@ -307,10 +312,10 @@ linters-settings:
     # Consider enums only in package scopes, not in inner scopes.
     # Default: false
     package-scope-only: true
-    # only run exhaustive check on switches with "//exhaustive:enforce" comment
+    # Only run exhaustive check on switches with "//exhaustive:enforce" comment.
     # Default: false
     explicit-exhaustive-switch: true
-    # only run exhaustive check on map literals with "//exhaustive:enforce" comment.
+    # Only run exhaustive check on map literals with "//exhaustive:enforce" comment.
     # Default: false
     explicit-exhaustive-map: true
 

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -25,10 +25,13 @@ var defaultLintersSettings = LintersSettings{
 		Comparison: true,
 	},
 	Exhaustive: ExhaustiveSettings{
+		Check:                      []string{"switch"},
 		CheckGenerated:             false,
 		DefaultSignifiesExhaustive: false,
 		IgnoreEnumMembers:          "",
 		PackageScopeOnly:           false,
+		ExplicitExhaustiveMap:      false,
+		ExplicitExhaustiveSwitch:   false,
 	},
 	Forbidigo: ForbidigoSettings{
 		ExcludeGodocExamples: true,
@@ -274,12 +277,13 @@ type ErrorLintSettings struct {
 }
 
 type ExhaustiveSettings struct {
-	CheckGenerated             bool   `mapstructure:"check-generated"`
-	DefaultSignifiesExhaustive bool   `mapstructure:"default-signifies-exhaustive"`
-	IgnoreEnumMembers          string `mapstructure:"ignore-enum-members"`
-	PackageScopeOnly           bool   `mapstructure:"package-scope-only"`
-	ExplicitExhaustiveMap      bool   `mapstructure:"explicit-exhaustive-map"`
-	ExplicitExhaustiveSwitch   bool   `mapstructure:"explicit-exhaustive-switch"`
+	Check                      []string `mapstructure:"check"`
+	CheckGenerated             bool     `mapstructure:"check-generated"`
+	DefaultSignifiesExhaustive bool     `mapstructure:"default-signifies-exhaustive"`
+	IgnoreEnumMembers          string   `mapstructure:"ignore-enum-members"`
+	PackageScopeOnly           bool     `mapstructure:"package-scope-only"`
+	ExplicitExhaustiveMap      bool     `mapstructure:"explicit-exhaustive-map"`
+	ExplicitExhaustiveSwitch   bool     `mapstructure:"explicit-exhaustive-switch"`
 }
 
 type ExhaustiveStructSettings struct {

--- a/pkg/golinters/exhaustive.go
+++ b/pkg/golinters/exhaustive.go
@@ -15,11 +15,13 @@ func NewExhaustive(settings *config.ExhaustiveSettings) *goanalysis.Linter {
 	if settings != nil {
 		cfg = map[string]map[string]interface{}{
 			a.Name: {
+				exhaustive.CheckFlag:                      settings.Check,
 				exhaustive.CheckGeneratedFlag:             settings.CheckGenerated,
 				exhaustive.DefaultSignifiesExhaustiveFlag: settings.DefaultSignifiesExhaustive,
-				exhaustive.ExplicitExhaustiveMapFlag:      settings.ExplicitExhaustiveMap,
-				exhaustive.ExplicitExhaustiveSwitchFlag:   settings.PackageScopeOnly,
 				exhaustive.IgnoreEnumMembersFlag:          settings.IgnoreEnumMembers,
+				exhaustive.PackageScopeOnlyFlag:           settings.PackageScopeOnly,
+				exhaustive.ExplicitExhaustiveMapFlag:      settings.ExplicitExhaustiveMap,
+				exhaustive.ExplicitExhaustiveSwitchFlag:   settings.ExplicitExhaustiveSwitch,
 			},
 		}
 	}


### PR DESCRIPTION
Several issues were introduced in #3207 to `exhaustive` linter.
This PR fixes them:
- Add missing `check` config
- Pass `package-scope-only` config to linter
- Use `explicit-exhaustive-switch` config correctly