### PR TITLE
docs: specify what code checks are related to staticcheck sub-linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -735,7 +735,7 @@ linters-settings:
     # Default: 1.13
     # Deprecated: use the global `run.go` instead.
     go: "1.15"
-    # https://staticcheck.io/docs/configuration/options/#checks
+    # Sxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
     checks: [ "all" ]
 
@@ -1630,7 +1630,7 @@ linters-settings:
     # Default: "1.13"
     # Deprecated: use the global `run.go` instead.
     go: "1.15"
-    # https://staticcheck.io/docs/configuration/options/#checks
+    # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
     checks: [ "all" ]
 
@@ -1639,7 +1639,7 @@ linters-settings:
     # Default: 1.13
     # Deprecated: use the global `run.go` instead.
     go: "1.15"
-    # https://staticcheck.io/docs/configuration/options/#checks
+    # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
     # Default: ["*"]
     checks: [ "all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022" ]
     # https://staticcheck.io/docs/configuration/options/#dot_import_whitelist


### PR DESCRIPTION
## Summary

PR extracts the info in the description of #2017 into the reference YAML config file. I didn't create an issue first because this PR is simple, and it's just moving existing info written by a maintainer.

## Why

I was migrating from `staticcheck` to `golangci-lint`, so I naturally tried to configure the `checks` of the `staticcheck` linter, and it took me some time to find #2017 to understand why it didn't work. This PR can be helpful for this kind of cases.