### PR TITLE
feat: add linter todolint

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2047,6 +2047,7 @@ linters:
     - testableexamples
     - testpackage
     - thelper
+    - logrlint
     - tparallel
     - typecheck
     - unconvert
@@ -2154,6 +2155,7 @@ linters:
     - testableexamples
     - testpackage
     - thelper
+    - logrlint
     - tparallel
     - typecheck
     - unconvert

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1738,6 +1738,14 @@ linters-settings:
       # Default: true
       begin: false
 
+  todolint:
+    # List of case-insensitive "TODO" keywords to check for.
+    # Default: ["TODO", "FIXME"]
+    keywords:
+      - TODO
+      - FIXME
+      - XXX
+
   usestdlibvars:
     # Suggest the use of http.MethodXX
     # Default: true

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/tetafro/godot v1.4.11
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144
 	github.com/timonwong/loggercheck v0.9.3
+	github.com/timonwong/todolint v0.2.0
 	github.com/tomarrell/wrapcheck/v2 v2.6.2
 	github.com/tommy-muehle/go-mnd/v2 v2.5.0
 	github.com/ultraware/funlen v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -536,6 +536,8 @@ github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 h1:kl4KhGNsJIbDH
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/timonwong/loggercheck v0.9.3 h1:ecACo9fNiHxX4/Bc02rW2+kaJIAMAes7qJ7JKxt0EZI=
 github.com/timonwong/loggercheck v0.9.3/go.mod h1:wUqnk9yAOIKtGA39l1KLE9Iz0QiTocu/YZoOf+OzFdw=
+github.com/timonwong/todolint v0.2.0 h1:10HYsqzp0gJxvsQWpibMOTOomuGZqVhb+uqC7fZn2P0=
+github.com/timonwong/todolint v0.2.0/go.mod h1:8OOdPuRD4zy7QPlXopJACcibxVGrAnpNj93Ml375TpY=
 github.com/tklauser/go-sysconf v0.3.10 h1:IJ1AZGZRWbY8T5Vfk04D9WOA5WSejdflXxP03OUqALw=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
 github.com/tklauser/numcpus v0.4.0 h1:E53Dm1HjH1/R2/aoCtXtPgzmElmn51aOkhCFSuZq//o=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -198,6 +198,7 @@ type LintersSettings struct {
 	Tenv             TenvSettings
 	Testpackage      TestpackageSettings
 	Thelper          ThelperSettings
+	TODOLint         TODOLintSettings
 	Unparam          UnparamSettings
 	Unused           StaticCheckSettings
 	UseStdlibVars    UseStdlibVarsSettings
@@ -649,6 +650,10 @@ type ThelperOptions struct {
 
 type TenvSettings struct {
 	All bool `mapstructure:"all"`
+}
+
+type TODOLintSettings struct {
+	Keywords []string `mapstructure:"keywords"`
 }
 
 type UseStdlibVarsSettings struct {

--- a/pkg/golinters/todolint.go
+++ b/pkg/golinters/todolint.go
@@ -1,0 +1,33 @@
+package golinters
+
+import (
+	"strings"
+
+	"github.com/timonwong/todolint"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewTODOLint(settings *config.TODOLintSettings) *goanalysis.Linter {
+	analyzer := todolint.NewAnalyzer()
+
+	cfgMap := map[string]map[string]interface{}{}
+	if settings != nil {
+		keywords := strings.Join(settings.Keywords, ",")
+		cfg := map[string]interface{}{}
+		if keywords != "" {
+			cfg["keywords"] = keywords
+		}
+
+		cfgMap[analyzer.Name] = cfg
+	}
+
+	return goanalysis.NewLinter(
+		analyzer.Name,
+		analyzer.Doc,
+		[]*analysis.Analyzer{analyzer},
+		cfgMap,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -166,6 +166,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		tenvCfg             *config.TenvSettings
 		testpackageCfg      *config.TestpackageSettings
 		thelperCfg          *config.ThelperSettings
+		todoLintCfg         *config.TODOLintSettings
 		unparamCfg          *config.UnparamSettings
 		unusedCfg           *config.StaticCheckSettings
 		usestdlibvars       *config.UseStdlibVarsSettings
@@ -242,6 +243,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		tenvCfg = &m.cfg.LintersSettings.Tenv
 		testpackageCfg = &m.cfg.LintersSettings.Testpackage
 		thelperCfg = &m.cfg.LintersSettings.Thelper
+		todoLintCfg = &m.cfg.LintersSettings.TODOLint
 		unparamCfg = &m.cfg.LintersSettings.Unparam
 		unusedCfg = &m.cfg.LintersSettings.Unused
 		varcheckCfg = &m.cfg.LintersSettings.Varcheck
@@ -773,6 +775,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kulti/thelper"),
+
+		linter.NewConfig(golinters.NewTODOLint(todoLintCfg)).
+			WithSince("v1.50.0").
+			WithPresets(linter.PresetStyle, linter.PresetComment).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/timonwong/todolint"),
 
 		linter.NewConfig(golinters.NewTparallel()).
 			WithSince("v1.32.0").

--- a/test/testdata/configs/todolint.yml
+++ b/test/testdata/configs/todolint.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  todolint:
+    keywords:
+      - XXX

--- a/test/testdata/todolint.go
+++ b/test/testdata/todolint.go
@@ -1,0 +1,35 @@
+//golangcitest:args -Etodolint
+package testdata
+
+import "fmt"
+
+// TODO: This is not ok // want `TODO comment should be in the form TODO\(author\)`
+func todoLintNotOkFunc() {
+}
+
+// TODO(author1): This is ok
+func todoLintOkFunc() {
+}
+
+type todoLintStruct struct {
+	A int    // @FIXME: This field comment is not ok // want `TODO comment should be in the form FIXME\(author\)`
+	B string // FIXME(author2): This field comment is ok
+}
+
+func todoLintExample() {
+	// TODO(timonwong): This is ok
+	//
+
+	// 🚀🚀🚀 FixMe: 你好世界 // want `TODO comment should be in the form FIXME\(author\)`
+	fmt.Println("Hello")
+
+	fmt.Println("你好，世界") // fixme: more languages // want `TODO comment should be in the form FIXME\(author\)`
+
+	/* TODO: old C-style comment is also supported // want `TODO comment should be in the form TODO\(author\)`
+	 */
+
+	/*
+	 * TODO(timonwong) This is OK
+	 *
+	 */
+}

--- a/test/testdata/todolint_with_options.go
+++ b/test/testdata/todolint_with_options.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Etodolint
+//golangcitest:config_path testdata/configs/todolint.yml
+package testdata
+
+import "fmt"
+
+func todoLintWithOptionsExample() {
+	// TODO: This is ignored due to keywords config
+
+	fmt.Println("你好，世界") // XXX: more languages // want `TODO comment should be in the form XXX\(author\)`
+}


### PR DESCRIPTION
todolint checks for possible TODOs in comments, and required TODO in the following form, for example:

- `// TODO(timonwong): This is ok`
- `// TODO: This is not ok, missing author`
- `// Todo: This is not ok, not caps`

Which makes it easier to find out who the actual author of the comment was (git blame is not enough after refactoring by other users).

https://github.com/timonwong/todolint

