### PR TITLE
paralleltest: add tests of the ignore-missing option

### DIFF
--- a/pkg/golinters/paralleltest.go
+++ b/pkg/golinters/paralleltest.go
@@ -23,7 +23,7 @@ func NewParallelTest(settings *config.ParallelTestSettings) *goanalysis.Linter {
 	return goanalysis.NewLinter(
 		"paralleltest",
 		"paralleltest detects missing usage of t.Parallel() method in your Go test",
-		[]*analysis.Analyzer{paralleltest.Analyzer},
+		[]*analysis.Analyzer{a},
 		cfg,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/test/testdata/configs/paralleltest.yml
+++ b/test/testdata/configs/paralleltest.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  paralleltest:
+    ignore-missing: true

--- a/test/testdata/paralleltest_custom.go
+++ b/test/testdata/paralleltest_custom.go
@@ -1,0 +1,24 @@
+//golangcitest:args -Eparalleltest
+//golangcitest:config_path testdata/configs/paralleltest.yml
+//golangcitest:expected_exitcode 0
+package testdata
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParallelTestIgnore(t *testing.T) {
+	testCases := []struct {
+		name string
+	}{{name: "foo"}}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fmt.Println(tc.name)
+		})
+	}
+}
+
+func TestParallelTestEmptyIgnore(t *testing.T) {}


### PR DESCRIPTION
just add tests to prove that `ignore-missing` option works.