### PR TITLE
feat: add allfields linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1951,6 +1951,7 @@ linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
+    - allfields
     - asasalint
     - asciicheck
     - bidichk
@@ -2058,6 +2059,7 @@ linters:
   # Disable specific linter
   # https://golangci-lint.run/usage/linters/#disabled-by-default
   disable:
+    - allfields
     - asasalint
     - asciicheck
     - bidichk

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1
 	github.com/stbenjam/no-sprintf-host-port v0.1.1
 	github.com/stretchr/testify v1.8.0
+	github.com/subtle-byte/allfields v0.1.1
 	github.com/tdakkota/asciicheck v0.1.1
 	github.com/tetafro/godot v1.4.11
 	github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144

--- a/go.sum
+++ b/go.sum
@@ -525,6 +525,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/subtle-byte/allfields v0.1.1 h1:ltym+9nhYUAeCiSPfKOYuyXwS7mfAhghHB4x5nr4BIM=
+github.com/subtle-byte/allfields v0.1.1/go.mod h1:SkziUBt3oLS++ppqjG6WMXVltP11BIX5FRh6unoOjWE=
 github.com/tdakkota/asciicheck v0.1.1 h1:PKzG7JUTUmVspQTDqtkX9eSiLGossXTybutHwTXuO0A=
 github.com/tdakkota/asciicheck v0.1.1/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tenntenn/modver v1.0.1 h1:2klLppGhDgzJrScMpkj9Ujy3rXPUspSjAcev9tSEBgA=

--- a/pkg/golinters/allfields.go
+++ b/pkg/golinters/allfields.go
@@ -1,0 +1,17 @@
+package golinters
+
+import (
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"github.com/subtle-byte/allfields/pkg/analyzer"
+	"golang.org/x/tools/go/analysis"
+)
+
+func NewAllfields() *goanalysis.Linter {
+	a := analyzer.Analyzer
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -277,6 +277,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	// The linters are sorted in the alphabetical order (case-insensitive).
 	// When a new linter is added the version in `WithSince(...)` must be the next minor version of golangci-lint.
 	lcs := []*linter.Config{
+		linter.NewConfig(golinters.NewAllfields()).
+			WithSince("1.50.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/subtle-byte/allfields"),
+
 		linter.NewConfig(golinters.NewAsasalint(asasalintCfg)).
 			WithSince("1.47.0").
 			WithPresets(linter.PresetBugs).

--- a/test/testdata/allfields.go
+++ b/test/testdata/allfields.go
@@ -1,0 +1,24 @@
+//golangcitest:args -Eallfields
+package testdata
+
+import "time"
+
+type user struct {
+	Name      string
+	CreatedAt time.Time
+}
+
+func Allfields() {
+	_ = user{
+		Name:      "John",
+		CreatedAt: time.Now(),
+		//allfields
+	}
+	_ = user{ // want "field CreatedAt is not set"
+		Name: "John",
+		//allfields
+	}
+	_ = user{
+		Name: "John",
+	}
+}


### PR DESCRIPTION
`allfields` is a linter that checks that all fields in the struct literal are set. It is useful when we need to fill the struct with data, if we add the field to the struct the `allfields` help us not forget to update struct literals.

https://github.com/subtle-byte/allfields