### PR TITLE
feat: add gomegacheck

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1992,6 +1992,7 @@ linters:
     - goheader
     - goimports
     - golint
+    - gomegacheck
     - gomnd
     - gomoddirectives
     - gomodguard
@@ -2099,6 +2100,7 @@ linters:
     - goheader
     - goimports
     - golint
+    - gomegacheck
     - gomnd
     - gomoddirectives
     - gomodguard

--- a/go.mod
+++ b/go.mod
@@ -186,3 +186,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 )
+
+require github.com/gardener/gardener/hack/tools/gomegacheck v0.0.0-20221004145958-3f57fd0f4151

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
+github.com/gardener/gardener/hack/tools/gomegacheck v0.0.0-20221004145958-3f57fd0f4151 h1:cm/eXC5wUourlh7Ag9tWWF0057c64GCdB4ZePTtskgQ=
+github.com/gardener/gardener/hack/tools/gomegacheck v0.0.0-20221004145958-3f57fd0f4151/go.mod h1:TcHHjqWfEy44bLuVq2Qv0pJzqKgIQfwCEiv2DOs4vKs=
 github.com/go-critic/go-critic v0.6.5 h1:fDaR/5GWURljXwF8Eh31T2GZNz9X4jeboS912mWF8Uo=
 github.com/go-critic/go-critic v0.6.5/go.mod h1:ezfP/Lh7MA6dBNn4c6ab5ALv3sKnZVLx37tr00uuaOY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/pkg/golinters/gomegacheck.go
+++ b/pkg/golinters/gomegacheck.go
@@ -1,0 +1,19 @@
+package golinters
+
+import (
+	"github.com/gardener/gardener/hack/tools/gomegacheck/pkg/gomegacheck"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewGomegaCheck() *goanalysis.Linter {
+	a := gomegacheck.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeWholeProgram)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -850,6 +850,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/bombsimon/wsl"),
 
+		linter.NewConfig(golinters.NewGomegaCheck()).
+			WithSince("v1.51.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/gardener/gardener/tree/master/hack/tools/gomegacheck"),
+
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(golinters.NewNoLintLint(noLintLintCfg)).
 			WithSince("v1.26.0").

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -30,6 +30,7 @@ func TestTypecheck(t *testing.T) {
 func TestSourcesFromTestdataSubDir(t *testing.T) {
 	subDirs := []string{
 		"loggercheck",
+		"gomegacheck",
 	}
 
 	for _, dir := range subDirs {

--- a/test/testdata/gomegacheck/go.mod
+++ b/test/testdata/gomegacheck/go.mod
@@ -1,0 +1,12 @@
+module gomegacheck
+
+go 1.19
+
+require github.com/onsi/gomega v1.20.2
+
+require (
+	github.com/google/go-cmp v0.5.8 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+	golang.org/x/text v0.3.7 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/test/testdata/gomegacheck/go.sum
+++ b/test/testdata/gomegacheck/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/onsi/ginkgo/v2 v2.1.6 h1:Fx2POJZfKRQcM1pH49qSZiYeu319wji004qX+GDovrU=
+github.com/onsi/gomega v1.20.2 h1:8uQq0zMgLEfa0vRrrBgaJF2gyW9Da9BmfGV+OyUzfkY=
+github.com/onsi/gomega v1.20.2/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8luStNc=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/testdata/gomegacheck/gomegacheck.go
+++ b/test/testdata/gomegacheck/gomegacheck.go
@@ -1,0 +1,204 @@
+//golangcitest:args -Egomegacheck
+package gomegacheck
+
+import (
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for executing unit tests for gomegacheck using golang.org/x/tools/go/analysis/analysistest.
+
+func expect() {
+	gomega.Expect("foo").To(Match())
+	gomega.Expect("foo").Should(Match())
+	gomega.Expect("foo").NotTo(Match())
+	gomega.Expect("foo").ToNot(Match())
+	gomega.Expect("foo").ShouldNot(Match())
+	gomega.Expect("foo").WithOffset(1).To(Match())
+	gomega.Expect("foo").WithOffset(1).Should(Match())
+	gomega.Expect("foo").WithOffset(1).NotTo(Match())
+	gomega.Expect("foo").WithOffset(1).ToNot(Match())
+	gomega.Expect("foo").WithOffset(1).ShouldNot(Match())
+
+	gomega.Expect("foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	gomega.Expect("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+
+	gomega.Expect("foo").To(Match(), Match())               // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").Should(Match(), Match())           // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").NotTo(Match(), Match())            // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").ToNot(Match(), Match())            // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").ShouldNot(Match(), Match())        // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").WithOffset(1).To(Match(), Match()) // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+}
+
+func expectWithOffset() {
+	gomega.ExpectWithOffset(1, "foo").To(Match())
+	gomega.ExpectWithOffset(1, "foo").Should(Match())
+	gomega.ExpectWithOffset(1, "foo").NotTo(Match())
+	gomega.ExpectWithOffset(1, "foo").ToNot(Match())
+	gomega.ExpectWithOffset(1, "foo").ShouldNot(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).To(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).Should(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).NotTo(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).ToNot(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).ShouldNot(Match())
+
+	gomega.ExpectWithOffset(1, "foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+}
+
+func omega() {
+	gomega.Ω("foo").To(Match())
+	gomega.Ω("foo").Should(Match())
+	gomega.Ω("foo").NotTo(Match())
+	gomega.Ω("foo").ToNot(Match())
+	gomega.Ω("foo").ShouldNot(Match())
+	gomega.Ω("foo").WithOffset(1).To(Match())
+	gomega.Ω("foo").WithOffset(1).Should(Match())
+	gomega.Ω("foo").WithOffset(1).NotTo(Match())
+	gomega.Ω("foo").WithOffset(1).ToNot(Match())
+	gomega.Ω("foo").WithOffset(1).ShouldNot(Match())
+
+	gomega.Ω("foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	gomega.Ω("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+}
+
+func eventually() {
+	c := make(chan bool)
+
+	gomega.Eventually(c).Should(Match())
+	gomega.Eventually(c).ShouldNot(Match())
+	gomega.Eventually(c).WithOffset(1).Should(Match())
+	gomega.Eventually(c).WithOffset(1).ShouldNot(Match())
+	gomega.Eventually(c).WithTimeout(time.Second).Should(Match())
+	gomega.Eventually(c).WithTimeout(time.Second).ShouldNot(Match())
+	gomega.Eventually(c).WithPolling(time.Second).Should(Match())
+	gomega.Eventually(c).WithPolling(time.Second).ShouldNot(Match())
+
+	gomega.Eventually(c)                          // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Eventually(c).WithOffset(1)            // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Eventually(c).WithTimeout(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Eventually(c).WithPolling(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+}
+
+func consistently() {
+	c := make(chan bool)
+
+	gomega.Consistently(c).Should(Match())
+	gomega.Consistently(c).ShouldNot(Match())
+	gomega.Consistently(c).WithOffset(1).Should(Match())
+	gomega.Consistently(c).WithOffset(1).ShouldNot(Match())
+	gomega.Consistently(c).WithTimeout(time.Second).Should(Match())
+	gomega.Consistently(c).WithTimeout(time.Second).ShouldNot(Match())
+	gomega.Consistently(c).WithPolling(time.Second).Should(Match())
+	gomega.Consistently(c).WithPolling(time.Second).ShouldNot(Match())
+
+	gomega.Consistently(c)                          // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Consistently(c).WithOffset(1)            // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Consistently(c).WithTimeout(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Consistently(c).WithPolling(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+}
+
+func assertionInAsync() {
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").To(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").Should(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").NotTo(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").ToNot(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").ShouldNot(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).To(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).Should(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).NotTo(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).ToNot(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).ShouldNot(Match())
+	}).Should(Match())
+
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo") // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	}).Should(Match())
+}
+
+// returning Assertion/AsyncAssertion should not yield an error.
+
+func helper(actual interface{}) gomega.Assertion {
+	return gomega.Expect(actual).WithOffset(1)
+}
+
+func helperAsync(actual interface{}) gomega.AsyncAssertion {
+	return gomega.Eventually(actual).WithOffset(1)
+}
+
+// calling helpers should however yield an error
+
+func callingHelper() {
+	helper("foo").To(Match())
+	helper("foo").Should(Match())
+	helper("foo").NotTo(Match())
+	helper("foo").ToNot(Match())
+	helper("foo").ShouldNot(Match())
+	helper("foo").WithOffset(1).To(Match())
+	helper("foo").WithOffset(1).Should(Match())
+	helper("foo").WithOffset(1).NotTo(Match())
+	helper("foo").WithOffset(1).ToNot(Match())
+	helper("foo").WithOffset(1).ShouldNot(Match())
+
+	helper("foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	helper("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+}
+
+func callingHelperAsync() {
+	helperAsync("foo").Should(Match())
+	helperAsync("foo").ShouldNot(Match())
+	helperAsync("foo").WithOffset(1).Should(Match())
+	helperAsync("foo").WithOffset(1).ShouldNot(Match())
+
+	helperAsync("foo")               // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	helperAsync("foo").WithOffset(1) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+}
+
+func Match() types.GomegaMatcher {
+	return dummyMatcher{}
+}
+
+type dummyMatcher struct{}
+
+func (m dummyMatcher) Match(actual interface{}) (success bool, err error)        { return true, nil }
+func (m dummyMatcher) FailureMessage(actual interface{}) (message string)        { return "fail" }
+func (m dummyMatcher) NegatedFailureMessage(actual interface{}) (message string) { return "whatever" }


### PR DESCRIPTION
This adds the `gomegacheck` linter.

Source: https://github.com/gardener/gardener/tree/master/hack/tools/gomegacheck
Discussion of the problem: https://github.com/onsi/gomega/issues/561

Async assertions written with `gomega` don't actually assert anything unless there is an assertion on the the entire async block. It can be easy to miss, since there will often be one or more assertions inside the async block.

This linter was written by @timebertt, who has given permission to include it here.