### PR TITLE
code-climate: add default severity

### DIFF
--- a/pkg/printers/checkstyle.go
+++ b/pkg/printers/checkstyle.go
@@ -12,6 +12,8 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
+const defaultCheckstyleSeverity = "error"
+
 type checkstyleOutput struct {
 	XMLName xml.Name          `xml:"checkstyle"`
 	Version string            `xml:"version,attr"`
@@ -30,8 +32,6 @@ type checkstyleError struct {
 	Severity string `xml:"severity,attr"`
 	Source   string `xml:"source,attr"`
 }
-
-const defaultCheckstyleSeverity = "error"
 
 type Checkstyle struct {
 	w io.Writer

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -40,6 +40,7 @@ func (p CodeClimate) Print(ctx context.Context, issues []result.Issue) error {
 		codeClimateIssue.Location.Path = issue.Pos.Filename
 		codeClimateIssue.Location.Lines.Begin = issue.Pos.Line
 		codeClimateIssue.Fingerprint = issue.Fingerprint()
+		codeClimateIssue.Severity = "critical"
 
 		if issue.Severity != "" {
 			codeClimateIssue.Severity = issue.Severity

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -9,8 +9,12 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-// CodeClimateIssue is a subset of the Code Climate spec - https://github.com/codeclimate/spec/blob/master/SPEC.md#data-types
-// It is just enough to support GitLab CI Code Quality - https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html
+const defaultCodeClimateSeverity = "critical"
+
+// CodeClimateIssue is a subset of the Code Climate spec.
+// https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
+// It is just enough to support GitLab CI Code Quality.
+// https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html
 type CodeClimateIssue struct {
 	Description string `json:"description"`
 	Severity    string `json:"severity,omitempty"`
@@ -40,7 +44,7 @@ func (p CodeClimate) Print(ctx context.Context, issues []result.Issue) error {
 		codeClimateIssue.Location.Path = issue.Pos.Filename
 		codeClimateIssue.Location.Lines.Begin = issue.Pos.Line
 		codeClimateIssue.Fingerprint = issue.Fingerprint()
-		codeClimateIssue.Severity = "critical"
+		codeClimateIssue.Severity = defaultCodeClimateSeverity
 
 		if issue.Severity != "" {
 			codeClimateIssue.Severity = issue.Severity

--- a/pkg/printers/codeclimate_test.go
+++ b/pkg/printers/codeclimate_test.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package printers
 
 import (

--- a/pkg/printers/codeclimate_test.go
+++ b/pkg/printers/codeclimate_test.go
@@ -42,6 +42,21 @@ func TestCodeClimate_Print(t *testing.T) {
 				Column:   9,
 			},
 		},
+		{
+			FromLinter: "linter-c",
+			Text:       "issue c",
+			SourceLines: []string{
+				"func foo() {",
+				"\tfmt.Println(\"ccc\")",
+				"}",
+			},
+			Pos: token.Position{
+				Filename: "path/to/filec.go",
+				Offset:   6,
+				Line:     200,
+				Column:   2,
+			},
+		},
 	}
 
 	buf := new(bytes.Buffer)
@@ -51,7 +66,7 @@ func TestCodeClimate_Print(t *testing.T) {
 	require.NoError(t, err)
 
 	//nolint:lll
-	expected := `[{"description":"linter-a: some issue","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"linter-b: another issue","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}}]`
+	expected := `[{"description":"linter-a: some issue","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"linter-b: another issue","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"linter-c: issue c","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]`
 
 	assert.Equal(t, expected, buf.String())
 }

--- a/pkg/printers/github_test.go
+++ b/pkg/printers/github_test.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package printers
 
 import (


### PR DESCRIPTION
when I output code climate format report,  GitLab CI code quality report can show the report, but  GitLab MR code quality widget can not.

MR: https://jihulab.com/premium-plan/features/04Verify/code-quality-report/golang/-/merge_requests/1

```
golangci-lint run --enable-all --out-format code-climate:gl-code-quality-report.json
```

<details>

<img width="636" alt="image" src="https://user-images.githubusercontent.com/4971414/195976465-8d7cf419-3ee5-4944-b66f-a89dbd28fc9e.png">

<img width="668" alt="image" src="https://user-images.githubusercontent.com/4971414/195976451-f2942cba-3258-4532-886c-4ae0d5eb5bc0.png">

</details>

I try to add those required columns in the docs: https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types

add `type` is useless: https://jihulab.com/premium-plan/features/04Verify/code-quality-report/golang/-/merge_requests/3

```
golangci-lint run --enable-all --out-format code-climate:report.json
cat report.json | jq '.[] += { type: "issue" }' > gl-code-quality-report.json
```

add `severity` is usefull: https://jihulab.com/premium-plan/features/04Verify/code-quality-report/golang/-/merge_requests/4

```
golangci-lint run --enable-all --out-format code-climate:report.json
cat report.json | jq '.[] += { severity: "critical" }' > gl-code-quality-report.json
```

<details>

<img width="700" alt="image" src="https://user-images.githubusercontent.com/4971414/195976526-50a1ee19-272a-48bd-ad18-14be949de10b.png">

</details>

so I create this PR to add `severity` default value.