### PR TITLE
Retain exitcode after fixing issues with the -fix args

### DIFF
--- a/test/testdata/fix/in/gci.go
+++ b/test/testdata/fix/in/gci.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egci
 //golangcitest:config_path testdata/configs/gci.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package gci
 
 import (

--- a/test/testdata/fix/in/gocritic.go
+++ b/test/testdata/fix/in/gocritic.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egocritic
 //golangcitest:config_path testdata/configs/gocritic-fix.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import (

--- a/test/testdata/fix/in/godot.go
+++ b/test/testdata/fix/in/godot.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egodot
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 /*

--- a/test/testdata/fix/in/gofmt.go
+++ b/test/testdata/fix/in/gofmt.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofmt
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
  func gofmt(a, b int) int {

--- a/test/testdata/fix/in/gofmt_rewrite_rules.go
+++ b/test/testdata/fix/in/gofmt_rewrite_rules.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egofmt
 //golangcitest:config_path testdata/configs/gofmt_rewrite_rules.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "fmt"

--- a/test/testdata/fix/in/gofumpt.go
+++ b/test/testdata/fix/in/gofumpt.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egofumpt
 //golangcitest:config_path testdata/configs/gofumpt-fix.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "fmt"

--- a/test/testdata/fix/in/goimports.go
+++ b/test/testdata/fix/in/goimports.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofmt,goimports
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import (

--- a/test/testdata/fix/in/misspell.go
+++ b/test/testdata/fix/in/misspell.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Emisspell
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "log"

--- a/test/testdata/fix/in/whitespace.go
+++ b/test/testdata/fix/in/whitespace.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Ewhitespace
 //golangcitest:config_path testdata/configs/whitespace-fix.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "fmt"

--- a/test/testdata/fix/out/gci.go
+++ b/test/testdata/fix/out/gci.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egci
 //golangcitest:config_path testdata/configs/gci.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package gci
 
 import (

--- a/test/testdata/fix/out/gocritic.go
+++ b/test/testdata/fix/out/gocritic.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egocritic
 //golangcitest:config_path testdata/configs/gocritic-fix.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import (

--- a/test/testdata/fix/out/godot.go
+++ b/test/testdata/fix/out/godot.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egodot
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 /*

--- a/test/testdata/fix/out/gofmt.go
+++ b/test/testdata/fix/out/gofmt.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofmt
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 func gofmt(a, b int) int {

--- a/test/testdata/fix/out/gofmt_rewrite_rules.go
+++ b/test/testdata/fix/out/gofmt_rewrite_rules.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egofmt
 //golangcitest:config_path testdata/configs/gofmt_rewrite_rules.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "fmt"

--- a/test/testdata/fix/out/gofumpt.go
+++ b/test/testdata/fix/out/gofumpt.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Egofumpt
 //golangcitest:config_path testdata/configs/gofumpt-fix.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "fmt"

--- a/test/testdata/fix/out/goimports.go
+++ b/test/testdata/fix/out/goimports.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Egofmt,goimports
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 func goimports(a, b int) int {

--- a/test/testdata/fix/out/misspell.go
+++ b/test/testdata/fix/out/misspell.go
@@ -1,5 +1,5 @@
 //golangcitest:args -Emisspell
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "log"

--- a/test/testdata/fix/out/whitespace.go
+++ b/test/testdata/fix/out/whitespace.go
@@ -1,6 +1,6 @@
 //golangcitest:args -Ewhitespace
 //golangcitest:config_path testdata/configs/whitespace-fix.yml
-//golangcitest:expected_exitcode 0
+//golangcitest:expected_exitcode 1
 package p
 
 import "fmt"


### PR DESCRIPTION
After using the `-fix` parameter to turn on automatic issue repair, if all the issues found are repaired, the `exitcode` will be `0`. 

This behavior is not written in the documentation.

There are two directions to modify this issue:
- if we think this behavior is correct, then we need to state it in the documentation
- if this behavior is not correct, we need to modify the code.