### PR TITLE
docs(gomnd): add missing always ignored functions

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -684,7 +684,9 @@ linters-settings:
     ignored-files:
       - 'magic1_.*.go'
     # List of function patterns to exclude from analysis.
-    # Values always ignored: `time.Date`
+    # Following functions are always ignored: `time.Date`,
+    # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+    # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
     # Default: []
     ignored-functions:
       - 'math.*'


### PR DESCRIPTION
`gomnd` has been updated in #3295.
New version introduced [more functions](https://github.com/tommy-muehle/go-mnd/commit/86c7103981d88b6598d38e3927275cab84f17192) which always ignored.
This PR updates reference accordingly.