### PR TITLE
Add new linter: gokeyword

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -655,6 +655,12 @@ linters-settings:
     # Default: ""
     local-prefixes: github.com/org/project
 
+  gokeyword:
+    # Detecting the go keyword is a very opininated rule. Be sure to add details explaining why it is enabled.
+    # Suggest a link to documentation + alternatives (ie a helper function that spawns a new go routine
+    # and recovers from panics)
+    details: https://example.com/gokeyword
+
   golint:
     # Minimal confidence for issues.
     # Default: 0.8
@@ -1998,6 +2004,7 @@ linters:
     - gofumpt
     - goheader
     - goimports
+    - gokeyword
     - golint
     - gomnd
     - gomoddirectives
@@ -2105,6 +2112,7 @@ linters:
     - gofumpt
     - goheader
     - goimports
+    - gokeyword
     - golint
     - gomnd
     - gomoddirectives

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -160,6 +160,7 @@ type LintersSettings struct {
 	Gofumpt          GofumptSettings
 	Goheader         GoHeaderSettings
 	Goimports        GoImportsSettings
+	GoKeyword        GoKeywordSettings
 	Golint           GoLintSettings
 	Gomnd            GoMndSettings
 	GoModDirectives  GoModDirectivesSettings
@@ -389,6 +390,10 @@ type GoHeaderSettings struct {
 
 type GoImportsSettings struct {
 	LocalPrefixes string `mapstructure:"local-prefixes"`
+}
+
+type GoKeywordSettings struct {
+	Details string `mapstructure:"details"`
 }
 
 type GoLintSettings struct {

--- a/pkg/golinters/gokeyword.go
+++ b/pkg/golinters/gokeyword.go
@@ -1,0 +1,51 @@
+package golinters
+
+import (
+	"go/ast"
+
+	"github.com/pkg/errors"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+const (
+	goKeywordName        = "gokeyword"
+	goKeywordErrorMsg    = "detected use of go keyword: %s"
+	goKeywordDescription = "detects presence of the go keyword"
+	defaultDetails       = "no details provided"
+)
+
+func NewGoKeyword(cfg *config.GoKeywordSettings) *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		goKeywordName,
+		goKeywordDescription,
+		[]*analysis.Analyzer{{
+			Name: goKeywordName,
+			Doc:  goKeywordDescription,
+			Run: func(pass *analysis.Pass) (interface{}, error) {
+				details := defaultDetails
+				if cfg != nil && cfg.Details != "" {
+					details = cfg.Details
+				}
+
+				i, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+				if !ok {
+					return nil, errors.New("analyzer is not type *inspector.Inspector")
+				}
+
+				i.Preorder([]ast.Node{(*ast.GoStmt)(nil)}, func(node ast.Node) {
+					if _, ok := node.(*ast.GoStmt); ok {
+						pass.Reportf(node.Pos(), goKeywordErrorMsg, details)
+					}
+				})
+				return nil, nil
+			},
+			Requires: []*analysis.Analyzer{inspect.Analyzer},
+		}},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -128,6 +128,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		gofumptCfg          *config.GofumptSettings
 		goheaderCfg         *config.GoHeaderSettings
 		goimportsCfg        *config.GoImportsSettings
+		goKeywordCfg        *config.GoKeywordSettings
 		golintCfg           *config.GoLintSettings
 		goMndCfg            *config.GoMndSettings
 		goModDirectivesCfg  *config.GoModDirectivesSettings
@@ -204,6 +205,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		gofumptCfg = &m.cfg.LintersSettings.Gofumpt
 		goheaderCfg = &m.cfg.LintersSettings.Goheader
 		goimportsCfg = &m.cfg.LintersSettings.Goimports
+		goKeywordCfg = &m.cfg.LintersSettings.GoKeyword
 		golintCfg = &m.cfg.LintersSettings.Golint
 		goMndCfg = &m.cfg.LintersSettings.Gomnd
 		goModDirectivesCfg = &m.cfg.LintersSettings.GoModDirectives
@@ -500,6 +502,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetFormatting, linter.PresetImport).
 			WithAutoFix().
 			WithURL("https://godoc.org/golang.org/x/tools/cmd/goimports"),
+
+		linter.NewConfig(golinters.NewGoKeyword(goKeywordCfg)).
+			WithSince("1.51.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithURL("https://www.google.com"),
 
 		linter.NewConfig(golinters.NewGolint(golintCfg)).
 			WithSince("v1.0.0").

--- a/test/testdata/configs/gokeyword.yml
+++ b/test/testdata/configs/gokeyword.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  gokeyword:
+    details: via test/testdata/configs/gokeyword.yml
+

--- a/test/testdata/gokeyword.go
+++ b/test/testdata/gokeyword.go
@@ -1,0 +1,7 @@
+//golangcitest:args -Egokeyword
+//golangcitest:config_path testdata/configs/gokeyword.yml
+package testdata
+
+func GoKeyword() {
+	go func() {}() // want "detected use of go keyword: via test/testdata/configs/gokeyword.yml"
+}


### PR DESCRIPTION
The motivation for this linter is to detect usages of the go keyword in web servers etc where its direct usage inside a request handler can  be an anti-pattern: any panics will cause the whole process to crash. Internally we (LaunchDarkly) use helpers that recover from any panics and log them for investigation.

My intent is to not include this in the default set of linters, so please verify that this is true. 
