### PR TITLE
typecheck: Remove check if crushed message equals original message

### DIFF
--- a/pkg/packages/util.go
+++ b/pkg/packages/util.go
@@ -26,10 +26,6 @@ func ExtractErrors(pkg *packages.Package) []packages.Error {
 			continue
 		}
 
-		if msg != err.Error() {
-			continue
-		}
-
 		seenErrors[msg] = true
 
 		uniqErrors = append(uniqErrors, err)


### PR DESCRIPTION
Hi.


First, I hope you are fine and the same for your relatives.

When running `golangci-lint` on our project, I got this strange error message:

```bash
root@90995a178979:/mnt/inspektor-gadget# golangci-lint run --fix
gadget-container/gadgettracermanager/controller.go:35:2: "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets" imported but not used (typecheck)
        "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
```

Indeed, this package is actually used below to do a [type assertion](https://github.com/inspektor-gadget/inspektor-gadget/blob/5009deb2aa16b6e5d98e47a9f690428a75eda289/gadget-container/gadgettracermanager/controller.go#L50).

I nonetheless found than adding `libseccomp-dev` removed the above message (our project uses `libseccomp-golang` which needs the C library).
So, I decided to check everything under `dlv`:

```bash
(dlv) p ill.Pkg.Errors
[]golang.org/x/tools/go/packages.Error len: 2, cap: 2, [
        {
                Pos: "/mnt/inspektor-gadget/gadget-container/gadgettracermanager/controller.go:34:19",
                Msg: "could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (/mnt/inspektor-gadget/pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (/mnt/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (/mnt/inspektor-gadget/pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))",
                Kind: TypeError (3),},
        {
                Pos: "/mnt/inspektor-gadget/gadget-container/gadgettracermanager/controller.go:35:2",
                Msg: "\"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets\" imported but not used",
                Kind: TypeError (3),},
]
```

When `buildIssuesFromIllTypedError()` is called it contains actually 2 errors but the one about `Cgo` is not printed:

```bash
(dlv) p msg
"/mnt/inspektor-gadget/cmd/gen-doc/gen-doc.go:30:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (/mnt/inspektor-gadget/pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (/mnt/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (/mnt/inspektor-gadget/pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))"
...
(dlv) p msg
"/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)"
(dlv) n
> github.com/golangci/golangci-lint/pkg/packages.ExtractErrors() /mnt/golangci-lint/pkg/packages/util.go:29 (PC: 0xde8365)
Warning: debugging optimized function
    24:                 msg := stackCrusher(err.Error())
    25:                 if seenErrors[msg] {
    26:                         continue
    27:                 }
    28:
    29:                 if msg != err.Error() {
=>  30:                         continue
    31:                 }
    32:
    33:                 seenErrors[msg] = true
    34:
(dlv)
```

Indeed, if the crushed message is not equal to the original one, it is skipped.
So, I decided to remove this check and now errors related to `Cgo` are printed:

```bash
root@90995a178979:/mnt/inspektor-gadget# golangci-lint run --fix
cmd/gen-doc/gen-doc.go:30:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed))))) (typecheck)
        gadgetcollection "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection"
                         ^
cmd/local-gadget/audit/seccomp.go:32:21: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager (pkg/local-gadget-manager/local-gadget-manager.go:25:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))) (typecheck)
        localgadgetmanager "github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager"
                           ^
cmd/local-gadget/containers/containers.go:29:21: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager (pkg/local-gadget-manager/local-gadget-manager.go:25:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))) (typecheck)
        localgadgetmanager "github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager"
                           ^
cmd/local-gadget/interactive/interactive.go:30:21: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager (pkg/local-gadget-manager/local-gadget-manager.go:25:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))) (typecheck)
        localgadgetmanager "github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager"
                           ^
cmd/local-gadget/main.go:22:2: could not import github.com/inspektor-gadget/inspektor-gadget/cmd/local-gadget/audit (cmd/local-gadget/audit/seccomp.go:32:21: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager (pkg/local-gadget-manager/local-gadget-manager.go:25:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed))))))) (typecheck)
        "github.com/inspektor-gadget/inspektor-gadget/cmd/local-gadget/audit"
        ^
cmd/local-gadget/snapshot/process.go:26:21: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager (pkg/local-gadget-manager/local-gadget-manager.go:25:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))) (typecheck)
        localgadgetmanager "github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager"
                           ^
cmd/local-gadget/trace/dns.go:33:21: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager (pkg/local-gadget-manager/local-gadget-manager.go:25:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))))) (typecheck)
        localgadgetmanager "github.com/inspektor-gadget/inspektor-gadget/pkg/local-gadget-manager"
                           ^
gadget-container/gadgettracermanager/controller.go:34:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed))))) (typecheck)
        gadgetcollection "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection"
                         ^
gadget-container/gadgettracermanager/controller.go:35:2: "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets" imported but not used (typecheck)
        "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets"
        ^
pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)))) (typecheck)
        traceloop "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop"
                  ^
pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed))) (typecheck)
        tracelooptracer "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer"
                        ^
pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed)) (typecheck)
        libseccomp "github.com/seccomp/libseccomp-golang"
                   ^
pkg/local-gadget-manager/local-gadget-manager.go:25:19: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection (pkg/gadget-collection/gadget-collection.go:42:12: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection/gadgets/traceloop (pkg/gadget-collection/gadgets/traceloop/gadget.go:30:18: could not import github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/traceloop/tracer (pkg/gadgets/traceloop/tracer/syscall_helpers.go:28:13: could not import github.com/seccomp/libseccomp-golang (/go/pkg/mod/github.com/seccomp/libseccomp-golang@v0.9.2-0.20210429002308-3879420cc921/seccomp.go:33:8: could not import C (cgo preprocessing failed))))) (typecheck)
        gadgetcollection "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-collection"
```

If you see any way to improve this contribution, feel free to share.

https://github.com/inspektor-gadget/inspektor-gadget

Best regards and thank you in advance.