### PR TITLE
wsl: fix force-err-cuddling flag

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1928,15 +1928,15 @@ linters-settings:
     
     # Causes an error when an If statement that checks an error variable doesn't
     # cuddle with the assignment of that variable.
-    enforce-err-cuddling: false
+    force-err-cuddling: false
     
-    # When enforce-err-cuddling is enabled this is a list of names
+    # When force-err-cuddling is enabled this is a list of names
     # used for error variables to check for in the conditional.
     error-variable-names: [ "err" ]
     
     # Causes an error if a short declaration (:=) cuddles with anything other than
     # another short declaration.
-    # This logic overrides enforce-err-cuddling among others.
+    # This logic overrides force-err-cuddling among others.
     force-short-decl-cuddling: false
 
   # The custom section can be used to define linter plugins to be loaded at runtime.

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -713,7 +713,7 @@ type WSLSettings struct {
 	AllowCuddleDeclaration           bool     `mapstructure:"allow-cuddle-declarations"`
 	AllowCuddleWithCalls             []string `mapstructure:"allow-cuddle-with-calls"`
 	AllowCuddleWithRHS               []string `mapstructure:"allow-cuddle-with-rhs"`
-	ForceCuddleErrCheckAndAssign     bool     `mapstructure:"enforce-err-cuddling"`
+	ForceCuddleErrCheckAndAssign     bool     `mapstructure:"force-err-cuddling"`
 	ErrorVariableNames               []string `mapstructure:"error-variable-names"`
 	ForceExclusiveShortDeclarations  bool     `mapstructure:"force-short-decl-cuddling"`
 }

--- a/pkg/golinters/wsl.go
+++ b/pkg/golinters/wsl.go
@@ -32,6 +32,9 @@ func NewWSL(settings *config.WSLSettings) *goanalysis.Linter {
 		conf.AllowCuddleDeclaration = settings.AllowCuddleDeclaration
 		conf.AllowCuddleWithCalls = settings.AllowCuddleWithCalls
 		conf.AllowCuddleWithRHS = settings.AllowCuddleWithRHS
+		conf.ForceCuddleErrCheckAndAssign = settings.ForceCuddleErrCheckAndAssign
+		conf.ErrorVariableNames = settings.ErrorVariableNames
+		conf.ForceExclusiveShortDeclarations = settings.ForceExclusiveShortDeclarations
 	}
 
 	analyzer := &analysis.Analyzer{


### PR DESCRIPTION
According to [documentation](https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#force-err-cuddling) `enforce` is misspelled for `force-err-cuddling` flag. It also fix the configuration assignment when creating a new WSL linter.