### PR TITLE
go1.20 support

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.19
+          go-version: 1.18.0-rc.1
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.1
+          go-version: 1.20.0-rc.2
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.18.0-rc.1
+          go-version: 1.20.0-rc.1
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.3
+          go-version: 1.20
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.2
+          go-version: 1.20.0-rc.3
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.1
+          go-version: 1.20.0-rc.2
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.19
+          go-version: 1.20.0-rc.1
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20
+          go-version: '1.20'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.3
+          go-version: 1.20
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.2
+          go-version: 1.20.0-rc.3
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: 1.20.0-rc.1
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -89,7 +89,7 @@ jobs:
       matrix:
         golang:
           - 1.18
-          - 1.19
+          - 1.20.0-rc.1
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.18
+          - 1.19
           - 1.20.0-rc.1
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.20.0-rc.1
+  GO_VERSION: 1.20.0-rc.2
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -91,7 +91,7 @@ jobs:
       matrix:
         golang:
           - 1.19
-          - 1.20.0-rc.1
+          - 1.20.0-rc.2
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.20.0-rc.3
+  GO_VERSION: 1.20
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -91,7 +91,7 @@ jobs:
       matrix:
         golang:
           - 1.19
-          - 1.20.0-rc.3
+          - 1.20
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: '1.20'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -91,7 +91,7 @@ jobs:
       matrix:
         golang:
           - 1.19
-          - 1.20
+          - '1.20'
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,9 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: ${{ env.GO_VERSION }}
+          # TODO(ldez) must be changed after the first release of golangci-lint with go1.20
+          # go-version: ${{ env.GO_VERSION }}
+          go-version: 1.19
       - name: lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.20.0-rc.2
+  GO_VERSION: 1.20.0-rc.3
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -91,7 +91,7 @@ jobs:
       matrix:
         golang:
           - 1.19
-          - 1.20.0-rc.2
+          - 1.20.0-rc.3
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.1
+          go-version: 1.20.0-rc.2
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.1
+          go-version: 1.20.0-rc.2
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.19
+          go-version: 1.20.0-rc.1
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.19
+          go-version: 1.20.0-rc.1
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.3
+          go-version: 1.20
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.3
+          go-version: 1.20
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20
+          go-version: '1.20'
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.2
+          go-version: 1.20.0-rc.3
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: 1.20.0-rc.2
+          go-version: 1.20.0-rc.3
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -10,7 +10,7 @@ WORKDIR /golangci
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.19
+FROM golang:1.20
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume

--- a/build/alpine.Dockerfile
+++ b/build/alpine.Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.19-alpine as builder
+FROM golang:1.20-alpine as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -15,7 +15,7 @@ RUN apk --no-cache add gcc musl-dev git mercurial
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
 # gcc is required to support cgo;

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.19
+go 1.20
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
@@ -39,7 +39,7 @@ require (
 	github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
 	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
-	github.com/golangci/misspell v0.3.5
+	github.com/golangci/misspell v0.4.0
 	github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4
 	github.com/gordonklaus/ineffassign v0.0.0-20210914165742-4cc7213b9bc8
@@ -112,7 +112,7 @@ require (
 	gitlab.com/bosi/decorder v0.2.3
 	golang.org/x/tools v0.5.0
 	gopkg.in/yaml.v3 v3.0.1
-	honnef.co/go/tools v0.3.3
+	honnef.co/go/tools v0.4.0-0.dev.0.20221209223220-58c4d7e4b720
 	mvdan.cc/gofumpt v0.4.0
 	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed
 	mvdan.cc/unparam v0.0.0-20221223090309-7455f1af531d
@@ -179,7 +179,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
-	golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91 // indirect
+	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.20
+go 1.19
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPz
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29MYHubXix4aDDuE3RWHkPvopM/EDv/MA=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca/go.mod h1:tvlJhZqDe4LMs4ZHD0oMUlt9G2LWuDGoisJTBzLMV9o=
-github.com/golangci/misspell v0.3.5 h1:pLzmVdl3VxTOncgzHcvLOKirdvcx/TydsClUQXTehjo=
-github.com/golangci/misspell v0.3.5/go.mod h1:dEbvlSfYbMQDtrpRMQU675gSDLDNa8sCPPChZ7PhiVA=
+github.com/golangci/misspell v0.4.0 h1:KtVB/hTK4bbL/S6bs64rYyk8adjmh1BygbBiaAiX+a0=
+github.com/golangci/misspell v0.4.0/go.mod h1:W6O/bwV6lGDxUCChm2ykw9NQdd5bYd1Xkjo88UcWyJc=
 github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6 h1:DIPQnGy2Gv2FSA4B/hh8Q7xx3B7AIDk3DAMeHclH1vQ=
 github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6/go.mod h1:0AKcRCkMoKvUvlf89F6O7H2LYdhr1zBh736mBItOdRs=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=
@@ -614,8 +614,9 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
-golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91 h1:Ic/qN6TEifvObMGQy72k0n1LlJr7DjWWEi+MOsDOiSk=
 golang.org/x/exp/typeparams v0.0.0-20220827204233-334a2380cb91/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a h1:Jw5wfR+h9mnIYH+OtGT2im5wV1YGGDora5vTv/aa5bE=
+golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1001,8 +1002,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.3.3 h1:oDx7VAwstgpYpb3wv0oxiZlxY+foCpRAwY7Vk6XpAgA=
-honnef.co/go/tools v0.3.3/go.mod h1:jzwdWgg7Jdq75wlfblQxO4neNaFFSvgc1tD5Wv8U0Yw=
+honnef.co/go/tools v0.4.0-0.dev.0.20221209223220-58c4d7e4b720 h1:L3lQbXWMmkBfyGXTvipQVmLXSM5SsT/39qcf+0RBIlQ=
+honnef.co/go/tools v0.4.0-0.dev.0.20221209223220-58c4d7e4b720/go.mod h1:lbrxuU0wR28B7d2OiCxa+DVcNWwTjaY3RfXQNu3r10U=
 mvdan.cc/gofumpt v0.4.0 h1:JVf4NN1mIpHogBj7ABpgOyZc65/UUOkKQFkoURsz4MM=
 mvdan.cc/gofumpt v0.4.0/go.mod h1:PljLOHDeZqgS8opHRKLzp2It2VBuSdteAgqUfzMTxlQ=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed h1:WX1yoOaKQfddO/mLzdV4wptyWgoH/6hwLs7QHTixo0I=

--- a/pkg/golinters/goanalysis/runner_loadingpackage.go
+++ b/pkg/golinters/goanalysis/runner_loadingpackage.go
@@ -434,6 +434,7 @@ func (lp *loadingPackage) convertError(err error) []packages.Error {
 		// If you see this error message, please file a bug.
 		lp.log.Warnf("Internal error: error %q (%T) without position", err, err)
 	}
+
 	return errs
 }
 

--- a/pkg/golinters/gofmt_common.go
+++ b/pkg/golinters/gofmt_common.go
@@ -242,7 +242,7 @@ func extractIssuesFromPatch(patch string, lintCtx *linter.Context, linterName st
 	}
 
 	if len(diffs) == 0 {
-		return nil, fmt.Errorf("got no diffs from patch parser: %v", diffs)
+		return nil, fmt.Errorf("got no diffs from patch parser: %v", patch)
 	}
 
 	var issues []result.Issue

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -453,8 +453,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 
 		linter.NewConfig(golinters.NewGochecknoinits()).
 			WithSince("v1.12.0").
-			WithPresets(linter.PresetStyle).
-			WithURL("https://github.com/leighmcculloch/gochecknoinits"),
+			WithPresets(linter.PresetStyle),
 
 		linter.NewConfig(golinters.NewGocognit(gocognitCfg)).
 			WithSince("v1.20.0").

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -208,6 +208,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 
 				return
 			}
+
 			issues = append(issues, linterIssues...)
 		})
 	}

--- a/test/testdata/notcompiles/typecheck_many_issues.go
+++ b/test/testdata/notcompiles/typecheck_many_issues.go
@@ -2,8 +2,8 @@
 package testdata
 
 func TypeCheckBadCalls() {
-	typecheckNotExists1.F1() // want "undeclared name: `typecheckNotExists1`"
-	typecheckNotExists2.F2() // want "undeclared name: `typecheckNotExists2`"
-	typecheckNotExists3.F3() // want "undeclared name: `typecheckNotExists3`"
-	typecheckNotExists4.F4() // want "undeclared name: `typecheckNotExists4`"
+	typecheckNotExists1.F1() // want "undefined: typecheckNotExists1"
+	typecheckNotExists2.F2() // want "undefined: typecheckNotExists2"
+	typecheckNotExists3.F3() // want "undefined: typecheckNotExists3"
+	typecheckNotExists4.F4() // want "undefined: typecheckNotExists4"
 }

--- a/test/testdata/notcompiles/typecheck_many_issues.go
+++ b/test/testdata/notcompiles/typecheck_many_issues.go
@@ -1,3 +1,5 @@
+//go:build go1.20
+
 //golangcitest:args -Etypecheck
 package testdata
 


### PR DESCRIPTION
This PR adds the support of go1.20.

Note for GitHub Action users: the Go version must be quoted (`'1.20'`) otherwise it is interpreted as a float (`1.2`).

~~This PR is to evaluate and prepare golangci-lint to [go1.20](https://tip.golang.org/doc/go1.20).~~

~~This PR will evolve during the beta and RC phases of [go1.20](https://tip.golang.org/doc/go1.20).~~

Fixes #3420