### PR TITLE
doc: usage typo in tagliatelle

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1671,7 +1671,7 @@ linters-settings:
     http-status-code-whitelist: [ "200", "400", "404", "500" ]
 
   tagliatelle:
-    # Check the struck tag name case.
+    # Check the struct tag name case.
     case:
       # Use the struct field name to check the name of the struct tag.
       # Default: false


### PR DESCRIPTION
I believe *struck* is a typo of **struct**. Sorry if spammy PR, but that word is tickling my brain :)