### PR TITLE
docs: add note about binary requirement for plugin

### DIFF
--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -41,7 +41,10 @@ Some people and organizations may choose to have custom-made linters run as a pa
 Typically, these linters can't be open-sourced or too specific.
 Such linters can be added through Go's plugin library.
 
-For a private linter (which acts as a plugin) to work properly, the plugin as well as the golangci-lint binary needs to be built for the same environment. `CGO_ENABLED` is another requirement. This means that `golangci-lint` needs to be built for whatever machine you intend to run it on (cloning the golangci-lint repository and running a `CGO_ENABLED=1 make build` should do the trick for your machine).
+For a private linter (which acts as a plugin) to work properly,
+the plugin as well as the golangci-lint binary needs to be built for the same environment. `CGO_ENABLED` is another requirement.
+This means that `golangci-lint` needs to be built for whatever machine you intend to run it on
+(cloning the golangci-lint repository and running a `CGO_ENABLED=1 make build` should do the trick for your machine).
 
 ### Configure a Plugin
 

--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -41,6 +41,8 @@ Some people and organizations may choose to have custom-made linters run as a pa
 Typically, these linters can't be open-sourced or too specific.
 Such linters can be added through Go's plugin library.
 
+For a private linter (which acts as a plugin) to work properly, the plugin as well as the golangci-lint binary needs to be built for the same environment. `CGO_ENABLED` is another requirement. This means that `golangci-lint` needs to be built for whatever machine you intend to run it on (cloning the golangci-lint repository and running a `CGO_ENABLED=1 make build` should do the trick for your machine).
+
 ### Configure a Plugin
 
 If you already have a linter plugin available, you can follow these steps to define it's usage in a projects


### PR DESCRIPTION
The binary releases aren't compatible with private linters. This commit adds a section in the new linters documentation that describes the requirements for private linters to work.