### PR TITLE
feat: add auto detection of module name for goimport

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -671,6 +671,9 @@ linters-settings:
     # with the given prefixes are grouped after 3rd-party packages.
     # Default: ""
     local-prefixes: github.com/org/project
+    # If set to true and local-prefixes is empty, the module name from go.mod
+    # will automatically be used as the local prefix.
+    auto-local-prefix: false
 
   golint:
     # Minimal confidence for issues.

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -110,8 +110,14 @@ func NewExecutor(version, commit, date string) *Executor {
 		e.log.Fatalf("Can't read config: %s", err)
 	}
 
-	if (commandLineCfg == nil || commandLineCfg.Run.Go == "") && e.cfg != nil && e.cfg.Run.Go == "" {
-		e.cfg.Run.Go = config.DetectGoVersion()
+	if e.cfg != nil {
+		if (commandLineCfg == nil || commandLineCfg.Run.Go == "") && e.cfg.Run.Go == "" {
+			e.cfg.Run.Go = config.DetectGoVersion()
+		}
+
+		if (commandLineCfg == nil || commandLineCfg.Run.Module == "") && e.cfg.Run.Module == "" {
+			e.cfg.Run.Module = config.DetectGoModuleName()
+		}
 	}
 
 	// recreate after getting config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,3 +68,8 @@ func DetectGoVersion() string {
 
 	return "1.17"
 }
+
+func DetectGoModuleName() string {
+	file, _ := gomoddirectives.GetModuleFile()
+	return file.Module.Mod.Path
+}

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -397,7 +397,8 @@ type GoHeaderSettings struct {
 }
 
 type GoImportsSettings struct {
-	LocalPrefixes string `mapstructure:"local-prefixes"`
+	LocalPrefixes   string `mapstructure:"local-prefixes"`
+	AutoLocalPrefix bool   `mapstructure:"auto-local-prefix"`
 }
 
 type GoLintSettings struct {

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -17,7 +17,8 @@ type Run struct {
 
 	Args []string
 
-	Go string `mapstructure:"go"`
+	Go     string `mapstructure:"go"`
+	Module string `mapstructure:"module"`
 
 	BuildTags           []string `mapstructure:"build-tags"`
 	ModulesDownloadMode string   `mapstructure:"modules-download-mode"`

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -274,6 +274,9 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		if unusedCfg != nil && unusedCfg.GoVersion == "" {
 			unusedCfg.GoVersion = m.cfg.Run.Go
 		}
+		if goimportsCfg != nil && goimportsCfg.LocalPrefixes == "" && goimportsCfg.AutoLocalPrefix {
+			goimportsCfg.LocalPrefixes = m.cfg.Run.Module
+		}
 	}
 
 	const megacheckName = "megacheck"

--- a/test/testdata/configs/goimports_local_auto.yml
+++ b/test/testdata/configs/goimports_local_auto.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  goimports:
+    auto-local-prefix: true

--- a/test/testdata/goimports_local_auto.go
+++ b/test/testdata/goimports_local_auto.go
@@ -1,0 +1,16 @@
+//golangcitest:args -Egoimports
+//golangcitest:config_path testdata/configs/goimports_local_auto.yml
+package testdata
+
+import (
+	"fmt"
+
+	"github.com/golangci/golangci-lint/pkg/config" // want "File is not `goimports`-ed with -local github.com/golangci/golangci-lint"
+	"github.com/pkg/errors"
+)
+
+func GoimportsLocalAutoPrefixTest() {
+	fmt.Print("x")
+	_ = config.Config{}
+	_ = errors.New("")
+}


### PR DESCRIPTION
Hi :),

we manage the `.golanglint-ci.yml` inside a central repo for several projects at our company. The ci/cd-pipeline fetches the current config when the linter is executed (e.g. on branch push).

The problem now is that repo-specific settings like the module name are not possible that way. Currently, golanglint-ci already supports auto-detection of the go version which is determinated via `go.mod`.

This pr introduces auto detection of the module name for goimport if the user enables it via config. I've thought about setting it be default if `local-prefixes` is empty but this would lead to a breacking change in linting behaviour. I created this pr as work-in-progress since I want to gather some feedback about this idea before fixing pipeline etc.