### PR TITLE
chore: fix install.sh to point at releases API

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -317,8 +317,11 @@ http_copy() {
 github_release() {
   owner_repo=$1
   version=$2
-  test -z "$version" && version="latest"
-  giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
+  if [ -z "$version" ]; then
+      giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
+  else
+      giturl="https://api.github.com/repos/${owner_repo}/releases/latest"
+  fi
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1
   version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name": "//' | sed 's/".*//')

--- a/install.sh
+++ b/install.sh
@@ -318,10 +318,10 @@ github_release() {
   owner_repo=$1
   version=$2
   test -z "$version" && version="latest"
-  giturl="https://github.com/${owner_repo}/releases/${version}"
+  giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1
-  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name": "//' | sed 's/".*//')
   test -z "$version" && return 1
   echo "$version"
 }

--- a/install.sh
+++ b/install.sh
@@ -318,9 +318,9 @@ github_release() {
   owner_repo=$1
   version=$2
   if [ -z "$version" ]; then
-      giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
-  else
       giturl="https://api.github.com/repos/${owner_repo}/releases/latest"
+  else
+      giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
   fi
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1


### PR DESCRIPTION
Uses the releases API to validate a release.

Fixes #3509
