### PR TITLE
chore: fix install script (revert)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -317,14 +317,11 @@ http_copy() {
 github_release() {
   owner_repo=$1
   version=$2
-  if [ -z "$version" ]; then
-      giturl="https://api.github.com/repos/${owner_repo}/releases/latest"
-  else
-      giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"
-  fi
+  test -z "$version" && version="latest"
+  giturl="https://github.com/${owner_repo}/releases/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1
-  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name": "//' | sed 's/".*//')
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
   test -z "$version" && return 1
   echo "$version"
 }

--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,7 @@ http_copy() {
 github_release() {
   owner_repo=$1
   version=$2
-  if [ -z "$version" ] || [ "$version" = "latest" ]; then
+  if [ -z "$version" ]; then
       giturl="https://api.github.com/repos/${owner_repo}/releases/latest"
   else
       giturl="https://api.github.com/repos/${owner_repo}/releases/tags/${version}"


### PR DESCRIPTION
GitHub engineers have pushed a change that has reverted the bug, so we can revert the changes.

https://github.com/orgs/community/discussions/45590#discussioncomment-4802887

The problem with the changes is the use of the API, this requires a GitHub token to avoid rate limits.

https://github.com/orgs/community/discussions/45590#discussioncomment-4802681

related to #3509, #3510, #3511, #3512, #3513.
