### PR TITLE
docs: update output example to use valid checkstyle example; add json example

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -80,7 +80,7 @@ output:
   # Multiple can be specified by separating them by comma, output can be provided
   # for each of them by separating format name and path by colon symbol.
   # Output path can be either `stdout`, `stderr` or path to the file to write to.
-  # Example: "checkstyle:report.json,colored-line-number"
+  # Example: "checkstyle:report.xml,json:stdout,colored-line-number"
   #
   # Default: colored-line-number
   format: json


### PR DESCRIPTION
the current example listed for outputs leads to checkstyle XML being saved to a .json file, which is a bit confusing since the output is xml. this PR updates the example to use xml for the checkstyle report, and send json to stdout to still show those capabilities