### PR TITLE
feat: check only changed files in pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: golangci-lint
   name: golangci-lint
   description: Fast linters runner for Go.
-  entry: golangci-lint run --fix
+  entry: golangci-lint run --new-from-rev HEAD --fix
   types: [go]
   language: golang
-  pass_filenames: false
+  pass_filenames: true


### PR DESCRIPTION
Fixes #1245
by passing filenames from pre-commit to `golangci-lint run` (which supports this since that issue was originally opened) and when used with `--new-from-rev HEAD` allows for partial commit support.