### PR TITLE
feat: add typeswitch linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2086,6 +2086,7 @@ linters:
     - thelper
     - tparallel
     - typecheck
+    - typeswitch
     - unconvert
     - unparam
     - unused
@@ -2196,6 +2197,7 @@ linters:
     - thelper
     - tparallel
     - typecheck
+    - typeswitch
     - unconvert
     - unparam
     - unused

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/gordonklaus/ineffassign v0.0.0-20210914165742-4cc7213b9bc8
 	github.com/gostaticanalysis/forcetypeassert v0.1.0
 	github.com/gostaticanalysis/nilerr v0.1.1
+	github.com/gostaticanalysis/typeswitch v0.0.0-20200129070600-0c79224605d6
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hexops/gotextdiff v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
+github.com/gostaticanalysis/typeswitch v0.0.0-20200129070600-0c79224605d6 h1:visJU4Kv4Z7feLZnQ9uV9+A2E0EtrYD58QriMP1nYjE=
+github.com/gostaticanalysis/typeswitch v0.0.0-20200129070600-0c79224605d6/go.mod h1:j0m96roq+ru7H2EuJBie/V8kWCuIONwrDx6ysJqzCAs=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
@@ -828,6 +830,7 @@ golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200117220505-0cba7a3a9ee9/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200122220014-bf1340f18c4a/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200129045341-207d3de1faaf/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/pkg/golinters/typeswitch.go
+++ b/pkg/golinters/typeswitch.go
@@ -1,0 +1,19 @@
+package golinters
+
+import (
+	"github.com/gostaticanalysis/typeswitch"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewTypeswitch() *goanalysis.Linter {
+	a := typeswitch.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -803,6 +803,11 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/moricho/tparallel"),
 
+		linter.NewConfig(golinters.NewTypeswitch()).
+			WithSince("v1.51.0").
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/gostaticanalysis/typeswitch"),
+
 		linter.NewConfig(golinters.NewTypecheck()).
 			WithSince("v1.3.0").
 			WithLoadForGoAnalysis().

--- a/test/testdata/typeswitch.go
+++ b/test/testdata/typeswitch.go
@@ -1,0 +1,54 @@
+//golangcitest:args -Etypeswitch
+package testdata
+
+type I interface{ i() }
+
+type A struct{}
+
+func (A) i() {}
+
+type B struct{}
+
+func (B) i() {}
+
+type C struct{}
+
+func (C) i() {}
+
+func g() {
+	var i I = A{}
+
+	switch i.(type) { // want "type C does not appear in any cases"
+	case A:
+	case B:
+	}
+
+	switch i.(type) { // want "type B does not appear in any cases"
+	case A:
+		println("a")
+	case C:
+		println("c")
+	}
+
+	switch v := i.(type) { // want "type B does not appear in any cases"
+	case A:
+		println(v)
+	case C:
+		println(v)
+	}
+
+	switch i.(type) { // OK
+	case A, B, C:
+		println("a, b, c")
+	}
+
+	switch i.(type) { // OK
+	case A:
+	default:
+	}
+
+	switch i.(type) { // OK
+	case A:
+	default:
+	}
+}


### PR DESCRIPTION
The `typeswitch` linter finds types implementing an interface which are not checked against in type-switches:

```go
package main

type I interface{ F() }
type A struct{I} // implements I
type B struct{I} // implements I

func main() {
	var i I = A{}
	switch i.(type) { // want "type B does not appear in any cases"
	case A:
	}
}
```

https://github.com/gostaticanalysis/typeswitch

Fixes #3487