### PR TITLE
dev: use Go1.20 to run tests with the latest golangci-lint version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,9 +41,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          # TODO(ldez) must be changed after the first release of golangci-lint with go1.20
-          # go-version: ${{ env.GO_VERSION }}
-          go-version: 1.19
+          go-version: ${{ env.GO_VERSION }}
       - name: lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:


### PR DESCRIPTION
temporarily used go1.19 explicitly in 5afb30ed542f37b8099d2ec4c5aeefdb2835e7d4