### PR TITLE
docs: revert url to gochecknoinits

### DIFF
--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -453,7 +453,8 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 
 		linter.NewConfig(golinters.NewGochecknoinits()).
 			WithSince("v1.12.0").
-			WithPresets(linter.PresetStyle),
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/leighmcculloch/gochecknoinits"),
 
 		linter.NewConfig(golinters.NewGocognit(gocognitCfg)).
 			WithSince("v1.20.0").


### PR DESCRIPTION
This PR reverts URL to `gochecknoinits` removed by mistake in #3414.