### PR TITLE
Add unusedtypeparam linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2089,6 +2089,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - unusedtypeparam
     - usestdlibvars
     - varcheck
     - varnamelen
@@ -2199,6 +2200,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - unusedtypeparam
     - usestdlibvars
     - varcheck
     - varnamelen

--- a/go.mod
+++ b/go.mod
@@ -189,3 +189,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 )
+
+require github.com/sivchari/unusedtypeparam v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -488,6 +488,8 @@ github.com/sivchari/nosnakecase v1.7.0 h1:7QkpWIRMe8x25gckkFd2A5Pi6Ymo0qgr4JrhGt
 github.com/sivchari/nosnakecase v1.7.0/go.mod h1:CwDzrzPea40/GB6uynrNLiorAlgFRvRbFSgJx2Gs+QY=
 github.com/sivchari/tenv v1.7.1 h1:PSpuD4bu6fSmtWMxSGWcvqUUgIn7k3yOJhOIzVWn8Ak=
 github.com/sivchari/tenv v1.7.1/go.mod h1:64yStXKSOxDfX47NlhVwND4dHwfZDdbp2Lyl018Icvg=
+github.com/sivchari/unusedtypeparam v1.0.0 h1:zZutRTMzB31X17EfQottVJrH2WqUBaxvs+vyzptVxcg=
+github.com/sivchari/unusedtypeparam v1.0.0/go.mod h1:NAEUEuDfMKDF5w9eNFGri5UgHjdkpJt6DjXUuThYydM=
 github.com/sonatard/noctx v0.0.1 h1:VC1Qhl6Oxx9vvWo3UDgrGXYCeKCe3Wbw7qAWL6FrmTY=
 github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4lqBjiZI=
 github.com/sourcegraph/go-diff v0.7.0 h1:9uLlrd5T46OXs5qpp8L/MTltk0zikUGi0sNNyCpA8G0=

--- a/pkg/golinters/unusedtypeparam.go
+++ b/pkg/golinters/unusedtypeparam.go
@@ -1,0 +1,19 @@
+package golinters
+
+import (
+	"github.com/sivchari/unusedtypeparam"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewUnusedTypeParam() *goanalysis.Linter {
+	a := unusedtypeparam.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -762,6 +762,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			Deprecated("The owner seems to have abandoned the linter.", "v1.49.0", "unused").
 			WithNoopFallback(m.cfg),
 
+		linter.NewConfig(golinters.NewUnusedTypeParam()).
+			WithSince("v1.52.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetUnused).
+			WithURL("https://github.com/sivchari/unusedtypeparam"),
+
 		linter.NewConfig(golinters.NewStylecheck(stylecheckCfg)).
 			WithSince("v1.20.0").
 			WithLoadForGoAnalysis().

--- a/test/testdata/unusedtypeparam.go
+++ b/test/testdata/unusedtypeparam.go
@@ -1,0 +1,18 @@
+//golangcitest:args -Eunusedtypeparam
+package testdata
+
+type Constraint interface {
+	string | ~int
+}
+
+func ok[E Constraint](arg E) {
+	arg2 := arg
+	_ = arg2
+	var arg3 E
+	_ = arg3
+}
+
+func ng[E Constraint](arg any) { // want "This func unused type parameter."
+	arg2 := arg
+	_ = arg2
+}


### PR DESCRIPTION
unusedtypeparam is analyzer that detects unused type parameters.
In detail, please check [this link](https://github.com/sivchari/unusedtypeparam)
For example, this linter can detect the bug like the atomic.Pointer.

Ref
https://github.com/golang/go/issues/56603
https://go-review.googlesource.com/c/go/+/448275/5/src/sync/atomic/type.go