### PR TITLE
ginkgolinter: fix panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/nakabonne/nestif v0.3.1
 	github.com/nishanths/exhaustive v0.9.5
 	github.com/nishanths/predeclared v0.2.2
-	github.com/nunnatsa/ginkgolinter v0.7.1
+	github.com/nunnatsa/ginkgolinter v0.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/polyfloyd/go-errorlint v1.0.6
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.7.1 h1:j4mzqx1hkE75mXHs3AUlWghZBi59c3GDWXp6zzcI+kE=
 github.com/nunnatsa/ginkgolinter v0.7.1/go.mod h1:jTgd60EAdXDmmIPZi+xoMDqAYo/4AakhWNmnPisd7Rc=
+github.com/nunnatsa/ginkgolinter v0.8.0 h1:YSDyuN7l/aBFnFHkTbTAYmL3enfSq/DEG990zGTPIS8=
+github.com/nunnatsa/ginkgolinter v0.8.0/go.mod h1:+GntEXV3IsiuQicDsSBegtnMEZFQ9ulOSs9mCT6rnvQ=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.3.1 h1:8SbseP7qM32WcvE6VaN6vfXxv698izmsJ1UQX9ve7T8=


### PR DESCRIPTION
Fix ginkgolinter so it won't modify the ast tree. This PR bumps the ginkgolinter version to adopt the fix.


https://github.com/nunnatsa/ginkgolinter/compare/v0.7.1...v0.8.0

Fix #3548 