### PR TITLE
dev: use T.TempDir instead of os.MkdirTemp

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -21,12 +21,8 @@ func init() {
 func TestBasic(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	_, err = Open(filepath.Join(dir, "notexist"))
+	dir := t.TempDir()
+	_, err := Open(filepath.Join(dir, "notexist"))
 	if err == nil {
 		t.Fatal(`Open("tmp/notexist") succeeded, want failure`)
 	}
@@ -68,13 +64,7 @@ func TestBasic(t *testing.T) {
 func TestGrowth(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	c, err := Open(dir)
+	c, err := Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -121,13 +111,7 @@ func TestVerifyPanic(t *testing.T) {
 		t.Fatal("initEnv did not set verify")
 	}
 
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	c, err := Open(dir)
+	c, err := Open(t.TempDir())
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -156,12 +140,7 @@ func dummyID(x int) [HashSize]byte {
 func TestCacheTrim(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "cachetest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	c, err := Open(dir)
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/internal/cache/hash_test.go
+++ b/internal/cache/hash_test.go
@@ -27,13 +27,12 @@ func TestHash(t *testing.T) {
 }
 
 func TestHashFile(t *testing.T) {
-	f, err := os.CreateTemp("", "cmd-go-test-")
+	f, err := os.CreateTemp(t.TempDir(), "cmd-go-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
 	name := f.Name()
 	fmt.Fprintf(f, "hello world")
-	defer os.Remove(name)
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/renameio/renameio_test.go
+++ b/internal/renameio/renameio_test.go
@@ -9,7 +9,6 @@ package renameio
 import (
 	"encoding/binary"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -22,12 +21,7 @@ import (
 )
 
 func TestConcurrentReadsAndWrites(t *testing.T) {
-	dir, err := os.MkdirTemp("", "renameio")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	path := filepath.Join(dir, "blob.bin")
+	path := filepath.Join(t.TempDir(), "blob.bin")
 
 	const chunkWords = 8 << 10
 	buf := make([]byte, 2*chunkWords*8)

--- a/internal/renameio/umask_test.go
+++ b/internal/renameio/umask_test.go
@@ -14,18 +14,12 @@ import (
 )
 
 func TestWriteFileModeAppliesUmask(t *testing.T) {
-	dir, err := os.MkdirTemp("", "renameio")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
 	const mode = 0644
 	const umask = 0007
 	defer syscall.Umask(syscall.Umask(umask))
 
-	file := filepath.Join(dir, "testWrite")
-	err = WriteFile(file, []byte("go-build"), mode)
+	file := filepath.Join(t.TempDir(), "testWrite")
+	err := WriteFile(file, []byte("go-build"), mode)
 	if err != nil {
 		t.Fatalf("Failed to write file: %v", err)
 	}


### PR DESCRIPTION
This PR refactors tests by using [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) which automatically removes at the end of a test.