### PR TITLE
dev: do not print extra whitespace in deprecated lint log

### DIFF
--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -58,7 +58,7 @@ func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env, es *lint
 
 			var extra string
 			if lc.Deprecation.Replacement != "" {
-				extra = fmt.Sprintf(" Replaced by %s.", lc.Deprecation.Replacement)
+				extra = fmt.Sprintf("Replaced by %s.", lc.Deprecation.Replacement)
 			}
 
 			log.Warnf("The linter '%s' is deprecated (since %s) due to: %s %s", name, lc.Deprecation.Since, lc.Deprecation.Message, extra)


### PR DESCRIPTION
This PR removes extra whitespace in the warning log about deprecated linter.

Instead of
```
WARN [runner] The linter "golint" is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
```

now prints without two whitespaces after `the owner`
```
WARN [runner] The linter "golint" is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner. Replaced by revive.
```