### PR TITLE
govet: enable timeformat by default

### DIFF
--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -89,7 +89,6 @@ var (
 		unusedwrite.Analyzer,
 	}
 
-	// https://github.com/golang/go/blob/879db69ce2de814bc3203c39b45617ba51cc5366/src/cmd/vet/main.go#L40-L68
 	defaultAnalyzers = []*analysis.Analyzer{
 		asmdecl.Analyzer,
 		assign.Analyzer,
@@ -114,6 +113,7 @@ var (
 		structtag.Analyzer,
 		testinggoroutine.Analyzer,
 		tests.Analyzer,
+		timeformat.Analyzer,
 		unmarshal.Analyzer,
 		unreachable.Analyzer,
 		unsafeptr.Analyzer,

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -89,6 +89,7 @@ var (
 		unusedwrite.Analyzer,
 	}
 
+	// https://github.com/golang/go/blob/9f834a559c9ed6cdf883e29b36e21e5f956df74f/src/cmd/vet/main.go#L46-L76
 	defaultAnalyzers = []*analysis.Analyzer{
 		asmdecl.Analyzer,
 		assign.Analyzer,


### PR DESCRIPTION
Updates #3353 

It seems my comment was wrong in #3353. It was enabled by default in go vet.

https://github.com/golang/go/blob/release-branch.go1.20/src/cmd/vet/main.go