### PR TITLE
dev: remove duplicated test asserts

### DIFF
--- a/test/testshared/runner_test.go
+++ b/test/testshared/runner_test.go
@@ -179,8 +179,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 			assert.NotNil(t, runner.log)
 			assert.NotNil(t, runner.tb)
 			assert.Equal(t, test.expected.env, runner.env)
-			assert.Equal(t, test.expected.env, runner.env)
-			assert.Equal(t, test.expected.env, runner.env)
 			assert.Equal(t, test.expected.command, runner.command)
 			assert.Equal(t, test.expected.args, runner.args)
 		})


### PR DESCRIPTION
This test removes duplicated `assert.Equal(t, test.expected.env, runner.env)` line in `TestRunnerBuilder_Runner`.