### PR TITLE
fix: cache status size calculation

### DIFF
--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -64,7 +64,7 @@ func dirSizeBytes(path string) (int64, error) {
 	var size int64
 	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
 		if err == nil && !info.IsDir() {
-			size = info.Size()
+			size += info.Size()
 		}
 		return err
 	})


### PR DESCRIPTION
related #2971 

`golangci-lint cache status` always shows 10B if cache directory exists.
That's the size of trim.txt.