### PR TITLE
.golangci.reference.yml validation

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1018,48 +1018,51 @@ linters-settings:
       - unusedwrite
 
     # Enable all analyzers.
+    # enable-all and disable-all cannot both be true, therefore this section is
+    # commented out.
+    #
     # Default: false
-    enable-all: true
+    # enable-all: true
     # Disable analyzers by name.
     # Run `go tool vet help` to see all analyzers.
     # Default: []
-    disable:
-      - asmdecl
-      - assign
-      - atomic
-      - atomicalign
-      - bools
-      - buildtag
-      - cgocall
-      - composites
-      - copylocks
-      - deepequalerrors
-      - errorsas
-      - fieldalignment
-      - findcall
-      - framepointer
-      - httpresponse
-      - ifaceassert
-      - loopclosure
-      - lostcancel
-      - nilfunc
-      - nilness
-      - printf
-      - reflectvaluecompare
-      - shadow
-      - shift
-      - sigchanyzer
-      - sortslice
-      - stdmethods
-      - stringintconv
-      - structtag
-      - testinggoroutine
-      - tests
-      - unmarshal
-      - unreachable
-      - unsafeptr
-      - unusedresult
-      - unusedwrite
+    # disable:
+    #   - asmdecl
+    #   - assign
+    #   - atomic
+    #   - atomicalign
+    #   - bools
+    #   - buildtag
+    #   - cgocall
+    #   - composites
+    #   - copylocks
+    #   - deepequalerrors
+    #   - errorsas
+    #   - fieldalignment
+    #   - findcall
+    #   - framepointer
+    #   - httpresponse
+    #   - ifaceassert
+    #   - loopclosure
+    #   - lostcancel
+    #   - nilfunc
+    #   - nilness
+    #   - printf
+    #   - reflectvaluecompare
+    #   - shadow
+    #   - shift
+    #   - sigchanyzer
+    #   - sortslice
+    #   - stdmethods
+    #   - stringintconv
+    #   - structtag
+    #   - testinggoroutine
+    #   - tests
+    #   - unmarshal
+    #   - unreachable
+    #   - unsafeptr
+    #   - unusedresult
+    #   - unusedwrite
 
   grouper:
     # Require the use of a single global 'const' declaration only.

--- a/pkg/config/reader_test.go
+++ b/pkg/config/reader_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/pkg/logutils"
+)
+
+func TestReader(t *testing.T) {
+	var toCfg, commandLineCfg Config
+	logger := logutils.NewStderrLog("")
+	logger.SetLevel(logutils.LogLevelDebug)
+
+	commandLineCfg.Run.Config = "../../.golangci.reference.yml"
+	reader := NewFileReader(&toCfg, &commandLineCfg, logger)
+	if err := reader.Read(); err != nil {
+		t.Fatalf("unexpected error reading .golangci.reference.yml: %v", err)
+	}
+}


### PR DESCRIPTION
I recently (see https://github.com/golangci/golangci-lint/pull/3612) worked on configuration changes that touched the reader. I found no unit test for it, so I added one with the `.golangci.reference.yml` file as input.

The positive side effect is that putting something invalid there now gets flagged during testing. The negative effect is that invalid configuration entries must be commented out, which makes it a bit less readable.
