### PR TITLE
dev: enable revive linter with default config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,10 @@ linters-settings:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+  revive:
+    rules:
+      - name: unexported-return
+        disabled: true
 
 linters:
   disable-all: true
@@ -91,6 +95,7 @@ linters:
     - nakedret
     - noctx
     - nolintlint
+    - revive
     - staticcheck
     - stylecheck
     - typecheck
@@ -112,7 +117,6 @@ linters:
   # - nestif
   # - prealloc
   # - testpackage
-  # - revive
   # - wsl
 
 issues:


### PR DESCRIPTION
This PR enables `revive` in the `.golangci.yml` config.
