### PR TITLE
dev: bytes.NewBuffer/bytes.NewBufferString to shorten initialization

### DIFF
--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -157,8 +157,7 @@ func (e *Executor) initHashSalt(version string) error {
 		return fmt.Errorf("failed to calculate config salt: %w", err)
 	}
 
-	var b bytes.Buffer
-	b.Write(binSalt)
+	b := bytes.NewBuffer(binSalt)
 	b.Write(configSalt)
 	cache.SetSalt(b.Bytes())
 	return nil
@@ -198,8 +197,7 @@ func computeConfigSalt(cfg *config.Config) ([]byte, error) {
 		return nil, fmt.Errorf("failed to json marshal config linter settings: %w", err)
 	}
 
-	var configData bytes.Buffer
-	configData.WriteString("linters-settings=")
+	configData := bytes.NewBufferString("linters-settings=")
 	configData.Write(lintersSettingsBytes)
 	configData.WriteString("\nbuild-tags=%s" + strings.Join(cfg.Run.BuildTags, ","))
 

--- a/pkg/golinters/gofumpt.go
+++ b/pkg/golinters/gofumpt.go
@@ -88,13 +88,9 @@ func runGofumpt(lintCtx *linter.Context, pass *analysis.Pass, diff differ, optio
 		}
 
 		if !bytes.Equal(input, output) {
-			out := bytes.Buffer{}
-			_, err = out.WriteString(fmt.Sprintf("--- %[1]s\n+++ %[1]s\n", f))
-			if err != nil {
-				return nil, fmt.Errorf("error while running gofumpt: %w", err)
-			}
+			out := bytes.NewBufferString(fmt.Sprintf("--- %[1]s\n+++ %[1]s\n", f))
 
-			err = diff.Diff(&out, bytes.NewReader(input), bytes.NewReader(output))
+			err := diff.Diff(out, bytes.NewReader(input), bytes.NewReader(output))
 			if err != nil {
 				return nil, fmt.Errorf("error while running gofumpt: %w", err)
 			}

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -64,8 +64,7 @@ func updateStateFile(replacements map[string]string) error {
 		return err
 	}
 
-	var contentBuf bytes.Buffer
-	contentBuf.WriteString("This file stores hash of website templates to trigger " +
+	contentBuf := bytes.NewBufferString("This file stores hash of website templates to trigger " +
 		"Netlify rebuild when something changes, e.g. new linter is added.\n")
 	contentBuf.WriteString(hex.EncodeToString(h.Sum(nil)))
 


### PR DESCRIPTION
This PR refactors code to use `bytes.NewBuffer` or `bytes.NewBufferString` to shorten the code.