### PR TITLE
dev: git ignore golangci-lint.exe on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.vscode/
 /dist/
 /golangci-lint
+/golangci-lint.exe
 /test/path
 /tools/Dracula.itermcolors
 /tools/dist/


### PR DESCRIPTION
When running integration tests on Windows the file `golangci-lint.exe` is created.