### PR TITLE
dev: remove github.com/pkg/errors inside tests

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -75,7 +75,7 @@ run:
 
 # output configuration options
 output:
-  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions|teamcity
   #
   # Multiple can be specified by separating them by comma, output can be provided
   # for each of them by separating format name and path by colon symbol.

--- a/test/testdata/configs/importas.yml
+++ b/test/testdata/configs/importas.yml
@@ -5,5 +5,5 @@ linters-settings:
         alias: fff
       - pkg: os
         alias: std_os
-      - pkg: github.com/pkg/errors
-        alias: pkgerr
+      - pkg: golang.org/x/tools/go/analysis
+        alias: ananas

--- a/test/testdata/configs/importas_strict.yml
+++ b/test/testdata/configs/importas_strict.yml
@@ -6,5 +6,5 @@ linters-settings:
         alias: fff
       - pkg: os
         alias: std_os
-      - pkg: github.com/pkg/errors
-        alias: pkgerr
+      - pkg: golang.org/x/tools/go/analysis
+        alias: ananas

--- a/test/testdata/fix/in/gci.go
+++ b/test/testdata/fix/in/gci.go
@@ -5,12 +5,12 @@ package gci
 
 import (
 	"github.com/golangci/golangci-lint/pkg/config"
-	"github.com/pkg/errors"
+	"golang.org/x/tools/go/analysis"
 	"fmt"
 )
 
 func GoimportsLocalTest() {
 	fmt.Print("x")
 	_ = config.Config{}
-	_ = errors.New("")
+	_ = analysis.Analyzer{}
 }

--- a/test/testdata/fix/out/gci.go
+++ b/test/testdata/fix/out/gci.go
@@ -6,7 +6,7 @@ package gci
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 )
@@ -14,5 +14,5 @@ import (
 func GoimportsLocalTest() {
 	fmt.Print("x")
 	_ = config.Config{}
-	_ = errors.New("")
+	_ = analysis.Analyzer{}
 }

--- a/test/testdata/gci.go
+++ b/test/testdata/gci.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/golangci/golangci-lint/pkg/config" // want "File is not \\`gci\\`-ed with --skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
 
-	"github.com/pkg/errors" // want "File is not \\`gci\\`-ed with --skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
+	"golang.org/x/tools/go/analysis" // want "File is not \\`gci\\`-ed with --skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
 )
 
 func GoimportsLocalTest() {
 	fmt.Print("x")
 	_ = config.Config{}
-	_ = errors.New("")
+	_ = analysis.Analyzer{}
 }

--- a/test/testdata/goimports_local.go
+++ b/test/testdata/goimports_local.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 
 	"github.com/golangci/golangci-lint/pkg/config" // want "File is not `goimports`-ed with -local github.com/golangci/golangci-lint"
-	"github.com/pkg/errors"
+	"golang.org/x/tools/go/analysis"
 )
 
 func GoimportsLocalPrefixTest() {
 	fmt.Print("x")
 	_ = config.Config{}
-	_ = errors.New("")
+	_ = analysis.Analyzer{}
 }

--- a/test/testdata/importas.go
+++ b/test/testdata/importas.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	wrong_alias_again "os" // want `import "os" imported as "wrong_alias_again" but must be "std_os" according to config`
 
-	wrong "github.com/pkg/errors" // want `import "github.com/pkg/errors" imported as "wrong" but must be "pkgerr" according to config`
+	wrong "golang.org/x/tools/go/analysis" // want `import "golang.org/x/tools/go/analysis" imported as "wrong" but must be "ananas" according to config`
 )
 
 func ImportAsWrongAlias() {
 	wrong_alias.Println("foo")
 	wrong_alias_again.Stdout.WriteString("bar")
 	os.Stdout.WriteString("test")
-	_ = wrong.New("baz")
+	_ = wrong.Analyzer{}
 }

--- a/test/testdata/importas_strict.go
+++ b/test/testdata/importas_strict.go
@@ -7,12 +7,12 @@ import (
 	"os"                   // want `import "os" imported without alias but must be with alias "std_os" according to config`
 	wrong_alias_again "os" // want `import "os" imported as "wrong_alias_again" but must be "std_os" according to config`
 
-	wrong "github.com/pkg/errors" // want `import "github.com/pkg/errors" imported as "wrong" but must be "pkgerr" according to config`
+	wrong "golang.org/x/tools/go/analysis" // want `import "golang.org/x/tools/go/analysis" imported as "wrong" but must be "ananas" according to config`
 )
 
 func ImportAsStrictWrongAlias() {
 	wrong_alias.Println("foo")
 	wrong_alias_again.Stdout.WriteString("bar")
 	os.Stdout.WriteString("test")
-	_ = wrong.New("baz")
+	_ = wrong.Analyzer{}
 }


### PR DESCRIPTION
I completely remove `github.com/pkg/errors` from tests because the files inside tests are not considered to create the go.mod.

So when the latest dependency will remove `github.com/pkg/errors`, and then this package will be removed from the go.mod, a lot of tests will fail.

The latest dependency that uses `github.com/pkg/errors` is `forbidigo` and the dependency will be removed inside PR #3639.
