### PR TITLE
build(deps): bump github.com/nunnatsa/ginkgolinter from 0.8.1 to 0.9.0

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -418,6 +418,14 @@ linters-settings:
     # Default: false
     suppress-err-assertion: true
 
+    # Suppress the wrong comparison assertion warning.
+    # Default: false
+    suppress-compare-assertion: true
+
+    # Don't trigger warnings for HaveLen(0)
+    # Default: false
+    allow-havelen-zero: true
+
   gocognit:
     # Minimal code complexity to report.
     # Default: 30 (but we recommend 10-20)

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/nakabonne/nestif v0.3.1
 	github.com/nishanths/exhaustive v0.9.5
 	github.com/nishanths/predeclared v0.2.2
-	github.com/nunnatsa/ginkgolinter v0.8.1
+	github.com/nunnatsa/ginkgolinter v0.9.0
 	github.com/polyfloyd/go-errorlint v1.2.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/ryancurrah/gomodguard v1.3.0
@@ -128,7 +128,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-toolsmith/astcast v1.1.0 // indirect
-	github.com/go-toolsmith/astcopy v1.0.3 // indirect
+	github.com/go-toolsmith/astcopy v1.1.0 // indirect
 	github.com/go-toolsmith/astequal v1.1.0 // indirect
 	github.com/go-toolsmith/astfmt v1.1.0 // indirect
 	github.com/go-toolsmith/astp v1.1.0 // indirect
@@ -178,7 +178,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
-	golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9 // indirect
+	golang.org/x/exp/typeparams v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,9 +152,8 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-toolsmith/astcast v1.1.0 h1:+JN9xZV1A+Re+95pgnMgDboWNVnIMMQXwfBwLRPgSC8=
 github.com/go-toolsmith/astcast v1.1.0/go.mod h1:qdcuFWeGGS2xX5bLM/c3U9lewg7+Zu4mr+xPwZIB4ZU=
-github.com/go-toolsmith/astcopy v1.0.3 h1:r0bgSRlMOAgO+BdQnVAcpMSMkrQCnV6ZJmIkrJgcJj0=
-github.com/go-toolsmith/astcopy v1.0.3/go.mod h1:4TcEdbElGc9twQEYpVo/aieIXfHhiuLh4aLAck6dO7Y=
-github.com/go-toolsmith/astequal v1.0.2/go.mod h1:9Ai4UglvtR+4up+bAD4+hCj7iTo4m/OXVTSLnCyTAx4=
+github.com/go-toolsmith/astcopy v1.1.0 h1:YGwBN0WM+ekI/6SS6+52zLDEf8Yvp3n2seZITCUBt5s=
+github.com/go-toolsmith/astcopy v1.1.0/go.mod h1:hXM6gan18VA1T/daUEHCFcYiW8Ai1tIwIzHY6srfEAw=
 github.com/go-toolsmith/astequal v1.0.3/go.mod h1:9Ai4UglvtR+4up+bAD4+hCj7iTo4m/OXVTSLnCyTAx4=
 github.com/go-toolsmith/astequal v1.1.0 h1:kHKm1AWqClYn15R0K1KKE4RG614D46n+nqUQ06E1dTw=
 github.com/go-toolsmith/astequal v1.1.0/go.mod h1:sedf7VIdCL22LD8qIvv7Nn9MuWJruQA/ysswh64lffQ=
@@ -389,8 +388,8 @@ github.com/nishanths/exhaustive v0.9.5 h1:TzssWan6orBiLYVqewCG8faud9qlFntJE30ACp
 github.com/nishanths/exhaustive v0.9.5/go.mod h1:IbwrGdVMizvDcIxPYGVdQn5BqWJaOwpCvg4RGb8r/TA=
 github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm/w98Vk=
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
-github.com/nunnatsa/ginkgolinter v0.8.1 h1:/y4o/0hV+ruUHj4xXh89xlFjoaitnI4LnkpuYs02q1c=
-github.com/nunnatsa/ginkgolinter v0.8.1/go.mod h1:FYYLtszIdmzCH8XMaMPyxPVXZ7VCaIm55bA+gugx+14=
+github.com/nunnatsa/ginkgolinter v0.9.0 h1:Sm0zX5QfjJzkeCjEp+t6d3Ha0jwvoDjleP9XCsrEzOA=
+github.com/nunnatsa/ginkgolinter v0.9.0/go.mod h1:FHaMLURXP7qImeH6bvxWJUpyH+2tuqe5j4rW1gxJRmI=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.8.0 h1:pAM+oBNPrpXRs+E/8spkeGx9QgekbRVyr74EUvRVOUI=
@@ -603,8 +602,9 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
-golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9 h1:6WHiuFL9FNjg8RljAaT7FNUuKDbvMqS1i5cr2OE2sLQ=
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/exp/typeparams v0.0.0-20230224173230-c95f2b4c22f2 h1:J74nGeMgeFnYQJN59eFwh06jX/V8g0lB7LWpjSLxtgU=
+golang.org/x/exp/typeparams v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -325,9 +325,11 @@ type GciSettings struct {
 }
 
 type GinkgoLinterSettings struct {
-	SuppressLenAssertion bool `mapstructure:"suppress-len-assertion"`
-	SuppressNilAssertion bool `mapstructure:"suppress-nil-assertion"`
-	SuppressErrAssertion bool `mapstructure:"suppress-err-assertion"`
+	SuppressLenAssertion     bool `mapstructure:"suppress-len-assertion"`
+	SuppressNilAssertion     bool `mapstructure:"suppress-nil-assertion"`
+	SuppressErrAssertion     bool `mapstructure:"suppress-err-assertion"`
+	SuppressCompareAssertion bool `mapstructure:"suppress-compare-assertion"`
+	AllowHaveLenZero         bool `mapstructure:"allow-havelen-zero"`
 }
 
 type GocognitSettings struct {

--- a/pkg/golinters/ginkgolinter.go
+++ b/pkg/golinters/ginkgolinter.go
@@ -14,9 +14,11 @@ func NewGinkgoLinter(cfg *config.GinkgoLinterSettings) *goanalysis.Linter {
 	cfgMap := make(map[string]map[string]interface{})
 	if cfg != nil {
 		cfgMap[a.Name] = map[string]interface{}{
-			"suppress-len-assertion": cfg.SuppressLenAssertion,
-			"suppress-nil-assertion": cfg.SuppressNilAssertion,
-			"suppress-err-assertion": cfg.SuppressErrAssertion,
+			"suppress-len-assertion":     cfg.SuppressLenAssertion,
+			"suppress-nil-assertion":     cfg.SuppressNilAssertion,
+			"suppress-err-assertion":     cfg.SuppressErrAssertion,
+			"suppress-compare-assertion": cfg.SuppressCompareAssertion,
+			"allow-havelen-0":            cfg.AllowHaveLenZero,
 		}
 	}
 

--- a/test/testdata/ginkgolinter/configs/ginkgolinter_allow_havelen0.yml
+++ b/test/testdata/ginkgolinter/configs/ginkgolinter_allow_havelen0.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  ginkgolinter:
+    allow-havelen-zero: true

--- a/test/testdata/ginkgolinter/configs/ginkgolinter_suppress_compare.yml
+++ b/test/testdata/ginkgolinter/configs/ginkgolinter_suppress_compare.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  ginkgolinter:
+    suppress-compare-assertion: true

--- a/test/testdata/ginkgolinter/ginkgolinter.go
+++ b/test/testdata/ginkgolinter/ginkgolinter.go
@@ -49,3 +49,18 @@ func ErrorUsecase() {
 	Expect(err != nil).To(BeTrue())      // want "ginkgo-linter: wrong error assertion; consider using .Expect\\(err\\)\\.To\\(HaveOccurred\\(\\)\\). instead"
 	Expect(funcReturnsErr()).To(BeNil()) // want "ginkgo-linter: wrong error assertion; consider using .Expect\\(funcReturnsErr\\(\\)\\)\\.To\\(Succeed\\(\\)\\). instead"
 }
+
+func HaveLen0Usecase() {
+	x := make([]string, 0)
+	Expect(x).To(HaveLen(0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(x\\)\\.To\\(BeEmpty\\(\\)\\). instead"
+}
+
+func WrongComparisonUsecase() {
+	x := 8
+	Expect(x == 8).To(BeTrue())    // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(Equal\\(8\\)\\). instead"
+	Expect(x < 9).To(BeTrue())     // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(BeNumerically\\(\"<\", 9\\)\\). instead"
+	Expect(x < 7).To(Equal(false)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.ToNot\\(BeNumerically\\(\"<\", 7\\)\\). instead"
+
+	p1, p2 := &x, &x
+	Expect(p1 == p2).To(Equal(true)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(p1\\).To\\(BeIdenticalTo\\(p2\\)\\). instead"
+}

--- a/test/testdata/ginkgolinter/ginkgolinter_havelen0.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_havelen0.go
@@ -1,4 +1,4 @@
-//golangcitest:config_path configs/ginkgolinter_suppress_len.yml
+//golangcitest:config_path configs/ginkgolinter_allow_havelen0.yml
 //golangcitest:args --disable-all -Eginkgolinter
 package ginkgolinter
 
@@ -7,25 +7,24 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// LenUsecase_len should not trigger any warning
-func LenUsecase_len() {
+func LenUsecase_havelen0() {
 	var fakeVarUnderTest []int
 	Expect(fakeVarUnderTest).Should(BeEmpty())     // valid
 	Expect(fakeVarUnderTest).ShouldNot(HaveLen(5)) // valid
 
-	Expect(len(fakeVarUnderTest)).Should(Equal(0))
-	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(2))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically("==", 0))
+	Expect(len(fakeVarUnderTest)).Should(Equal(0))           // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.Should\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(2))        // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ShouldNot\\(HaveLen\\(2\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically("==", 0)) // // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.To\\(BeEmpty\\(\\)\\). instead"
 
 	fakeVarUnderTest = append(fakeVarUnderTest, 3)
-	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(0))
-	Expect(len(fakeVarUnderTest)).Should(Equal(1))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically(">", 0))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically(">=", 1))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically("!=", 0))
+	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(0))        // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ShouldNot\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).Should(Equal(1))           // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.Should\\(HaveLen\\(1\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically(">", 0))  // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ToNot\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically(">=", 1)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ToNot\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically("!=", 0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ToNot\\(BeEmpty\\(\\)\\). instead"
 }
 
-func NilUsecase_len() {
+func NilUsecase_havelen0() {
 	y := 5
 	x := &y
 	Expect(x == nil).To(Equal(true)) // want "ginkgo-linter: wrong nil assertion; consider using .Expect\\(x\\)\\.To\\(BeNil\\(\\)\\). instead"
@@ -34,14 +33,14 @@ func NilUsecase_len() {
 	Expect(x == nil).To(BeTrue())    // want "ginkgo-linter: wrong nil assertion; consider using .Expect\\(x\\)\\.To\\(BeNil\\(\\)\\). instead"
 	Expect(x == nil).To(BeFalse())   // want "ginkgo-linter: wrong nil assertion; consider using .Expect\\(x\\)\\.ToNot\\(BeNil\\(\\)\\). instead"
 }
-func BooleanUsecase_len() {
+func BooleanUsecase_havelen0() {
 	x := true
 	Expect(x).To(Equal(true)) // want "ginkgo-linter: wrong boolean assertion; consider using .Expect\\(x\\)\\.To\\(BeTrue\\(\\)\\). instead"
 	x = false
 	Expect(x).To(Equal(false)) // want "ginkgo-linter: wrong boolean assertion; consider using .Expect\\(x\\)\\.To\\(BeFalse\\(\\)\\). instead"
 }
 
-func ErrorUsecase_len() {
+func ErrorUsecase_havelen0() {
 	err := errors.New("fake error")
 	funcReturnsErr := func() error { return err }
 
@@ -52,12 +51,12 @@ func ErrorUsecase_len() {
 	Expect(funcReturnsErr()).To(BeNil()) // want "ginkgo-linter: wrong error assertion; consider using .Expect\\(funcReturnsErr\\(\\)\\)\\.To\\(Succeed\\(\\)\\). instead"
 }
 
-func HaveLen0Usecase_len() {
+func HaveLen0Usecase_havelen0() {
 	x := make([]string, 0)
-	Expect(x).To(HaveLen(0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(x\\)\\.To\\(BeEmpty\\(\\)\\). instead"
+	Expect(x).To(HaveLen(0))
 }
 
-func WrongComparisonUsecase_len() {
+func WrongComparisonUsecase_havelen0() {
 	x := 8
 	Expect(x == 8).To(BeTrue())    // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(Equal\\(8\\)\\). instead"
 	Expect(x < 9).To(BeTrue())     // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(BeNumerically\\(\"<\", 9\\)\\). instead"

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_compare.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_compare.go
@@ -1,4 +1,4 @@
-//golangcitest:config_path configs/ginkgolinter_suppress_len.yml
+//golangcitest:config_path configs/ginkgolinter_suppress_compare.yml
 //golangcitest:args --disable-all -Eginkgolinter
 package ginkgolinter
 
@@ -7,25 +7,24 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// LenUsecase_len should not trigger any warning
-func LenUsecase_len() {
+func LenUsecase_compare() {
 	var fakeVarUnderTest []int
 	Expect(fakeVarUnderTest).Should(BeEmpty())     // valid
 	Expect(fakeVarUnderTest).ShouldNot(HaveLen(5)) // valid
 
-	Expect(len(fakeVarUnderTest)).Should(Equal(0))
-	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(2))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically("==", 0))
+	Expect(len(fakeVarUnderTest)).Should(Equal(0))           // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.Should\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(2))        // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ShouldNot\\(HaveLen\\(2\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically("==", 0)) // // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.To\\(BeEmpty\\(\\)\\). instead"
 
 	fakeVarUnderTest = append(fakeVarUnderTest, 3)
-	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(0))
-	Expect(len(fakeVarUnderTest)).Should(Equal(1))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically(">", 0))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically(">=", 1))
-	Expect(len(fakeVarUnderTest)).To(BeNumerically("!=", 0))
+	Expect(len(fakeVarUnderTest)).ShouldNot(Equal(0))        // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ShouldNot\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).Should(Equal(1))           // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.Should\\(HaveLen\\(1\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically(">", 0))  // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ToNot\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically(">=", 1)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ToNot\\(BeEmpty\\(\\)\\). instead"
+	Expect(len(fakeVarUnderTest)).To(BeNumerically("!=", 0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ToNot\\(BeEmpty\\(\\)\\). instead"
 }
 
-func NilUsecase_len() {
+func NilUsecase_compare() {
 	y := 5
 	x := &y
 	Expect(x == nil).To(Equal(true)) // want "ginkgo-linter: wrong nil assertion; consider using .Expect\\(x\\)\\.To\\(BeNil\\(\\)\\). instead"
@@ -34,14 +33,14 @@ func NilUsecase_len() {
 	Expect(x == nil).To(BeTrue())    // want "ginkgo-linter: wrong nil assertion; consider using .Expect\\(x\\)\\.To\\(BeNil\\(\\)\\). instead"
 	Expect(x == nil).To(BeFalse())   // want "ginkgo-linter: wrong nil assertion; consider using .Expect\\(x\\)\\.ToNot\\(BeNil\\(\\)\\). instead"
 }
-func BooleanUsecase_len() {
+func BooleanUsecase_compare() {
 	x := true
 	Expect(x).To(Equal(true)) // want "ginkgo-linter: wrong boolean assertion; consider using .Expect\\(x\\)\\.To\\(BeTrue\\(\\)\\). instead"
 	x = false
 	Expect(x).To(Equal(false)) // want "ginkgo-linter: wrong boolean assertion; consider using .Expect\\(x\\)\\.To\\(BeFalse\\(\\)\\). instead"
 }
 
-func ErrorUsecase_len() {
+func ErrorUsecase_compare() {
 	err := errors.New("fake error")
 	funcReturnsErr := func() error { return err }
 
@@ -52,17 +51,18 @@ func ErrorUsecase_len() {
 	Expect(funcReturnsErr()).To(BeNil()) // want "ginkgo-linter: wrong error assertion; consider using .Expect\\(funcReturnsErr\\(\\)\\)\\.To\\(Succeed\\(\\)\\). instead"
 }
 
-func HaveLen0Usecase_len() {
+func HaveLen0Usecase_compare() {
 	x := make([]string, 0)
 	Expect(x).To(HaveLen(0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(x\\)\\.To\\(BeEmpty\\(\\)\\). instead"
 }
 
-func WrongComparisonUsecase_len() {
+// WrongComparisonUsecase_compare should not trigger any warning
+func WrongComparisonUsecase_compare() {
 	x := 8
-	Expect(x == 8).To(BeTrue())    // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(Equal\\(8\\)\\). instead"
-	Expect(x < 9).To(BeTrue())     // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(BeNumerically\\(\"<\", 9\\)\\). instead"
-	Expect(x < 7).To(Equal(false)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.ToNot\\(BeNumerically\\(\"<\", 7\\)\\). instead"
+	Expect(x == 8).To(BeTrue())
+	Expect(x < 9).To(BeTrue())
+	Expect(x < 7).To(Equal(false))
 
 	p1, p2 := &x, &x
-	Expect(p1 == p2).To(Equal(true)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(p1\\).To\\(BeIdenticalTo\\(p2\\)\\). instead"
+	Expect(p1 == p2).To(Equal(true))
 }

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_err.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_err.go
@@ -40,6 +40,7 @@ func BooleanUsecase_err() {
 	Expect(x).To(Equal(false)) // want "ginkgo-linter: wrong boolean assertion; consider using .Expect\\(x\\)\\.To\\(BeFalse\\(\\)\\). instead"
 }
 
+// ErrorUsecase_err should not trigger any warning
 func ErrorUsecase_err() {
 	err := errors.New("fake error")
 	funcReturnsErr := func() error { return err }
@@ -49,4 +50,19 @@ func ErrorUsecase_err() {
 	Expect(err == nil).To(BeFalse())
 	Expect(err != nil).To(BeTrue())
 	Expect(funcReturnsErr()).To(BeNil())
+}
+
+func HaveLen0Usecase_err() {
+	x := make([]string, 0)
+	Expect(x).To(HaveLen(0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(x\\)\\.To\\(BeEmpty\\(\\)\\). instead"
+}
+
+func WrongComparisonUsecase_err() {
+	x := 8
+	Expect(x == 8).To(BeTrue())    // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(Equal\\(8\\)\\). instead"
+	Expect(x < 9).To(BeTrue())     // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(BeNumerically\\(\"<\", 9\\)\\). instead"
+	Expect(x < 7).To(Equal(false)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.ToNot\\(BeNumerically\\(\"<\", 7\\)\\). instead"
+
+	p1, p2 := &x, &x
+	Expect(p1 == p2).To(Equal(true)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(p1\\).To\\(BeIdenticalTo\\(p2\\)\\). instead"
 }

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_nil.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_nil.go
@@ -24,6 +24,7 @@ func LenUsecase_nil() {
 	Expect(len(fakeVarUnderTest)).To(BeNumerically("!=", 0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(fakeVarUnderTest\\)\\.ToNot\\(BeEmpty\\(\\)\\). instead"
 }
 
+// NilUsecase_nil should not trigger any warning
 func NilUsecase_nil() {
 	y := 5
 	x := &y
@@ -49,4 +50,19 @@ func ErrorUsecase_nil() {
 	Expect(err == nil).To(BeFalse())     // want "ginkgo-linter: wrong error assertion; consider using .Expect\\(err\\)\\.To\\(HaveOccurred\\(\\)\\). instead"
 	Expect(err != nil).To(BeTrue())      // want "ginkgo-linter: wrong error assertion; consider using .Expect\\(err\\)\\.To\\(HaveOccurred\\(\\)\\). instead"
 	Expect(funcReturnsErr()).To(BeNil()) // want "ginkgo-linter: wrong error assertion; consider using .Expect\\(funcReturnsErr\\(\\)\\)\\.To\\(Succeed\\(\\)\\). instead"
+}
+
+func HaveLen0Usecase_nil() {
+	x := make([]string, 0)
+	Expect(x).To(HaveLen(0)) // want "ginkgo-linter: wrong length assertion; consider using .Expect\\(x\\)\\.To\\(BeEmpty\\(\\)\\). instead"
+}
+
+func WrongComparisonUsecase_nil() {
+	x := 8
+	Expect(x == 8).To(BeTrue())    // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(Equal\\(8\\)\\). instead"
+	Expect(x < 9).To(BeTrue())     // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.To\\(BeNumerically\\(\"<\", 9\\)\\). instead"
+	Expect(x < 7).To(Equal(false)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(x\\)\\.ToNot\\(BeNumerically\\(\"<\", 7\\)\\). instead"
+
+	p1, p2 := &x, &x
+	Expect(p1 == p2).To(Equal(true)) // want "ginkgo-linter: wrong comparison assertion; consider using .Expect\\(p1\\).To\\(BeIdenticalTo\\(p2\\)\\). instead"
 }


### PR DESCRIPTION
ginkgolinter version v0.9.0 brings two new rules. Both rules can be disabled from the configuration.

This PR bumps the ginkgolinter to v0.9.0 and adds the new configurations.

https://github.com/nunnatsa/ginkgolinter/compare/v0.8.1...v0.9.0

The two new rules are:
* haveLen(0) rule: `HaveLen(0)` ==> `BeEmpty()`
* wrong comparison rule: `Expect(x == y).To(BeTrue())` ==>
`Expect(x).To(Equal(y))`

The two new configurations are:
* `allow-havelen-0` - to not trigger warnings for the HaveLen(0) rule
* `suppress-compare-assertion` - to not trigger warnings for the wrong comparison rule.

Full details are in the ginkgolinter README.md file, here: https://github.com/nunnatsa/ginkgolinter#readme.