### PR TITLE
doc: remove from FAQ golangci.com mention

### DIFF
--- a/docs/src/docs/usage/faq.mdx
+++ b/docs/src/docs/usage/faq.mdx
@@ -9,7 +9,7 @@ Or you can create a [GitHub Issue](https://github.com/golangci/golangci-lint/iss
 
 ## How to integrate `golangci-lint` into large project with thousands of issues
 
-We are sure that every project can easily integrate `golangci-lint`, even the large one. The idea is to not fix all existing issues. Fix only newly added issue: issues in new code. To do this setup CI (or better use [GolangCI](https://golangci.com)) to run `golangci-lint` with option `--new-from-rev=HEAD~1`. Also, take a look at option `--new`, but consider that CI scripts that generate unstaged files will make `--new` only point out issues in those files and not in the last commit. In that regard `--new-from-rev=HEAD~1` is safer.
+We are sure that every project can easily integrate `golangci-lint`, even the large one. The idea is to not fix all existing issues. Fix only newly added issue: issues in new code. To do this setup CI to run `golangci-lint` with option `--new-from-rev=HEAD~1`. Also, take a look at option `--new`, but consider that CI scripts that generate unstaged files will make `--new` only point out issues in those files and not in the last commit. In that regard `--new-from-rev=HEAD~1` is safer.
 By doing this you won't create new issues in your code and can choose fix existing issues (or not).
 
 ## How to use `golangci-lint` in CI


### PR DESCRIPTION
This CI service [stopped](https://medium.com/golangci/golangci-com-is-closing-d1fc1bd30e0e) on 15-th of April, 2020.
