### PR TITLE
docs: remove description for deprecated "go" option

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -625,8 +625,6 @@ linters-settings:
         replacement: 'a[b:]'
 
   gofumpt:
-    # Select the Go version to target.
-    # Default: "1.15"
     # Deprecated: use the global `run.go` instead.
     lang-version: "1.17"
 
@@ -770,8 +768,6 @@ linters-settings:
       local_replace_directives: false
 
   gosimple:
-    # Select the Go version to target.
-    # Default: 1.13
     # Deprecated: use the global `run.go` instead.
     go: "1.15"
     # Sxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
@@ -1685,8 +1681,6 @@ linters-settings:
       - github.com/jmoiron/sqlx
 
   staticcheck:
-    # Select the Go version to target.
-    # Default: "1.13"
     # Deprecated: use the global `run.go` instead.
     go: "1.15"
     # SAxxxx checks in https://staticcheck.io/docs/configuration/options/#checks
@@ -1694,8 +1688,6 @@ linters-settings:
     checks: [ "all" ]
 
   stylecheck:
-    # Select the Go version to target.
-    # Default: 1.13
     # Deprecated: use the global `run.go` instead.
     go: "1.15"
     # STxxxx checks in https://staticcheck.io/docs/configuration/options/#checks


### PR DESCRIPTION
The default value for `go` and `lang-version` options are always overridden by the global [`run.go:`](https://github.com/alexandear/golangci-lint/blob/51f9218f6cc37b56af7ed85d573cc50b7b0e559a/.golangci.reference.yml#L73).