### PR TITLE
feat: add `gochecksumtype` linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2214,6 +2214,7 @@ linters:
     - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits
+    - gochecksumtype
     - gocognit
     - goconst
     - gocritic
@@ -2329,6 +2330,7 @@ linters:
     - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits
+    - gochecksumtype
     - gocognit
     - goconst
     - gocritic

--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,7 @@ require (
 
 require (
 	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/alecthomas/go-check-sumtype v0.1.3
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.1.0
 	github.com/OpenPeeDeeP/depguard/v2 v2.1.0
+	github.com/alecthomas/go-check-sumtype v0.1.3
 	github.com/alexkohler/nakedret/v2 v2.0.2
 	github.com/alexkohler/prealloc v1.0.0
 	github.com/alingse/asasalint v0.0.11
@@ -128,7 +129,6 @@ require (
 
 require (
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/alecthomas/go-check-sumtype v0.1.3
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,10 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OpenPeeDeeP/depguard/v2 v2.1.0 h1:aQl70G173h/GZYhWf36aE5H0KaujXfVMnn/f1kSDVYY=
 github.com/OpenPeeDeeP/depguard/v2 v2.1.0/go.mod h1:PUBgk35fX4i7JDmwzlJwJ+GMe6NfO1723wmJMgPThNQ=
+github.com/alecthomas/assert/v2 v2.2.2 h1:Z/iVC0xZfWTaFNE6bA3z07T86hd45Xe2eLt6WVy2bbk=
+github.com/alecthomas/go-check-sumtype v0.1.3 h1:M+tqMxB68hcgccRXBMVCPI4UJ+QUfdSx0xdbypKCqA8=
+github.com/alecthomas/go-check-sumtype v0.1.3/go.mod h1:WyYPfhfkdhyrdaligV6svFopZV8Lqdzn5pyVBaV6jhQ=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/pkg/golinters/gochecksumtype.go
+++ b/pkg/golinters/gochecksumtype.go
@@ -1,0 +1,73 @@
+package golinters
+
+import (
+	"strings"
+	"sync"
+
+	gochecksumtype "github.com/alecthomas/go-check-sumtype"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/lint/linter"
+	"github.com/golangci/golangci-lint/pkg/result"
+)
+
+const goCheckSumTypeName = "gochecksumtype"
+
+func NewGoCheckSumType() *goanalysis.Linter {
+	var mu sync.Mutex
+	var resIssues []goanalysis.Issue
+
+	analyzer := &analysis.Analyzer{
+		Name: goCheckSumTypeName,
+		Doc:  goanalysis.TheOnlyanalyzerDoc,
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			issues, err := runGoCheckSumType(pass)
+			if err != nil {
+				return nil, err
+			}
+			if len(issues) == 0 {
+				return nil, nil
+			}
+			mu.Lock()
+			resIssues = append(resIssues, issues...)
+			mu.Unlock()
+			return nil, nil
+		},
+	}
+	return goanalysis.NewLinter(
+		goCheckSumTypeName,
+		`Run exhaustiveness checks on Go "sum types"`,
+		[]*analysis.Analyzer{analyzer},
+		nil,
+	).WithIssuesReporter(func(ctx *linter.Context) []goanalysis.Issue {
+		return resIssues
+	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}
+
+func runGoCheckSumType(pass *analysis.Pass) ([]goanalysis.Issue, error) {
+	resIssues := []goanalysis.Issue{}
+	pkg := &packages.Package{
+		Fset:      pass.Fset,
+		Syntax:    pass.Files,
+		Types:     pass.Pkg,
+		TypesInfo: pass.TypesInfo,
+	}
+	var unknownError error
+	errors := gochecksumtype.Run([]*packages.Package{pkg})
+	for _, err := range errors {
+		err, ok := err.(gochecksumtype.Error)
+		if !ok {
+			unknownError = err
+			continue
+		}
+		prefix := err.Pos().String() + ": "
+		resIssues = append(resIssues, goanalysis.NewIssue(&result.Issue{
+			FromLinter: goCheckSumTypeName,
+			Text:       strings.TrimPrefix(err.Error(), prefix),
+			Pos:        err.Pos(),
+		}, pass))
+	}
+	return resIssues, unknownError
+}

--- a/pkg/golinters/gochecksumtype.go
+++ b/pkg/golinters/gochecksumtype.go
@@ -22,7 +22,7 @@ func NewGoCheckSumType() *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: goCheckSumTypeName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoCheckSumType(pass)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/unparam.go
+++ b/pkg/golinters/unparam.go
@@ -37,7 +37,6 @@ func NewUnparam(settings *config.UnparamSettings) *goanalysis.Linter {
 			mu.Lock()
 			resIssues = append(resIssues, issues...)
 			mu.Unlock()
-
 			return nil, nil
 		},
 	}

--- a/pkg/golinters/unparam.go
+++ b/pkg/golinters/unparam.go
@@ -37,6 +37,7 @@ func NewUnparam(settings *config.UnparamSettings) *goanalysis.Linter {
 			mu.Lock()
 			resIssues = append(resIssues, issues...)
 			mu.Unlock()
+
 			return nil, nil
 		},
 	}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -442,7 +442,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle),
 
 		linter.NewConfig(golinters.NewGoCheckSumType()).
-			WithSince("v1.53.0").
+			WithSince("v1.55.0").
 			WithPresets(linter.PresetBugs).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/alecthomas/go-check-sumtype"),

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -442,8 +442,9 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle),
 
 		linter.NewConfig(golinters.NewGoCheckSumType()).
-			WithSince("v1.51.2").
+			WithSince("v1.53.0").
 			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
 			WithURL("https://github.com/alecthomas/go-check-sumtype"),
 
 		linter.NewConfig(golinters.NewGocognit(gocognitCfg)).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -441,6 +441,11 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.12.0").
 			WithPresets(linter.PresetStyle),
 
+		linter.NewConfig(golinters.NewGoCheckSumType()).
+			WithSince("v1.51.2").
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/alecthomas/go-check-sumtype"),
+
 		linter.NewConfig(golinters.NewGocognit(gocognitCfg)).
 			WithSince("v1.20.0").
 			WithPresets(linter.PresetComplexity).

--- a/test/testdata/gochecksumtype.go
+++ b/test/testdata/gochecksumtype.go
@@ -1,0 +1,32 @@
+//golangcitest:args -Egochecksumtype
+package testdata
+
+//sumtype:decl
+type SumType interface{ isSumType() }
+
+//sumtype:decl
+type One struct{} // want "type 'One' is not an interface"
+
+func (One) isSumType() {}
+
+type Two struct{}
+
+func (Two) isSumType() {}
+
+func sumTypeTest() {
+	var sum SumType = One{}
+	switch sum.(type) { // want "exhaustiveness check failed for sum type.*SumType.*missing cases for Two"
+	case One:
+	}
+
+	switch sum.(type) { // want "exhaustiveness check failed for sum type.*SumType.*missing cases for Two"
+	case One:
+	default:
+		panic("??")
+	}
+
+	switch sum.(type) {
+	case One:
+	case Two:
+	}
+}

--- a/test/testdata/gochecksumtype.go
+++ b/test/testdata/gochecksumtype.go
@@ -1,6 +1,10 @@
 //golangcitest:args -Egochecksumtype
 package testdata
 
+import (
+	"log"
+)
+
 //sumtype:decl
 type SumType interface{ isSumType() }
 
@@ -22,6 +26,7 @@ func sumTypeTest() {
 	switch sum.(type) { // want "exhaustiveness check failed for sum type.*SumType.*missing cases for Two"
 	case One:
 	default:
+		log.Println("??")
 		panic("??")
 	}
 

--- a/test/testdata/gochecksumtype.go
+++ b/test/testdata/gochecksumtype.go
@@ -26,9 +26,10 @@ func sumTypeTest() {
 	switch sum.(type) { // want "exhaustiveness check failed for sum type.*SumType.*missing cases for Two"
 	case One:
 	default:
-		log.Println("??")
 		panic("??")
 	}
+
+	log.Println("??")
 
 	switch sum.(type) {
 	case One:


### PR DESCRIPTION
`gochecksumtype` is a linter that checks that type switches on "sum types" in Go are exhaustive.

https://github.com/alecthomas/go-check-sumtype

This is based on BurntSushi/go-sumtype, but fixes, modernises and simplifies it.

fixes #402