### PR TITLE
rowserrcheck: remove limitation related to generics support

### DIFF
--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -733,8 +733,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.23.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetBugs, linter.PresetSQL).
-			WithURL("https://github.com/jingyugao/rowserrcheck").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/jingyugao/rowserrcheck"),
 
 		linter.NewConfig(golinters.NewScopelint()).
 			WithSince("v1.12.0").


### PR DESCRIPTION
I run my tests suite (not the golangci-lint tests) that contains multiple and complex generics usages and everything seems to work.

Related to #2649
Related to https://github.com/jingyugao/rowserrcheck/pull/28