### PR TITLE
docs: fix typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See [contibuting quick start](https://golangci-lint.run/contributing/quick-start/) on our website.
+See [contributing quick start](https://golangci-lint.run/contributing/quick-start/) on our website.

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -165,7 +165,7 @@ exports.onPreBootstrap = ({ store, reporter }, themeOptions) => {
 
   dirs.forEach((dir) => {
     if (!fs.existsSync(dir)) {
-      reporter.success(`docs: intialized the ${dir} directory`);
+      reporter.success(`docs: initialized the ${dir} directory`);
       fs.mkdirSync(dir);
     }
   });


### PR DESCRIPTION
Correct the typo in `CONTRIBUTING.md` and in the success report message in `docs/gatsby-node.js`.