### PR TITLE
feat: add linter to check number of params and return values of func

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 linters-settings:
+  toomanyparams:
+    max_returns: 3
+    max_params: 5
   depguard:
     list-type: denylist
     packages:

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -208,6 +208,7 @@ type LintersSettings struct {
 	Whitespace       WhitespaceSettings
 	Wrapcheck        WrapcheckSettings
 	WSL              WSLSettings
+	TooManyParams    TooManyParamsSettings
 
 	Custom map[string]CustomLinterSettings
 }
@@ -508,6 +509,11 @@ type InterfaceBloatSettings struct {
 type IreturnSettings struct {
 	Allow  []string `mapstructure:"allow"`
 	Reject []string `mapstructure:"reject"`
+}
+
+type TooManyParamsSettings struct {
+	MaxParams  int `mapstructure:"max_params"`
+	MaxReturns int `mapstructure:"max_returns"`
 }
 
 type LllSettings struct {

--- a/pkg/golinters/toomanyparams.go
+++ b/pkg/golinters/toomanyparams.go
@@ -1,0 +1,114 @@
+package golinters
+
+import (
+	"fmt"
+	"go/ast"
+	"sync"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/lint/linter"
+	"github.com/golangci/golangci-lint/pkg/result"
+)
+
+const (
+	toomanyparams = "toomanyparams"
+
+	maxIncomingParams = 5
+	maxOutgoingParams = 3
+)
+
+//nolint:dupl
+func NewTooManyParams(settings *config.TooManyParamsSettings) *goanalysis.Linter {
+	var mu sync.Mutex
+	var resIssues []goanalysis.Issue
+
+	analyzer := &analysis.Analyzer{
+		Name: toomanyparams,
+		Doc:  goanalysis.TheOnlyanalyzerDoc,
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			issues, err := runTooManyParams(pass, settings)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(issues) == 0 {
+				return nil, nil
+			}
+
+			mu.Lock()
+			resIssues = append(resIssues, issues...)
+			mu.Unlock()
+
+			return nil, nil
+		},
+	}
+
+	return goanalysis.NewLinter(
+		toomanyparams,
+		"Reports too many func paramters and return values",
+		[]*analysis.Analyzer{analyzer},
+		nil,
+	).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
+		return resIssues
+	}).WithLoadMode(goanalysis.LoadModeSyntax)
+}
+
+func runTooManyParams(pass *analysis.Pass, settings *config.TooManyParamsSettings) ([]goanalysis.Issue, error) {
+	var issues []goanalysis.Issue
+
+	for _, f := range pass.Files {
+		newIssues := runFuncTooManyParams(pass, f, settings)
+		issues = append(issues, newIssues...)
+	}
+
+	return issues, nil
+}
+
+func runFuncTooManyParams(pass *analysis.Pass, f *ast.File, settings *config.TooManyParamsSettings) []goanalysis.Issue {
+	var issues []goanalysis.Issue
+	for _, decl := range f.Decls {
+		fnDecl, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		fnType := fnDecl.Type
+		if fnType.Params != nil {
+			num := 0
+			for _, l := range fnType.Params.List {
+				num += len(l.Names)
+			}
+			if num > settings.MaxParams {
+				text := fmt.Sprintf("too many parameters (%d>%d) in func %s",
+					num, settings.MaxParams, fnDecl.Name.Name)
+				issues = append(issues, goanalysis.Issue{
+					Issue: result.Issue{
+						FromLinter: toomanyparams,
+						Text:       text,
+						Severity:   "warn",
+						Pos:        pass.Fset.Position(fnType.Params.Pos()),
+					},
+					Pass: pass,
+				})
+			}
+		}
+		if fnType.Results != nil {
+			if num := len(fnType.Results.List); num > settings.MaxReturns {
+				text := fmt.Sprintf("too many return values (%d>%d) in func %s",
+					num, settings.MaxReturns, fnDecl.Name.Name)
+				issues = append(issues, goanalysis.Issue{
+					Issue: result.Issue{
+						FromLinter: toomanyparams,
+						Text:       text,
+						Severity:   "warn",
+						Pos:        pass.Fset.Position(fnType.Results.Pos()),
+					},
+					Pass: pass,
+				})
+			}
+		}
+	}
+	return issues
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -176,6 +176,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		whitespaceCfg       *config.WhitespaceSettings
 		wrapcheckCfg        *config.WrapcheckSettings
 		wslCfg              *config.WSLSettings
+		tooManyParamsCfg    *config.TooManyParamsSettings
 	)
 
 	if m.cfg != nil {
@@ -253,6 +254,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		whitespaceCfg = &m.cfg.LintersSettings.Whitespace
 		wrapcheckCfg = &m.cfg.LintersSettings.Wrapcheck
 		wslCfg = &m.cfg.LintersSettings.WSL
+		tooManyParamsCfg = &m.cfg.LintersSettings.TooManyParams
 
 		if govetCfg != nil {
 			govetCfg.Go = m.cfg.Run.Go
@@ -874,16 +876,22 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.26.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/README.md"),
+
+		linter.NewConfig(golinters.NewTooManyParams(tooManyParamsCfg)).
+			WithSince("v1.0.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("github.com/hitzhangjie"),
 	}
 
 	enabledByDefault := map[string]bool{
-		golinters.NewGovet(nil).Name():                  true,
-		golinters.NewErrcheck(errcheckCfg).Name():       true,
-		golinters.NewStaticcheck(staticcheckCfg).Name(): true,
-		golinters.NewUnused(unusedCfg).Name():           true,
-		golinters.NewGosimple(gosimpleCfg).Name():       true,
-		golinters.NewIneffassign().Name():               true,
-		golinters.NewTypecheck().Name():                 true,
+		golinters.NewGovet(nil).Name():                      true,
+		golinters.NewErrcheck(errcheckCfg).Name():           true,
+		golinters.NewStaticcheck(staticcheckCfg).Name():     true,
+		golinters.NewUnused(unusedCfg).Name():               true,
+		golinters.NewGosimple(gosimpleCfg).Name():           true,
+		golinters.NewIneffassign().Name():                   true,
+		golinters.NewTypecheck().Name():                     true,
+		golinters.NewTooManyParams(tooManyParamsCfg).Name(): true,
 	}
 	return enableLinterConfigs(lcs, func(lc *linter.Config) bool {
 		return enabledByDefault[lc.Name()]


### PR DESCRIPTION
When function declaration contains too many parameters and return values, it will decrease the code readability.

And it is likely to improve the code by some refactoring.