### PR TITLE
fix: improve panic management

### DIFF
--- a/pkg/golinters/goanalysis/runner_action.go
+++ b/pkg/golinters/goanalysis/runner_action.go
@@ -98,11 +98,12 @@ func (act *action) waitUntilDependingAnalyzersWorked() {
 func (act *action) analyzeSafe() {
 	defer func() {
 		if p := recover(); p != nil {
-			// This line allows to display "hidden" panic with analyzers like buildssa.
-			// Some linters are dependent of sub-analyzers but when a sub-analyzer fails the linter is not aware of that,
-			// this results to another panic (ex: "interface conversion: interface {} is nil, not *buildssa.SSA").
-			// This line will create a duplication of the panic message on purpose.
-			act.r.log.Errorf("%s: panic during analysis: %v, %s", act.a.Name, p, string(debug.Stack()))
+			if !act.isroot {
+				// This line allows to display "hidden" panic with analyzers like buildssa.
+				// Some linters are dependent of sub-analyzers but when a sub-analyzer fails the linter is not aware of that,
+				// this results to another panic (ex: "interface conversion: interface {} is nil, not *buildssa.SSA").
+				act.r.log.Errorf("%s: panic during analysis: %v, %s", act.a.Name, p, string(debug.Stack()))
+			}
 
 			act.err = errorutil.NewPanicError(fmt.Sprintf("%s: package %q (isInitialPkg: %t, needAnalyzeSource: %t): %s",
 				act.a.Name, act.pkg.Name, act.isInitialPkg, act.needAnalyzeSource, p), debug.Stack())

--- a/pkg/golinters/goanalysis/runner_action.go
+++ b/pkg/golinters/goanalysis/runner_action.go
@@ -102,7 +102,7 @@ func (act *action) analyzeSafe() {
 			// Some linters are dependent of sub-analyzers but when a sub-analyzer fails the linter is not aware of that,
 			// this results to another panic (ex: "interface conversion: interface {} is nil, not *buildssa.SSA").
 			// This line will create a duplication of the panic message on purpose.
-			act.r.log.Errorf("panic during analysis: %v, %s", p, string(debug.Stack()))
+			act.r.log.Errorf("%s: panic during analysis: %v, %s", act.a.Name, p, string(debug.Stack()))
 
 			act.err = errorutil.NewPanicError(fmt.Sprintf("%s: package %q (isInitialPkg: %t, needAnalyzeSource: %t): %s",
 				act.a.Name, act.pkg.Name, act.isInitialPkg, act.needAnalyzeSource, p), debug.Stack())


### PR DESCRIPTION
Related to #3086

<details>
<summary>before the PR</summary>

```console
$ golangci-lint cache clean && golangci-lint run  --disable-all --print-issued-lines=false -Ebodyclose 
ERRO [runner] Panic: bodyclose: package "ent" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: interface {} is nil, not *buildssa.SSA: goroutine 1176 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:24 +0x65
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1()
        github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:102 +0x155
panic({0xfd4880, 0xc0022ec060})
        runtime/panic.go:884 +0x213
github.com/timakin/bodyclose/passes/bodyclose.runner.run({0xc00157a0f0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0, 0x0}, 0xc00157a0f0)
        github.com/timakin/bodyclose@v0.0.0-20221125081123-e39cf3fc478e/passes/bodyclose/bodyclose.go:45 +0x665
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc0005a7aa0)
        github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:188 +0xa25
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
        github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:106 +0x1d
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0004cafa0, {0x111e265, 0x9}, 0xc00011f748)
        github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x4a
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc000c8a900?)
        github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:105 +0x85
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0xc0005a7aa0)
        github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:80 +0xb4
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
        github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:75 +0x208 
WARN [runner] Can't run linter bodyclose: bodyclose: bodyclose: package "ent" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: interface {} is nil, not *buildssa.SSA 
ERRO Running error: 1 error occurred:
        * can't run linter bodyclose: bodyclose: bodyclose: package "ent" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: interface {} is nil, not *buildssa.SSA

```

</details>

<details>
<summary>With the PR</summary>

```console
$ ./golangci-lint cache clean && ./golangci-lint run  --disable-all --print-issued-lines=false -Ebodyclose
ERRO [linters_context/goanalysis] panic during analysis: in github.com/Antonboom/golangci-vs-ent-generics/ent.withHooks$1: cannot convert *t0 (M) to PM, goroutine 257 [running]:
runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:24 +0x65
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1()
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:106 +0x6b
panic({0x1555d00, 0xc0016dac60})
        /usr/lib/go/src/runtime/panic.go:884 +0x213
golang.org/x/tools/go/ssa.emitConv(0xc0005b9e00, {0x199f1e0, 0xc003a7bb00}, {0x1996750?, 0xc001a7c9f0})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/emit.go:286 +0xdbc
golang.org/x/tools/go/ssa.emitStore(0xc0005b9e00, {0x199f1e0, 0xc003a7ba40}, {0x199f1e0, 0xc003a7bb00}, 0x2a9377e)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/emit.go:377 +0x5f
golang.org/x/tools/go/ssa.(*address).store(0xc0019a93b0, 0xc0005b9e00?, {0x199f1e0?, 0xc003a7bb00?})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/lvalue.go:40 +0x47
golang.org/x/tools/go/ssa.(*storebuf).emit(...)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:533
golang.org/x/tools/go/ssa.(*builder).assignStmt(0xc0005b9e00?, 0xc0005b9e00, {0xc00120c2e0, 0x1, 0x16cb940?}, {0xc00120c2f0, 0x1, 0xc00317e7b0?}, 0x0)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:1207 +0x43d
golang.org/x/tools/go/ssa.(*builder).stmt(0xc00317e8e8?, 0xc0005b9e00, {0x1999650?, 0xc00120e640?})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2181 +0x425
golang.org/x/tools/go/ssa.(*builder).stmtList(0xc00317e901?, 0xc0019a9170?, {0xc00120e680?, 0x4, 0xc000185000?})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:946 +0x45
golang.org/x/tools/go/ssa.(*builder).stmt(0xc0005b9e00?, 0xc0005b9e00, {0x1999770?, 0xc001201140?})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2277 +0x859
golang.org/x/tools/go/ssa.(*builder).buildFunctionBody(0x0?, 0xc0005b9e00)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2391 +0x437
golang.org/x/tools/go/ssa.(*builder).expr0(0xc00317fa38, 0xc0038a7800, {0x1999a10?, 0xc00120c320?}, {0x7, {0x1996660, 0xc0020b9340}, {0x0, 0x0}})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:656 +0x4d6
golang.org/x/tools/go/ssa.(*builder).expr(0x15c4140?, 0xc0038a7800, {0x1999a10, 0xc00120c320})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:625 +0x17b
golang.org/x/tools/go/ssa.(*builder).expr0(0xc00317fa38, 0xc0038a7800, {0x19997d0?, 0xc00120e700?}, {0x7, {0x19965e8, 0xc0013f5dc0}, {0x0, 0x0}})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:676 +0x705
golang.org/x/tools/go/ssa.(*builder).expr(0xc003a7b440?, 0xc0038a7800, {0x19997d0, 0xc00120e700})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:625 +0x17b
golang.org/x/tools/go/ssa.(*builder).assign(0xc0038a7800?, 0xc0038a7800?, {0x199c0e8?, 0xc0019a90e0}, {0x19997d0?, 0xc00120e700?}, 0x8?, 0x0)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:598 +0x3db
golang.org/x/tools/go/ssa.(*builder).localValueSpec(0xc0038a7800?, 0xc0038a7800, 0xc0011a7ea0)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:1147 +0xe5
golang.org/x/tools/go/ssa.(*builder).stmt(0xc00317f598?, 0xc0038a7800, {0x19998c0?, 0xc00120c360?})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2147 +0x17c5
golang.org/x/tools/go/ssa.(*builder).stmtList(0xc003a7b140?, 0xc00317f5e8?, {0xc001031700?, 0x8, 0x8c9cc8?})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:946 +0x45
golang.org/x/tools/go/ssa.(*builder).stmt(0xc0038a7800?, 0xc0038a7800, {0x1999770?, 0xc001201380?})
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2277 +0x859
golang.org/x/tools/go/ssa.(*builder).buildFunctionBody(0xea2bd1?, 0xc0038a7800)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2391 +0x437
golang.org/x/tools/go/ssa.(*builder).buildFunction(0xea2c20?, 0xc0038a7800)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2326 +0x2e
golang.org/x/tools/go/ssa.(*builder).buildCreated(0xc00317fa38)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2413 +0x25
golang.org/x/tools/go/ssa.(*Package).build(0xc003880580)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2606 +0xc86
sync.(*Once).doSlow(0xc001fb6300?, 0xc00180ca50?)
        /usr/lib/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
        /usr/lib/go/src/sync/once.go:65
golang.org/x/tools/go/ssa.(*Package).Build(...)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/ssa/builder.go:2477
golang.org/x/tools/go/analysis/passes/buildssa.run(0xc0021c0870)
        /home/ldez/sources/go/pkg/mod/golang.org/x/tools@v0.7.0/go/analysis/passes/buildssa/buildssa.go:72 +0x1a8
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc001370630)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:196 +0xa25
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:114 +0x1d
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0012f57c0, {0x17326f6, 0x8}, 0xc0015b7748)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x4a
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc000f09320?)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:113 +0x85
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0xc001370630)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:80 +0xb4
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:75 +0x208 
ERRO [runner] Panic: bodyclose: package "ent" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: interface {} is nil, not *buildssa.SSA: goroutine 256 [running]:
runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:24 +0x65
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1()
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:110 +0x23c
panic({0x15e6880, 0xc0019b0060})
        /usr/lib/go/src/runtime/panic.go:884 +0x213
github.com/timakin/bodyclose/passes/bodyclose.runner.run({0xc00330c000, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0, 0x0}, 0xc00330c000)
        /home/ldez/sources/go/pkg/mod/github.com/timakin/bodyclose@v0.0.0-20221125081123-e39cf3fc478e/passes/bodyclose/bodyclose.go:45 +0x665
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc0013705a0)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:196 +0xa25
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:114 +0x1d
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0012f57c0, {0x1741351, 0x9}, 0xc000117748)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x4a
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc000f09320?)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_action.go:113 +0x85
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0xc0013705a0)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:80 +0xb4
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner_loadingpackage.go:75 +0x208 
WARN [runner] Can't run linter bodyclose: bodyclose: bodyclose: package "ent" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: interface {} is nil, not *buildssa.SSA 
ERRO Running error: 1 error occurred:
        * can't run linter bodyclose: bodyclose: bodyclose: package "ent" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: interface {} is nil, not *buildssa.SSA
```

</details>
