### PR TITLE
fix(pre-commit): require_serial & pass_filenames

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   name: golangci-lint
   description: Fast linters runner for Go.
   entry: golangci-lint run --new-from-rev HEAD --fix
-  require_serial: true
   types: [go]
   language: golang
-  pass_filenames: true
+  require_serial: true
+  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
   name: golangci-lint
   description: Fast linters runner for Go.
   entry: golangci-lint run --new-from-rev HEAD --fix
+  require_serial: true
   types: [go]
   language: golang
   pass_filenames: true


### PR DESCRIPTION
In order to avoid the following error when running pre-commit

> Error: parallel golangci-lint is running

We need to force golangci-lint to run in sequence.


Fixes #3715