### PR TITLE
tests: remove go version restrictions

### DIFF
--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -759,8 +759,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetUnused).
 			WithURL("https://github.com/opennota/check").
-			Deprecated("The owner seems to have abandoned the linter.", "v1.49.0", "unused").
-			WithNoopFallback(m.cfg),
+			Deprecated("The owner seems to have abandoned the linter.", "v1.49.0", "unused"),
 
 		linter.NewConfig(golinters.NewStylecheck(stylecheckCfg)).
 			WithSince("v1.20.0").

--- a/test/testshared/runner.go
+++ b/test/testshared/runner.go
@@ -164,7 +164,6 @@ func (b *RunnerBuilder) Runner() *Runner {
 	}
 
 	arguments := []string{
-		"--go=1.17", //  TODO(ldez): we force to use an old version of Go for the CI and the tests.
 		"--internal-cmd-test",
 	}
 

--- a/test/testshared/runner_test.go
+++ b/test/testshared/runner_test.go
@@ -23,7 +23,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 				},
@@ -36,7 +35,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "example",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 				},
@@ -49,7 +47,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 					"--no-config",
@@ -63,7 +60,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 					"-c",
@@ -78,7 +74,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 					"-c",
@@ -96,7 +91,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string{"FOO=BAR", "FII=BIR"},
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 				},
@@ -109,7 +103,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 				},
 			},
@@ -121,7 +114,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 					"-Efoo",
@@ -137,7 +129,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 					filepath.FromSlash("testdata/all.go"),
@@ -156,7 +147,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 				env:     []string(nil),
 				command: "run",
 				args: []string{
-					"--go=1.17",
 					"--internal-cmd-test",
 					"--allow-parallel-runners",
 					"-c",


### PR DESCRIPTION
The limitation was introduced when the generics appears to avoid compatibility problems.
Now the generics are in all versions of Go so we can remove restrictions.