### PR TITLE
dev: gofmt -w -r 'interface{} -> any' pkg scripts

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -368,7 +368,7 @@ type GoCriticSettings struct {
 	SettingsPerCheck map[string]GoCriticCheckSettings `mapstructure:"settings"`
 }
 
-type GoCriticCheckSettings map[string]interface{}
+type GoCriticCheckSettings map[string]any
 
 type GoCycloSettings struct {
 	MinComplexity int `mapstructure:"min-complexity"`
@@ -421,11 +421,11 @@ type GoLintSettings struct {
 }
 
 type GoMndSettings struct {
-	Settings         map[string]map[string]interface{} // Deprecated
-	Checks           []string                          `mapstructure:"checks"`
-	IgnoredNumbers   []string                          `mapstructure:"ignored-numbers"`
-	IgnoredFiles     []string                          `mapstructure:"ignored-files"`
-	IgnoredFunctions []string                          `mapstructure:"ignored-functions"`
+	Settings         map[string]map[string]any // Deprecated
+	Checks           []string                  `mapstructure:"checks"`
+	IgnoredNumbers   []string                  `mapstructure:"ignored-numbers"`
+	IgnoredFiles     []string                  `mapstructure:"ignored-files"`
+	IgnoredFunctions []string                  `mapstructure:"ignored-functions"`
 }
 
 type GoModDirectivesSettings struct {
@@ -454,13 +454,13 @@ type GoModGuardSettings struct {
 }
 
 type GoSecSettings struct {
-	Includes         []string               `mapstructure:"includes"`
-	Excludes         []string               `mapstructure:"excludes"`
-	Severity         string                 `mapstructure:"severity"`
-	Confidence       string                 `mapstructure:"confidence"`
-	ExcludeGenerated bool                   `mapstructure:"exclude-generated"`
-	Config           map[string]interface{} `mapstructure:"config"`
-	Concurrency      int                    `mapstructure:"concurrency"`
+	Includes         []string       `mapstructure:"includes"`
+	Excludes         []string       `mapstructure:"excludes"`
+	Severity         string         `mapstructure:"severity"`
+	Confidence       string         `mapstructure:"confidence"`
+	ExcludeGenerated bool           `mapstructure:"exclude-generated"`
+	Config           map[string]any `mapstructure:"config"`
+	Concurrency      int            `mapstructure:"concurrency"`
 }
 
 type GosmopolitanSettings struct {
@@ -473,7 +473,7 @@ type GosmopolitanSettings struct {
 type GovetSettings struct {
 	Go             string `mapstructure:"-"`
 	CheckShadowing bool   `mapstructure:"check-shadowing"`
-	Settings       map[string]map[string]interface{}
+	Settings       map[string]map[string]any
 
 	Enable     []string
 	Disable    []string
@@ -628,7 +628,7 @@ type ReviveSettings struct {
 	EnableAllRules        bool `mapstructure:"enable-all-rules"`
 	Rules                 []struct {
 		Name      string
-		Arguments []interface{}
+		Arguments []any
 		Severity  string
 		Disabled  bool
 	}

--- a/pkg/fsutils/filecache.go
+++ b/pkg/fsutils/filecache.go
@@ -54,7 +54,7 @@ func PrettifyBytesCount(n int64) string {
 func (fc *FileCache) PrintStats(log logutils.Log) {
 	var size int64
 	var mapLen int
-	fc.files.Range(func(_, fileBytes interface{}) bool {
+	fc.files.Range(func(_, fileBytes any) bool {
 		mapLen++
 		size += int64(len(fileBytes.([]byte)))
 

--- a/pkg/golinters/bidichk.go
+++ b/pkg/golinters/bidichk.go
@@ -13,7 +13,7 @@ import (
 func NewBiDiChkFuncName(cfg *config.BiDiChkSettings) *goanalysis.Linter {
 	a := bidichk.NewAnalyzer()
 
-	cfgMap := map[string]map[string]interface{}{}
+	cfgMap := map[string]map[string]any{}
 	if cfg != nil {
 		var opts []string
 
@@ -45,7 +45,7 @@ func NewBiDiChkFuncName(cfg *config.BiDiChkSettings) *goanalysis.Linter {
 			opts = append(opts, "POP-DIRECTIONAL-ISOLATE")
 		}
 
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			"disallowed-runes": strings.Join(opts, ","),
 		}
 	}

--- a/pkg/golinters/cyclop.go
+++ b/pkg/golinters/cyclop.go
@@ -13,9 +13,9 @@ const cyclopName = "cyclop"
 func NewCyclop(settings *config.Cyclop) *goanalysis.Linter {
 	a := analyzer.NewAnalyzer()
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		d := map[string]interface{}{
+		d := map[string]any{
 			"skipTests": settings.SkipTests,
 		}
 
@@ -27,7 +27,7 @@ func NewCyclop(settings *config.Cyclop) *goanalysis.Linter {
 			d["packageAverage"] = settings.PackageAverage
 		}
 
-		cfg = map[string]map[string]interface{}{a.Name: d}
+		cfg = map[string]map[string]any{a.Name: d}
 	}
 
 	return goanalysis.NewLinter(

--- a/pkg/golinters/deadcode.go
+++ b/pkg/golinters/deadcode.go
@@ -21,7 +21,7 @@ func NewDeadcode() *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: deadcodeName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			prog := goanalysis.MakeFakeLoaderProgram(pass)
 
 			issues, err := deadcodeAPI.Run(prog)

--- a/pkg/golinters/decorder.go
+++ b/pkg/golinters/decorder.go
@@ -14,7 +14,7 @@ func NewDecorder(settings *config.DecorderSettings) *goanalysis.Linter {
 	a := decorder.Analyzer
 
 	// disable all rules/checks by default
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"disable-dec-num-check":         true,
 		"disable-dec-order-check":       true,
 		"disable-init-func-first-check": true,
@@ -31,6 +31,6 @@ func NewDecorder(settings *config.DecorderSettings) *goanalysis.Linter {
 		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
-		map[string]map[string]interface{}{a.Name: cfg},
+		map[string]map[string]any{a.Name: cfg},
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/depguard.go
+++ b/pkg/golinters/depguard.go
@@ -36,7 +36,7 @@ func NewDepguard(settings *config.DepGuardSettings) *goanalysis.Linter {
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		dg, err := newDepGuard(settings)
 
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/golinters/dogsled.go
+++ b/pkg/golinters/dogsled.go
@@ -24,7 +24,7 @@ func NewDogsled(settings *config.DogsledSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: dogsledName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runDogsled(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/dupl.go
+++ b/pkg/golinters/dupl.go
@@ -25,7 +25,7 @@ func NewDupl(settings *config.DuplSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: duplName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runDupl(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/dupword.go
+++ b/pkg/golinters/dupword.go
@@ -13,9 +13,9 @@ import (
 func NewDupWord(setting *config.DupWordSettings) *goanalysis.Linter {
 	a := dupword.NewAnalyzer()
 
-	cfgMap := map[string]map[string]interface{}{}
+	cfgMap := map[string]map[string]any{}
 	if setting != nil {
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			"keyword": strings.Join(setting.Keywords, ","),
 		}
 	}

--- a/pkg/golinters/errcheck.go
+++ b/pkg/golinters/errcheck.go
@@ -49,7 +49,7 @@ func NewErrcheck(settings *config.ErrcheckSettings) *goanalysis.Linter {
 
 		checker.Tags = lintCtx.Cfg.Run.BuildTags
 
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues := runErrCheck(lintCtx, pass, checker)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/errchkjson.go
+++ b/pkg/golinters/errchkjson.go
@@ -11,12 +11,12 @@ import (
 func NewErrChkJSONFuncName(cfg *config.ErrChkJSONSettings) *goanalysis.Linter {
 	a := errchkjson.NewAnalyzer()
 
-	cfgMap := map[string]map[string]interface{}{}
-	cfgMap[a.Name] = map[string]interface{}{
+	cfgMap := map[string]map[string]any{}
+	cfgMap[a.Name] = map[string]any{
 		"omit-safe": true,
 	}
 	if cfg != nil {
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			"omit-safe":          !cfg.CheckErrorFreeEncoding,
 			"report-no-exported": cfg.ReportNoExported,
 		}

--- a/pkg/golinters/errorlint.go
+++ b/pkg/golinters/errorlint.go
@@ -11,10 +11,10 @@ import (
 func NewErrorLint(cfg *config.ErrorLintSettings) *goanalysis.Linter {
 	a := errorlint.NewAnalyzer()
 
-	cfgMap := map[string]map[string]interface{}{}
+	cfgMap := map[string]map[string]any{}
 
 	if cfg != nil {
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			"errorf":       cfg.Errorf,
 			"errorf-multi": cfg.ErrorfMulti,
 			"asserts":      cfg.Asserts,

--- a/pkg/golinters/exhaustive.go
+++ b/pkg/golinters/exhaustive.go
@@ -11,9 +11,9 @@ import (
 func NewExhaustive(settings *config.ExhaustiveSettings) *goanalysis.Linter {
 	a := exhaustive.Analyzer
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				exhaustive.CheckFlag:                      settings.Check,
 				exhaustive.CheckGeneratedFlag:             settings.CheckGenerated,

--- a/pkg/golinters/exhaustivestruct.go
+++ b/pkg/golinters/exhaustivestruct.go
@@ -13,9 +13,9 @@ import (
 func NewExhaustiveStruct(settings *config.ExhaustiveStructSettings) *goanalysis.Linter {
 	a := analyzer.Analyzer
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				"struct_patterns": strings.Join(settings.StructPatterns, ","),
 			},

--- a/pkg/golinters/forbidigo.go
+++ b/pkg/golinters/forbidigo.go
@@ -23,7 +23,7 @@ func NewForbidigo(settings *config.ForbidigoSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: forbidigoName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runForbidigo(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/funlen.go
+++ b/pkg/golinters/funlen.go
@@ -24,7 +24,7 @@ func NewFunlen(settings *config.FunlenSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: funlenName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runFunlen(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/gci.go
+++ b/pkg/golinters/gci.go
@@ -61,7 +61,7 @@ func NewGci(settings *config.GciSettings) *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues, err := runGci(pass, lintCtx, cfg, &lock)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/ginkgolinter.go
+++ b/pkg/golinters/ginkgolinter.go
@@ -11,9 +11,9 @@ import (
 func NewGinkgoLinter(cfg *config.GinkgoLinterSettings) *goanalysis.Linter {
 	a := ginkgolinter.NewAnalyzer()
 
-	cfgMap := make(map[string]map[string]interface{})
+	cfgMap := make(map[string]map[string]any)
 	if cfg != nil {
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			"suppress-len-assertion":     cfg.SuppressLenAssertion,
 			"suppress-nil-assertion":     cfg.SuppressNilAssertion,
 			"suppress-err-assertion":     cfg.SuppressErrAssertion,

--- a/pkg/golinters/goanalysis/linter.go
+++ b/pkg/golinters/goanalysis/linter.go
@@ -44,14 +44,14 @@ const (
 type Linter struct {
 	name, desc              string
 	analyzers               []*analysis.Analyzer
-	cfg                     map[string]map[string]interface{}
+	cfg                     map[string]map[string]any
 	issuesReporter          func(*linter.Context) []Issue
 	contextSetter           func(*linter.Context)
 	loadMode                LoadMode
 	needUseOriginalPackages bool
 }
 
-func NewLinter(name, desc string, analyzers []*analysis.Analyzer, cfg map[string]map[string]interface{}) *Linter {
+func NewLinter(name, desc string, analyzers []*analysis.Analyzer, cfg map[string]map[string]any) *Linter {
 	return &Linter{name: name, desc: desc, analyzers: analyzers, cfg: cfg}
 }
 
@@ -102,7 +102,7 @@ func (lnt *Linter) allAnalyzerNames() []string {
 	return ret
 }
 
-func (lnt *Linter) configureAnalyzer(a *analysis.Analyzer, cfg map[string]interface{}) error {
+func (lnt *Linter) configureAnalyzer(a *analysis.Analyzer, cfg map[string]any) error {
 	for k, v := range cfg {
 		f := a.Flags.Lookup(k)
 		if f == nil {
@@ -195,12 +195,12 @@ func allFlagNames(fs *flag.FlagSet) []string {
 	return ret
 }
 
-func valueToString(v interface{}) string {
+func valueToString(v any) string {
 	if ss, ok := v.([]string); ok {
 		return strings.Join(ss, ",")
 	}
 
-	if is, ok := v.([]interface{}); ok {
+	if is, ok := v.([]any); ok {
 		var ss []string
 		for _, i := range is {
 			ss = append(ss, fmt.Sprint(i))
@@ -212,6 +212,6 @@ func valueToString(v interface{}) string {
 	return fmt.Sprint(v)
 }
 
-func DummyRun(_ *analysis.Pass) (interface{}, error) {
+func DummyRun(_ *analysis.Pass) (any, error) {
 	return nil, nil
 }

--- a/pkg/golinters/goanalysis/runner_action.go
+++ b/pkg/golinters/goanalysis/runner_action.go
@@ -50,7 +50,7 @@ type action struct {
 	deps                []*action
 	objectFacts         map[objectFactKey]analysis.Fact
 	packageFacts        map[packageFactKey]analysis.Fact
-	result              interface{}
+	result              any
 	diagnostics         []analysis.Diagnostic
 	err                 error
 	r                   *runner
@@ -145,7 +145,7 @@ func (act *action) analyze() {
 
 	// Plumb the output values of the dependencies
 	// into the inputs of this action.  Also facts.
-	inputs := make(map[*analysis.Analyzer]interface{})
+	inputs := make(map[*analysis.Analyzer]any)
 	startedAt := time.Now()
 	for _, dep := range act.deps {
 		if dep.pkg == act.pkg {

--- a/pkg/golinters/goanalysis/runner_loadingpackage.go
+++ b/pkg/golinters/goanalysis/runner_loadingpackage.go
@@ -446,7 +446,7 @@ type importerFunc func(path string) (*types.Package, error)
 
 func (f importerFunc) Import(path string) (*types.Package, error) { return f(path) }
 
-func sizeOfValueTreeBytes(v interface{}) int {
+func sizeOfValueTreeBytes(v any) int {
 	return sizeOfReflectValueTreeBytes(reflect.ValueOf(v), map[uintptr]struct{}{})
 }
 

--- a/pkg/golinters/gochecknoglobals.go
+++ b/pkg/golinters/gochecknoglobals.go
@@ -14,7 +14,7 @@ func NewGochecknoglobals() *goanalysis.Linter {
 	// pass the `t` flag as true to the analyzer before running it. This can be
 	// turned off by using the regular golangci-lint flags such as `--tests` or
 	// `--skip-files`.
-	linterConfig := map[string]map[string]interface{}{
+	linterConfig := map[string]map[string]any{
 		gochecknoglobals.Name: {
 			"t": true,
 		},

--- a/pkg/golinters/gochecknoinits.go
+++ b/pkg/golinters/gochecknoinits.go
@@ -22,7 +22,7 @@ func NewGochecknoinits() *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: gochecknoinitsName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			var res []goanalysis.Issue
 			for _, file := range pass.Files {
 				fileIssues := checkFileForInits(file, pass.Fset)

--- a/pkg/golinters/gocognit.go
+++ b/pkg/golinters/gocognit.go
@@ -24,7 +24,7 @@ func NewGocognit(settings *config.GocognitSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: goanalysis.TheOnlyAnalyzerName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runGocognit(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/goconst.go
+++ b/pkg/golinters/goconst.go
@@ -23,7 +23,7 @@ func NewGoconst(settings *config.GoConstSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: goconstName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoconst(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -42,7 +42,7 @@ func NewGoCritic(settings *config.GoCriticSettings, cfg *config.Config) *goanaly
 	analyzer := &analysis.Analyzer{
 		Name: goCriticName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := wrapper.run(pass)
 			if err != nil {
 				return nil, err
@@ -245,7 +245,7 @@ func normalizeCheckerInfoParams(info *gocriticlinter.CheckerInfo) gocriticlinter
 // but the file parsers (TOML, YAML, JSON) don't create the same representation for raw type.
 // then we have to convert value types into the expected value types.
 // Maybe in the future, this kind of conversion will be done in go-critic itself.
-func (w *goCriticWrapper) normalizeCheckerParamsValue(p interface{}) interface{} {
+func (w *goCriticWrapper) normalizeCheckerParamsValue(p any) any {
 	rv := reflect.ValueOf(p)
 	switch rv.Type().Kind() {
 	case reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int:
@@ -621,7 +621,7 @@ func sprintStrings(ss []string) string {
 	return fmt.Sprint(ss)
 }
 
-func debugChecksListf(checks []string, format string, args ...interface{}) {
+func debugChecksListf(checks []string, format string, args ...any) {
 	if !isGoCriticDebug {
 		return
 	}

--- a/pkg/golinters/gocritic_test.go
+++ b/pkg/golinters/gocritic_test.go
@@ -36,23 +36,23 @@ func Test_filterByDisableTags(t *testing.T) {
 
 type tLog struct{}
 
-func (l *tLog) Fatalf(format string, args ...interface{}) {
+func (l *tLog) Fatalf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
-func (l *tLog) Panicf(format string, args ...interface{}) {
+func (l *tLog) Panicf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
-func (l *tLog) Errorf(format string, args ...interface{}) {
+func (l *tLog) Errorf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
-func (l *tLog) Warnf(format string, args ...interface{}) {
+func (l *tLog) Warnf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
-func (l *tLog) Infof(format string, args ...interface{}) {
+func (l *tLog) Infof(format string, args ...any) {
 	log.Printf(format, args...)
 }
 

--- a/pkg/golinters/gocyclo.go
+++ b/pkg/golinters/gocyclo.go
@@ -23,7 +23,7 @@ func NewGocyclo(settings *config.GoCycloSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: gocycloName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runGoCyclo(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/godot.go
+++ b/pkg/golinters/godot.go
@@ -42,7 +42,7 @@ func NewGodot(settings *config.GodotSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: godotName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGodot(pass, dotSettings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/godox.go
+++ b/pkg/golinters/godox.go
@@ -24,7 +24,7 @@ func NewGodox(settings *config.GodoxSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: godoxName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runGodox(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/gofmt.go
+++ b/pkg/golinters/gofmt.go
@@ -31,7 +31,7 @@ func NewGofmt(settings *config.GoFmtSettings) *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues, err := runGofmt(lintCtx, pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/gofumpt.go
+++ b/pkg/golinters/gofumpt.go
@@ -50,7 +50,7 @@ func NewGofumpt(settings *config.GofumptSettings) *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues, err := runGofumpt(lintCtx, pass, diff, options)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/goheader.go
+++ b/pkg/golinters/goheader.go
@@ -31,7 +31,7 @@ func NewGoHeader(settings *config.GoHeaderSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: goHeaderName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoHeader(pass, conf)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/goimports.go
+++ b/pkg/golinters/goimports.go
@@ -34,7 +34,7 @@ func NewGoimports(settings *config.GoImportsSettings) *goanalysis.Linter {
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		imports.LocalPrefix = settings.LocalPrefixes
 
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoImports(lintCtx, pass)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/golint.go
+++ b/pkg/golinters/golint.go
@@ -23,7 +23,7 @@ func NewGolint(settings *config.GoLintSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: golintName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoLint(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/gomnd.go
+++ b/pkg/golinters/gomnd.go
@@ -9,14 +9,14 @@ import (
 )
 
 func NewGoMND(settings *config.GoMndSettings) *goanalysis.Linter {
-	var linterCfg map[string]map[string]interface{}
+	var linterCfg map[string]map[string]any
 
 	if settings != nil {
 		// TODO(ldez) For compatibility only, must be drop in v2.
 		if len(settings.Settings) > 0 {
 			linterCfg = settings.Settings
 		} else {
-			cfg := make(map[string]interface{})
+			cfg := make(map[string]any)
 			if len(settings.Checks) > 0 {
 				cfg["checks"] = settings.Checks
 			}
@@ -30,7 +30,7 @@ func NewGoMND(settings *config.GoMndSettings) *goanalysis.Linter {
 				cfg["ignored-functions"] = settings.IgnoredFunctions
 			}
 
-			linterCfg = map[string]map[string]interface{}{
+			linterCfg = map[string]map[string]any{
 				"mnd": cfg,
 			}
 		}

--- a/pkg/golinters/gomoddirectives.go
+++ b/pkg/golinters/gomoddirectives.go
@@ -39,7 +39,7 @@ func NewGoModDirectives(settings *config.GoModDirectivesSettings) *goanalysis.Li
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			once.Do(func() {
 				results, err := gomoddirectives.Analyze(opts)
 				if err != nil {

--- a/pkg/golinters/gomodguard.go
+++ b/pkg/golinters/gomodguard.go
@@ -72,7 +72,7 @@ func NewGomodguard(settings *config.GoModGuardSettings) *goanalysis.Linter {
 			return
 		}
 
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			gomodguardIssues := processor.ProcessFiles(getFileNames(pass))
 
 			mu.Lock()

--- a/pkg/golinters/gosec.go
+++ b/pkg/golinters/gosec.go
@@ -58,7 +58,7 @@ func NewGosec(settings *config.GoSecSettings) *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			// The `gosecAnalyzer` is here because of concurrency issue.
 			gosecAnalyzer := gosec.NewAnalyzer(conf, true, settings.ExcludeGenerated, false, settings.Concurrency, logger)
 			gosecAnalyzer.LoadRules(ruleDefinitions.RulesInfo())

--- a/pkg/golinters/gosmopolitan.go
+++ b/pkg/golinters/gosmopolitan.go
@@ -13,9 +13,9 @@ import (
 func NewGosmopolitan(s *config.GosmopolitanSettings) *goanalysis.Linter {
 	a := gosmopolitan.NewAnalyzer()
 
-	cfgMap := map[string]map[string]interface{}{}
+	cfgMap := map[string]map[string]any{}
 	if s != nil {
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			"allowtimelocal":  s.AllowTimeLocal,
 			"escapehatches":   strings.Join(s.EscapeHatches, ","),
 			"lookattests":     !s.IgnoreTests,

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -123,7 +123,7 @@ var (
 )
 
 func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
-	var conf map[string]map[string]interface{}
+	var conf map[string]map[string]any
 	if settings != nil {
 		conf = settings.Settings
 	}

--- a/pkg/golinters/grouper.go
+++ b/pkg/golinters/grouper.go
@@ -9,9 +9,9 @@ import (
 )
 
 func NewGrouper(settings *config.GrouperSettings) *goanalysis.Linter {
-	linterCfg := map[string]map[string]interface{}{}
+	linterCfg := map[string]map[string]any{}
 	if settings != nil {
-		linterCfg["grouper"] = map[string]interface{}{
+		linterCfg["grouper"] = map[string]any{
 			"const-require-single-const":   settings.ConstRequireSingleConst,
 			"const-require-grouping":       settings.ConstRequireGrouping,
 			"import-require-single-import": settings.ImportRequireSingleImport,

--- a/pkg/golinters/ifshort.go
+++ b/pkg/golinters/ifshort.go
@@ -9,9 +9,9 @@ import (
 )
 
 func NewIfshort(settings *config.IfshortSettings) *goanalysis.Linter {
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			analyzer.Analyzer.Name: {
 				"max-decl-lines": settings.MaxDeclLines,
 				"max-decl-chars": settings.MaxDeclChars,

--- a/pkg/golinters/interfacebloat.go
+++ b/pkg/golinters/interfacebloat.go
@@ -11,9 +11,9 @@ import (
 func NewInterfaceBloat(settings *config.InterfaceBloatSettings) *goanalysis.Linter {
 	a := analyzer.New()
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				analyzer.InterfaceMaxMethodsFlag: settings.Max,
 			},

--- a/pkg/golinters/interfacer.go
+++ b/pkg/golinters/interfacer.go
@@ -22,7 +22,7 @@ func NewInterfacer() *goanalysis.Linter {
 		Name:     interfacerName,
 		Doc:      goanalysis.TheOnlyanalyzerDoc,
 		Requires: []*analysis.Analyzer{buildssa.Analyzer},
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runInterfacer(pass)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/ireturn.go
+++ b/pkg/golinters/ireturn.go
@@ -13,9 +13,9 @@ import (
 func NewIreturn(settings *config.IreturnSettings) *goanalysis.Linter {
 	a := analyzer.NewAnalyzer()
 
-	cfg := map[string]map[string]interface{}{}
+	cfg := map[string]map[string]any{}
 	if settings != nil {
-		cfg[a.Name] = map[string]interface{}{
+		cfg[a.Name] = map[string]any{
 			"allow":  strings.Join(settings.Allow, ","),
 			"reject": strings.Join(settings.Reject, ","),
 		}

--- a/pkg/golinters/lll.go
+++ b/pkg/golinters/lll.go
@@ -29,7 +29,7 @@ func NewLLL(settings *config.LllSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: lllName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runLll(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/maintidx.go
+++ b/pkg/golinters/maintidx.go
@@ -11,12 +11,12 @@ import (
 func NewMaintIdx(cfg *config.MaintIdxSettings) *goanalysis.Linter {
 	analyzer := maintidx.Analyzer
 
-	cfgMap := map[string]map[string]interface{}{
+	cfgMap := map[string]map[string]any{
 		analyzer.Name: {"under": 20},
 	}
 
 	if cfg != nil {
-		cfgMap[analyzer.Name] = map[string]interface{}{
+		cfgMap[analyzer.Name] = map[string]any{
 			"under": cfg.Under,
 		}
 	}

--- a/pkg/golinters/makezero.go
+++ b/pkg/golinters/makezero.go
@@ -23,7 +23,7 @@ func NewMakezero(settings *config.MakezeroSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: makezeroName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runMakeZero(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/maligned.go
+++ b/pkg/golinters/maligned.go
@@ -23,7 +23,7 @@ func NewMaligned(settings *config.MalignedSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: malignedName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runMaligned(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/misspell.go
+++ b/pkg/golinters/misspell.go
@@ -35,7 +35,7 @@ func NewMisspell(settings *config.MisspellSettings) *goanalysis.Linter {
 	).WithContextSetter(func(lintCtx *linter.Context) {
 		replacer, ruleErr := createMisspellReplacer(settings)
 
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			if ruleErr != nil {
 				return nil, ruleErr
 			}

--- a/pkg/golinters/nakedret.go
+++ b/pkg/golinters/nakedret.go
@@ -24,7 +24,7 @@ func NewNakedret(settings *config.NakedretSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: nakedretName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runNakedRet(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/nestif.go
+++ b/pkg/golinters/nestif.go
@@ -23,7 +23,7 @@ func NewNestif(settings *config.NestifSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: goanalysis.TheOnlyAnalyzerName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runNestIf(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/nilnil.go
+++ b/pkg/golinters/nilnil.go
@@ -13,9 +13,9 @@ import (
 func NewNilNil(cfg *config.NilNilSettings) *goanalysis.Linter {
 	a := analyzer.New()
 
-	cfgMap := make(map[string]map[string]interface{})
+	cfgMap := make(map[string]map[string]any)
 	if cfg != nil && len(cfg.CheckedTypes) != 0 {
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			"checked-types": strings.Join(cfg.CheckedTypes, ","),
 		}
 	}

--- a/pkg/golinters/nlreturn.go
+++ b/pkg/golinters/nlreturn.go
@@ -11,9 +11,9 @@ import (
 func NewNLReturn(settings *config.NlreturnSettings) *goanalysis.Linter {
 	a := nlreturn.NewAnalyzer()
 
-	cfg := map[string]map[string]interface{}{}
+	cfg := map[string]map[string]any{}
 	if settings != nil {
-		cfg[a.Name] = map[string]interface{}{
+		cfg[a.Name] = map[string]any{
 			"block-size": settings.BlockSize,
 		}
 	}

--- a/pkg/golinters/nolintlint.go
+++ b/pkg/golinters/nolintlint.go
@@ -24,7 +24,7 @@ func NewNoLintLint(settings *config.NoLintLintSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: NoLintLintName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runNoLintLint(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/nonamedreturns.go
+++ b/pkg/golinters/nonamedreturns.go
@@ -11,9 +11,9 @@ import (
 func NewNoNamedReturns(settings *config.NoNamedReturnsSettings) *goanalysis.Linter {
 	a := analyzer.Analyzer
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				analyzer.FlagReportErrorInDefer: settings.ReportErrorInDefer,
 			},

--- a/pkg/golinters/paralleltest.go
+++ b/pkg/golinters/paralleltest.go
@@ -11,9 +11,9 @@ import (
 func NewParallelTest(settings *config.ParallelTestSettings) *goanalysis.Linter {
 	a := paralleltest.Analyzer
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				"i": settings.IgnoreMissing,
 			},

--- a/pkg/golinters/prealloc.go
+++ b/pkg/golinters/prealloc.go
@@ -23,7 +23,7 @@ func NewPreAlloc(settings *config.PreallocSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: preallocName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runPreAlloc(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/predeclared.go
+++ b/pkg/golinters/predeclared.go
@@ -11,9 +11,9 @@ import (
 func NewPredeclared(settings *config.PredeclaredSettings) *goanalysis.Linter {
 	a := predeclared.Analyzer
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				predeclared.IgnoreFlag:    settings.Ignore,
 				predeclared.QualifiedFlag: settings.Qualified,

--- a/pkg/golinters/promlinter.go
+++ b/pkg/golinters/promlinter.go
@@ -30,7 +30,7 @@ func NewPromlinter(settings *config.PromlinterSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: promlinterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runPromLinter(pass, promSettings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/reassign.go
+++ b/pkg/golinters/reassign.go
@@ -14,9 +14,9 @@ import (
 func NewReassign(settings *config.ReassignSettings) *goanalysis.Linter {
 	a := reassign.NewAnalyzer()
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil && len(settings.Patterns) > 0 {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				reassign.FlagPattern: fmt.Sprintf("^(%s)$", strings.Join(settings.Patterns, "|")),
 			},

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -51,7 +51,7 @@ func NewRevive(settings *config.ReviveSettings) *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues, err := runRevive(lintCtx, pass, settings)
 			if err != nil {
 				return nil, err
@@ -187,8 +187,8 @@ func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
 	return conf, nil
 }
 
-func createConfigMap(cfg *config.ReviveSettings) map[string]interface{} {
-	rawRoot := map[string]interface{}{
+func createConfigMap(cfg *config.ReviveSettings) map[string]any {
+	rawRoot := map[string]any{
 		"ignoreGeneratedHeader": cfg.IgnoreGeneratedHeader,
 		"confidence":            cfg.Confidence,
 		"severity":              cfg.Severity,
@@ -197,9 +197,9 @@ func createConfigMap(cfg *config.ReviveSettings) map[string]interface{} {
 		"enableAllRules":        cfg.EnableAllRules,
 	}
 
-	rawDirectives := map[string]map[string]interface{}{}
+	rawDirectives := map[string]map[string]any{}
 	for _, directive := range cfg.Directives {
-		rawDirectives[directive.Name] = map[string]interface{}{
+		rawDirectives[directive.Name] = map[string]any{
 			"severity": directive.Severity,
 		}
 	}
@@ -208,9 +208,9 @@ func createConfigMap(cfg *config.ReviveSettings) map[string]interface{} {
 		rawRoot["directive"] = rawDirectives
 	}
 
-	rawRules := map[string]map[string]interface{}{}
+	rawRules := map[string]map[string]any{}
 	for _, s := range cfg.Rules {
-		rawRules[s.Name] = map[string]interface{}{
+		rawRules[s.Name] = map[string]any{
 			"severity":  s.Severity,
 			"arguments": safeTomlSlice(s.Arguments),
 			"disabled":  s.Disabled,
@@ -224,19 +224,19 @@ func createConfigMap(cfg *config.ReviveSettings) map[string]interface{} {
 	return rawRoot
 }
 
-func safeTomlSlice(r []interface{}) []interface{} {
+func safeTomlSlice(r []any) []any {
 	if len(r) == 0 {
 		return nil
 	}
 
-	if _, ok := r[0].(map[interface{}]interface{}); !ok {
+	if _, ok := r[0].(map[any]any); !ok {
 		return r
 	}
 
-	var typed []interface{}
+	var typed []any
 	for _, elt := range r {
-		item := map[string]interface{}{}
-		for k, v := range elt.(map[interface{}]interface{}) {
+		item := map[string]any{}
+		for k, v := range elt.(map[any]any) {
 			item[k.(string)] = v
 		}
 

--- a/pkg/golinters/scopelint.go
+++ b/pkg/golinters/scopelint.go
@@ -23,7 +23,7 @@ func NewScopelint() *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: scopelintName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runScopeLint(pass)
 
 			if len(issues) == 0 {
@@ -176,12 +176,12 @@ func (f *Node) Visit(node ast.Node) ast.Visitor {
 // and must end with a format string and any arguments.
 //
 //nolint:interfacer
-func (f *Node) errorf(n ast.Node, format string, args ...interface{}) {
+func (f *Node) errorf(n ast.Node, format string, args ...any) {
 	pos := f.fset.Position(n.Pos())
 	f.errorAtf(pos, format, args...)
 }
 
-func (f *Node) errorAtf(pos token.Position, format string, args ...interface{}) {
+func (f *Node) errorAtf(pos token.Position, format string, args ...any) {
 	*f.issues = append(*f.issues, result.Issue{
 		Pos:        pos,
 		Text:       fmt.Sprintf(format, args...),

--- a/pkg/golinters/structcheck.go
+++ b/pkg/golinters/structcheck.go
@@ -23,7 +23,7 @@ func NewStructcheck(settings *config.StructCheckSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: structcheckName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runStructCheck(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/stylecheck.go
+++ b/pkg/golinters/stylecheck.go
@@ -15,7 +15,7 @@ func NewStylecheck(settings *config.StaticCheckSettings) *goanalysis.Linter {
 	// `scconfig.Analyzer` is a singleton, then it's not possible to have more than one instance for all staticcheck "sub-linters".
 	// When we will merge the 4 "sub-linters", the problem will disappear: https://github.com/golangci/golangci-lint/issues/357
 	// Currently only stylecheck analyzer has a configuration in staticcheck.
-	scconfig.Analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+	scconfig.Analyzer.Run = func(pass *analysis.Pass) (any, error) {
 		return cfg, nil
 	}
 

--- a/pkg/golinters/tenv.go
+++ b/pkg/golinters/tenv.go
@@ -11,9 +11,9 @@ import (
 func NewTenv(settings *config.TenvSettings) *goanalysis.Linter {
 	a := tenv.Analyzer
 
-	var cfg map[string]map[string]interface{}
+	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]interface{}{
+		cfg = map[string]map[string]any{
 			a.Name: {
 				tenv.A: settings.All,
 			},

--- a/pkg/golinters/testpackage.go
+++ b/pkg/golinters/testpackage.go
@@ -13,9 +13,9 @@ import (
 func NewTestpackage(cfg *config.TestpackageSettings) *goanalysis.Linter {
 	var a = testpackage.NewAnalyzer()
 
-	var settings map[string]map[string]interface{}
+	var settings map[string]map[string]any
 	if cfg != nil {
-		settings = map[string]map[string]interface{}{
+		settings = map[string]map[string]any{
 			a.Name: {
 				testpackage.SkipRegexpFlagName:    cfg.SkipRegexp,
 				testpackage.AllowPackagesFlagName: strings.Join(cfg.AllowPackages, ","),

--- a/pkg/golinters/thelper.go
+++ b/pkg/golinters/thelper.go
@@ -47,7 +47,7 @@ func NewThelper(cfg *config.ThelperSettings) *goanalysis.Linter {
 		args = append(args, k)
 	}
 
-	cfgMap := map[string]map[string]interface{}{
+	cfgMap := map[string]map[string]any{
 		a.Name: {
 			"checks": strings.Join(args, ","),
 		},

--- a/pkg/golinters/unconvert.go
+++ b/pkg/golinters/unconvert.go
@@ -21,7 +21,7 @@ func NewUnconvert() *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: unconvertName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runUnconvert(pass)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/unparam.go
+++ b/pkg/golinters/unparam.go
@@ -24,7 +24,7 @@ func NewUnparam(settings *config.UnparamSettings) *goanalysis.Linter {
 		Name:     unparamName,
 		Doc:      goanalysis.TheOnlyanalyzerDoc,
 		Requires: []*analysis.Analyzer{buildssa.Analyzer},
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runUnparam(pass, settings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/unused.go
+++ b/pkg/golinters/unused.go
@@ -27,7 +27,7 @@ func NewUnused(settings *config.StaticCheckSettings) *goanalysis.Linter {
 		Name:     unusedName,
 		Doc:      unused.Analyzer.Analyzer.Doc,
 		Requires: unused.Analyzer.Analyzer.Requires,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runUnused(pass)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/usestdlibvars.go
+++ b/pkg/golinters/usestdlibvars.go
@@ -11,9 +11,9 @@ import (
 func NewUseStdlibVars(cfg *config.UseStdlibVarsSettings) *goanalysis.Linter {
 	a := analyzer.New()
 
-	cfgMap := make(map[string]map[string]interface{})
+	cfgMap := make(map[string]map[string]any)
 	if cfg != nil {
-		cfgMap[a.Name] = map[string]interface{}{
+		cfgMap[a.Name] = map[string]any{
 			analyzer.ConstantKindFlag:       cfg.ConstantKind,
 			analyzer.CryptoHashFlag:         cfg.CryptoHash,
 			analyzer.HTTPMethodFlag:         cfg.HTTPMethod,

--- a/pkg/golinters/varcheck.go
+++ b/pkg/golinters/varcheck.go
@@ -31,7 +31,7 @@ func NewVarcheck(settings *config.VarCheckSettings) *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues := runVarCheck(pass, settings)
 
 			if len(issues) == 0 {

--- a/pkg/golinters/varnamelen.go
+++ b/pkg/golinters/varnamelen.go
@@ -13,10 +13,10 @@ import (
 
 func NewVarnamelen(settings *config.VarnamelenSettings) *goanalysis.Linter {
 	analyzer := varnamelen.NewAnalyzer()
-	cfg := map[string]map[string]interface{}{}
+	cfg := map[string]map[string]any{}
 
 	if settings != nil {
-		vnlCfg := map[string]interface{}{
+		vnlCfg := map[string]any{
 			"checkReceiver":      strconv.FormatBool(settings.CheckReceiver),
 			"checkReturn":        strconv.FormatBool(settings.CheckReturn),
 			"checkTypeParam":     strconv.FormatBool(settings.CheckTypeParam),

--- a/pkg/golinters/whitespace.go
+++ b/pkg/golinters/whitespace.go
@@ -41,7 +41,7 @@ func NewWhitespace(settings *config.WhitespaceSettings) *goanalysis.Linter {
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (interface{}, error) {
+		analyzer.Run = func(pass *analysis.Pass) (any, error) {
 			issues, err := runWhitespace(lintCtx, pass, wsSettings)
 			if err != nil {
 				return nil, err

--- a/pkg/golinters/wsl.go
+++ b/pkg/golinters/wsl.go
@@ -40,7 +40,7 @@ func NewWSL(settings *config.WSLSettings) *goanalysis.Linter {
 	analyzer := &analysis.Analyzer{
 		Name: goanalysis.TheOnlyAnalyzerName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (interface{}, error) {
+		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runWSL(pass, &conf)
 
 			if len(issues) == 0 {

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -127,7 +127,7 @@ func (lc *Config) WithNoopFallback(cfg *config.Config) *Config {
 		lc.Linter = &Noop{
 			name: lc.Linter.Name(),
 			desc: lc.Linter.Desc(),
-			run: func(pass *analysis.Pass) (interface{}, error) {
+			run: func(pass *analysis.Pass) (any, error) {
 				return nil, nil
 			},
 		}

--- a/pkg/lint/linter/linter.go
+++ b/pkg/lint/linter/linter.go
@@ -17,7 +17,7 @@ type Linter interface {
 type Noop struct {
 	name string
 	desc string
-	run  func(pass *analysis.Pass) (interface{}, error)
+	run  func(pass *analysis.Pass) (any, error)
 }
 
 func (n Noop) Run(_ context.Context, lintCtx *Context) ([]result.Issue, error) {

--- a/pkg/logutils/log.go
+++ b/pkg/logutils/log.go
@@ -1,11 +1,11 @@
 package logutils
 
 type Log interface {
-	Fatalf(format string, args ...interface{})
-	Panicf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
+	Fatalf(format string, args ...any)
+	Panicf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Warnf(format string, args ...any)
+	Infof(format string, args ...any)
 
 	Child(name string) Log
 	SetLevel(level LogLevel)

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -77,9 +77,9 @@ func getEnabledDebugs() map[string]bool {
 
 var enabledDebugs = getEnabledDebugs()
 
-type DebugFunc func(format string, args ...interface{})
+type DebugFunc func(format string, args ...any)
 
-func nopDebugf(format string, args ...interface{}) {}
+func nopDebugf(format string, args ...any) {}
 
 func Debug(tag string) DebugFunc {
 	if !enabledDebugs[tag] {
@@ -89,7 +89,7 @@ func Debug(tag string) DebugFunc {
 	logger := NewStderrLog(tag)
 	logger.SetLevel(LogLevelDebug)
 
-	return func(format string, args ...interface{}) {
+	return func(format string, args ...any) {
 		logger.Debugf(format, args...)
 	}
 }

--- a/pkg/logutils/mock.go
+++ b/pkg/logutils/mock.go
@@ -12,28 +12,28 @@ func NewMockLog() *MockLog {
 	return &MockLog{}
 }
 
-func (m *MockLog) Fatalf(format string, args ...interface{}) {
-	mArgs := []interface{}{format}
+func (m *MockLog) Fatalf(format string, args ...any) {
+	mArgs := []any{format}
 	m.Called(append(mArgs, args...)...)
 }
 
-func (m *MockLog) Panicf(format string, args ...interface{}) {
-	mArgs := []interface{}{format}
+func (m *MockLog) Panicf(format string, args ...any) {
+	mArgs := []any{format}
 	m.Called(append(mArgs, args...)...)
 }
 
-func (m *MockLog) Errorf(format string, args ...interface{}) {
-	mArgs := []interface{}{format}
+func (m *MockLog) Errorf(format string, args ...any) {
+	mArgs := []any{format}
 	m.Called(append(mArgs, args...)...)
 }
 
-func (m *MockLog) Warnf(format string, args ...interface{}) {
-	mArgs := []interface{}{format}
+func (m *MockLog) Warnf(format string, args ...any) {
+	mArgs := []any{format}
 	m.Called(append(mArgs, args...)...)
 }
 
-func (m *MockLog) Infof(format string, args ...interface{}) {
-	mArgs := []interface{}{format}
+func (m *MockLog) Infof(format string, args ...any) {
+	mArgs := []any{format}
 	m.Called(append(mArgs, args...)...)
 }
 

--- a/pkg/logutils/stderr_log.go
+++ b/pkg/logutils/stderr_log.go
@@ -67,17 +67,17 @@ func (sl StderrLog) prefix() string {
 	return prefix
 }
 
-func (sl StderrLog) Fatalf(format string, args ...interface{}) {
+func (sl StderrLog) Fatalf(format string, args ...any) {
 	sl.logger.Errorf("%s%s", sl.prefix(), fmt.Sprintf(format, args...))
 	os.Exit(exitcodes.Failure)
 }
 
-func (sl StderrLog) Panicf(format string, args ...interface{}) {
+func (sl StderrLog) Panicf(format string, args ...any) {
 	v := fmt.Sprintf("%s%s", sl.prefix(), fmt.Sprintf(format, args...))
 	panic(v)
 }
 
-func (sl StderrLog) Errorf(format string, args ...interface{}) {
+func (sl StderrLog) Errorf(format string, args ...any) {
 	if sl.level > LogLevelError {
 		return
 	}
@@ -88,7 +88,7 @@ func (sl StderrLog) Errorf(format string, args ...interface{}) {
 	// called on hidden errors, see log levels comments.
 }
 
-func (sl StderrLog) Warnf(format string, args ...interface{}) {
+func (sl StderrLog) Warnf(format string, args ...any) {
 	if sl.level > LogLevelWarn {
 		return
 	}
@@ -96,7 +96,7 @@ func (sl StderrLog) Warnf(format string, args ...interface{}) {
 	sl.logger.Warnf("%s%s", sl.prefix(), fmt.Sprintf(format, args...))
 }
 
-func (sl StderrLog) Infof(format string, args ...interface{}) {
+func (sl StderrLog) Infof(format string, args ...any) {
 	if sl.level > LogLevelInfo {
 		return
 	}
@@ -104,7 +104,7 @@ func (sl StderrLog) Infof(format string, args ...interface{}) {
 	sl.logger.Infof("%s%s", sl.prefix(), fmt.Sprintf(format, args...))
 }
 
-func (sl StderrLog) Debugf(format string, args ...interface{}) {
+func (sl StderrLog) Debugf(format string, args ...any) {
 	if sl.level > LogLevelDebug {
 		return
 	}

--- a/pkg/printers/tab.go
+++ b/pkg/printers/tab.go
@@ -26,7 +26,7 @@ func NewTab(printLinterName bool, log logutils.Log, w io.Writer) *Tab {
 	}
 }
 
-func (p *Tab) SprintfColored(ca color.Attribute, format string, args ...interface{}) string {
+func (p *Tab) SprintfColored(ca color.Attribute, format string, args ...any) string {
 	c := color.New(ca)
 	return c.Sprintf(format, args...)
 }

--- a/pkg/printers/text.go
+++ b/pkg/printers/text.go
@@ -31,7 +31,7 @@ func NewText(printIssuedLine, useColors, printLinterName bool, log logutils.Log,
 	}
 }
 
-func (p *Text) SprintfColored(ca color.Attribute, format string, args ...interface{}) string {
+func (p *Text) SprintfColored(ca color.Attribute, format string, args ...any) string {
 	if !p.useColors {
 		return fmt.Sprintf(format, args...)
 	}

--- a/pkg/report/log.go
+++ b/pkg/report/log.go
@@ -20,20 +20,20 @@ func NewLogWrapper(log logutils.Log, reportData *Data) *LogWrapper {
 	}
 }
 
-func (lw LogWrapper) Fatalf(format string, args ...interface{}) {
+func (lw LogWrapper) Fatalf(format string, args ...any) {
 	lw.origLog.Fatalf(format, args...)
 }
 
-func (lw LogWrapper) Panicf(format string, args ...interface{}) {
+func (lw LogWrapper) Panicf(format string, args ...any) {
 	lw.origLog.Panicf(format, args...)
 }
 
-func (lw LogWrapper) Errorf(format string, args ...interface{}) {
+func (lw LogWrapper) Errorf(format string, args ...any) {
 	lw.origLog.Errorf(format, args...)
 	lw.rd.Error = fmt.Sprintf(format, args...)
 }
 
-func (lw LogWrapper) Warnf(format string, args ...interface{}) {
+func (lw LogWrapper) Warnf(format string, args ...any) {
 	lw.origLog.Warnf(format, args...)
 	w := Warning{
 		Tag:  strings.Join(lw.tags, "/"),
@@ -43,7 +43,7 @@ func (lw LogWrapper) Warnf(format string, args ...interface{}) {
 	lw.rd.Warnings = append(lw.rd.Warnings, w)
 }
 
-func (lw LogWrapper) Infof(format string, args ...interface{}) {
+func (lw LogWrapper) Infof(format string, args ...any) {
 	lw.origLog.Infof(format, args...)
 }
 

--- a/scripts/gen_github_action_config/main.go
+++ b/scripts/gen_github_action_config/main.go
@@ -215,7 +215,7 @@ func fetchAllReleases(ctx context.Context) ([]release, error) {
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"owner":          githubv4.String("golangci"),
 		"name":           githubv4.String("golangci-lint"),
 		"releasesCursor": (*githubv4.String)(nil),


### PR DESCRIPTION
This PR replaces `interface{}` with `any` in `pkg` and `scripts` directories. Because golangci-lint supports Go >= 1.19 this is a safe change.

`test`, `internal`, `third_party` directories didn't touch.