### PR TITLE
dev: remove golangci-releaser from generated team

### DIFF
--- a/.github/contributors/generate.ts
+++ b/.github/contributors/generate.ts
@@ -124,6 +124,7 @@ const main = async () => {
       fossabot: true,
       golangcibot: true,
       kortschak: true,
+      "golanci-releaser": true,
     }
 
     const res: DataJSON = {


### PR DESCRIPTION
I suppose [`golangci-releaser`](https://github.com/golangci-releaser) is a service user.

<img width="116" alt="image" src="https://user-images.githubusercontent.com/3228886/228263455-d445ee91-7881-4cda-8f06-b8dca8b80fe7.png">
