### PR TITLE
importas: detect duplicate alias or package in the configuration

### DIFF
--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -37,6 +37,7 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 		}
 
 		uniqPackages := make(map[string]config.ImportAsAlias)
+		uniqAliases := make(map[string]config.ImportAsAlias)
 		for _, a := range settings.Alias {
 			if a.Pkg == "" {
 				lintCtx.Log.Errorf("invalid configuration, empty package: pkg=%s alias=%s", a.Pkg, a.Alias)
@@ -44,9 +45,15 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			}
 
 			if v, ok := uniqPackages[a.Pkg]; ok {
-				lintCtx.Log.Errorf("invalid configuration, two aliases for the same package: pkg=%s aliases=[%s,%s]", a.Pkg, a.Alias, v.Alias)
+				lintCtx.Log.Errorf("invalid configuration, multiple aliases for the same package: pkg=%s aliases=[%s,%s]", a.Pkg, a.Alias, v.Alias)
 			} else {
 				uniqPackages[a.Pkg] = a
+			}
+
+			if v, ok := uniqAliases[a.Alias]; ok {
+				lintCtx.Log.Errorf("invalid configuration, multiple packages with the same alias: pkg=%s packages=[%s,%s]", a.Alias, a.Pkg, v.Pkg)
+			} else {
+				uniqAliases[a.Alias] = a
 			}
 
 			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", a.Pkg, a.Alias))

--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -36,10 +36,17 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 		}
 
+		uniqPackages := make(map[string]config.ImportAsAlias)
 		for _, a := range settings.Alias {
 			if a.Pkg == "" {
 				lintCtx.Log.Errorf("invalid configuration, empty package: pkg=%s alias=%s", a.Pkg, a.Alias)
 				continue
+			}
+
+			if v, ok := uniqPackages[a.Pkg]; ok {
+				lintCtx.Log.Errorf("invalid configuration, two aliases for the same package: pkg=%s aliases=[%s,%s]", a.Pkg, a.Alias, v.Alias)
+			} else {
+				uniqPackages[a.Pkg] = a
 			}
 
 			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", a.Pkg, a.Alias))


### PR DESCRIPTION
Produce an error log when a package has multiple aliases:

```yml
  importas:
    no-unaliased: true
    alias:
      - alias: netv1
        pkg: "k8s.io/api/networking/v1"
      - alias: networkingv1
        pkg: "k8s.io/api/networking/v1"
```

Produce an error log when an alias is used for several packages:
```yml
  importas:
    no-unaliased: true
    alias:
    - alias: netv1
      pkg: "k8s.io/api/networking/v1"
    - alias: netv1
      pkg: "k8s.io/api/networking/v1beta1"
```
