### PR TITLE
dev: remove unused ctx parameter from Printer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,7 @@ linters-settings:
     rules:
       - name: unexported-return
         disabled: true
+      - name: unused-parameter
 
 linters:
   disable-all: true

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -411,7 +411,7 @@ func (e *Executor) runAndPrint(ctx context.Context, args []string) error {
 			out = append(out, "")
 		}
 
-		err := e.printReports(ctx, issues, out[1], out[0])
+		err := e.printReports(issues, out[1], out[0])
 		if err != nil {
 			return err
 		}
@@ -424,7 +424,7 @@ func (e *Executor) runAndPrint(ctx context.Context, args []string) error {
 	return nil
 }
 
-func (e *Executor) printReports(ctx context.Context, issues []result.Issue, path, format string) error {
+func (e *Executor) printReports(issues []result.Issue, path, format string) error {
 	w, shouldClose, err := e.createWriter(path)
 	if err != nil {
 		return fmt.Errorf("can't create output for %s: %w", path, err)
@@ -438,7 +438,7 @@ func (e *Executor) printReports(ctx context.Context, issues []result.Issue, path
 		return err
 	}
 
-	if err = p.Print(ctx, issues); err != nil {
+	if err = p.Print(issues); err != nil {
 		if file, ok := w.(io.Closer); shouldClose && ok {
 			_ = file.Close()
 		}

--- a/pkg/golinters/gocritic_test.go
+++ b/pkg/golinters/gocritic_test.go
@@ -56,6 +56,6 @@ func (l *tLog) Infof(format string, args ...any) {
 	log.Printf(format, args...)
 }
 
-func (l *tLog) Child(name string) logutils.Log { return nil }
+func (l *tLog) Child(_ string) logutils.Log { return nil }
 
-func (l *tLog) SetLevel(level logutils.LogLevel) {}
+func (l *tLog) SetLevel(_ logutils.LogLevel) {}

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -79,7 +79,7 @@ var enabledDebugs = getEnabledDebugs()
 
 type DebugFunc func(format string, args ...any)
 
-func nopDebugf(format string, args ...any) {}
+func nopDebugf(_ string, _ ...any) {}
 
 func Debug(tag string) DebugFunc {
 	if !enabledDebugs[tag] {

--- a/pkg/printers/checkstyle.go
+++ b/pkg/printers/checkstyle.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -41,7 +40,7 @@ func NewCheckstyle(w io.Writer) *Checkstyle {
 	return &Checkstyle{w: w}
 }
 
-func (p Checkstyle) Print(ctx context.Context, issues []result.Issue) error {
+func (p Checkstyle) Print(issues []result.Issue) error {
 	out := checkstyleOutput{
 		Version: "5.0",
 	}

--- a/pkg/printers/checkstyle_test.go
+++ b/pkg/printers/checkstyle_test.go
@@ -2,7 +2,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"strings"
 	"testing"
@@ -47,7 +46,7 @@ func TestCheckstyle_Print(t *testing.T) {
 	buf := new(bytes.Buffer)
 	printer := NewCheckstyle(buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	//nolint:lll

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -35,7 +34,7 @@ func NewCodeClimate(w io.Writer) *CodeClimate {
 	return &CodeClimate{w: w}
 }
 
-func (p CodeClimate) Print(ctx context.Context, issues []result.Issue) error {
+func (p CodeClimate) Print(issues []result.Issue) error {
 	codeClimateIssues := make([]CodeClimateIssue, 0, len(issues))
 	for i := range issues {
 		issue := &issues[i]

--- a/pkg/printers/codeclimate_test.go
+++ b/pkg/printers/codeclimate_test.go
@@ -2,7 +2,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -61,7 +60,7 @@ func TestCodeClimate_Print(t *testing.T) {
 	buf := new(bytes.Buffer)
 	printer := NewCodeClimate(buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	//nolint:lll

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -36,7 +35,7 @@ func formatIssueAsGithub(issue *result.Issue) string {
 	return ret
 }
 
-func (p *github) Print(_ context.Context, issues []result.Issue) error {
+func (p *github) Print(issues []result.Issue) error {
 	for ind := range issues {
 		_, err := fmt.Fprintln(p.w, formatIssueAsGithub(&issues[ind]))
 		if err != nil {

--- a/pkg/printers/github_test.go
+++ b/pkg/printers/github_test.go
@@ -3,7 +3,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -47,7 +46,7 @@ func TestGithub_Print(t *testing.T) {
 	buf := new(bytes.Buffer)
 	printer := NewGithub(buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	expected := `::warning file=path/to/filea.go,line=10,col=4::some issue (linter-a)

--- a/pkg/printers/html.go
+++ b/pkg/printers/html.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"fmt"
 	"html/template"
 	"io"
@@ -131,7 +130,7 @@ func NewHTML(w io.Writer) *HTML {
 	return &HTML{w: w}
 }
 
-func (p HTML) Print(_ context.Context, issues []result.Issue) error {
+func (p HTML) Print(issues []result.Issue) error {
 	var htmlIssues []htmlIssue
 
 	for i := range issues {

--- a/pkg/printers/html_test.go
+++ b/pkg/printers/html_test.go
@@ -2,7 +2,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -153,7 +152,7 @@ func TestHTML_Print(t *testing.T) {
 	buf := new(bytes.Buffer)
 	printer := NewHTML(buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedHTML, buf.String())

--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 
@@ -26,7 +25,7 @@ type JSONResult struct {
 	Report *report.Data
 }
 
-func (p JSON) Print(ctx context.Context, issues []result.Issue) error {
+func (p JSON) Print(issues []result.Issue) error {
 	res := JSONResult{
 		Issues: issues,
 		Report: p.rd,

--- a/pkg/printers/json_test.go
+++ b/pkg/printers/json_test.go
@@ -2,7 +2,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -47,7 +46,7 @@ func TestJSON_Print(t *testing.T) {
 
 	printer := NewJSON(nil, buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	//nolint:lll

--- a/pkg/printers/junitxml.go
+++ b/pkg/printers/junitxml.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -45,7 +44,7 @@ func NewJunitXML(w io.Writer) *JunitXML {
 	return &JunitXML{w: w}
 }
 
-func (p JunitXML) Print(ctx context.Context, issues []result.Issue) error {
+func (p JunitXML) Print(issues []result.Issue) error {
 	suites := make(map[string]testSuiteXML) // use a map to group by file
 
 	for ind := range issues {

--- a/pkg/printers/junitxml_test.go
+++ b/pkg/printers/junitxml_test.go
@@ -3,7 +3,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -47,7 +46,7 @@ func TestJunitXML_Print(t *testing.T) {
 	buf := new(bytes.Buffer)
 	printer := NewJunitXML(buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	expected := `<testsuites>

--- a/pkg/printers/printer.go
+++ b/pkg/printers/printer.go
@@ -1,11 +1,9 @@
 package printers
 
 import (
-	"context"
-
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
 type Printer interface {
-	Print(ctx context.Context, issues []result.Issue) error
+	Print(issues []result.Issue) error
 }

--- a/pkg/printers/tab.go
+++ b/pkg/printers/tab.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"text/tabwriter"
@@ -31,7 +30,7 @@ func (p *Tab) SprintfColored(ca color.Attribute, format string, args ...any) str
 	return c.Sprintf(format, args...)
 }
 
-func (p *Tab) Print(ctx context.Context, issues []result.Issue) error {
+func (p *Tab) Print(issues []result.Issue) error {
 	w := tabwriter.NewWriter(p.w, 0, 0, 2, ' ', 0)
 
 	for i := range issues {

--- a/pkg/printers/tab_test.go
+++ b/pkg/printers/tab_test.go
@@ -2,7 +2,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestTab_Print(t *testing.T) {
 
 	printer := NewTab(true, logutils.NewStderrLog(logutils.DebugKeyEmpty), buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	expected := `path/to/filea.go:10:4   linter-a  some issue

--- a/pkg/printers/teamcity.go
+++ b/pkg/printers/teamcity.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -38,7 +37,7 @@ func NewTeamCity(w io.Writer) *TeamCity {
 	}
 }
 
-func (p *TeamCity) Print(_ context.Context, issues []result.Issue) error {
+func (p *TeamCity) Print(issues []result.Issue) error {
 	uniqLinters := map[string]struct{}{}
 
 	for i := range issues {

--- a/pkg/printers/teamcity_test.go
+++ b/pkg/printers/teamcity_test.go
@@ -2,7 +2,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -54,7 +53,7 @@ func TestTeamCity_Print(t *testing.T) {
 	buf := new(bytes.Buffer)
 	printer := NewTeamCity(buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	expected := `##teamcity[InspectionType id='linter-a' name='linter-a' description='linter-a' category='Golangci-lint reports']

--- a/pkg/printers/text.go
+++ b/pkg/printers/text.go
@@ -1,7 +1,6 @@
 package printers
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -40,7 +39,7 @@ func (p *Text) SprintfColored(ca color.Attribute, format string, args ...any) st
 	return c.Sprintf(format, args...)
 }
 
-func (p *Text) Print(ctx context.Context, issues []result.Issue) error {
+func (p *Text) Print(issues []result.Issue) error {
 	for i := range issues {
 		p.printIssue(&issues[i])
 

--- a/pkg/printers/text_test.go
+++ b/pkg/printers/text_test.go
@@ -2,7 +2,6 @@ package printers
 
 import (
 	"bytes"
-	"context"
 	"go/token"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestText_Print(t *testing.T) {
 
 	printer := NewText(true, false, true, logutils.NewStderrLog(logutils.DebugKeyEmpty), buf)
 
-	err := printer.Print(context.Background(), issues)
+	err := printer.Print(issues)
 	require.NoError(t, err)
 
 	expected := `path/to/filea.go:10:4: some issue (linter-a)


### PR DESCRIPTION
This PR removes `ctx` parameter from the `Printer.Print` method because it's not used in any of the printers.
Also, enable revive `unused-parameter` rule for detecting this. And fix occurred issues in other files.