### PR TITLE
gci: improve error message

### DIFF
--- a/pkg/golinters/gci.go
+++ b/pkg/golinters/gci.go
@@ -2,7 +2,6 @@ package golinters
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	gcicfg "github.com/daixiang0/gci/pkg/config"
@@ -145,7 +144,13 @@ func getErrorTextForGci(settings config.GciSettings) string {
 	}
 
 	if len(settings.Sections) > 0 {
-		text += " -s " + strings.Join(settings.Sections, ",")
+		for _, section := range settings.Sections {
+			text += " -s " + section
+		}
+	}
+
+	if settings.CustomOrder {
+		text += " --custom-order"
 	}
 
 	return text

--- a/test/testdata/configs/gci.yml
+++ b/test/testdata/configs/gci.yml
@@ -2,5 +2,6 @@ linters-settings:
   gci:
     sections:
       - standard
-      - prefix(github.com/golangci/golangci-lint)
+      - prefix(github.com/golangci/golangci-lint,github.com/daixiang0/gci)
       - default
+    custom-order: true

--- a/test/testdata/fix/in/gci.go
+++ b/test/testdata/fix/in/gci.go
@@ -6,11 +6,15 @@ package gci
 import (
 	"github.com/golangci/golangci-lint/pkg/config"
 	"golang.org/x/tools/go/analysis"
+
 	"fmt"
+
+	gcicfg "github.com/daixiang0/gci/pkg/config"
 )
 
 func GoimportsLocalTest() {
 	fmt.Print("x")
 	_ = config.Config{}
 	_ = analysis.Analyzer{}
+	_ = gcicfg.BoolConfig{}
 }

--- a/test/testdata/fix/out/gci.go
+++ b/test/testdata/fix/out/gci.go
@@ -6,13 +6,15 @@ package gci
 import (
 	"fmt"
 
-	"golang.org/x/tools/go/analysis"
-
+	gcicfg "github.com/daixiang0/gci/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/config"
+
+	"golang.org/x/tools/go/analysis"
 )
 
 func GoimportsLocalTest() {
 	fmt.Print("x")
 	_ = config.Config{}
 	_ = analysis.Analyzer{}
+	_ = gcicfg.BoolConfig{}
 }

--- a/test/testdata/gci.go
+++ b/test/testdata/gci.go
@@ -3,15 +3,16 @@
 package testdata
 
 import (
+	"golang.org/x/tools/go/analysis" // want "File is not \\`gci\\`-ed with --skip-generated -s standard -s prefix\\(github.com/golangci/golangci-lint,github.com/daixiang0/gci\\) -s default --custom-order"
+	"github.com/golangci/golangci-lint/pkg/config"
 	"fmt"
-
-	"github.com/golangci/golangci-lint/pkg/config" // want "File is not \\`gci\\`-ed with --skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
-
-	"golang.org/x/tools/go/analysis" // want "File is not \\`gci\\`-ed with --skip-generated -s standard,prefix\\(github.com/golangci/golangci-lint\\),default"
+	"errors"
+	gcicfg "github.com/daixiang0/gci/pkg/config"  // want "File is not \\`gci\\`-ed with --skip-generated -s standard -s prefix\\(github.com/golangci/golangci-lint,github.com/daixiang0/gci\\) -s default --custom-order"
 )
 
 func GoimportsLocalTest() {
-	fmt.Print("x")
+	fmt.Print(errors.New("x"))
 	_ = config.Config{}
 	_ = analysis.Analyzer{}
+	_ = gcicfg.BoolConfig{}
 }


### PR DESCRIPTION
~~Adds custom-order flag~~
~~Supports gci StringArray breaking change introduced in version 0.10.0. CSV-style `-s one,two,three` must now be `use -s one -s two -s three` which now supports multiple prefixes.~~

~~Fixes #3776~~

Improve error message.