### PR TITLE
Add "inamedparam": checks for interface method with unnamed params

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2261,6 +2261,7 @@ linters:
     - grouper
     - ifshort
     - importas
+    - inamedparam
     - ineffassign
     - interfacebloat
     - interfacer
@@ -2378,6 +2379,7 @@ linters:
     - grouper
     - ifshort
     - importas
+    - inamedparam
     - ineffassign
     - interfacebloat
     - interfacer

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/ldez/tagliatelle v0.5.0
 	github.com/leonklingele/grouper v1.1.1
 	github.com/lufeee/execinquery v1.2.1
+	github.com/macabu/inamedparam v0.1.2
 	github.com/maratori/testableexamples v1.0.0
 	github.com/maratori/testpackage v1.1.1
 	github.com/matoous/godox v0.0.0-20230222163458-006bad1f9d26

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,8 @@ github.com/lufeee/execinquery v1.2.1 h1:hf0Ems4SHcUGBxpGN7Jz78z1ppVkP/837ZlETPCE
 github.com/lufeee/execinquery v1.2.1/go.mod h1:EC7DrEKView09ocscGHC+apXMIaorh4xqSxS/dy8SbM=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
+github.com/macabu/inamedparam v0.1.2 h1:RR5cnayM6Q7cDhQol32DE2BGAPGMnffJ31LFE+UklaU=
+github.com/macabu/inamedparam v0.1.2/go.mod h1:Xg25QvY7IBRl1KLPV9Rbml8JOMZtF/iAkNkmV7eQgjw=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/maratori/testableexamples v1.0.0 h1:dU5alXRrD8WKSjOUnmJZuzdxWOEQ57+7s93SLMxb2vI=
@@ -406,8 +408,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.12.1 h1:uHNEO1RP2SpuZApSkel9nEh1/Mu+hmQe7Q+Pepg5OYA=
 github.com/onsi/gomega v1.28.0 h1:i2rg/p9n/UqIDAMFUJ6qIUUMcsqOuUHgbpbu235Vr1c=
-github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
+github.com/otiai10/copy v1.11.0 h1:OKBD80J/mLBrwnzXqGtFCzprFSGioo30JcmR4APsNwc=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=

--- a/pkg/golinters/inamedparam.go
+++ b/pkg/golinters/inamedparam.go
@@ -1,0 +1,21 @@
+package golinters
+
+import (
+	"github.com/macabu/inamedparam"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewINamedParam() *goanalysis.Linter {
+	analyzer := inamedparam.Analyzer
+
+	return goanalysis.NewLinter(
+		analyzer.Name,
+		analyzer.Doc,
+		[]*analysis.Analyzer{
+			analyzer,
+		},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/inamedparam.go
+++ b/pkg/golinters/inamedparam.go
@@ -8,14 +8,12 @@ import (
 )
 
 func NewINamedParam() *goanalysis.Linter {
-	analyzer := inamedparam.Analyzer
+	a := inamedparam.Analyzer
 
 	return goanalysis.NewLinter(
-		analyzer.Name,
-		analyzer.Doc,
-		[]*analysis.Analyzer{
-			analyzer,
-		},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -579,9 +579,8 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/julz/importas"),
 
 		linter.NewConfig(golinters.NewINamedParam()).
-			WithSince("v1.54.0").
+			WithSince("v1.55.0").
 			WithPresets(linter.PresetStyle).
-			WithLoadForGoAnalysis().
 			WithURL("https://github.com/macabu/inamedparam"),
 
 		linter.NewConfig(golinters.NewIneffassign()).

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -578,6 +578,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/julz/importas"),
 
+		linter.NewConfig(golinters.NewINamedParam()).
+			WithSince("v1.54.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/macabu/inamedparam"),
+
 		linter.NewConfig(golinters.NewIneffassign()).
 			WithEnabledByDefault().
 			WithSince("v1.0.0").

--- a/test/testdata/inamedparam.go
+++ b/test/testdata/inamedparam.go
@@ -1,0 +1,29 @@
+//golangcitest:args -Einamedparam
+package testdata
+
+import "context"
+
+type tStruct struct {
+	a int
+}
+
+type Doer interface {
+	Do() string
+}
+
+type NamedParam interface {
+	Void()
+
+	NoArgs() string
+
+	WithName(ctx context.Context, number int, toggle bool, tStruct *tStruct, doer Doer) (bool, error)
+
+	WithoutName(
+		context.Context, // want "interface method WithoutName must have named param for type context.Context"
+		int, // want "interface method WithoutName must have named param for type int"
+		bool, // want "interface method WithoutName must have named param for type bool"
+		tStruct, // want "interface method WithoutName must have named param for type tStruct"
+		Doer, // want "interface method WithoutName must have named param for type Doer"
+		struct{ b bool }, // want "interface method WithoutName must have all named params"
+	)
+}


### PR DESCRIPTION
I'd like to add the following linter: https://github.com/macabu/inamedparam 

It detects interface methods that don't have a named param and nudges to name them to improve clarity.  

I haven't found something similar in the available golangci-lint linters.