### PR TITLE
docs: Fix minor typo in new-linters.mdx

### DIFF
--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -10,7 +10,7 @@ from scratch and integrate it into `golangci-lint`.
 ## How to add a public linter to `golangci-lint`
 
 You need to implement a new linter using `go/analysis` API.
-We don't accept not `go/analysis` linters.
+We don't accept non `go/analysis` linters.
 
 After that:
 


### PR DESCRIPTION
This PR fixes a minor grammatical issue in the new linters doc.