### PR TITLE
gocritic: set Go version in configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/firefart/nonamedreturns v1.0.4
 	github.com/fzipp/gocyclo v0.6.0
-	github.com/go-critic/go-critic v0.7.0
+	github.com/go-critic/go-critic v0.8.0
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/gofrs/flock v0.8.1
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
-github.com/go-critic/go-critic v0.7.0 h1:tqbKzB8pqi0NsRZ+1pyU4aweAF7A7QN0Pi4Q02+rYnQ=
-github.com/go-critic/go-critic v0.7.0/go.mod h1:moYzd7GdVXE2C2hYTwd7h0CPcqlUeclsyBRwMa38v64=
+github.com/go-critic/go-critic v0.8.0 h1:4zOcpvDoKvBOl+R1W81IBznr78f8YaE4zKXkfDVxGGA=
+github.com/go-critic/go-critic v0.8.0/go.mod h1:5TjdkPI9cu/yKbYS96BTsslihjKd6zg6vd8O9RZXj2s=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -371,6 +371,7 @@ type GoConstSettings struct {
 }
 
 type GoCriticSettings struct {
+	Go               string                           `mapstructure:"-"`
 	EnabledChecks    []string                         `mapstructure:"enabled-checks"`
 	DisabledChecks   []string                         `mapstructure:"disabled-checks"`
 	EnabledTags      []string                         `mapstructure:"enabled-tags"`

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -113,6 +113,8 @@ func (w *goCriticWrapper) run(pass *analysis.Pass) ([]goanalysis.Issue, error) {
 
 	linterCtx := gocriticlinter.NewContext(pass.Fset, w.sizes)
 
+	linterCtx.SetGoVersion(w.settingsWrapper.Go)
+
 	enabledCheckers, err := w.buildEnabledCheckers(linterCtx)
 	if err != nil {
 		return nil, err

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -263,6 +263,10 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			govetCfg.Go = m.cfg.Run.Go
 		}
 
+		if gocriticCfg != nil {
+			gocriticCfg.Go = m.cfg.Run.Go
+		}
+
 		if gofumptCfg != nil && gofumptCfg.LangVersion == "" {
 			gofumptCfg.LangVersion = m.cfg.Run.Go
 		}

--- a/test/testdata/configs/gocritic.yml
+++ b/test/testdata/configs/gocritic.yml
@@ -1,3 +1,5 @@
+run:
+  go: 1.14
 linters-settings:
   gocritic:
     enabled-checks:
@@ -5,6 +7,7 @@ linters-settings:
       - flagDeref
       - wrapperFunc
       - ruleguard
+      - syncMapLoadAndDelete # ignored because sync#Map.LoadAndDelete added in Go 1.15
     settings:
       rangeValCopy:
         sizeThreshold: 2

--- a/test/testdata/gocritic.go
+++ b/test/testdata/gocritic.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"log"
 	"strings"
+	"sync"
 )
 
 var _ = *flag.Bool("global1", false, "") // want `flagDeref: immediate deref in \*flag.Bool\(.global1., false, ..\) is most likely an error; consider using flag\.BoolVar`
@@ -45,4 +46,14 @@ func gocriticDup(x bool) {
 
 func gocriticRuleWrapperFunc() {
 	strings.Replace("abcabc", "a", "d", -1) // want "ruleguard: this Replace call can be simplified.*"
+}
+
+func gocriticSink(args ...any) {}
+
+func gocriticIgnoreSyncMapLoadAndDelete(cond bool, m, m2 *sync.Map) {
+	actual, ok := m.Load("key")
+	if ok {
+		m.Delete("key")
+		gocriticSink(actual)
+	}
 }


### PR DESCRIPTION
This PR adds support for Go-language for `gocritic` linter.

```
$ gocritic check -h

...
-go string
        select the Go version to target. Leave as string for the latest
```