### PR TITLE
doc: update tagliatelle documentation

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1776,13 +1776,15 @@ linters-settings:
       # Default: {}
       rules:
         # Any struct tag type can be used.
-        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`
+        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `upperSnake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`
         json: camel
         yaml: camel
         xml: camel
         bson: camel
         avro: snake
         mapstructure: kebab
+        env: upperSnake
+        envconfig: upperSnake
 
   tenv:
     # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.

--- a/pkg/golinters/tagliatelle.go
+++ b/pkg/golinters/tagliatelle.go
@@ -11,11 +11,9 @@ import (
 func NewTagliatelle(settings *config.TagliatelleSettings) *goanalysis.Linter {
 	cfg := tagliatelle.Config{
 		Rules: map[string]string{
-			"json":      "camel",
-			"yaml":      "camel",
-			"header":    "header",
-			"env":       "upperSnake",
-			"envconfig": "upperSnake",
+			"json":   "camel",
+			"yaml":   "camel",
+			"header": "header",
 		},
 	}
 

--- a/pkg/golinters/tagliatelle.go
+++ b/pkg/golinters/tagliatelle.go
@@ -11,9 +11,11 @@ import (
 func NewTagliatelle(settings *config.TagliatelleSettings) *goanalysis.Linter {
 	cfg := tagliatelle.Config{
 		Rules: map[string]string{
-			"json":   "camel",
-			"yaml":   "camel",
-			"header": "header",
+			"json":      "camel",
+			"yaml":      "camel",
+			"header":    "header",
+			"env":       "upperSnake",
+			"envconfig": "upperSnake",
 		},
 	}
 


### PR DESCRIPTION
Minor change to the Tagliatelle docs/config to add support for v0.5.0 which adds `upperSnake` casing. The gomod version has [already been updated by dependabot](https://github.com/golangci/golangci-lint/pull/3782).

Related:

- https://github.com/ldez/tagliatelle/pull/17
- https://github.com/SchemaStore/schemastore/pull/2941