### PR TITLE
dev: simplify issues and enabled set tests

### DIFF
--- a/pkg/config/issues_test.go
+++ b/pkg/config/issues_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,27 +9,13 @@ import (
 func TestGetExcludePatterns(t *testing.T) {
 	assert.Equal(t, GetExcludePatterns(nil), DefaultExcludePatterns)
 
-	include := make([]string, 2)
-	include[0], include[1] = DefaultExcludePatterns[0].ID, DefaultExcludePatterns[1].ID
+	include := []string{DefaultExcludePatterns[0].ID, DefaultExcludePatterns[1].ID}
 
 	exclude := GetExcludePatterns(include)
-	assert.Equal(t, len(exclude), len(DefaultExcludePatterns)-len(include))
+	assert.Len(t, exclude, len(DefaultExcludePatterns)-len(include))
 
 	for _, p := range exclude {
-		// Not in include.
-		for _, i := range include {
-			if i == p.ID {
-				t.Fatalf("%s can't appear inside include.", p.ID)
-			}
-		}
-		// Must in DefaultExcludePatterns.
-		var inDefaultExc bool
-		for _, i := range DefaultExcludePatterns {
-			if i == p {
-				inDefaultExc = true
-				break
-			}
-		}
-		assert.True(t, inDefaultExc, fmt.Sprintf("%s must appear inside DefaultExcludePatterns.", p.ID))
+		assert.NotContains(t, include, p.ID)
+		assert.Contains(t, DefaultExcludePatterns, p)
 	}
 }

--- a/pkg/lint/lintersdb/enabled_set_test.go
+++ b/pkg/lint/lintersdb/enabled_set_test.go
@@ -1,7 +1,6 @@
 package lintersdb
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,10 +108,7 @@ func TestGetEnabledLintersSet(t *testing.T) {
 				enabledLinters = append(enabledLinters, ln)
 			}
 
-			sort.Strings(enabledLinters)
-			sort.Strings(c.exp)
-
-			assert.Equal(t, c.exp, enabledLinters)
+			assert.ElementsMatch(t, c.exp, enabledLinters)
 		})
 	}
 }


### PR DESCRIPTION
This PR refactors tests:
- replace raw loops with `assert.Contains` and `assert.NotContains`;
- use `assert.ElementsMatch` instead of `sort.Stirngs` with `assert.Equal`.