### PR TITLE
Fix go install instructions

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -120,7 +120,7 @@ Note: such `go install`/`go get` installation aren't guaranteed to work. We reco
 <div style="margin-top: 2em;">
 
 ```sh
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@{.LatestVersion}
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 ```
 
 </div>


### PR DESCRIPTION
The `{.LatestVersion}` token isn't being populated correctly on https://golangci-lint.run/usage/install#install-from-source

<img width="747" alt="image" src="https://github.com/golangci/golangci-lint/assets/133747/fbe93294-ce1d-4925-9106-aa6505c29f17">

A better solution is probably to just to use `@latest` unless there's some reason not to I am not understanding.