### PR TITLE
docs: update supported Go versions FAQ

### DIFF
--- a/docs/src/docs/usage/faq.mdx
+++ b/docs/src/docs/usage/faq.mdx
@@ -22,8 +22,6 @@ See [how to properly install `golangci-lint` in CI](/usage/install#ci-installati
 
 The same as the Go team (the 2 last minor versions)
 
-go1.18+ is officially supported, with some [limitations](https://github.com/golangci/golangci-lint/issues/2649), since golangci-lint v1.45.0.
-
 ## `golangci-lint` doesn't work
 
 1. Please, ensure you are using the latest binary release.


### PR DESCRIPTION
Issue https://github.com/golangci/golangci-lint/issues/2649 is closed now. Suppose it works without limitations now.