### PR TITLE
depguard: fix GOROOT detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/BurntSushi/toml v1.3.0
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0
-	github.com/OpenPeeDeeP/depguard/v2 v2.0.1
 	github.com/alexkohler/nakedret/v2 v2.0.1
 	github.com/alexkohler/prealloc v1.0.0
 	github.com/alingse/asasalint v0.0.11
@@ -37,6 +36,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/gofrs/flock v0.8.1
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
+	github.com/golangci/depguard/v2 v2.0.2-0.20230601235138-ed68d3771f48
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
 	github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe
 	github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0 h1:+r1rSv4gvYn0wmRjC8X7I
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0/go.mod h1:b3g59n2Y+T5xmcxJL+UEG2f8cQploZm1mR/v6BW0mU0=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
-github.com/OpenPeeDeeP/depguard/v2 v2.0.1 h1:yr9ZswukmNxl/hmJHEoLEjCF1d+f2pQrC0m1jzVljAE=
-github.com/OpenPeeDeeP/depguard/v2 v2.0.1/go.mod h1:gwSk4XDpowOuQSsMWNK5F7+C3kMz7QIexKRkD/GL4GU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -213,6 +211,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 h1:23T5iq8rbUYlhpt5DB4XJkc6BU31uODLD1o1gKvZmD0=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
+github.com/golangci/depguard/v2 v2.0.2-0.20230601235138-ed68d3771f48 h1:7HCx5L1RlH1KRijM95B57+ZraC7ddDW331jKPQY0iF4=
+github.com/golangci/depguard/v2 v2.0.2-0.20230601235138-ed68d3771f48/go.mod h1:e28gyM56ocHUQq3sLM1+C0iCx6NTPupOboWMllp1E/8=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9uMCefW1WDie15eSP/4MssdenaM=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe h1:6RGUuS7EGotKx6J5HIP8ZtyMdiDscjMLfRBSPuzVVeo=

--- a/pkg/golinters/depguard.go
+++ b/pkg/golinters/depguard.go
@@ -1,7 +1,7 @@
 package golinters
 
 import (
-	"github.com/OpenPeeDeeP/depguard/v2"
+	"github.com/golangci/depguard/v2"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"


### PR DESCRIPTION
Following the plan that I explained [here](https://github.com/golangci/golangci-lint/issues/3862#issuecomment-1572907138):
- create a fork inside the golangci org
- apply the fix
- use the fork as a dependency (I will create a dedicated module to avoid `replace` directives, because `replace` directives are not transitive, so users that are using that use the `tools` pattern will not have a problem.)

---

Summary of issue #3862:
depguard uses `build.Default.GOROOT` but this value is filled correctly only if the `GOROOT` is defined through an env var.

```console
$ go env | grep GOROOT
GOROOT="/usr/local/go"

$ env | grep GOROOT

$ export GOROOT=/usr/local/go

$ env | grep GOROOT
GOROOT=/usr/local/go
```

The "expander" cannot be overridden because it's a global variable inside an internal package, the `compile` method that produces the error and the analyzer constructor are not exported.

---

The fix I have done in our `depguard` fork is based on what is done inside [`golang.org/x/tools`](https://github.com/golang/tools/blob/86c93e8732cce300d0270bce23117456ce92bb17/cmd/godoc/goroot.go#L15-L30).

https://github.com/golangci/depguard/compare/v2.0.1...ed68d37

When the PR https://github.com/OpenPeeDeeP/depguard/pull/48 will be merged and when depguard will create a new release, we will drop this dependency (but we will have to keep the fork for compatibility.)

Fixes #3862
