### PR TITLE
docs: Update assets

### DIFF
--- a/assets/github-action-config.json
+++ b/assets/github-action-config.json
@@ -1,8 +1,8 @@
 {
   "MinorVersionToConfig": {
     "latest": {
-      "TargetVersion": "v1.53.0",
-      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.53.0/golangci-lint-1.53.0-linux-amd64.tar.gz"
+      "TargetVersion": "v1.53.1",
+      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.53.1/golangci-lint-1.53.1-linux-amd64.tar.gz"
     },
     "v1.10": {
       "Error": "golangci-lint version 'v1.10' isn't supported: we support only v1.14.0 and later versions"
@@ -182,8 +182,8 @@
       "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.52.2/golangci-lint-1.52.2-linux-amd64.tar.gz"
     },
     "v1.53": {
-      "TargetVersion": "v1.53.0",
-      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.53.0/golangci-lint-1.53.0-linux-amd64.tar.gz"
+      "TargetVersion": "v1.53.1",
+      "AssetURL": "https://github.com/golangci/golangci-lint/releases/download/v1.53.1/golangci-lint-1.53.1-linux-amd64.tar.gz"
     },
     "v1.6": {
       "Error": "golangci-lint version 'v1.6' isn't supported: we support only v1.14.0 and later versions"


### PR DESCRIPTION
Following the release of `v1.53.1`, `golangci/golangci-lint-action` still resolves the latest version to `v1.53.0`. This PR changes that to targets the latest, `v1.53.1`, release.