### PR TITLE
depguard: throw error only when the linter is called

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/gofrs/flock v0.8.1
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
-	github.com/golangci/depguard/v2 v2.0.2-0.20230601235138-ed68d3771f48
+	github.com/golangci/depguard/v2 v2.0.2-0.20230602133032-4f22f8585733
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
 	github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe
 	github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 h1:23T5iq8rbUYlhpt5DB4XJkc6BU31uODLD1o1gKvZmD0=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
-github.com/golangci/depguard/v2 v2.0.2-0.20230601235138-ed68d3771f48 h1:7HCx5L1RlH1KRijM95B57+ZraC7ddDW331jKPQY0iF4=
-github.com/golangci/depguard/v2 v2.0.2-0.20230601235138-ed68d3771f48/go.mod h1:e28gyM56ocHUQq3sLM1+C0iCx6NTPupOboWMllp1E/8=
+github.com/golangci/depguard/v2 v2.0.2-0.20230602133032-4f22f8585733 h1:8JUsvfXgBTLXGNvwL8QTYe4rmkeJUoiiqA+bAREQsBU=
+github.com/golangci/depguard/v2 v2.0.2-0.20230602133032-4f22f8585733/go.mod h1:e28gyM56ocHUQq3sLM1+C0iCx6NTPupOboWMllp1E/8=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9uMCefW1WDie15eSP/4MssdenaM=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe h1:6RGUuS7EGotKx6J5HIP8ZtyMdiDscjMLfRBSPuzVVeo=


### PR DESCRIPTION
I change our depguard fork to be able to handle the error.

Now the error (related to GOROOT) can only happen when the linter is called.


https://github.com/golangci/depguard/compare/ed68d37...4f22f85

I created an issue on the depguard repository to discuss a change in the API.
https://github.com/OpenPeeDeeP/depguard/issues/50
