### PR TITLE
build(deps): bump github.com/OpenPeeDeeP/depguard/v2 from v2.0.1 to 2.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/BurntSushi/toml v1.3.0
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0
+	github.com/OpenPeeDeeP/depguard/v2 v2.1.0
 	github.com/alexkohler/nakedret/v2 v2.0.1
 	github.com/alexkohler/prealloc v1.0.0
 	github.com/alingse/asasalint v0.0.11
@@ -36,7 +37,6 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/gofrs/flock v0.8.1
 	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2
-	github.com/golangci/depguard/v2 v2.0.2-0.20230602133032-4f22f8585733
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
 	github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe
 	github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0 h1:+r1rSv4gvYn0wmRjC8X7I
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0/go.mod h1:b3g59n2Y+T5xmcxJL+UEG2f8cQploZm1mR/v6BW0mU0=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/OpenPeeDeeP/depguard/v2 v2.1.0 h1:aQl70G173h/GZYhWf36aE5H0KaujXfVMnn/f1kSDVYY=
+github.com/OpenPeeDeeP/depguard/v2 v2.1.0/go.mod h1:PUBgk35fX4i7JDmwzlJwJ+GMe6NfO1723wmJMgPThNQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -211,8 +213,6 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 h1:23T5iq8rbUYlhpt5DB4XJkc6BU31uODLD1o1gKvZmD0=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
-github.com/golangci/depguard/v2 v2.0.2-0.20230602133032-4f22f8585733 h1:8JUsvfXgBTLXGNvwL8QTYe4rmkeJUoiiqA+bAREQsBU=
-github.com/golangci/depguard/v2 v2.0.2-0.20230602133032-4f22f8585733/go.mod h1:e28gyM56ocHUQq3sLM1+C0iCx6NTPupOboWMllp1E/8=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a h1:w8hkcTqaFpzKqonE9uMCefW1WDie15eSP/4MssdenaM=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
 github.com/golangci/go-misc v0.0.0-20220329215616-d24fe342adfe h1:6RGUuS7EGotKx6J5HIP8ZtyMdiDscjMLfRBSPuzVVeo=

--- a/pkg/golinters/depguard.go
+++ b/pkg/golinters/depguard.go
@@ -1,7 +1,7 @@
 package golinters
 
 import (
-	"github.com/golangci/depguard/v2"
+	"github.com/OpenPeeDeeP/depguard/v2"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
@@ -33,19 +33,17 @@ func NewDepguard(settings *config.DepGuardSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := depguard.NewCoreAnalyzer(depguard.CoreSettings{})
+	a := depguard.NewUncompiledAnalyzer(&conf)
 
 	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
+		a.Analyzer.Name,
+		a.Analyzer.Doc,
+		[]*analysis.Analyzer{a.Analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
-		coreSettings, err := conf.Compile()
+		err := a.Compile()
 		if err != nil {
 			lintCtx.Log.Errorf("create analyzer: %v", err)
 		}
-
-		a.Run = coreSettings.Run
 	}).WithLoadMode(goanalysis.LoadModeSyntax)
 }


### PR DESCRIPTION
Do the same thing as #3880 but remove our fork.