### PR TITLE
dev: use to GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,65 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  doc:
+    name: Build and deploy documentation
+    runs-on: ubuntu-latest
+    env:
+      GO_VERSION: '1.20'
+      NODE_VERSION: '20.x'
+      CGO_ENABLED: 0
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: docs-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            docs-${{ runner.os }}-go-
+
+      - run: go mod download
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - run:  npm install --legacy-peer-deps
+        working-directory: ./docs
+
+      - name: Build Documentation
+        run: npm run build
+        working-directory: ./docs
+
+      - name: Deploy to GitHub Pages
+        uses: crazy-max/ghaction-github-pages@v3
+        with:
+          target_branch: gh-pages
+          build_dir: docs/public
+        env:
+          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,10 +56,8 @@ jobs:
         working-directory: ./docs
 
       - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v3
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          target_branch: gh-pages
-          build_dir: docs/public
-        env:
-          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
-
+          publish_dir: docs/public
+          force_orphan: true
+          github_token: ${{ secrets.GOLANGCI_LINT_TOKEN }}


### PR DESCRIPTION
Currently, only one person has access to the Netlify administration (it's not me) and this is a problem because it can be really difficult when we have to update something inside the Netlify admin.

It will be easier to diagnose and fix problems like #3663.

This PR introduces Github Pages in parallel with Netlify because we need to have the branch and the content before setting up the custom domain.

When we will set the custom domain, I will open another PR to remove Netlify-related files.

FYI: I tested this PR on my fork.