### PR TITLE
dev: tidy go deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.5
 	github.com/sirupsen/logrus v1.9.2
 	github.com/sivchari/containedctx v1.0.3
+	github.com/sivchari/nosnakecase v1.7.0
 	github.com/sivchari/tenv v1.7.1
 	github.com/sonatard/noctx v0.0.2
 	github.com/sourcegraph/go-diff v0.7.0
@@ -170,7 +171,6 @@ require (
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	github.com/sivchari/nosnakecase v1.7.0
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect


### PR DESCRIPTION
`nosnakecase` is a direct dependency, and I just tidied the `go.mod` file