### PR TITLE
build(deps): bump github.com/golangci/misspell 0.4.0 to 0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/golangci/gofmt v0.0.0-20220901101216-f2edd75033f2
 	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0
 	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca
-	github.com/golangci/misspell v0.4.0
+	github.com/golangci/misspell v0.4.1
 	github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4
 	github.com/gordonklaus/ineffassign v0.0.0-20230610083614-0e73809eb601

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPz
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0/go.mod h1:66R6K6P6VWk9I95jvqGxkqJxVWGFy9XlDwLwVz1RCFg=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca h1:kNY3/svz5T29MYHubXix4aDDuE3RWHkPvopM/EDv/MA=
 github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca/go.mod h1:tvlJhZqDe4LMs4ZHD0oMUlt9G2LWuDGoisJTBzLMV9o=
-github.com/golangci/misspell v0.4.0 h1:KtVB/hTK4bbL/S6bs64rYyk8adjmh1BygbBiaAiX+a0=
-github.com/golangci/misspell v0.4.0/go.mod h1:W6O/bwV6lGDxUCChm2ykw9NQdd5bYd1Xkjo88UcWyJc=
+github.com/golangci/misspell v0.4.1 h1:+y73iSicVy2PqyX7kmUefHusENlrP9YwuHZHPLGQj/g=
+github.com/golangci/misspell v0.4.1/go.mod h1:9mAN1quEo3DlpbaIKKyEvRxK1pwqR9s/Sea1bJCtlNI=
 github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6 h1:DIPQnGy2Gv2FSA4B/hh8Q7xx3B7AIDk3DAMeHclH1vQ=
 github.com/golangci/revgrep v0.0.0-20220804021717-745bb2f7c2e6/go.mod h1:0AKcRCkMoKvUvlf89F6O7H2LYdhr1zBh736mBItOdRs=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -609,7 +609,8 @@ type MalignedSettings struct {
 }
 
 type MisspellSettings struct {
-	Locale      string
+	Locale string
+	// TODO(ldez): v2 the options must be renamed to `IgnoredRules`.
 	IgnoreWords []string `mapstructure:"ignore-words"`
 }
 

--- a/pkg/golinters/misspell.go
+++ b/pkg/golinters/misspell.go
@@ -95,11 +95,11 @@ func createMisspellReplacer(settings *config.MisspellSettings) (*misspell.Replac
 	}
 
 	if len(settings.IgnoreWords) != 0 {
-		var ignoreWords []string
+		var ignoredRules []string
 		for _, word := range settings.IgnoreWords {
-			ignoreWords = append(ignoreWords, strings.ToLower(word))
+			ignoredRules = append(ignoredRules, strings.ToLower(word))
 		}
-		replacer.RemoveRule(ignoreWords)
+		replacer.RemoveRule(ignoredRules)
 	}
 
 	// It can panic.

--- a/pkg/golinters/misspell.go
+++ b/pkg/golinters/misspell.go
@@ -95,7 +95,11 @@ func createMisspellReplacer(settings *config.MisspellSettings) (*misspell.Replac
 	}
 
 	if len(settings.IgnoreWords) != 0 {
-		replacer.RemoveRule(settings.IgnoreWords)
+		var ignoreWords []string
+		for _, word := range settings.IgnoreWords {
+			ignoreWords = append(ignoreWords, strings.ToLower(word))
+		}
+		replacer.RemoveRule(ignoreWords)
 	}
 
 	// It can panic.

--- a/pkg/golinters/misspell.go
+++ b/pkg/golinters/misspell.go
@@ -95,11 +95,7 @@ func createMisspellReplacer(settings *config.MisspellSettings) (*misspell.Replac
 	}
 
 	if len(settings.IgnoreWords) != 0 {
-		var ignoredRules []string
-		for _, word := range settings.IgnoreWords {
-			ignoredRules = append(ignoredRules, strings.ToLower(word))
-		}
-		replacer.RemoveRule(ignoredRules)
+		replacer.RemoveRule(settings.IgnoreWords)
 	}
 
 	// It can panic.

--- a/test/testdata/configs/misspell.yml
+++ b/test/testdata/configs/misspell.yml
@@ -1,4 +1,6 @@
 linters-settings:
   misspell:
+    locale: US
     ignore-words:
       - langauge
+      - Dialogue

--- a/test/testdata/misspell.go
+++ b/test/testdata/misspell.go
@@ -7,3 +7,4 @@ func Misspell() {
 }
 
 // the word langauge should be ignored here: it's set in config
+// the word Dialogue should be ignored here: it's set in config


### PR DESCRIPTION
misspell: convert ignore-words to lowercase


https://github.com/golangci/misspell/compare/v0.4.0...v0.4.1

Fixes #3406

