### PR TITLE
go1.21 support

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.20'
+      GO_VERSION: '1.21.0-rc.2'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.21.0-rc.4'
+      GO_VERSION: '1.21'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.21.0-rc.3'
+      GO_VERSION: '1.21.0-rc.4'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.21.0-rc.2'
+      GO_VERSION: '1.21.0-rc.3'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.3'
+          go-version: '1.21.0-rc.4'
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.2'
+          go-version: '1.21.0-rc.3'
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.20'
+          go-version: '1.21.0-rc.2'
 
       - name: Update GitHub action config
         run: make assets/github-action-config.json

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.3'
+          go-version: '1.21.0-rc.4'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.2'
+          go-version: '1.21.0-rc.3'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.20'
+          go-version: '1.21.0-rc.2'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.21.0-rc.4'
+  GO_VERSION: '1.21'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -91,7 +91,7 @@ jobs:
       matrix:
         golang:
           - '1.20'
-          - '1.21.0-rc.4'
+          - '1.21'
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.20'
+  GO_VERSION: '1.21.0-rc.2'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -41,7 +41,9 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: ${{ env.GO_VERSION }}
+          # TODO(ldez) must be changed after the first release of golangci-lint with go1.20
+          # go-version: ${{ env.GO_VERSION }}
+          go-version: '1.20'
       - name: lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:
@@ -88,8 +90,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          - 1.19
           - '1.20'
+          - '1.21.0-rc.2'
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.21.0-rc.2'
+  GO_VERSION: '1.21.0-rc.3'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -41,7 +41,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          # TODO(ldez) must be changed after the first release of golangci-lint with go1.20
+          # TODO(ldez) must be changed after the first release of golangci-lint with go1.21
           # go-version: ${{ env.GO_VERSION }}
           go-version: '1.20'
       - name: lint
@@ -91,7 +91,7 @@ jobs:
       matrix:
         golang:
           - '1.20'
-          - '1.21.0-rc.2'
+          - '1.21.0-rc.3'
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.21.0-rc.3'
+  GO_VERSION: '1.21.0-rc.4'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -91,7 +91,7 @@ jobs:
       matrix:
         golang:
           - '1.20'
-          - '1.21.0-rc.3'
+          - '1.21.0-rc.4'
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.20'
+          go-version: '1.21.0-rc.2'
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.20'
+          go-version: '1.21.0-rc.2'
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.4'
+          go-version: '1.21'
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.2'
+          go-version: '1.21.0-rc.3'
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.2'
+          go-version: '1.21.0-rc.3'
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.3'
+          go-version: '1.21.0-rc.4'
       - name: Unshallow
         run: git fetch --prune --unshallow
 
@@ -48,7 +48,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.21.0-rc.3'
+          go-version: '1.21.0-rc.4'
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,6 +155,8 @@ issues:
       text: "SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead."
     - path: pkg/golinters/unused.go
       text: "rangeValCopy: each iteration copies 160 bytes \\(consider pointers or indexing\\)"
+    - path: test/(fix|linters)_test.go
+      text: "string `gocritic.go` has 3 occurrences, make it a constant"
 
 run:
   timeout: 5m

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -10,7 +10,7 @@ WORKDIR /golangci
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.20
+FROM golang:1.21
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume

--- a/build/alpine.Dockerfile
+++ b/build/alpine.Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 building the code
-FROM golang:1.20-alpine as builder
+FROM golang:1.21-alpine as builder
 
 ARG VERSION
 ARG SHORT_COMMIT
@@ -15,7 +15,7 @@ RUN apk --no-cache add gcc musl-dev git mercurial
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
-FROM golang:1.20-alpine
+FROM golang:1.21-alpine
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
 # gcc is required to support cgo;

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.19
+go 1.20
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,13 +41,13 @@ type Version struct {
 	Debug  bool   `mapstructure:"debug"`
 }
 
-func IsGreaterThanOrEqualGo118(v string) bool {
+func IsGreaterThanOrEqualGo121(v string) bool {
 	v1, err := hcversion.NewVersion(strings.TrimPrefix(v, "go"))
 	if err != nil {
 		return false
 	}
 
-	limit, err := hcversion.NewVersion("1.18")
+	limit, err := hcversion.NewVersion("1.21")
 	if err != nil {
 		return false
 	}

--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -283,6 +283,20 @@ func newGoCriticSettingsWrapper(settings *config.GoCriticSettings, logger loguti
 		allCheckerMap[checkInfo.Name] = checkInfo
 	}
 
+	if settings != nil && config.IsGreaterThanOrEqualGo121(settings.Go) {
+		var enabledChecks []string
+		for _, check := range settings.EnabledChecks {
+			if check == "ruleguard" {
+				logger.Warnf("%s: check %q is disabled for go1.21 https://github.com/golangci/golangci-lint/issues/3933", goCriticName, "ruleguard")
+				continue
+			}
+
+			enabledChecks = append(enabledChecks, check)
+		}
+
+		settings.EnabledChecks = enabledChecks
+	}
+
 	return &goCriticSettingsWrapper{
 		GoCriticSettings:      settings,
 		logger:                logger,

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -134,7 +134,7 @@ func (lc *Config) Name() string {
 }
 
 func (lc *Config) WithNoopFallback(cfg *config.Config) *Config {
-	if cfg != nil && config.IsGreaterThanOrEqualGo118(cfg.Run.Go) {
+	if cfg != nil && config.IsGreaterThanOrEqualGo121(cfg.Run.Go) {
 		lc.Linter = &Noop{
 			name: lc.Linter.Name(),
 			desc: lc.Linter.Desc(),

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -451,7 +451,8 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.12.0").
 			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/go-critic/go-critic"),
+			WithURL("https://github.com/go-critic/go-critic").
+			WithNoopFallback(m.cfg),
 
 		linter.NewConfig(golinters.NewGocyclo(gocycloCfg)).
 			WithSince("v1.0.0").

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -451,8 +451,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithSince("v1.12.0").
 			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/go-critic/go-critic").
-			WithNoopFallback(m.cfg),
+			WithURL("https://github.com/go-critic/go-critic"),
 
 		linter.NewConfig(golinters.NewGocyclo(gocycloCfg)).
 			WithSince("v1.0.0").

--- a/test/fix_test.go
+++ b/test/fix_test.go
@@ -44,6 +44,7 @@ func TestFix(t *testing.T) {
 	for _, input := range sources {
 		input := input
 
+		// TODO(ldez): remove this limitation when gocritic/ruleguard will be fixed.
 		if filepath.Base(input) == "gocritic.go" {
 			t.Logf("skip gocritic because of a bug with ruleguard")
 			continue
@@ -87,6 +88,7 @@ func TestFix_pathPrefix(t *testing.T) {
 	for _, input := range sources {
 		input := input
 
+		// TODO(ldez): remove this limitation when gocritic/ruleguard will be fixed.
 		if filepath.Base(input) == "gocritic.go" {
 			t.Logf("skip gocritic because of a bug with ruleguard")
 			continue

--- a/test/fix_test.go
+++ b/test/fix_test.go
@@ -43,6 +43,12 @@ func TestFix(t *testing.T) {
 
 	for _, input := range sources {
 		input := input
+
+		if filepath.Base(input) == "gocritic.go" {
+			t.Logf("skip gocritic because of a bug with ruleguard")
+			continue
+		}
+
 		t.Run(filepath.Base(input), func(t *testing.T) {
 			t.Parallel()
 
@@ -80,6 +86,12 @@ func TestFix_pathPrefix(t *testing.T) {
 
 	for _, input := range sources {
 		input := input
+
+		if filepath.Base(input) == "gocritic.go" {
+			t.Logf("skip gocritic because of a bug with ruleguard")
+			continue
+		}
+
 		t.Run(filepath.Base(input), func(t *testing.T) {
 			t.Parallel()
 

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -63,6 +63,7 @@ func testSourcesFromDir(t *testing.T, dir string) {
 	for _, source := range sources {
 		source := source
 
+		// TODO(ldez): remove this limitation when gocritic/ruleguard will be fixed.
 		if filepath.Base(source) == "gocritic.go" {
 			t.Logf("skip gocritic because of a bug with ruleguard")
 			continue

--- a/test/linters_test.go
+++ b/test/linters_test.go
@@ -62,6 +62,12 @@ func testSourcesFromDir(t *testing.T, dir string) {
 
 	for _, source := range sources {
 		source := source
+
+		if filepath.Base(source) == "gocritic.go" {
+			t.Logf("skip gocritic because of a bug with ruleguard")
+			continue
+		}
+
 		t.Run(filepath.Base(source), func(subTest *testing.T) {
 			subTest.Parallel()
 


### PR DESCRIPTION
This PR is to evaluate and prepare golangci-lint to [go1.21](https://tip.golang.org/doc/go1.21).

This PR will evolve during the beta and RC phases of [go1.21](https://tip.golang.org/doc/go1.21).