### PR TITLE
 Allow exit failure only on specified severities

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2443,6 +2443,12 @@ severity:
   # Default: false
   case-sensitive: true
 
+  # Issue severities required to cause an exit with a non-successful code. An empty list means
+  # that any issue severity will cause a non-successful exit code. Severities should match the
+  # supported severity names of the selected out format.
+  # Default: []
+  fail-on-severities: ["warning", "error"]
+
   # When a list of severity rules are provided, severity information will be added to lint issues.
   # Severity rules have the same filtering capability as exclude rules
   # except you are allowed to specify one matcher per severity rule.

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -144,6 +144,9 @@ func (r *FileReader) validateConfig() error {
 	if len(c.Severity.Rules) > 0 && c.Severity.Default == "" {
 		return errors.New("can't set severity rule option: no default severity defined")
 	}
+	if len(c.Severity.FailOnSeverities) > 0 && c.Severity.Default == "" {
+		return errors.New("can't set severity failure set option: no default severity defined")
+	}
 	for i, rule := range c.Severity.Rules {
 		if err := rule.Validate(); err != nil {
 			return fmt.Errorf("error in severity rule #%d: %v", i, err)

--- a/pkg/config/severity.go
+++ b/pkg/config/severity.go
@@ -3,9 +3,10 @@ package config
 const severityRuleMinConditionsCount = 1
 
 type Severity struct {
-	Default       string         `mapstructure:"default-severity"`
-	CaseSensitive bool           `mapstructure:"case-sensitive"`
-	Rules         []SeverityRule `mapstructure:"rules"`
+	Default          string         `mapstructure:"default-severity"`
+	CaseSensitive    bool           `mapstructure:"case-sensitive"`
+	FailOnSeverities []string       `mapstructure:"fail-on-severities"`
+	Rules            []SeverityRule `mapstructure:"rules"`
 }
 
 type SeverityRule struct {

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -452,6 +452,37 @@ func TestUnusedCheckExported(t *testing.T) {
 		ExpectNoIssues()
 }
 
+func TestSuccessfulExitOnInsufficientlySevereIssues(t *testing.T) {
+	testshared.NewRunnerBuilder(t).
+		WithConfigFile("testdata_etc/fail_on_severities/staticcheck_ignore_warning_level.yml").
+		WithTargetPath("testdata_etc/fail_on_severities/...").
+		Runner().
+		Install().
+		Run().
+		ExpectExitCode(exitcodes.Success)
+}
+
+func TestFailedExitOnSufficientlySevereIssues(t *testing.T) {
+	testshared.NewRunnerBuilder(t).
+		WithConfigFile("testdata_etc/fail_on_severities/staticcheck_ignore_info_level.yml").
+		WithTargetPath("testdata_etc/fail_on_severities/...").
+		Runner().
+		Install().
+		Run().
+		ExpectExitCode(exitcodes.IssuesFound)
+}
+
+func TestFailedExitOnSufficientlySevereIssuesCmdFlag(t *testing.T) {
+	testshared.NewRunnerBuilder(t).
+		WithConfigFile("testdata_etc/fail_on_severities/staticcheck_ignore_warning_level.yml").
+		WithTargetPath("testdata_etc/fail_on_severities/...").
+		WithArgs("--fail-on-severities", "warning,error").
+		Runner().
+		Install().
+		Run().
+		ExpectExitCode(exitcodes.IssuesFound)
+}
+
 func TestConfigFileIsDetected(t *testing.T) {
 	testshared.InstallGolangciLint(t)
 

--- a/test/testdata_etc/fail_on_severities/staticcheck_deprecated.go
+++ b/test/testdata_etc/fail_on_severities/staticcheck_deprecated.go
@@ -1,0 +1,29 @@
+package testdata
+
+import (
+	"fmt"
+)
+
+const half = 0.5
+
+// Deprecated: use floatRounder instead
+func deprecatedFloatRounder(f float64) int64 {
+	return int64(f)
+}
+
+func floatRounder(f float64) int64 {
+	sgn := int64(1)
+	if f < 0 {
+		sgn = -1
+	}
+	out := int64(f)
+	if f-float64(out) > half {
+		out++
+	}
+	return sgn * out
+}
+
+func StaticCheckExitSuccessOnInfo() {
+	fmt.Println(deprecatedFloatRounder(1.0)) // want "SA1019: deprecatedFloatRounder is deprecated"
+	fmt.Println(floatRounder(1.0))
+}

--- a/test/testdata_etc/fail_on_severities/staticcheck_ignore_info_level.yml
+++ b/test/testdata_etc/fail_on_severities/staticcheck_ignore_info_level.yml
@@ -1,0 +1,18 @@
+linter-settings:
+  disable-all: true
+  enable:
+    - staticcheck 
+severity:
+  default-severity: error
+  fail-on-severities:
+    - warning
+    - error
+  rules:
+    - linters:
+        - staticcheck
+      severity: info
+      text: 'SA1019:'
+    - linters:
+        - staticcheck
+      severity: warning 
+      text: 'SA4016:'

--- a/test/testdata_etc/fail_on_severities/staticcheck_ignore_warning_level.yml
+++ b/test/testdata_etc/fail_on_severities/staticcheck_ignore_warning_level.yml
@@ -1,0 +1,17 @@
+linter-settings:
+  disable-all: true
+  enable:
+    - staticcheck 
+severity:
+  default-severity: error
+  fail-on-severities:
+    - error
+  rules:
+    - linters:
+        - staticcheck
+      severity: info
+      text: 'SA1019:'
+    - linters:
+        - staticcheck
+      severity: warning 
+      text: 'SA4016:'

--- a/test/testdata_etc/fail_on_severities/staticcheck_self_assign.go
+++ b/test/testdata_etc/fail_on_severities/staticcheck_self_assign.go
@@ -1,0 +1,14 @@
+package testdata
+
+import (
+	"fmt"
+)
+
+func uselessFunction(val int) int {
+	return val ^ 0
+}
+
+func StaticCheckExitFailOnInfo() {
+	x := uselessFunction(1)
+	fmt.Println(x)
+}


### PR DESCRIPTION
# Summary

Allow golangci-lint runs to exit with failed statuses only on specified issue severities

Fixes #1981

# Details

- Define `severity.fail-on-severities` string slice config option as well as `--fail-on-severities` string slice command
  line option
- When this option is empty or nil (default value), keep behavior identical to current behavior
- When this option is not empty, only exit with an "issues found" code when at least one issue's severity matches one of
  values specified in the option
  
# Notes / Concerns

- This implementation requires an explicit list of all codes resulting in failures; there is no "minimum cutoff" logic
  e.g. fail on warnings and above. A more sophisticated solution would need to establish total orderings of error
  severities across each output format and possibly across output formats, which is annoying to maintain and may
  confuse users.
- An empty config list is more strict than nonempty config lists, but larger config lists are more strict than smaller
  nonempty config lists; this is not _that_ hard to fathom for users, since never exiting with a failed code is not too
  useful. 
- Mixing config files with command line flags will merge the lists of exit codes upon which to fail; this can be a bit
  counterintuitive for the above reason.
  
# Testing

- Add special test cases for the following cases
  - [x] Info and warning issues with a config that fails on errors will result in a successful exit code
  - [x] Info and warning issues with a config that fails on errors and warnings will result in a failed exit code
  - [x] Info and warning issues with a config that fails on errors + a command line flag that fails on errors and
    warnings will fail

