### PR TITLE
unexportedglobal: Linter to require '_' prefix on globals

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2175,6 +2175,7 @@ linters:
     - tparallel
     - typecheck
     - unconvert
+    - unexportedglobal
     - unparam
     - unused
     - usestdlibvars
@@ -2289,6 +2290,7 @@ linters:
     - tparallel
     - typecheck
     - unconvert
+    - unexportedglobal
     - unparam
     - unused
     - usestdlibvars

--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/yeya24/promlinter v0.2.0
 	github.com/ykadowak/zerologlint v0.1.3
 	gitlab.com/bosi/decorder v0.2.3
+	go.abhg.dev/unexportedglobal v0.2.1
 	go.tmz.dev/musttag v0.7.1
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/tools v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -579,6 +579,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
 gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
 go-simpler.org/assert v0.5.0 h1:+5L/lajuQtzmbtEfh69sr5cRf2/xZzyJhFjoOz/PPqs=
+go.abhg.dev/unexportedglobal v0.2.1 h1:uxlNjpBk7WvCaTryyqj2h4aS0t5264cQGrURVbUVLGg=
+go.abhg.dev/unexportedglobal v0.2.1/go.mod h1:cgoKzc+6zAgv8FiRZ1xkZS+OrQcwjrtztP4A0ZJvgRg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/golinters/unexportedglobal.go
+++ b/pkg/golinters/unexportedglobal.go
@@ -1,0 +1,16 @@
+package golinters
+
+import (
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"go.abhg.dev/unexportedglobal"
+	"golang.org/x/tools/go/analysis"
+)
+
+func NewUnexportedGlobal() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		"unexportedglobal",
+		"Disallows unexported globals without a '_' prefix",
+		[]*analysis.Analyzer{unexportedglobal.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -817,6 +817,13 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/mdempsky/unconvert"),
 
+		linter.NewConfig(golinters.NewUnexportedGlobal()).
+			WithSince("v1.54.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithAutoFix().
+			WithURL("https://github.com/abhinav/unexportedglobal"),
+
 		linter.NewConfig(golinters.NewUnparam(unparamCfg)).
 			WithSince("v1.9.0").
 			WithPresets(linter.PresetUnused).

--- a/test/testdata/unexportedglobal.go
+++ b/test/testdata/unexportedglobal.go
@@ -1,0 +1,15 @@
+//golangcitest:args -Eunexportedglobal
+package testdata
+
+import "fmt"
+
+var ExportedVar = 1 // ok
+
+var unexportedVar = 1 // want `unexported global "unexportedVar" should be prefixed with '_'`
+
+var _unexportedVar = 1 // ok
+
+func _1() {
+	var local = 42
+	fmt.Println(local) // ok
+}


### PR DESCRIPTION
This adds a unexportedglobal to golangci-lint.
[unexportedglobal][1] is a linter that requires that unexported global variables and constants are prefixed with '_'.

  [1]: https://github.com/abhinav/unexportedglobal

```go
package foo

// Bad
var pool = sync.Pool{ /* ... */ }

// Good
var _pool = sync.Pool{ /* ... */ }
```

The idea is to eliminate the risk of conflict between names of local variables and names of global variables.

The linter is inspired by the [Prefix Unexported Globals with `_`][2] guidance in [Uber's Go Style Guide][3].

  [2]: https://github.com/uber-go/guide/blob/master/style.md#prefix-unexported-globals-with-_
  [3]: https://github.com/uber-go/guide/blob/master/style.md

The linter is not enabled by default.
I have also not added it to the 'style' preset because not everyone may agree with this change.
