### PR TITLE
docs: add linters description

### DIFF
--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -16,13 +16,13 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-
-	"gopkg.in/yaml.v3"
+	"unicode"
 
 	"github.com/golangci/golangci-lint/internal/renameio"
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
+	"gopkg.in/yaml.v3"
 )
 
 const listItemPrefix = "list-item-"
@@ -580,8 +580,8 @@ func marshallSnippet(node *yaml.Node) (string, error) {
 }
 
 func normalizeDesc(dsc string) string {
-	dsc = strings.ToUpper(dsc)
-	fmt.Println(dsc[len(dsc)-2:])
+	runes := []rune(dsc)
+	runes[0] = unicode.ToUpper([]rune(dsc)[0])
 	if dsc[len(dsc)-1:] != "." {
 		dsc = fmt.Sprintf("%s.", dsc)
 	}

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -584,8 +584,8 @@ func formatDesc(desc string) string {
 	runes := []rune(desc)
 	runes[0] = unicode.ToUpper([]rune(desc)[0])
 
-	if desc[len(desc)-1:] != "." {
-		desc = fmt.Sprintf("%s.", desc)
+	if runes[len(runes)-1] != '.' {
+		runes = append(runes, '.')
 	}
 
 	return strings.ReplaceAll(string(runes), "\n", "<br/>")

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -468,7 +468,14 @@ func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 		globalNode.Content = append(globalNode.Content, node, newNode)
 
 		if node.Value == "linters-settings" {
-			snippets.LintersSettings, err = getLintersSettingSnippets(node, nextNode)
+			var lintersDesc = make(map[string]string)
+			lcs := lintersdb.NewManager(nil, nil).GetAllSupportedLinterConfigs()
+
+			for _, lint := range lcs {
+				lintersDesc[getName(lint)] = getDesc(lint)
+			}
+
+			snippets.LintersSettings, err = getLintersSettingSnippets(node, nextNode, lintersDesc)
 			if err != nil {
 				return nil, err
 			}
@@ -508,7 +515,7 @@ func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 	return &snippets, nil
 }
 
-func getLintersSettingSnippets(node, nextNode *yaml.Node) (string, error) {
+func getLintersSettingSnippets(node, nextNode *yaml.Node, lintersDesc map[string]string) (string, error) {
 	builder := &strings.Builder{}
 
 	for i := 0; i < len(nextNode.Content); i += 2 {
@@ -530,6 +537,7 @@ func getLintersSettingSnippets(node, nextNode *yaml.Node) (string, error) {
 		}
 
 		_, _ = fmt.Fprintf(builder, "### %s\n\n", nextNode.Content[i].Value)
+		_, _ = fmt.Fprintf(builder, "%s\n\n", lintersDesc[nextNode.Content[i].Value])
 		_, _ = fmt.Fprintln(builder, "```yaml")
 
 		encoder := yaml.NewEncoder(builder)

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -18,11 +18,12 @@ import (
 	"strings"
 	"unicode"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/golangci/golangci-lint/internal/renameio"
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
-	"gopkg.in/yaml.v3"
 )
 
 const listItemPrefix = "list-item-"

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -302,7 +302,7 @@ func getDesc(lc *linter.Config) string {
 		}
 	}
 
-	return strings.ReplaceAll(desc, "\n", "<br/>")
+	return normalizeDesc(strings.ReplaceAll(desc, "\n", "<br/>"))
 }
 
 func check(b bool, title string) string {
@@ -577,4 +577,14 @@ func marshallSnippet(node *yaml.Node) (string, error) {
 	_, _ = fmt.Fprintln(builder)
 
 	return builder.String(), nil
+}
+
+func normalizeDesc(dsc string) string {
+	dsc = strings.ToUpper(dsc)
+	fmt.Println(dsc[len(dsc)-2:])
+	if dsc[len(dsc)-1:] != "." {
+		dsc = fmt.Sprintf("%s.", dsc)
+	}
+
+	return dsc
 }

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -472,7 +472,7 @@ func extractExampleSnippets(example []byte) (*SettingSnippets, error) {
 			lcs := lintersdb.NewManager(nil, nil).GetAllSupportedLinterConfigs()
 
 			for _, lint := range lcs {
-				lintersDesc[getName(lint)] = getDesc(lint)
+				lintersDesc[lint.Name()] = getDesc(lint)
 			}
 
 			snippets.LintersSettings, err = getLintersSettingSnippets(node, nextNode, lintersDesc)

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -582,6 +582,7 @@ func marshallSnippet(node *yaml.Node) (string, error) {
 func capitalizeAndAddFinalDot(dsc string) string {
 	runes := []rune(dsc)
 	runes[0] = unicode.ToUpper([]rune(dsc)[0])
+	dsc = string(runes)
 	if dsc[len(dsc)-1:] != "." {
 		dsc = fmt.Sprintf("%s.", dsc)
 	}

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -302,7 +302,7 @@ func getDesc(lc *linter.Config) string {
 		}
 	}
 
-	return normalizeDesc(strings.ReplaceAll(desc, "\n", "<br/>"))
+	return capitalizeAndAddFinalDot(strings.ReplaceAll(desc, "\n", "<br/>"))
 }
 
 func check(b bool, title string) string {
@@ -579,7 +579,7 @@ func marshallSnippet(node *yaml.Node) (string, error) {
 	return builder.String(), nil
 }
 
-func normalizeDesc(dsc string) string {
+func capitalizeAndAddFinalDot(dsc string) string {
 	runes := []rune(dsc)
 	runes[0] = unicode.ToUpper([]rune(dsc)[0])
 	if dsc[len(dsc)-1:] != "." {

--- a/scripts/expand_website_templates/main.go
+++ b/scripts/expand_website_templates/main.go
@@ -303,7 +303,7 @@ func getDesc(lc *linter.Config) string {
 		}
 	}
 
-	return capitalizeAndAddFinalDot(strings.ReplaceAll(desc, "\n", "<br/>"))
+	return formatDesc(desc)
 }
 
 func check(b bool, title string) string {
@@ -580,13 +580,13 @@ func marshallSnippet(node *yaml.Node) (string, error) {
 	return builder.String(), nil
 }
 
-func capitalizeAndAddFinalDot(dsc string) string {
-	runes := []rune(dsc)
-	runes[0] = unicode.ToUpper([]rune(dsc)[0])
-	dsc = string(runes)
-	if dsc[len(dsc)-1:] != "." {
-		dsc = fmt.Sprintf("%s.", dsc)
+func formatDesc(desc string) string {
+	runes := []rune(desc)
+	runes[0] = unicode.ToUpper([]rune(desc)[0])
+
+	if desc[len(desc)-1:] != "." {
+		desc = fmt.Sprintf("%s.", desc)
 	}
 
-	return dsc
+	return strings.ReplaceAll(string(runes), "\n", "<br/>")
 }


### PR DESCRIPTION
## What?

resolves #3927 

The idea was to add the description for each linter before the snippet in the /linters section.

**Additional**
I added a formatting function that normalizes all linters' descriptions. This function uppercases the first letter and adds a final dot if missing.

## Why?

This is for better understanding so the user doesn't have to scroll all the way up to read the linter's description.

## How?

I call the function GetAllSupportedLinterConfigs() and create a map with each linter's name and description. This way I decrease the complexity since I use just one loop to make it and the later search is O(1).

## Testing?

Everything is working fine.

## Screenshots

From this:
![Captura de pantalla 2023-07-09 175357](https://github.com/golangci/golangci-lint/assets/60699220/e840dfd4-0d6d-4862-95b8-4d5b6ccf1203)

To this: 
![Captura de pantalla 2023-07-09 175328](https://github.com/golangci/golangci-lint/assets/60699220/ef0e4670-1701-4d9c-9184-cff9f4cc9ac0)

**Additional**

From this:
![Captura de pantalla 2023-07-09 175216](https://github.com/golangci/golangci-lint/assets/60699220/6c774bc1-347b-4570-bc8c-9e09d406001b)

To this:
![Captura de pantalla 2023-07-09 175236](https://github.com/golangci/golangci-lint/assets/60699220/c8253c46-7c83-4015-9ea0-4af7a4e2c598)

Looking forward to your comments :)

