### PR TITLE
build(deps): bump gitlab.com/bosi/decorder from 0.2.3 to 0.4.0

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -158,6 +158,10 @@ linters-settings:
       - var
       - func
 
+    # If true, underscore vars (vars with "_" as the name) will be ignored at all checks
+    # Default: false (underscore vars are not ignored)
+    ignore-underscore-vars: false
+
     # If true, order of declarations is not checked at all.
     # Default: true (disabled)
     disable-dec-order-check: false
@@ -169,6 +173,18 @@ linters-settings:
     # If true, multiple global `type`, `const` and `var` declarations are allowed.
     # Default: true (disabled)
     disable-dec-num-check: false
+
+    # If true, type declarations will be ignored for dec num check
+    # Default: false (type statements are not ignored)
+    disable-type-dec-num-check: false
+
+    # If true, const declarations will be ignored for dec num check
+    # Default: false (const statements are not ignored)
+    disable-const-dec-num-check: false
+
+    # If true, var declarations will be ignored for dec num check
+    # Default: false (var statements are not ignored)
+    disable-var-dec-num-check: false
 
   depguard:
     # Rules to apply.

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0
 	github.com/yeya24/promlinter v0.2.0
 	github.com/ykadowak/zerologlint v0.1.3
-	gitlab.com/bosi/decorder v0.2.3
+	gitlab.com/bosi/decorder v0.4.0
 	go.tmz.dev/musttag v0.7.1
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/tools v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-gitlab.com/bosi/decorder v0.2.3 h1:gX4/RgK16ijY8V+BRQHAySfQAb354T7/xQpDB2n10P0=
-gitlab.com/bosi/decorder v0.2.3/go.mod h1:9K1RB5+VPNQYtXtTDAzd2OEftsZb1oV0IrJrzChSdGE=
+gitlab.com/bosi/decorder v0.4.0 h1:HWuxAhSxIvsITcXeP+iIRg9d1cVfvVkmlF7M68GaoDY=
+gitlab.com/bosi/decorder v0.4.0/go.mod h1:xarnteyUoJiOTEldDysquWKTVDCKo2TOIOIibSuWqOg=
 go-simpler.org/assert v0.5.0 h1:+5L/lajuQtzmbtEfh69sr5cRf2/xZzyJhFjoOz/PPqs=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -272,7 +272,11 @@ type DepGuardDeny struct {
 
 type DecorderSettings struct {
 	DecOrder                  []string `mapstructure:"dec-order"`
+	IgnoreUnderscoreVars      bool     `mapstructure:"ignore-underscore-vars"`
 	DisableDecNumCheck        bool     `mapstructure:"disable-dec-num-check"`
+	DisableTypeDecNumCheck    bool     `mapstructure:"disable-type-dec-num-check"`
+	DisableConstDecNumCheck   bool     `mapstructure:"disable-const-dec-num-check"`
+	DisableVarDecNumCheck     bool     `mapstructure:"disable-var-dec-num-check"`
 	DisableDecOrderCheck      bool     `mapstructure:"disable-dec-order-check"`
 	DisableInitFuncFirstCheck bool     `mapstructure:"disable-init-func-first-check"`
 }

--- a/pkg/golinters/decorder.go
+++ b/pkg/golinters/decorder.go
@@ -15,14 +15,22 @@ func NewDecorder(settings *config.DecorderSettings) *goanalysis.Linter {
 
 	// disable all rules/checks by default
 	cfg := map[string]any{
+		"ignore-underscore-vars":        false,
 		"disable-dec-num-check":         true,
+		"disable-type-dec-num-check":    false,
+		"disable-const-dec-num-check":   false,
+		"disable-var-dec-num-check":     false,
 		"disable-dec-order-check":       true,
 		"disable-init-func-first-check": true,
 	}
 
 	if settings != nil {
 		cfg["dec-order"] = strings.Join(settings.DecOrder, ",")
+		cfg["ignore-underscore-vars"] = settings.IgnoreUnderscoreVars
 		cfg["disable-dec-num-check"] = settings.DisableDecNumCheck
+		cfg["disable-type-dec-num-check"] = settings.DisableTypeDecNumCheck
+		cfg["disable-const-dec-num-check"] = settings.DisableConstDecNumCheck
+		cfg["disable-var-dec-num-check"] = settings.DisableVarDecNumCheck
 		cfg["disable-dec-order-check"] = settings.DisableDecOrderCheck
 		cfg["disable-init-func-first-check"] = settings.DisableInitFuncFirstCheck
 	}


### PR DESCRIPTION
Hi everyone :),

I've just updated my linter with a few more config options. This pr adds new options to golangci-lint. 

Please let me know if I miss any spots or if you want anything else to change before merging.

https://gitlab.com/bosi/decorder/-/compare/v0.2.3...v0.4.0
