### PR TITLE
build(deps): bump github.com/nunnatsa/ginkgolinter from 0.13.0 to 0.13.3

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -449,9 +449,9 @@ linters-settings:
     # Default: false
     suppress-async-assertion: true
 
-    # Suppress warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt
+    # Trigger warning for ginkgo focus containers like FDescribe, FContext, FWhen or FIt
     # Default: false
-    suppress-focus-container: true
+    forbid-focus-container: true
 
     # Don't trigger warnings for HaveLen(0)
     # Default: false

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/nakabonne/nestif v0.3.1
 	github.com/nishanths/exhaustive v0.11.0
 	github.com/nishanths/predeclared v0.2.2
-	github.com/nunnatsa/ginkgolinter v0.13.0
+	github.com/nunnatsa/ginkgolinter v0.13.3
 	github.com/polyfloyd/go-errorlint v1.4.3
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/ryancurrah/gomodguard v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,8 @@ github.com/nishanths/exhaustive v0.11.0 h1:T3I8nUGhl/Cwu5Z2hfc92l0e04D2GEW6e0l8p
 github.com/nishanths/exhaustive v0.11.0/go.mod h1:RqwDsZ1xY0dNdqHho2z6X+bgzizwbLYOWnZbbl2wLB4=
 github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm/w98Vk=
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
-github.com/nunnatsa/ginkgolinter v0.13.0 h1:kvnXNJXKDcYXTlHsgsfc1dQNziWASXAtQ3xyExV3v6U=
-github.com/nunnatsa/ginkgolinter v0.13.0/go.mod h1:aTKXo8WddENYxNEFT+4ZxEgWXqlD9uMD3w9Bfw/ABEc=
+github.com/nunnatsa/ginkgolinter v0.13.3 h1:wEvjrzSMfDdnoWkctignX9QTf4rT9f4GkQ3uVoXBmiU=
+github.com/nunnatsa/ginkgolinter v0.13.3/go.mod h1:aTKXo8WddENYxNEFT+4ZxEgWXqlD9uMD3w9Bfw/ABEc=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -396,7 +396,7 @@ type GinkgoLinterSettings struct {
 	SuppressErrAssertion     bool `mapstructure:"suppress-err-assertion"`
 	SuppressCompareAssertion bool `mapstructure:"suppress-compare-assertion"`
 	SuppressAsyncAssertion   bool `mapstructure:"suppress-async-assertion"`
-	SuppressFocusContainer   bool `mapstructure:"suppress-focus-container"`
+	ForbidFocusContainer     bool `mapstructure:"forbid-focus-container"`
 	AllowHaveLenZero         bool `mapstructure:"allow-havelen-zero"`
 }
 

--- a/pkg/golinters/ginkgolinter.go
+++ b/pkg/golinters/ginkgolinter.go
@@ -19,7 +19,7 @@ func NewGinkgoLinter(cfg *config.GinkgoLinterSettings) *goanalysis.Linter {
 			"suppress-err-assertion":     cfg.SuppressErrAssertion,
 			"suppress-compare-assertion": cfg.SuppressCompareAssertion,
 			"suppress-async-assertion":   cfg.SuppressAsyncAssertion,
-			"suppress-focus-container":   cfg.SuppressFocusContainer,
+			"forbid-focus-container":     cfg.ForbidFocusContainer,
 			"allow-havelen-0":            cfg.AllowHaveLenZero,
 		}
 	}

--- a/test/testdata/ginkgolinter/configs/ginkgolinter_suppress_focused_containers.yml
+++ b/test/testdata/ginkgolinter/configs/ginkgolinter_suppress_focused_containers.yml
@@ -1,3 +1,3 @@
 linters-settings:
   ginkgolinter:
-    suppress-focus-container: true
+    forbid-focus-container: true

--- a/test/testdata/ginkgolinter/ginkgolinter.go
+++ b/test/testdata/ginkgolinter/ginkgolinter.go
@@ -78,10 +78,10 @@ func WrongEventuallyWithFunction() {
 	Eventually(slowInt()).Should(Equal(42)) // want "ginkgo-linter: use a function call in Eventually. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; consider using .Eventually\\(slowInt\\)\\.Should\\(Equal\\(42\\)\\). instead"
 }
 
-var _ = Describe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
-		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
-			FIt("should not allow FIt", func() {}) // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
+var _ = FDescribe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() {
+		FWhen("should not allow FWhen", func() {
+			FIt("should not allow FIt", func() {})
 		})
 	})
 })

--- a/test/testdata/ginkgolinter/ginkgolinter_havelen0.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_havelen0.go
@@ -79,10 +79,10 @@ func WrongEventuallyWithFunction_havelen0() {
 	Eventually(slowInt_havelen0()).Should(Equal(42)) // want "ginkgo-linter: use a function call in Eventually. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; consider using .Eventually\\(slowInt_havelen0\\)\\.Should\\(Equal\\(42\\)\\). instead"
 }
 
-var _ = Describe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
-		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
-			FIt("should not allow FIt", func() {}) // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
+var _ = FDescribe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() {
+		FWhen("should not allow FWhen", func() {
+			FIt("should not allow FIt", func() {})
 		})
 	})
 })

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_async.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_async.go
@@ -80,10 +80,10 @@ func WrongEventuallyWithFunction_async() {
 	Eventually(slowInt_async()).Should(Equal(42)) // suppressed
 }
 
-var _ = Describe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
-		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
-			FIt("should not allow FIt", func() {}) // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
+var _ = FDescribe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() {
+		FWhen("should not allow FWhen", func() {
+			FIt("should not allow FIt", func() {})
 		})
 	})
 })

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_compare.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_compare.go
@@ -80,10 +80,10 @@ func WrongEventuallyWithFunction_compare() {
 	Eventually(slowInt_compare()).Should(Equal(42)) // want "ginkgo-linter: use a function call in Eventually. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; consider using .Eventually\\(slowInt_compare\\)\\.Should\\(Equal\\(42\\)\\). instead"
 }
 
-var _ = Describe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
-		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
-			FIt("should not allow FIt", func() {}) // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
+var _ = FDescribe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() {
+		FWhen("should not allow FWhen", func() {
+			FIt("should not allow FIt", func() {})
 		})
 	})
 })

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_err.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_err.go
@@ -80,10 +80,10 @@ func WrongEventuallyWithFunction_err() {
 	Eventually(slowInt_err()).Should(Equal(42)) // want "ginkgo-linter: use a function call in Eventually. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; consider using .Eventually\\(slowInt_err\\)\\.Should\\(Equal\\(42\\)\\). instead"
 }
 
-var _ = Describe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
-		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
-			FIt("should not allow FIt", func() {}) // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
+var _ = FDescribe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() {
+		FWhen("should not allow FWhen", func() {
+			FIt("should not allow FIt", func() {})
 		})
 	})
 })

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_focused_containers.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_focused_containers.go
@@ -79,10 +79,10 @@ func WrongEventuallyWithFunction_focus() {
 	Eventually(slowInt_focus()).Should(Equal(42)) // want "ginkgo-linter: use a function call in Eventually. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; consider using .Eventually\\(slowInt_focus\\)\\.Should\\(Equal\\(42\\)\\). instead"
 }
 
-var _ = FDescribe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() {
-		FWhen("should not allow FWhen", func() {
-			FIt("should not allow FIt", func() {
+var _ = Describe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
+		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
+			FIt("should not allow FIt", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
 
 			})
 		})

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_len.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_len.go
@@ -80,10 +80,10 @@ func WrongEventuallyWithFunction_len() {
 	Eventually(slowInt_len()).Should(Equal(42)) // want "ginkgo-linter: use a function call in Eventually. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; consider using .Eventually\\(slowInt_len\\)\\.Should\\(Equal\\(42\\)\\). instead"
 }
 
-var _ = Describe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
-		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
-			FIt("should not allow FIt", func() {}) // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
+var _ = FDescribe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() {
+		FWhen("should not allow FWhen", func() {
+			FIt("should not allow FIt", func() {})
 		})
 	})
 })

--- a/test/testdata/ginkgolinter/ginkgolinter_suppress_nil.go
+++ b/test/testdata/ginkgolinter/ginkgolinter_suppress_nil.go
@@ -80,10 +80,10 @@ func WrongEventuallyWithFunction_nil() {
 	Eventually(slowInt_nil()).Should(Equal(42)) // want "ginkgo-linter: use a function call in Eventually. This actually checks nothing, because Eventually receives the function returned value, instead of function itself, and this value is never changed; consider using .Eventually\\(slowInt_nil\\)\\.Should\\(Equal\\(42\\)\\). instead"
 }
 
-var _ = Describe("Should warn for focused containers", func() {
-	FContext("should not allow FContext", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"Context\""
-		FWhen("should not allow FWhen", func() { // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"When\""
-			FIt("should not allow FIt", func() {}) // want "ginkgo-linter: Focus container found. This is used only for local debug and should not be part of the actual source code, consider to replace with \"It\""
+var _ = FDescribe("Should warn for focused containers", func() {
+	FContext("should not allow FContext", func() {
+		FWhen("should not allow FWhen", func() {
+			FIt("should not allow FIt", func() {})
 		})
 	})
 })


### PR DESCRIPTION
This PR bumps ginkgolinter to v0.13.3

This version is a bugfix, and it set the new focused container rule to be disabled by default.

The configuration flag name was change to reflact that, so this PR also fixes the configuration parameter name:

`suppress-focus-container` ==> `forbid-focus-container`

https://github.com/nunnatsa/ginkgolinter/compare/v0.13.0...v0.13.3

@ldez - I don't want to wait for the auto-bump job, because this change breaks the previous change (not released yet).