### PR TITLE
build(deps): bump github.com/4meepo/tagalign from 1.3.1 to 1.3.2

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1806,6 +1806,7 @@ linters-settings:
     # Whether enable strict style.
     # In this style, the tags will be sorted and aligned in the dictionary order,
     # and the tags with the same name will be aligned together.
+    # Note: This option will be ignored if 'align' or 'sort' is false.
     # Default: false
     strict: true
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
 	4d63.com/gochecknoglobals v0.2.1
-	github.com/4meepo/tagalign v1.3.1
+	github.com/4meepo/tagalign v1.3.2
 	github.com/Abirdcfly/dupword v0.0.12
 	github.com/Antonboom/errname v0.1.10
 	github.com/Antonboom/nilnil v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/4meepo/tagalign v1.3.1 h1:rgmaEHXOCks52e6IpowKCPAIRJCVLlO3jyf97uDmmgo=
 github.com/4meepo/tagalign v1.3.1/go.mod h1:Q9c1rYMZJc9dPRkbQPpcBNCLEmY2njbAsXhQOZFE2dE=
+github.com/4meepo/tagalign v1.3.2 h1:1idD3yxlRGV18VjqtDbqYvQ5pXqQS0wO2dn6M3XstvI=
+github.com/4meepo/tagalign v1.3.2/go.mod h1:Q9c1rYMZJc9dPRkbQPpcBNCLEmY2njbAsXhQOZFE2dE=
 github.com/Abirdcfly/dupword v0.0.12 h1:56NnOyrXzChj07BDFjeRA+IUzSz01jmzEq+G4kEgFhc=
 github.com/Abirdcfly/dupword v0.0.12/go.mod h1:+us/TGct/nI9Ndcbcp3rgNcQzctTj68pq7TcgNpLfdI=
 github.com/Antonboom/errname v0.1.10 h1:RZ7cYo/GuZqjr1nuJLNe8ZH+a+Jd9DaZzttWzak9Bls=

--- a/pkg/golinters/tagalign.go
+++ b/pkg/golinters/tagalign.go
@@ -25,7 +25,8 @@ func NewTagAlign(settings *config.TagAlignSettings) *goanalysis.Linter {
 			options = append(options, tagalign.WithSort(settings.Order...))
 		}
 
-		if settings.Strict {
+		// Strict style will be applied only if Align and Sort are enabled together.
+		if settings.Strict && settings.Align && settings.Sort {
 			options = append(options, tagalign.WithStrictStyle())
 		}
 	}

--- a/test/testdata/configs/tagalign_strict.yml
+++ b/test/testdata/configs/tagalign_strict.yml
@@ -1,0 +1,5 @@
+linters-settings:
+  tagalign:
+    align: true
+    sort: true
+    strict: true

--- a/test/testdata/tagalign_strict.go
+++ b/test/testdata/tagalign_strict.go
@@ -1,0 +1,10 @@
+//golangcitest:args -Etagalign
+//golangcitest:config_path testdata/configs/tagalign_strict.yml
+package testdata
+
+import "time"
+
+type TagAlignExampleStrictKO struct {
+	Foo    time.Time `json:"foo,omitempty" validate:"required" zip:"foo"`                                                       // want `                     json:"foo,omitempty"    validate:"required"                            zip:"foo"`
+	FooBar struct{}  `gorm:"column:fooBar" validate:"required" zip:"fooBar" xml:"fooBar" json:"fooBar,omitempty" yaml:"fooBar"` // want `gorm:"column:fooBar" json:"fooBar,omitempty" validate:"required" xml:"fooBar" yaml:"fooBar" zip:"fooBar"`
+}


### PR DESCRIPTION
The strict style of `tagalign` must be used together with align and sort option, or it will be ignored.

Also add a test case for strict style.

https://github.com/4meepo/tagalign/compare/v1.3.1...v1.3.2
