### PR TITLE
feat: add noimportsasvar linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2176,6 +2176,7 @@ linters:
     - nilnil
     - nlreturn
     - noctx
+    - noimportsasvar
     - nolintlint
     - nonamedreturns
     - nosnakecase
@@ -2290,6 +2291,7 @@ linters:
     - nilnil
     - nlreturn
     - noctx
+    - noimportsasvar
     - nolintlint
     - nonamedreturns
     - nosnakecase

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.1.0
+	github.com/HarryTennent/noimportsasvar v1.0.2
 	github.com/OpenPeeDeeP/depguard/v2 v2.1.0
 	github.com/alexkohler/nakedret/v2 v2.0.2
 	github.com/alexkohler/prealloc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/4meepo/tagalign v1.3.1 h1:rgmaEHXOCks52e6IpowKCPAIRJCVLlO3jyf97uDmmgo=
-github.com/4meepo/tagalign v1.3.1/go.mod h1:Q9c1rYMZJc9dPRkbQPpcBNCLEmY2njbAsXhQOZFE2dE=
 github.com/4meepo/tagalign v1.3.2 h1:1idD3yxlRGV18VjqtDbqYvQ5pXqQS0wO2dn6M3XstvI=
 github.com/4meepo/tagalign v1.3.2/go.mod h1:Q9c1rYMZJc9dPRkbQPpcBNCLEmY2njbAsXhQOZFE2dE=
 github.com/Abirdcfly/dupword v0.0.12 h1:56NnOyrXzChj07BDFjeRA+IUzSz01jmzEq+G4kEgFhc=
@@ -58,6 +56,8 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rW
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.1.0 h1:3ZBs7LAezy8gh0uECsA6CGU43FF3zsx5f4eah5FxTMA=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.1.0/go.mod h1:rZLTje5A9kFBe0pzhpe2TdhRniBF++PRHQuRpR8esVc=
+github.com/HarryTennent/noimportsasvar v1.0.2 h1:c0bHtj4/tSFScpFNj4M7mx/eA2T4s2BeF2bszrY3uW0=
+github.com/HarryTennent/noimportsasvar v1.0.2/go.mod h1:7pXejxhRzjRSaVP1yinaL8tYQef4+xJ7P1vyYFDDC84=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OpenPeeDeeP/depguard/v2 v2.1.0 h1:aQl70G173h/GZYhWf36aE5H0KaujXfVMnn/f1kSDVYY=

--- a/pkg/golinters/noimportsasvar.go
+++ b/pkg/golinters/noimportsasvar.go
@@ -1,0 +1,16 @@
+package golinters
+
+import (
+	"github.com/HarryTennent/noimportsasvar/pkg/analyzer"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"golang.org/x/tools/go/analysis"
+)
+
+func NewNoImportsAsVar() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		"noimportsasvar",
+		"Checks that a file's imports are not used as variable names.",
+		[]*analysis.Analyzer{analyzer.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -676,7 +676,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithURL("https://github.com/sonatard/noctx"),
 
 		linter.NewConfig(golinters.NewNoImportsAsVar()).
-			WithSince("v1.1.0").
+			WithSince("v1.54.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle, linter.PresetBugs).
 			WithURL("https://github.com/HarryTennent/noimportsasvar"),

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -675,6 +675,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetPerformance, linter.PresetBugs).
 			WithURL("https://github.com/sonatard/noctx"),
 
+		linter.NewConfig(golinters.NewNoImportsAsVar()).
+			WithSince("v1.1.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle, linter.PresetBugs).
+			WithURL("https://github.com/HarryTennent/noimportsasvar"),
+
 		linter.NewConfig(golinters.NewNoNamedReturns(noNamedReturnsCfg)).
 			WithSince("v1.46.0").
 			WithLoadForGoAnalysis().

--- a/test/testdata/noimportsasvar.go
+++ b/test/testdata/noimportsasvar.go
@@ -1,0 +1,61 @@
+//golangcitest:args -Enoimportsasvar
+package testdata
+
+import (
+	"bytes"
+	err "errors"
+	"flag"
+	"fmt"
+	. "io"
+	"io/fs"
+	"math"
+	_ "net/http"
+	"os"
+)
+
+func sample() {
+	// prevent imports being auto removed by go fmt
+	_ = fs.ErrClosed
+	_ = math.E
+	_ = bytes.ErrTooLarge
+	_ = flag.ErrHelp
+	_ = err.New("fake error")
+	_ = os.ErrClosed
+
+	const fs = "FS" // want "const name 'fs' shared with import 'io/fs'"
+
+	var (
+		err error // want "var name 'err' shared with import 'err'"
+	)
+
+	fmt := fmt.Println // want "var name 'fmt' shared with import 'fmt'"
+
+	for _, bytes := range []byte{0, 1, 2} { // want "var name 'bytes' shared with import 'bytes'"
+		fmt(bytes)
+	}
+
+	for flag := 0; flag < 1; flag++ { // want "var name 'flag' shared with import 'flag'"
+		fmt(flag)
+	}
+
+	http := 200 // OK - underscore import, should not be flagged
+	io := EOF   // OK - dot import, should not be flagged
+
+	// avoid staticcheck warnings
+	fmt(http)
+	fmt(io)
+	fmt(err)
+	fmt(fs)
+	_ = doMath(func(a int, b int) int {
+		return a + b
+	})
+
+}
+
+func doMath(math func(int, int) int) int { // want "var name 'math' shared with import 'math'"
+	return math(1, 2)
+}
+
+func retOs() (os string) { // want "var name 'os' shared with import 'os"
+	return
+}


### PR DESCRIPTION
[noimportsasvar ](https://github.com/HarryTennent/noimportsasvar) is designed to identify potential naming conflicts between variables, constants, and function parameters with imported package names. The goal is to prevent bugs and improve code readability.
