### PR TITLE
lll: ignore comments containing only URL

### DIFF
--- a/pkg/golinters/lll.go
+++ b/pkg/golinters/lll.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"go/token"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -89,6 +90,8 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 	lineNumber := 0
 	multiImportEnabled := false
 
+	urlComment := regexp.MustCompile(`\s*//\s*http(s)?://[^ ]+$`)
+
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		lineNumber++
@@ -97,6 +100,10 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 		line = strings.ReplaceAll(line, "\t", tabSpaces)
 
 		if strings.HasPrefix(line, goCommentDirectivePrefix) {
+			continue
+		}
+
+		if urlComment.MatchString(line) {
 			continue
 		}
 

--- a/test/testdata/lll_comment_url.go
+++ b/test/testdata/lll_comment_url.go
@@ -1,0 +1,20 @@
+//golangcitest:args -Elll
+//golangcitest:config_path testdata/configs/lll.yml
+package testdata
+
+import (
+	"fmt"
+	_ "unsafe"
+)
+
+// https://github.com/golangci/golangci-lint/blob/master/pkg/result/processors/testdata/autogen_exclude_block_comment.go
+func lllCommentURL1() {
+	// https://github.com/golangci/golangci-lint/blob/master/pkg/result/processors/testdata/autogen_exclude_block_comment.go
+	fmt.Println("lll")
+}
+
+// https://github.com/golangci/golangci-lint/blob/master/pkg/result/processors/testdata/autogen_exclude_block_comment.go foobar // want "line is 160 characters"
+func lllCommentURL2() {
+	// https://github.com/golangci/golangci-lint/blob/master/pkg/result/processors/testdata/autogen_exclude_block_comment.go foobar // want "line is 164 characters"
+	fmt.Println("lll")
+}


### PR DESCRIPTION
Fixes #3983

As illustrated in the following example, to ignore long URLs the `nolint` directive should be placed on the top of the comments but this ignores `lll` on the whole function.

<details><summary>.golangci.yml</summary>

```yml
linters:
  disable-all: true
  enable:
    - lll
    - typecheck

linters-settings:
  lll:
    line-length: 50
```

```go
package main

import "fmt"

// main runs the app.
// https://github.com/walle/lll/blob/4438bccd245f7e87a5a69023625f01e7035c05c0/utils.go#L15
//
//nolint:lll
func main() {
	fmt.Println("Foo")
}
```

```console
$ golangci-lint run 
$
```

</details> 

