### PR TITLE
dev: upload debs and rpms to Packagecloud

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,6 +30,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
 
+      - name: Upload nfpms
+        run: |
+          gem install --no-document --user-install --bindir ~/.local/bin package_cloud
+          export CLICOLOR_FORCE=1
+          # deb: armv6 clashes with armv7, no loong64/mips64/riscv64 support (mips64le is ok)
+          ~/.local/bin/package_cloud push ${{ github.repository }}/any/any $(ls -1 dist/*.deb | grep -vwE 'armv6|loong64|mips64|riscv64')
+          ~/.local/bin/package_cloud push ${{ github.repository }}/rpm_any/rpm_any dist/*.rpm
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+
   docker-release:
     needs: release
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,9 @@ release:
   github:
     owner: golangci
     name: golangci-lint
+  footer: >-
+    apt and dnf/yum package repositories are available at
+    [Packagecloud](https://packagecloud.io/golangci/golangci-lint).
 
 builds:
   - binary: golangci-lint


### PR DESCRIPTION
Keeping local installs of golangci-lint on Linux systems up to date is a bit of a chore, because building from source is not recommended (so tools like `gup` won't help), and the binaries are not easily available for automatic installation, need to manually download and install from GH releases.

Since the .deb and .rpm packages are already available, it would be nice to have them in a public repo somewhere. This PR implements uploading them to https://packagecloud.io (I have no affiliation with them).

Demo release and repository created by this PR's content (along with some tweaks to avoid golangci specific things):
- Demo release including the footer note: https://github.com/scop/golangci-lint/releases/tag/v0.0.42 (do not mind the huge changelog, see below it)
- Populated packagecloud.io repository: https://packagecloud.io/scop/golangci-lint (packagecloud renames the rpms and debs to their liking)
(The packages in the repo are built off a branch that has also #4009 applied, but that's not a blocker for this.)

To make it work for the golangci/golangci-lint project, the PR requires two things set up by golangci-lint project admins:
1) A packagecloud.io account. This PR assumes the account name over there will be `golangci`, and the repo name `golangci-lint`. If they end up being something else, we can obviously adjust here. But I think they would make sense.
2) Packagecloud.io API token in the GH golangci-lint project's [actions secrets](https://github.com/golangci/golangci-lint/settings/secrets/actions) -> repository secrets, as `PACKAGECLOUD_TOKEN`.