### PR TITLE
dev: Add MessageAdjuster processor

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2434,6 +2434,16 @@ issues:
     - EXC0014
     - EXC0015
 
+  # Changing the content of messages.
+  # You can specify the existing-message by regular expression,
+  # and new-message by regular expression expansion syntax like below
+  # (see https://pkg.go.dev/regexp#Regexp.Expand for details).
+  # Specifying (optional) linter will speed up processing.
+  adjust-messages:
+    - linter: gocritic
+      existing-message: "^(appendAssign: append result not assigned to the same slice)$"
+      new-message: "${1}, use `slices.copyAndAppend` to safely concatenate two slices"
+
   # Maximum issues count per one linter.
   # Set to 0 to disable.
   # Default: 50

--- a/docs/src/docs/contributing/architecture.mdx
+++ b/docs/src/docs/contributing/architecture.mdx
@@ -268,6 +268,8 @@ $ tree -L 1 ./pkg/result/processors/
 ├── max_per_file_from_linter_test.go
 ├── max_same_issues.go
 ├── max_same_issues_test.go
+├── message_adjuster.go
+├── message_adjuster_test.go
 ├── nolint.go
 ├── nolint_test.go
 ├── path_prettifier.go

--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -109,6 +109,7 @@ type Issues struct {
 	ExcludePatterns        []string      `mapstructure:"exclude"`
 	ExcludeRules           []ExcludeRule `mapstructure:"exclude-rules"`
 	UseDefaultExcludes     bool          `mapstructure:"exclude-use-default"`
+	AdjustMessages         []MessageRule `mapstructure:"adjust-messages"`
 
 	MaxIssuesPerLinter int `mapstructure:"max-issues-per-linter"`
 	MaxSameIssues      int `mapstructure:"max-same-issues"`
@@ -210,4 +211,23 @@ func GetExcludePatterns(include []string) []ExcludePattern {
 	}
 
 	return ret
+}
+
+type MessageRule struct {
+	Linter          string `mapstructure:"linter"`
+	ExistingMessage string `mapstructure:"existing-message"`
+	NewMessage      string `mapstructure:"new-message"`
+}
+
+func (b *MessageRule) Validate() error {
+	if b.ExistingMessage == "" {
+		return fmt.Errorf("existing-message should be set")
+	}
+	if b.NewMessage == "" {
+		return fmt.Errorf("new-message should be set")
+	}
+	if err := validateOptionalRegex(b.ExistingMessage); err != nil {
+		return fmt.Errorf("invalid existing-message regex: %v", err)
+	}
+	return nil
 }

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -149,6 +149,11 @@ func (r *FileReader) validateConfig() error {
 			return fmt.Errorf("error in severity rule #%d: %v", i, err)
 		}
 	}
+	for i, msg := range c.Issues.AdjustMessages {
+		if err := msg.Validate(); err != nil {
+			return fmt.Errorf("error in adjust messages #%d: %v", i, err)
+		}
+	}
 	if err := c.LintersSettings.Govet.Validate(); err != nil {
 		return fmt.Errorf("error in govet config: %v", err)
 	}

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -100,6 +100,7 @@ func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env,
 			processors.NewSourceCode(lineCache, log.Child(logutils.DebugKeySourceCode)),
 			processors.NewPathShortener(),
 			getSeverityRulesProcessor(&cfg.Severity, log, files),
+			getMessageAdjusterProcessor(&cfg.Issues),
 
 			// The fixer still needs to see paths for the issues that are relative to the current directory.
 			processors.NewFixer(cfg, log, fileCache),
@@ -347,4 +348,17 @@ func getSeverityRulesProcessor(cfg *config.Severity, log logutils.Log, files *fs
 	}
 
 	return severityRulesProcessor
+}
+
+func getMessageAdjusterProcessor(cfg *config.Issues) processors.Processor {
+	var msgRules []processors.MessageRule
+	for _, msg := range cfg.AdjustMessages {
+		msgRules = append(msgRules, processors.MessageRule{
+			Linter:          msg.Linter,
+			ExistingMessage: msg.ExistingMessage,
+			NewMessage:      msg.NewMessage,
+		})
+	}
+
+	return processors.NewMessageAdjuster(msgRules)
 }

--- a/pkg/result/processors/message_adjuster.go
+++ b/pkg/result/processors/message_adjuster.go
@@ -1,0 +1,66 @@
+package processors
+
+import (
+	"regexp"
+
+	"github.com/golangci/golangci-lint/pkg/result"
+)
+
+type MessageRule struct {
+	Linter          string
+	ExistingMessage string
+	NewMessage      string
+}
+
+type messageRule struct {
+	linter          string
+	existingMessage *regexp.Regexp
+	newMessage      string
+}
+
+type MessageAdjuster struct {
+	messageRules []messageRule
+}
+
+func NewMessageAdjuster(msgRules []MessageRule) *MessageAdjuster {
+	parsedRules := make([]messageRule, 0, len(msgRules))
+	for _, rule := range msgRules {
+		parsedRules = append(parsedRules, messageRule{
+			linter:          rule.Linter,
+			existingMessage: regexp.MustCompile(rule.ExistingMessage),
+			newMessage:      rule.NewMessage,
+		})
+	}
+
+	return &MessageAdjuster{
+		messageRules: parsedRules,
+	}
+}
+
+func (ma MessageAdjuster) Process(issues []result.Issue) ([]result.Issue, error) {
+	if len(ma.messageRules) == 0 {
+		return issues, nil
+	}
+
+	return transformIssues(issues, func(issue *result.Issue) *result.Issue {
+		for _, msgRule := range ma.messageRules {
+			if msgRule.linter != "" && msgRule.linter != issue.FromLinter {
+				return issue
+			}
+
+			existingText := issue.Text
+			newText := msgRule.existingMessage.ReplaceAllString(existingText, msgRule.newMessage)
+			if existingText != newText {
+				issue.Text = newText
+				return issue
+			}
+		}
+
+		return issue
+	}), nil
+}
+
+func (ma MessageAdjuster) Name() string {
+	return "message_adjuster"
+}
+func (ma MessageAdjuster) Finish() {}

--- a/pkg/result/processors/message_adjuster_test.go
+++ b/pkg/result/processors/message_adjuster_test.go
@@ -1,0 +1,3 @@
+package processors
+
+//TODO: write tests


### PR DESCRIPTION
This PR adds `MessageAdjuster` processor which will allow to override/modify issue message (`Text` from `Issue`).
Mainly in order to better guide the developers towards the best way to fix issues found by `golangci-lint`.


```
  # Changing the content of messages.
  # You can specify the existing-message by regular expression,
  # and new-message by regular expression expansion syntax like below
  # (see https://pkg.go.dev/regexp#Regexp.Expand for details).
  # Specifying (optional) linter will speed up processing.
  adjust-messages:
    - linter: gocritic
      existing-message: "^(appendAssign: append result not assigned to the same slice)$"
      new-message: "${1}, use `slices.copyAndAppend` to safely concatenate two slices"
```

resolves: https://github.com/golangci/golangci-lint/issues/4027