### PR TITLE
fix: add all directories as safe git directories inside the Docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,8 +13,8 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X
 FROM golang:1.21
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
-# Set /app as safe
-RUN git config --global --add safe.directory /app
+# Set all directories as safe
+RUN git config --global --add safe.directory '*'
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,6 +13,8 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X
 FROM golang:1.21
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
+# Set /app as safe
+RUN git config --global --add safe.directory /app
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/alpine.Dockerfile
+++ b/build/alpine.Dockerfile
@@ -22,8 +22,8 @@ ENV GOROOT /usr/local/go
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80
 RUN apk --no-cache add gcc musl-dev git mercurial
-# Set /app as safe
-RUN git config --global --add safe.directory /app
+# Set all directories as safe
+RUN git config --global --add safe.directory '*'
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]

--- a/build/alpine.Dockerfile
+++ b/build/alpine.Dockerfile
@@ -22,6 +22,8 @@ ENV GOROOT /usr/local/go
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80
 RUN apk --no-cache add gcc musl-dev git mercurial
+# Set /app as safe
+RUN git config --global --add safe.directory /app
 # don't place it into $GOPATH/bin because Drone mounts $GOPATH as volume
 COPY --from=builder /golangci/golangci-lint /usr/bin/
 CMD ["golangci-lint"]


### PR DESCRIPTION
Related to https://github.com/golangci/golangci-lint/issues/3982#issuecomment-1662587360
Related to https://github.com/golangci/golangci-lint/issues/4033#issuecomment-1686025933


```console
$ git clone git@github.com:openshift-pipelines/pipelines-as-code.git
...
$ cd pipelines-as-code
$ docker run --rm -it -v $(pwd):/app -w /app golangci/golangci-lint:v1.54.1 sh
# golangci-lint run
cmd/pipelines-as-code-controller/main.go:1: : error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping. (typecheck)
package main
cmd/pipelines-as-code-watcher/main.go:1: : error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping. (typecheck)
package main
cmd/pipelines-as-code-webhook/main.go:1: : error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping. (typecheck)
package main
# git config --global --add safe.directory '*'
# golangci-lint run
# 
```

