### PR TITLE
upgrade gitlab.com/bosi/decorder to 0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0
 	github.com/yeya24/promlinter v0.2.0
 	github.com/ykadowak/zerologlint v0.1.3
-	gitlab.com/bosi/decorder v0.4.0
+	gitlab.com/bosi/decorder v0.4.1
 	go.tmz.dev/musttag v0.7.2
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/tools v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -576,6 +576,8 @@ github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFi
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 gitlab.com/bosi/decorder v0.4.0 h1:HWuxAhSxIvsITcXeP+iIRg9d1cVfvVkmlF7M68GaoDY=
 gitlab.com/bosi/decorder v0.4.0/go.mod h1:xarnteyUoJiOTEldDysquWKTVDCKo2TOIOIibSuWqOg=
+gitlab.com/bosi/decorder v0.4.1 h1:VdsdfxhstabyhZovHafFw+9eJ6eU0d2CkFNJcZz/NU4=
+gitlab.com/bosi/decorder v0.4.1/go.mod h1:jecSqWUew6Yle1pCr2eLWTensJMmsxHsBwt+PVbkAqA=
 go-simpler.org/assert v0.6.0 h1:QxSrXa4oRuo/1eHMXSBFHKvJIpWABayzKldqZyugG7E=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=


### PR DESCRIPTION
see MR https://gitlab.com/bosi/decorder/-/merge_requests/91
and the failed message

```
[2023-08-31T12:18:25.276Z] fatal error: concurrent map writes
[2023-08-31T12:18:25.276Z] 
[2023-08-31T12:18:25.276Z] goroutine 6758 [running]:
[2023-08-31T12:18:25.276Z] gitlab.com/bosi/decorder.run(0xc02a054000)
[2023-08-31T12:18:25.276Z] 	/go/pkg/mod/gitlab.com/bosi/decorder@v0.4.0/analyzer.go:83 +0x45
[2023-08-31T12:18:25.276Z] github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc002a85ab0)
```
