### PR TITLE
dev: remove golangci-releaser from generated team

### DIFF
--- a/.github/contributors/generate.ts
+++ b/.github/contributors/generate.ts
@@ -124,7 +124,7 @@ const main = async () => {
       fossabot: true,
       golangcibot: true,
       kortschak: true,
-      "golanci-releaser": true,
+      "golangci-releaser": true,
     }
 
     const res: DataJSON = {


### PR DESCRIPTION
Fixes a typo.

Follows #3744