### PR TITLE
docs: add source options to exclude-rules docs

### DIFF
--- a/docs/src/docs/usage/false-positives.mdx
+++ b/docs/src/docs/usage/false-positives.mdx
@@ -31,7 +31,7 @@ linters-settings:
 
 Exclude issue by text using command-line option `-e` or config option `issues.exclude`.
 It's helpful when you decided to ignore all issues of this type.
-Also, you can use `issues.exclude-rules` config option for per-path or per-linter configuration.
+Also, you can use `issues.exclude-rules` config option for per-path, per-linter, per-text or per-source configuration.
 
 In the following example, all the reports that contains the sentences defined in `exclude` are excluded:
 
@@ -62,7 +62,6 @@ issues:
         - lll
       source: "^//go:generate "
 ```
-
 
 In the following example, all the reports that contains the text (`text`) in the path (`path`) are excluded:
 

--- a/docs/src/docs/usage/false-positives.mdx
+++ b/docs/src/docs/usage/false-positives.mdx
@@ -53,6 +53,17 @@ issues:
       text: "mnd: Magic number: 9"
 ```
 
+In the following example, all the reports from the linters (`linters`) that are originated from the source (`source`) are excluded:
+
+```yml
+issues:
+  exclude-rules:
+    - linters:
+        - lll
+      source: "^//go:generate "
+```
+
+
 In the following example, all the reports that contains the text (`text`) in the path (`path`) are excluded:
 
 ```yml

--- a/docs/src/docs/usage/false-positives.mdx
+++ b/docs/src/docs/usage/false-positives.mdx
@@ -31,7 +31,7 @@ linters-settings:
 
 Exclude issue by text using command-line option `-e` or config option `issues.exclude`.
 It's helpful when you decided to ignore all issues of this type.
-Also, you can use `issues.exclude-rules` config option for per-path, per-linter, per-text or per-source configuration.
+Also, you can use `issues.exclude-rules` config option for per-path or per-linter configuration.
 
 In the following example, all the reports that contains the sentences defined in `exclude` are excluded:
 

--- a/docs/src/docs/usage/false-positives.mdx
+++ b/docs/src/docs/usage/false-positives.mdx
@@ -53,7 +53,7 @@ issues:
       text: "mnd: Magic number: 9"
 ```
 
-In the following example, all the reports from the linters (`linters`) that are originated from the source (`source`) are excluded:
+In the following example, all the reports from the linters (`linters`) that originated from the source (`source`) are excluded:
 
 ```yml
 issues:


### PR DESCRIPTION
Add `source` options to `exclude-rules` docs.

Fix #3409
