### PR TITLE
docs: add gosec G602 to includes/excludes inside .golangci.reference.yml

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -851,6 +851,7 @@ linters-settings:
       - G504 # Import blocklist: net/http/cgi
       - G505 # Import blocklist: crypto/sha1
       - G601 # Implicit memory aliasing of items from a range statement
+      - G602 # Slice access out of bounds
 
     # To specify a set of rules to explicitly exclude.
     # Available rules: https://github.com/securego/gosec#available-rules
@@ -890,6 +891,7 @@ linters-settings:
       - G504 # Import blocklist: net/http/cgi
       - G505 # Import blocklist: crypto/sha1
       - G601 # Implicit memory aliasing of items from a range statement
+      - G602 # Slice access out of bounds
 
     # Exclude generated files
     # Default: false


### PR DESCRIPTION
G602 (Slice access out of bounds) was added in gosec 2.17.

gosec Release/Changelog: https://github.com/securego/gosec/releases/tag/v2.17.0