### PR TITLE
fix: search for diff.exe on Windows

### DIFF
--- a/pkg/result/processors/diff.go
+++ b/pkg/result/processors/diff.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/golangci/revgrep"
@@ -35,6 +36,10 @@ func NewDiff(onlyNew bool, fromRev, patchFilePath string, wholeFiles bool) *Diff
 }
 
 func (p Diff) Name() string {
+	if runtime.GOOS == "windows" {
+		return "diff.exe"
+	}
+
 	return "diff"
 }
 


### PR DESCRIPTION
On Windows searching for `diff` returns PowerShell cmdlet, rather than diff binary even when it is installed.

Related to #3408.