### PR TITLE
dev: enable gocheckcompilerdirectives linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,6 +84,7 @@ linters:
     - errcheck
     - exportloopref
     - funlen
+    - gocheckcompilerdirectives
     - gochecknoinits
     - goconst
     - gocritic

--- a/test/ruleguard/dup.go
+++ b/test/ruleguard/dup.go
@@ -1,4 +1,5 @@
-// go:build ruleguard
+//go:build ruleguard
+
 package ruleguard
 
 import "github.com/quasilyte/go-ruleguard/dsl"

--- a/test/ruleguard/rangeExprCopy.go
+++ b/test/ruleguard/rangeExprCopy.go
@@ -1,4 +1,5 @@
-// go:build ruleguard
+//go:build ruleguard
+
 package ruleguard
 
 import (

--- a/test/ruleguard/strings_simplify.go
+++ b/test/ruleguard/strings_simplify.go
@@ -1,4 +1,5 @@
-// go:build ruleguard
+//go:build ruleguard
+
 package ruleguard
 
 import "github.com/quasilyte/go-ruleguard/dsl"


### PR DESCRIPTION
This PR enables `gocheckcompilerdirectives` and fixes compiler directives.