### PR TITLE
feat: add `sloglint` linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1799,6 +1799,20 @@ linters-settings:
     packages:
       - github.com/jmoiron/sqlx
 
+  sloglint:
+    # Enforce using key-value pairs only (incompatible with attr-only).
+    # Default: false
+    kv-only: true
+    # Enforce using attributes only (incompatible with kv-only).
+    # Default: false
+    attr-only: true
+    # Enforce using constants instead of raw keys.
+    # Default: false
+    no-raw-keys: true
+    # Enforce putting arguments on separate lines.
+    # Default: false
+    args-on-sep-lines: true
+
   staticcheck:
     # Deprecated: use the global `run.go` instead.
     go: "1.15"
@@ -2295,6 +2309,7 @@ linters:
     - revive
     - rowserrcheck
     - scopelint
+    - sloglint
     - sqlclosecheck
     - staticcheck
     - structcheck
@@ -2413,6 +2428,7 @@ linters:
     - revive
     - rowserrcheck
     - scopelint
+    - sloglint
     - sqlclosecheck
     - staticcheck
     - structcheck

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	github.com/yeya24/promlinter v0.2.0
 	github.com/ykadowak/zerologlint v0.1.3
 	gitlab.com/bosi/decorder v0.4.1
-	go-simpler.org/sloglint v0.1.1
+	go-simpler.org/sloglint v0.1.2
 	go.tmz.dev/musttag v0.7.2
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/tools v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	github.com/yeya24/promlinter v0.2.0
 	github.com/ykadowak/zerologlint v0.1.3
 	gitlab.com/bosi/decorder v0.4.1
+	go-simpler.org/sloglint v0.1.1
 	go.tmz.dev/musttag v0.7.2
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/tools v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -587,6 +587,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 gitlab.com/bosi/decorder v0.4.1 h1:VdsdfxhstabyhZovHafFw+9eJ6eU0d2CkFNJcZz/NU4=
 gitlab.com/bosi/decorder v0.4.1/go.mod h1:jecSqWUew6Yle1pCr2eLWTensJMmsxHsBwt+PVbkAqA=
 go-simpler.org/assert v0.6.0 h1:QxSrXa4oRuo/1eHMXSBFHKvJIpWABayzKldqZyugG7E=
+go-simpler.org/sloglint v0.1.1 h1:zFwGdgLg3Zosd9bteKnbjWOfn/lHu5znDVns+5cVz8k=
+go-simpler.org/sloglint v0.1.1/go.mod h1:2LL+QImPfTslD5muNPydAEYmpXIj6o/WYcqnJjLi4o4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 gitlab.com/bosi/decorder v0.4.1 h1:VdsdfxhstabyhZovHafFw+9eJ6eU0d2CkFNJcZz/NU4=
 gitlab.com/bosi/decorder v0.4.1/go.mod h1:jecSqWUew6Yle1pCr2eLWTensJMmsxHsBwt+PVbkAqA=
 go-simpler.org/assert v0.6.0 h1:QxSrXa4oRuo/1eHMXSBFHKvJIpWABayzKldqZyugG7E=
-go-simpler.org/sloglint v0.1.1 h1:zFwGdgLg3Zosd9bteKnbjWOfn/lHu5znDVns+5cVz8k=
-go-simpler.org/sloglint v0.1.1/go.mod h1:2LL+QImPfTslD5muNPydAEYmpXIj6o/WYcqnJjLi4o4=
+go-simpler.org/sloglint v0.1.2 h1:IjdhF8NPxyn0Ckn2+fuIof7ntSnVUAqBFcQRrnG9AiM=
+go-simpler.org/sloglint v0.1.2/go.mod h1:2LL+QImPfTslD5muNPydAEYmpXIj6o/WYcqnJjLi4o4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -113,6 +113,12 @@ var defaultLintersSettings = LintersSettings{
 		Ignore:    "",
 		Qualified: false,
 	},
+	SlogLint: SlogLintSettings{
+		KVOnly:         false,
+		AttrOnly:       false,
+		NoRawKeys:      false,
+		ArgsOnSepLines: false,
+	},
 	TagAlign: TagAlignSettings{
 		Align:  true,
 		Sort:   true,
@@ -222,6 +228,7 @@ type LintersSettings struct {
 	Reassign         ReassignSettings
 	Revive           ReviveSettings
 	RowsErrCheck     RowsErrCheckSettings
+	SlogLint         SlogLintSettings
 	Staticcheck      StaticCheckSettings
 	Structcheck      StructCheckSettings
 	Stylecheck       StaticCheckSettings
@@ -715,6 +722,13 @@ type ReviveSettings struct {
 
 type RowsErrCheckSettings struct {
 	Packages []string
+}
+
+type SlogLintSettings struct {
+	KVOnly         bool `mapstructure:"kv-only"`
+	AttrOnly       bool `mapstructure:"attr-only"`
+	NoRawKeys      bool `mapstructure:"no-raw-keys"`
+	ArgsOnSepLines bool `mapstructure:"args-on-sep-lines"`
 }
 
 type StaticCheckSettings struct {

--- a/pkg/golinters/sloglint.go
+++ b/pkg/golinters/sloglint.go
@@ -1,0 +1,27 @@
+package golinters
+
+import (
+	"go-simpler.org/sloglint"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewSlogLint(settings *config.SlogLintSettings) *goanalysis.Linter {
+	var opts *sloglint.Options
+	if settings != nil {
+		opts = &sloglint.Options{
+			KVOnly:         settings.KVOnly,
+			AttrOnly:       settings.AttrOnly,
+			NoRawKeys:      settings.NoRawKeys,
+			ArgsOnSepLines: settings.ArgsOnSepLines,
+		}
+	}
+
+	a := sloglint.New(opts)
+
+	return goanalysis.
+		NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, nil).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -127,6 +127,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		reassignCfg         *config.ReassignSettings
 		reviveCfg           *config.ReviveSettings
 		rowserrcheckCfg     *config.RowsErrCheckSettings
+		sloglintCfg         *config.SlogLintSettings
 		staticcheckCfg      *config.StaticCheckSettings
 		structcheckCfg      *config.StructCheckSettings
 		stylecheckCfg       *config.StaticCheckSettings
@@ -208,6 +209,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		reassignCfg = &m.cfg.LintersSettings.Reassign
 		reviveCfg = &m.cfg.LintersSettings.Revive
 		rowserrcheckCfg = &m.cfg.LintersSettings.RowsErrCheck
+		sloglintCfg = &m.cfg.LintersSettings.SlogLint
 		staticcheckCfg = &m.cfg.LintersSettings.Staticcheck
 		structcheckCfg = &m.cfg.LintersSettings.Structcheck
 		stylecheckCfg = &m.cfg.LintersSettings.Stylecheck
@@ -749,6 +751,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetBugs, linter.PresetSQL).
 			WithURL("https://github.com/jingyugao/rowserrcheck"),
+
+		linter.NewConfig(golinters.NewSlogLint(sloglintCfg)).
+			WithSince("v1.55.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle, linter.PresetFormatting).
+			WithURL("https://github.com/go-simpler/sloglint"),
 
 		linter.NewConfig(golinters.NewScopelint()).
 			WithSince("v1.12.0").

--- a/test/testdata/configs/sloglint_args_on_sep_lines.yml
+++ b/test/testdata/configs/sloglint_args_on_sep_lines.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  sloglint:
+    args-on-sep-lines: true

--- a/test/testdata/configs/sloglint_attr_only.yml
+++ b/test/testdata/configs/sloglint_attr_only.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  sloglint:
+    attr-only: true

--- a/test/testdata/configs/sloglint_kv_only.yml
+++ b/test/testdata/configs/sloglint_kv_only.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  sloglint:
+    kv-only: true

--- a/test/testdata/configs/sloglint_no_raw_keys.yml
+++ b/test/testdata/configs/sloglint_no_raw_keys.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  sloglint:
+    no-raw-keys: true

--- a/test/testdata/sloglint.go
+++ b/test/testdata/sloglint.go
@@ -1,3 +1,5 @@
+//go:build go1.21
+
 //golangcitest:args -Esloglint
 package testdata
 

--- a/test/testdata/sloglint.go
+++ b/test/testdata/sloglint.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Esloglint
+package testdata
+
+import "log/slog"
+
+func test() {
+	slog.Info("msg", "foo", 1, "bar", 2)
+	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2))
+
+	slog.Info("msg", "foo", 1, slog.Int("bar", 2)) // want `key-value pairs and attributes should not be mixed`
+}

--- a/test/testdata/sloglint_args_on_sep_lines.go
+++ b/test/testdata/sloglint_args_on_sep_lines.go
@@ -1,3 +1,5 @@
+//go:build go1.21
+
 //golangcitest:args -Esloglint
 //golangcitest:config_path testdata/configs/sloglint_args_on_sep_lines.yml
 package testdata

--- a/test/testdata/sloglint_args_on_sep_lines.go
+++ b/test/testdata/sloglint_args_on_sep_lines.go
@@ -1,0 +1,15 @@
+//golangcitest:args -Esloglint
+//golangcitest:config_path testdata/configs/sloglint_args_on_sep_lines.yml
+package testdata
+
+import "log/slog"
+
+func test() {
+	slog.Info("msg", "foo", 1)
+	slog.Info("msg",
+		"foo", 1,
+		"bar", 2,
+	)
+
+	slog.Info("msg", "foo", 1, "bar", 2) // want `arguments should be put on separate lines`
+}

--- a/test/testdata/sloglint_attr_only.go
+++ b/test/testdata/sloglint_attr_only.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Esloglint
+//golangcitest:config_path testdata/configs/sloglint_attr_only.yml
+package testdata
+
+import "log/slog"
+
+func test() {
+	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2))
+
+	slog.Info("msg", "foo", 1, "bar", 2) // want `key-value pairs should not be used`
+}

--- a/test/testdata/sloglint_attr_only.go
+++ b/test/testdata/sloglint_attr_only.go
@@ -1,3 +1,5 @@
+//go:build go1.21
+
 //golangcitest:args -Esloglint
 //golangcitest:config_path testdata/configs/sloglint_attr_only.yml
 package testdata

--- a/test/testdata/sloglint_kv_only.go
+++ b/test/testdata/sloglint_kv_only.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Esloglint
+//golangcitest:config_path testdata/configs/sloglint_kv_only.yml
+package testdata
+
+import "log/slog"
+
+func test() {
+	slog.Info("msg", "foo", 1, "bar", 2)
+
+	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2)) // want `attributes should not be used`
+}

--- a/test/testdata/sloglint_kv_only.go
+++ b/test/testdata/sloglint_kv_only.go
@@ -1,3 +1,5 @@
+//go:build go1.21
+
 //golangcitest:args -Esloglint
 //golangcitest:config_path testdata/configs/sloglint_kv_only.yml
 package testdata

--- a/test/testdata/sloglint_no_raw_keys.go
+++ b/test/testdata/sloglint_no_raw_keys.go
@@ -1,3 +1,5 @@
+//go:build go1.21
+
 //golangcitest:args -Esloglint
 //golangcitest:config_path testdata/configs/sloglint_no_raw_keys.yml
 package testdata

--- a/test/testdata/sloglint_no_raw_keys.go
+++ b/test/testdata/sloglint_no_raw_keys.go
@@ -1,0 +1,19 @@
+//golangcitest:args -Esloglint
+//golangcitest:config_path testdata/configs/sloglint_no_raw_keys.yml
+package testdata
+
+import "log/slog"
+
+const foo = "foo"
+
+func Foo(value int) slog.Attr {
+	return slog.Int("foo", value)
+}
+
+func test() {
+	slog.Info("msg", foo, 1)
+	slog.Info("msg", Foo(1))
+
+	slog.Info("msg", "foo", 1)           // want `raw keys should not be used`
+	slog.Info("msg", slog.Int("foo", 1)) // want `raw keys should not be used`
+}


### PR DESCRIPTION
Hello,

I'd like to add the [`sloglint`](https://github.com/go-simpler/sloglint) linter.

It ensures consistent code style when using `log/slog`.

Currently, the following checks are available:
- Forbid mixing key-value pairs and attributes within a single function call (default)
- Enforce using either key-value pairs or attributes for the entire project (optional)
- Enforce using constants instead of raw keys (optional)
- Enforce putting arguments on separate lines (optional)

I've tested it on several big projects that use `log/slog`, and it works just fine 😎
