### PR TITLE
docs: describe enabled and disabled by default analyzers of govet

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1284,6 +1284,7 @@ linters-settings:
       - k8s.io/klog/v2.InfoS   # package level exported functions
       - (github.com/go-logr/logr.Logger).Error  # "Methods"
       - (*go.uber.org/zap.SugaredLogger).With  # Also "Methods", but with a pointer receiver
+
   maintidx:
     # Show functions with maintainability index lower than N.
     # A high index indicates better maintainability (it's kind of the opposite of complexity).

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1043,22 +1043,28 @@ linters-settings:
         # Default: false
         strict: true
       unusedresult:
-        # Comma-separated list of functions whose results must be used
-        # (in addition to defaults context.WithCancel,context.WithDeadline,context.WithTimeout,context.WithValue,
-        # errors.New,fmt.Errorf,fmt.Sprint,fmt.Sprintf,sort.Reverse)
-        # Default []
+        # Comma-separated list of functions whose results must be used (in addition to default
+        #   context.WithCancel, context.WithDeadline, context.WithTimeout, context.WithValue, errors.New, fmt.Errorf,
+        #   fmt.Sprint, fmt.Sprintf, sort.Reverse
+        # ).
+        # Default: []
         funcs:
           - pkg.MyFunc
         # Comma-separated list of names of methods of type func() string whose results must be used
         # (in addition to default Error,String)
-        # Default []
+        # Default: []
         stringmethods:
           - MyMethod
 
     # Disable all analyzers.
     # Default: false
     disable-all: true
-    # Enable analyzers by name (in addition to default).
+    # Enable analyzers by name (in addition to default
+    #   appends, asmdecl, assign, atomic, bools, buildtag, cgocall, composites, copylocks, defers, directive, errorsas,
+    #   framepointer, httpresponse, ifaceassert, loopclosure, lostcancel, nilfunc, printf, shift, sigchanyzer, slog,
+    #   stdmethods, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr,
+    #   unusedresult
+    # ).
     # Run `go tool vet help` to see all analyzers.
     # Default: []
     enable:
@@ -1106,7 +1112,10 @@ linters-settings:
     # Enable all analyzers.
     # Default: false
     enable-all: true
-    # Disable analyzers by name.
+    # Disable analyzers by name (in addition to default
+    #   atomicalign, deepequalerrors, fieldalignment, findcall, nilness, reflectvaluecompare, shadow, sortslice,
+    #   timeformat, unusedwrite
+    # ).
     # Run `go tool vet help` to see all analyzers.
     # Default: []
     disable:

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1043,7 +1043,8 @@ linters-settings:
         # Default: false
         strict: true
       unusedresult:
-        # Comma-separated list of functions whose results must be used (in addition to default
+        # Comma-separated list of functions whose results must be used
+        # (in addition to default:
         #   context.WithCancel, context.WithDeadline, context.WithTimeout, context.WithValue, errors.New, fmt.Errorf,
         #   fmt.Sprint, fmt.Sprintf, sort.Reverse
         # ).
@@ -1059,7 +1060,8 @@ linters-settings:
     # Disable all analyzers.
     # Default: false
     disable-all: true
-    # Enable analyzers by name (in addition to default
+    # Enable analyzers by name.
+    # (in addition to default:
     #   appends, asmdecl, assign, atomic, bools, buildtag, cgocall, composites, copylocks, defers, directive, errorsas,
     #   framepointer, httpresponse, ifaceassert, loopclosure, lostcancel, nilfunc, printf, shift, sigchanyzer, slog,
     #   stdmethods, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr,
@@ -1112,7 +1114,8 @@ linters-settings:
     # Enable all analyzers.
     # Default: false
     enable-all: true
-    # Disable analyzers by name (in addition to default
+    # Disable analyzers by name.
+    # (in addition to default
     #   atomicalign, deepequalerrors, fieldalignment, findcall, nilness, reflectvaluecompare, shadow, sortslice,
     #   timeformat, unusedwrite
     # ).


### PR DESCRIPTION
Closes https://github.com/golangci/golangci-lint/issues/4134

@ldez, hi!

I reviewed all linters and yes, you are right:

> The majority of those empty defaults are real.

If you don't see the point in this pr, you can close it, I won't mind.

Thanks