### PR TITLE
output: convert backslashes to forward slashes for GitHub Action annotations printer

### DIFF
--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -3,6 +3,8 @@ package printers
 import (
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -26,7 +28,12 @@ func formatIssueAsGithub(issue *result.Issue) string {
 		severity = issue.Severity
 	}
 
-	ret := fmt.Sprintf("::%s file=%s,line=%d", severity, issue.FilePath(), issue.Line())
+	// Convert backslashes to forward slashes. This is needed when running on windows.
+	// Otherwise GitHub won't be able to show the annotations pointing to the file path with backslashes
+	list := filepath.SplitList(issue.FilePath())
+	file := strings.Join(list, "/")
+
+	ret := fmt.Sprintf("::%s file=%s,line=%d", severity, file, issue.Line())
 	if issue.Pos.Column != 0 {
 		ret += fmt.Sprintf(",col=%d", issue.Pos.Column)
 	}

--- a/pkg/printers/github.go
+++ b/pkg/printers/github.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -28,10 +27,10 @@ func formatIssueAsGithub(issue *result.Issue) string {
 		severity = issue.Severity
 	}
 
-	// Convert backslashes to forward slashes. This is needed when running on windows.
-	// Otherwise GitHub won't be able to show the annotations pointing to the file path with backslashes
-	list := filepath.SplitList(issue.FilePath())
-	file := strings.Join(list, "/")
+	// Convert backslashes to forward slashes.
+	// This is needed when running on windows.
+	// Otherwise, GitHub won't be able to show the annotations pointing to the file path with backslashes.
+	file := filepath.ToSlash(issue.FilePath())
 
 	ret := fmt.Sprintf("::%s file=%s,line=%d", severity, file, issue.Line())
 	if issue.Pos.Column != 0 {

--- a/pkg/printers/github_test.go
+++ b/pkg/printers/github_test.go
@@ -4,6 +4,7 @@ package printers
 import (
 	"bytes"
 	"go/token"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,26 @@ func TestFormatGithubIssue(t *testing.T) {
 		Text:       "some issue",
 		Pos: token.Position{
 			Filename: "path/to/file.go",
+			Offset:   2,
+			Line:     10,
+			Column:   4,
+		},
+	}
+	require.Equal(t, "::error file=path/to/file.go,line=10,col=4::some issue (sample-linter)", formatIssueAsGithub(&sampleIssue))
+
+	sampleIssue.Pos.Column = 0
+	require.Equal(t, "::error file=path/to/file.go,line=10::some issue (sample-linter)", formatIssueAsGithub(&sampleIssue))
+}
+
+func TestFormatGithubIssueWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Skipping test on non Windows")
+	}
+	sampleIssue := result.Issue{
+		FromLinter: "sample-linter",
+		Text:       "some issue",
+		Pos: token.Position{
+			Filename: "path\\to\\file.go",
 			Offset:   2,
 			Line:     10,
 			Column:   4,

--- a/pkg/printers/github_test.go
+++ b/pkg/printers/github_test.go
@@ -78,6 +78,7 @@ func TestFormatGithubIssueWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Skipping test on non Windows")
 	}
+
 	sampleIssue := result.Issue{
 		FromLinter: "sample-linter",
 		Text:       "some issue",


### PR DESCRIPTION
This commit addresses an issue in the GitHub Actions printer where file paths were using backslashes on Windows systems.
As result we didn't see correct annotations in the PRs. To ensure proper formatting we always convert to forward slash separator in filepathes.