### PR TITLE
[issue 4161] Fix perfsprint linter with latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/breml/errchkjson v0.3.6
 	github.com/butuzov/ireturn v0.2.1
 	github.com/butuzov/mirror v1.1.0
-	github.com/catenacyber/perfsprint v0.2.0
+	github.com/catenacyber/perfsprint v0.3.0
 	github.com/charithe/durationcheck v0.0.10
 	github.com/curioswitch/go-reassign v0.2.0
 	github.com/daixiang0/gci v0.11.2

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/butuzov/ireturn v0.2.1 h1:w5Ks4tnfeFDZskGJ2x1GAkx5gaQV+kdU3NKNr3NEBzY
 github.com/butuzov/ireturn v0.2.1/go.mod h1:RfGHUvvAuFFxoHKf4Z8Yxuh6OjlCw1KvR2zM1NFHeBk=
 github.com/butuzov/mirror v1.1.0 h1:ZqX54gBVMXu78QLoiqdwpl2mgmoOJTk7s4p4o+0avZI=
 github.com/butuzov/mirror v1.1.0/go.mod h1:8Q0BdQU6rC6WILDiBM60DBfvV78OLJmMmixe7GF45AE=
-github.com/catenacyber/perfsprint v0.2.0 h1:azOocHLscPjqXVJ7Mf14Zjlkn4uNua0+Hcg1wTR6vUo=
-github.com/catenacyber/perfsprint v0.2.0/go.mod h1:/wclWYompEyjUD2FuIIDVKNkqz7IgBIWXIH3V0Zol50=
+github.com/catenacyber/perfsprint v0.3.0 h1:xMciPd+OYZd2oWJhoqBlnu4Vfe284ktxDZHQkmdjNrU=
+github.com/catenacyber/perfsprint v0.3.0/go.mod h1:/wclWYompEyjUD2FuIIDVKNkqz7IgBIWXIH3V0Zol50=
 github.com/ccojocar/zxcvbn-go v1.0.1 h1:+sxrANSCj6CdadkcMnvde/GWU1vZiiXRbqYSCalV4/4=
 github.com/ccojocar/zxcvbn-go v1.0.1/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQdw6Qnz/hi60=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/golinters/perfsprint.go
+++ b/pkg/golinters/perfsprint.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewPerfSprint() *goanalysis.Linter {
-	a := analyzer.Analyzer
+	a := analyzer.New()
 
 	return goanalysis.NewLinter(
 		a.Name,


### PR DESCRIPTION
Fix for https://github.com/golangci/golangci-lint/issues/4161

Updates perfsprint to the latest version and fixes the Analyzer used.