### PR TITLE
build(deps): bump go-simpler.org/sloglint from 0.1.2 to 0.2.0

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1819,9 +1819,16 @@ linters-settings:
     # Enforce using attributes only (incompatible with kv-only).
     # Default: false
     attr-only: true
+    # Enforce using methods that accept a context.
+    # Default: false
+    context-only: true
     # Enforce using constants instead of raw keys.
     # Default: false
     no-raw-keys: true
+    # Enforce a single key naming convention.
+    # Values: snake, kebab, camel, pascal
+    # Default: ""
+    key-naming-case: snake
     # Enforce putting arguments on separate lines.
     # Default: false
     args-on-sep-lines: true

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/yeya24/promlinter v0.2.0
 	github.com/ykadowak/zerologlint v0.1.3
 	gitlab.com/bosi/decorder v0.4.1
-	go-simpler.org/sloglint v0.1.2
+	go-simpler.org/sloglint v0.2.0
 	go.tmz.dev/musttag v0.7.2
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/tools v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -592,6 +592,8 @@ gitlab.com/bosi/decorder v0.4.1/go.mod h1:jecSqWUew6Yle1pCr2eLWTensJMmsxHsBwt+PV
 go-simpler.org/assert v0.6.0 h1:QxSrXa4oRuo/1eHMXSBFHKvJIpWABayzKldqZyugG7E=
 go-simpler.org/sloglint v0.1.2 h1:IjdhF8NPxyn0Ckn2+fuIof7ntSnVUAqBFcQRrnG9AiM=
 go-simpler.org/sloglint v0.1.2/go.mod h1:2LL+QImPfTslD5muNPydAEYmpXIj6o/WYcqnJjLi4o4=
+go-simpler.org/sloglint v0.2.0 h1:XpOhA+7BCQJnl7KlDLmnFUFTSrl989ZmaVPSWWCWEtc=
+go-simpler.org/sloglint v0.2.0/go.mod h1:/RQr0TeTf89IyRjLJ9ogUbIp1Zs5zJJAj02pwQoDQdg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -116,7 +116,9 @@ var defaultLintersSettings = LintersSettings{
 	SlogLint: SlogLintSettings{
 		KVOnly:         false,
 		AttrOnly:       false,
+		ContextOnly:    false,
 		NoRawKeys:      false,
+		KeyNamingCase:  "",
 		ArgsOnSepLines: false,
 	},
 	TagAlign: TagAlignSettings{
@@ -725,10 +727,12 @@ type RowsErrCheckSettings struct {
 }
 
 type SlogLintSettings struct {
-	KVOnly         bool `mapstructure:"kv-only"`
-	AttrOnly       bool `mapstructure:"attr-only"`
-	NoRawKeys      bool `mapstructure:"no-raw-keys"`
-	ArgsOnSepLines bool `mapstructure:"args-on-sep-lines"`
+	KVOnly         bool   `mapstructure:"kv-only"`
+	AttrOnly       bool   `mapstructure:"attr-only"`
+	ContextOnly    bool   `mapstructure:"context-only"`
+	NoRawKeys      bool   `mapstructure:"no-raw-keys"`
+	KeyNamingCase  string `mapstructure:"key-naming-case"`
+	ArgsOnSepLines bool   `mapstructure:"args-on-sep-lines"`
 }
 
 type StaticCheckSettings struct {

--- a/pkg/golinters/sloglint.go
+++ b/pkg/golinters/sloglint.go
@@ -14,7 +14,9 @@ func NewSlogLint(settings *config.SlogLintSettings) *goanalysis.Linter {
 		opts = &sloglint.Options{
 			KVOnly:         settings.KVOnly,
 			AttrOnly:       settings.AttrOnly,
+			ContextOnly:    settings.ContextOnly,
 			NoRawKeys:      settings.NoRawKeys,
+			KeyNamingCase:  settings.KeyNamingCase,
 			ArgsOnSepLines: settings.ArgsOnSepLines,
 		}
 	}

--- a/test/testdata/configs/sloglint_context_only.yml
+++ b/test/testdata/configs/sloglint_context_only.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  sloglint:
+    context-only: true

--- a/test/testdata/configs/sloglint_key_naming_case.yml
+++ b/test/testdata/configs/sloglint_key_naming_case.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  sloglint:
+    key-naming-case: snake

--- a/test/testdata/sloglint_context_only.go
+++ b/test/testdata/sloglint_context_only.go
@@ -1,0 +1,16 @@
+//go:build go1.21
+
+//golangcitest:args -Esloglint
+//golangcitest:config_path testdata/configs/sloglint_context_only.yml
+package testdata
+
+import (
+	"context"
+	"log/slog"
+)
+
+func test() {
+	slog.InfoContext(context.Background(), "msg")
+
+	slog.Info("msg") // want `methods without a context should not be used`
+}

--- a/test/testdata/sloglint_key_naming_case.go
+++ b/test/testdata/sloglint_key_naming_case.go
@@ -1,0 +1,24 @@
+//go:build go1.21
+
+//golangcitest:args -Esloglint
+//golangcitest:config_path testdata/configs/sloglint_key_naming_case.yml
+package testdata
+
+import "log/slog"
+
+const (
+	snakeKey = "foo_bar"
+	kebabKey = "foo-bar"
+)
+
+func test() {
+	slog.Info("msg", "foo_bar", 1)
+	slog.Info("msg", snakeKey, 1)
+	slog.Info("msg", slog.Int("foo_bar", 1))
+	slog.Info("msg", slog.Int(snakeKey, 1))
+
+	slog.Info("msg", "foo-bar", 1)           // want `keys should be written in snake_case`
+	slog.Info("msg", kebabKey, 1)            // want `keys should be written in snake_case`
+	slog.Info("msg", slog.Int("foo-bar", 1)) // want `keys should be written in snake_case`
+	slog.Info("msg", slog.Int(kebabKey, 1))  // want `keys should be written in snake_case`
+}


### PR DESCRIPTION
A few options have been added:

- ContextOnly: enforce using methods that accept a context
- KeyNamingCase: enforce a single key naming convention

https://github.com/go-simpler/sloglint/compare/v0.1.2...v0.2.0