### PR TITLE
feat: add loopvar linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2297,6 +2297,7 @@ linters:
     - ireturn
     - lll
     - loggercheck
+    - loopvar
     - maintidx
     - makezero
     - maligned
@@ -2417,6 +2418,7 @@ linters:
     - ireturn
     - lll
     - loggercheck
+    - loopvar
     - maintidx
     - makezero
     - maligned

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/julz/importas v0.1.0
-	github.com/karamaru-alpha/loopvar v1.0.3
+	github.com/karamaru-alpha/loopvar v1.0.4
 	github.com/kisielk/errcheck v1.6.3
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/julz/importas v0.1.0
+	github.com/karamaru-alpha/loopvar v1.0.2
 	github.com/kisielk/errcheck v1.6.3
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/julz/importas v0.1.0
-	github.com/karamaru-alpha/loopvar v1.0.2
+	github.com/karamaru-alpha/loopvar v1.0.3
 	github.com/kisielk/errcheck v1.6.3
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
+github.com/karamaru-alpha/loopvar v1.0.2 h1:ZfkOWLbOOUpVlQM7g0eWzZ7+VoV0GHvM3V5IerVnXkE=
+github.com/karamaru-alpha/loopvar v1.0.2/go.mod h1:ayH86Bsn4k+Ou6dOqSkFssgZMPVoNciBbFs1ZlkblFw=
 github.com/kisielk/errcheck v1.6.3 h1:dEKh+GLHcWm2oN34nMvDzn1sqI0i0WxPvrgiJA5JuM8=
 github.com/kisielk/errcheck v1.6.3/go.mod h1:nXw/i/MfnvRHqXa7XXmQMUB0oNFGuBrNI8d8NLy0LPw=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
-github.com/karamaru-alpha/loopvar v1.0.3 h1:AOhkUFZ4hfHvmEtb8j+sXb/9vq25UUUCHH1t1eCC4ec=
-github.com/karamaru-alpha/loopvar v1.0.3/go.mod h1:ayH86Bsn4k+Ou6dOqSkFssgZMPVoNciBbFs1ZlkblFw=
+github.com/karamaru-alpha/loopvar v1.0.4 h1:fIum97+upQY21fNxXCi2KZ+ysDsKTGRYlhS7QG6hN6k=
+github.com/karamaru-alpha/loopvar v1.0.4/go.mod h1:ayH86Bsn4k+Ou6dOqSkFssgZMPVoNciBbFs1ZlkblFw=
 github.com/kisielk/errcheck v1.6.3 h1:dEKh+GLHcWm2oN34nMvDzn1sqI0i0WxPvrgiJA5JuM8=
 github.com/kisielk/errcheck v1.6.3/go.mod h1:nXw/i/MfnvRHqXa7XXmQMUB0oNFGuBrNI8d8NLy0LPw=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
-github.com/karamaru-alpha/loopvar v1.0.2 h1:ZfkOWLbOOUpVlQM7g0eWzZ7+VoV0GHvM3V5IerVnXkE=
-github.com/karamaru-alpha/loopvar v1.0.2/go.mod h1:ayH86Bsn4k+Ou6dOqSkFssgZMPVoNciBbFs1ZlkblFw=
+github.com/karamaru-alpha/loopvar v1.0.3 h1:AOhkUFZ4hfHvmEtb8j+sXb/9vq25UUUCHH1t1eCC4ec=
+github.com/karamaru-alpha/loopvar v1.0.3/go.mod h1:ayH86Bsn4k+Ou6dOqSkFssgZMPVoNciBbFs1ZlkblFw=
 github.com/kisielk/errcheck v1.6.3 h1:dEKh+GLHcWm2oN34nMvDzn1sqI0i0WxPvrgiJA5JuM8=
 github.com/kisielk/errcheck v1.6.3/go.mod h1:nXw/i/MfnvRHqXa7XXmQMUB0oNFGuBrNI8d8NLy0LPw=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/pkg/golinters/loopvar.go
+++ b/pkg/golinters/loopvar.go
@@ -1,0 +1,19 @@
+package golinters
+
+import (
+	"github.com/karamaru-alpha/loopvar"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewLoopVar() *goanalysis.Linter {
+	a := loopvar.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -620,6 +620,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithAlternativeNames("logrlint").
 			WithURL("https://github.com/timonwong/loggercheck"),
 
+		linter.NewConfig(golinters.NewLoopVar()).
+			WithSince("v1.56.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/karamaru-alpha/loopvar"),
+
 		linter.NewConfig(golinters.NewMaintIdx(maintIdxCfg)).
 			WithSince("v1.44.0").
 			WithPresets(linter.PresetComplexity).

--- a/test/testdata/loopvar.go
+++ b/test/testdata/loopvar.go
@@ -9,11 +9,11 @@ func foo() {
 	slice := []int{1, 2, 3}
 	fns := make([]func(), 0, len(slice)*2)
 	for i, v := range slice {
-		i := i // want `The loop variable "i" should not be copied \(GO_VERSION >= 1.22 or GOEXPERIMENT=loopvar\)`
+		i := i // want `The loop variable "i" should not be copied \(Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar\)`
 		fns = append(fns, func() {
 			fmt.Print(i)
 		})
-		_v := v // want `The loop variable "v" should not be copied \(GO_VERSION >= 1.22 or GOEXPERIMENT=loopvar\)`
+		_v := v // want `The loop variable "v" should not be copied \(Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar\)`
 		fns = append(fns, func() {
 			fmt.Print(_v)
 		})
@@ -27,7 +27,7 @@ func bar() {
 	loopCount := 3
 	fns := make([]func(), 0, loopCount)
 	for i := 1; i <= loopCount; i++ {
-		i := i // want `The loop variable "i" should not be copied \(GO_VERSION >= 1.22 or GOEXPERIMENT=loopvar\)`
+		i := i // want `The loop variable "i" should not be copied \(Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar\)`
 		fns = append(fns, func() {
 			fmt.Print(i)
 		})

--- a/test/testdata/loopvar.go
+++ b/test/testdata/loopvar.go
@@ -1,0 +1,38 @@
+//golangcitest:args -Eloopvar
+package testdata
+
+import (
+	"fmt"
+)
+
+func foo() {
+	slice := []int{1, 2, 3}
+	fns := make([]func(), 0, len(slice)*2)
+	for i, v := range slice {
+		i := i // want `The loop variable "i" should not be copied \(GO_VERSION >= 1.22 or GOEXPERIMENT=loopvar\)`
+		fns = append(fns, func() {
+			fmt.Print(i)
+		})
+		_v := v // want `The loop variable "v" should not be copied \(GO_VERSION >= 1.22 or GOEXPERIMENT=loopvar\)`
+		fns = append(fns, func() {
+			fmt.Print(_v)
+		})
+	}
+	for _, fn := range fns {
+		fn()
+	}
+}
+
+func bar() {
+	loopCount := 3
+	fns := make([]func(), 0, loopCount)
+	for i := 1; i <= loopCount; i++ {
+		i := i // want `The loop variable "i" should not be copied \(GO_VERSION >= 1.22 or GOEXPERIMENT=loopvar\)`
+		fns = append(fns, func() {
+			fmt.Print(i)
+		})
+	}
+	for _, fn := range fns {
+		fn()
+	}
+}


### PR DESCRIPTION
I'd like to add https://github.com/karamaru-alpha/loopvar.
This linter detects places where loop variables are copied.


For Go 1.21(set GOEXPERIMENT=loopvar) and Go 1.22~, it is unnecessary to copy loop variables because these variables have per-iteration scope instead of per-loop scope.


I understand that introducing this linter might be a bit premature, but I added it thinking it will be useful in the future.

cf. [Fixing For Loops in Go 1.22](https://go.dev/blog/loopvar-preview)

> For Go 1.22, we plan to change for loops to make these variables have per-iteration scope instead of per-loop scope. 

> Go 1.21 includes a preview of the scoping change. If you compile your code with GOEXPERIMENT=loopvar set in your environment, then the new semantics are applied to all loops.


<details><summary>golangci-lint run --no-config --disable-all -E loopvar ./test/testdata/loopvar.go</summary>

```
test/testdata/loopvar.go:12:3: The loop variable "i" should not be copied (Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar) (loopvar)
		i := i // want `The loop variable "i" should not be copied \(Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar\)`
		^
test/testdata/loopvar.go:16:3: The loop variable "v" should not be copied (Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar) (loopvar)
		_v := v // want `The loop variable "v" should not be copied \(Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar\)`
		^
test/testdata/loopvar.go:30:3: The loop variable "i" should not be copied (Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar) (loopvar)
		i := i // want `The loop variable "i" should not be copied \(Go 1.22~ or Go 1.21 GOEXPERIMENT=loopvar\)`
```
</details>
