### PR TITLE
set logrus PadLevelText field to true

### DIFF
--- a/pkg/logutils/stderr_log.go
+++ b/pkg/logutils/stderr_log.go
@@ -47,6 +47,7 @@ func NewStderrLog(name string) *StderrLog {
 	formatter := &logrus.TextFormatter{
 		DisableTimestamp:          true, // `INFO[0007] msg` -> `INFO msg`
 		EnvironmentOverrideColors: true,
+		PadLevelText:              true,
 	}
 	if os.Getenv(envLogTimestamp) == "1" {
 		formatter.DisableTimestamp = false


### PR DESCRIPTION
When running the `golangci-lint run --timeout 15m ./...` on my personal machine, I get an error output like this:

`ERRO Running error: unknown linters: 'inamedparam', run 'golangci-lint help linters' to see the list of supported linters`

The error itself is not the purpose of this PR but the leading `ERRO` 'misspelling. This PR will fix that.

N.B: not yet figured out how to write a test case to show this. But if you run the `golangci-lint` program in debug mode and force trigger any arbritrary error you should be able to reproduce this.

Also check --https://github.com/sirupsen/logrus/blob/7a997b92850ad24b0a836d7416ff2009bfc6e98d/text_formatter.go#L251C1-L259C3