### PR TITLE
Note that `exhaustruct` struct regular expressions are expected to match the entire `package/name/structname`

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -356,13 +356,15 @@ linters-settings:
       - 'example.com/package.ExampleStruct'
 
   exhaustruct:
-    # List of regular expressions to match struct packages and names.
+    # List of regular expressions to match struct packages and their names.
+    # Regular expressions must match complete canonical struct package/name/structname.
     # If this list is empty, all structs are tested.
     # Default: []
     include:
       - '.*\.Test'
       - 'example\.com/package\.ExampleStruct[\d]{1,2}'
-    # List of regular expressions to exclude struct packages and names from check.
+    # List of regular expressions to exclude struct packages and their names from checks.
+    # Regular expressions must match complete canonical struct package/name/structname.
     # Default: []
     exclude:
       - 'cobra\.Command$'


### PR DESCRIPTION
Quick one that tripped me up recently.

With the `exhaustruct` linter - the list of structs to `include/exclude` _must_ match the full `package/name/structname` - otherwise no match will be made/considered.

E.g. if I wish to target a struct of:

```
github.com/this/is/my/package/CoolStruct
```

These will work:

```
github\.com/this/is/my/package/CoolStruct
github\.com/this/is/my/package/Cool.+
```

This won't work:

```
github\.com/this/is/my/package/Cool
^github\.com/this/is/my/package/Cool
```

Hopefully this comment helps in that usage!