### PR TITLE
Add `goptrcmp` linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2364,6 +2364,7 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
+    - goptrcmp
     - gosec
     - gosimple
     - gosmopolitan
@@ -2484,6 +2485,7 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
+    - goptrcmp
     - gosec
     - gosimple
     - gosmopolitan

--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/ultraware/whitespace v0.1.0
 	github.com/uudashr/gocognit v1.1.2
 	github.com/valyala/quicktemplate v1.7.0
+	github.com/w1ck3dg0ph3r/goptrcmp v0.1.1
 	github.com/xen0n/gosmopolitan v1.2.2
 	github.com/yagipy/maintidx v1.0.0
 	github.com/yeya24/promlinter v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -570,6 +570,8 @@ github.com/valyala/fasthttp v1.30.0/go.mod h1:2rsYD01CKFrjjsvFxx75KlEUNpWNBY9JWD
 github.com/valyala/quicktemplate v1.7.0 h1:LUPTJmlVcb46OOUY3IeD9DojFpAVbsG+5WFTcjMJzCM=
 github.com/valyala/quicktemplate v1.7.0/go.mod h1:sqKJnoaOF88V07vkO+9FL8fb9uZg/VPSJnLYn+LmLk8=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
+github.com/w1ck3dg0ph3r/goptrcmp v0.1.1 h1:ZTXRt6TWQSNOMOaGD8w6nac054RcmMsClwbNREGnzek=
+github.com/w1ck3dg0ph3r/goptrcmp v0.1.1/go.mod h1:xlxqkKq/envW+otePu2Yq9QR07m1fxd0vCE3H/ExEpU=
 github.com/xen0n/gosmopolitan v1.2.2 h1:/p2KTnMzwRexIW8GlKawsTWOxn7UHA+jCMF/V8HHtvU=
 github.com/xen0n/gosmopolitan v1.2.2/go.mod h1:7XX7Mj61uLYrj0qmeN0zi7XDon9JRAEhYQqAPLVNTeg=
 github.com/yagipy/maintidx v1.0.0 h1:h5NvIsCz+nRDapQ0exNv4aJ0yXSI0420omVANTv3GJM=

--- a/pkg/golinters/goptrcmp.go
+++ b/pkg/golinters/goptrcmp.go
@@ -1,0 +1,17 @@
+package golinters
+
+import (
+	"github.com/w1ck3dg0ph3r/goptrcmp"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewGoPtrCmp() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		"goptrcmp",
+		"Reports comparison between pointer values",
+		[]*analysis.Analyzer{goptrcmp.Analyzer()},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -538,6 +538,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/jirfag/go-printf-func-name"),
 
+		linter.NewConfig(golinters.NewGoPtrCmp()).
+			WithLoadForGoAnalysis().
+			WithSince("v1.55.3").
+			WithPresets(linter.PresetBugs).
+			WithURL("https://github.com/w1ck3dg0ph3r/goptrcmp"),
+
 		linter.NewConfig(golinters.NewGosec(gosecCfg)).
 			WithSince("v1.0.0").
 			WithLoadForGoAnalysis().

--- a/test/testdata/goptrcmp.go
+++ b/test/testdata/goptrcmp.go
@@ -1,0 +1,48 @@
+//golangcitest:args -Egoptrcmp
+package testdata
+
+import (
+	"fmt"
+)
+
+type Foo struct {
+	String  string
+	Pointer *string
+}
+
+func CmpFoos(a, b *Foo) bool {
+	if a != b { // want "pointer comparison: a != b"
+		return false
+	}
+
+	if a == nil {
+		return false
+	}
+
+	if nil == b {
+		return false
+	}
+
+	if *a != *b {
+		return false
+	}
+
+	if a.String != b.String {
+		return false
+	}
+
+	if a.Pointer != b.Pointer { // want "pointer comparison: a.Pointer != b.Pointer"
+		return false
+	}
+
+	if *a.Pointer != *b.Pointer {
+		return false
+	}
+
+	fmt.Println(a == b) // want "pointer comparison: a == b"
+	fmt.Println(a.String == b.String)
+	fmt.Println(a.Pointer == b.Pointer) // want "pointer comparison: a.Pointer == b.Pointer"
+	fmt.Println(*a.Pointer == *b.Pointer)
+
+	return true
+}


### PR DESCRIPTION
Hi,
I would like to add [`goptrcmp`](https://github.com/w1ck3dg0ph3r/goptrcmp): a linter that reports comparison between pointers.

It may seem odd to lint for that as there are tons of valid occurrences, but on the other hand pointer comparisons can and have been a source of bugs (where the intention was to compare values, but e.g. the underlying types were quietly changed to a pointer).