### PR TITLE
Add static-msg option for sloglint

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1864,6 +1864,9 @@ linters-settings:
     # Enforce using methods that accept a context.
     # Default: false
     context-only: true
+    # Enforce using static values for log messages.
+    # Default: false
+    static-msg: true
     # Enforce using constants instead of raw keys.
     # Default: false
     no-raw-keys: true

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -123,6 +123,7 @@ var defaultLintersSettings = LintersSettings{
 		KVOnly:         false,
 		AttrOnly:       false,
 		ContextOnly:    false,
+		StaticMsg:      false,
 		NoRawKeys:      false,
 		KeyNamingCase:  "",
 		ArgsOnSepLines: false,
@@ -755,6 +756,7 @@ type SlogLintSettings struct {
 	KVOnly         bool   `mapstructure:"kv-only"`
 	AttrOnly       bool   `mapstructure:"attr-only"`
 	ContextOnly    bool   `mapstructure:"context-only"`
+	StaticMsg      bool   `mapstructure:"static-msg"`
 	NoRawKeys      bool   `mapstructure:"no-raw-keys"`
 	KeyNamingCase  string `mapstructure:"key-naming-case"`
 	ArgsOnSepLines bool   `mapstructure:"args-on-sep-lines"`

--- a/pkg/golinters/sloglint.go
+++ b/pkg/golinters/sloglint.go
@@ -15,6 +15,7 @@ func NewSlogLint(settings *config.SlogLintSettings) *goanalysis.Linter {
 			KVOnly:         settings.KVOnly,
 			AttrOnly:       settings.AttrOnly,
 			ContextOnly:    settings.ContextOnly,
+			StaticMsg:      settings.StaticMsg,
 			NoRawKeys:      settings.NoRawKeys,
 			KeyNamingCase:  settings.KeyNamingCase,
 			ArgsOnSepLines: settings.ArgsOnSepLines,

--- a/test/testdata/configs/sloglint_static_msg.yml
+++ b/test/testdata/configs/sloglint_static_msg.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  sloglint:
+    static-msg: true

--- a/test/testdata/sloglint_static_msg.go
+++ b/test/testdata/sloglint_static_msg.go
@@ -1,0 +1,19 @@
+//go:build go1.21
+
+//golangcitest:args -Esloglint
+//golangcitest:config_path testdata/configs/sloglint_static_msg.yml
+package testdata
+
+import (
+	"log/slog"
+)
+
+func test() {
+	slog.Info("msg")
+
+	const msg1 = "msg"
+	slog.Info(msg1)
+
+	msg2 := "msg"
+	slog.Info(msg2) // want `message should be a string literal or a constant`
+}


### PR DESCRIPTION
sloglint v0.3.0 was updated in #4183, but missed the new static-msg option. This adds support for that option to golangci-lint.