### PR TITLE
dev: use analyzer fields for name, doc instead of hardcoded strings

### DIFF
--- a/pkg/golinters/asciicheck.go
+++ b/pkg/golinters/asciicheck.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewAsciicheck() *goanalysis.Linter {
+	a := asciicheck.NewAnalyzer()
 	return goanalysis.NewLinter(
-		"asciicheck",
+		a.Name,
 		"Simple linter to check that your code does not contain non-ASCII identifiers",
-		[]*analysis.Analyzer{asciicheck.NewAnalyzer()},
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/asciicheck.go
+++ b/pkg/golinters/asciicheck.go
@@ -9,9 +9,10 @@ import (
 
 func NewAsciicheck() *goanalysis.Linter {
 	a := asciicheck.NewAnalyzer()
+
 	return goanalysis.NewLinter(
 		a.Name,
-		"Simple linter to check that your code does not contain non-ASCII identifiers",
+		a.Doc,
 		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeSyntax)

--- a/pkg/golinters/bidichk.go
+++ b/pkg/golinters/bidichk.go
@@ -51,7 +51,7 @@ func NewBiDiChkFuncName(cfg *config.BiDiChkSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		"bidichk",
+		a.Name,
 		"Checks for dangerous unicode character sequences",
 		[]*analysis.Analyzer{a},
 		cfgMap,

--- a/pkg/golinters/bodyclose.go
+++ b/pkg/golinters/bodyclose.go
@@ -8,11 +8,10 @@ import (
 )
 
 func NewBodyclose() *goanalysis.Linter {
-	a := bodyclose.Analyzer
 	return goanalysis.NewLinter(
-		a.Name,
+		"bodyclose",
 		"checks whether HTTP response body is closed successfully",
-		[]*analysis.Analyzer{a},
+		[]*analysis.Analyzer{bodyclose.Analyzer},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/bodyclose.go
+++ b/pkg/golinters/bodyclose.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewBodyclose() *goanalysis.Linter {
+	a := bodyclose.Analyzer
 	return goanalysis.NewLinter(
-		"bodyclose",
+		a.Name,
 		"checks whether HTTP response body is closed successfully",
-		[]*analysis.Analyzer{bodyclose.Analyzer},
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/cyclop.go
+++ b/pkg/golinters/cyclop.go
@@ -8,8 +8,6 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-const cyclopName = "cyclop"
-
 func NewCyclop(settings *config.Cyclop) *goanalysis.Linter {
 	a := analyzer.NewAnalyzer()
 
@@ -31,7 +29,7 @@ func NewCyclop(settings *config.Cyclop) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		cyclopName,
+		a.Name,
 		"checks function and package cyclomatic complexity",
 		[]*analysis.Analyzer{a},
 		cfg,

--- a/pkg/golinters/errchkjson.go
+++ b/pkg/golinters/errchkjson.go
@@ -23,10 +23,8 @@ func NewErrChkJSONFuncName(cfg *config.ErrChkJSONSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		"errchkjson",
-		"Checks types passed to the json encoding functions. "+
-			"Reports unsupported types and optionally reports occasions, "+
-			"where the check for the returned error can be omitted.",
+		a.Name,
+		a.Doc,
 		[]*analysis.Analyzer{a},
 		cfgMap,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)

--- a/pkg/golinters/errname.go
+++ b/pkg/golinters/errname.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewErrName() *goanalysis.Linter {
+	a := analyzer.New()
 	return goanalysis.NewLinter(
-		"errname",
-		"Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.",
-		[]*analysis.Analyzer{analyzer.New()},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/errname.go
+++ b/pkg/golinters/errname.go
@@ -9,6 +9,7 @@ import (
 
 func NewErrName() *goanalysis.Linter {
 	a := analyzer.New()
+
 	return goanalysis.NewLinter(
 		a.Name,
 		a.Doc,

--- a/pkg/golinters/goprintffuncname.go
+++ b/pkg/golinters/goprintffuncname.go
@@ -9,6 +9,7 @@ import (
 
 func NewGoPrintfFuncName() *goanalysis.Linter {
 	a := analyzer.Analyzer
+
 	return goanalysis.NewLinter(
 		a.Name,
 		a.Doc,

--- a/pkg/golinters/goprintffuncname.go
+++ b/pkg/golinters/goprintffuncname.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewGoPrintfFuncName() *goanalysis.Linter {
+	a := analyzer.Analyzer
 	return goanalysis.NewLinter(
-		"goprintffuncname",
-		"Checks that printf-like functions are named with `f` at the end",
-		[]*analysis.Analyzer{analyzer.Analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/grouper.go
+++ b/pkg/golinters/grouper.go
@@ -9,6 +9,7 @@ import (
 )
 
 func NewGrouper(settings *config.GrouperSettings) *goanalysis.Linter {
+	a := grouper.New()
 	linterCfg := map[string]map[string]any{}
 	if settings != nil {
 		linterCfg["grouper"] = map[string]any{
@@ -24,9 +25,9 @@ func NewGrouper(settings *config.GrouperSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		"grouper",
+		a.Name,
 		"An analyzer to analyze expression groups.",
-		[]*analysis.Analyzer{grouper.New()},
+		[]*analysis.Analyzer{a},
 		linterCfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/grouper.go
+++ b/pkg/golinters/grouper.go
@@ -9,7 +9,6 @@ import (
 )
 
 func NewGrouper(settings *config.GrouperSettings) *goanalysis.Linter {
-	a := grouper.New()
 	linterCfg := map[string]map[string]any{}
 	if settings != nil {
 		linterCfg["grouper"] = map[string]any{
@@ -25,9 +24,9 @@ func NewGrouper(settings *config.GrouperSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		a.Name,
-		"An analyzer to analyze expression groups.",
-		[]*analysis.Analyzer{a},
+		"grouper",
+		"Analyze expression groups.",
+		[]*analysis.Analyzer{grouper.New()},
 		linterCfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/ifshort.go
+++ b/pkg/golinters/ifshort.go
@@ -9,7 +9,6 @@ import (
 )
 
 func NewIfshort(settings *config.IfshortSettings) *goanalysis.Linter {
-	a := analyzer.Analyzer
 	var cfg map[string]map[string]any
 	if settings != nil {
 		cfg = map[string]map[string]any{
@@ -19,6 +18,8 @@ func NewIfshort(settings *config.IfshortSettings) *goanalysis.Linter {
 			},
 		}
 	}
+
+	a := analyzer.Analyzer
 
 	return goanalysis.NewLinter(
 		a.Name,

--- a/pkg/golinters/ifshort.go
+++ b/pkg/golinters/ifshort.go
@@ -9,6 +9,7 @@ import (
 )
 
 func NewIfshort(settings *config.IfshortSettings) *goanalysis.Linter {
+	a := analyzer.Analyzer
 	var cfg map[string]map[string]any
 	if settings != nil {
 		cfg = map[string]map[string]any{
@@ -20,9 +21,9 @@ func NewIfshort(settings *config.IfshortSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		"ifshort",
-		"Checks that your code uses short syntax for if-statements whenever possible",
-		[]*analysis.Analyzer{analyzer.Analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/ineffassign.go
+++ b/pkg/golinters/ineffassign.go
@@ -9,6 +9,7 @@ import (
 
 func NewIneffassign() *goanalysis.Linter {
 	a := ineffassign.Analyzer
+
 	return goanalysis.NewLinter(
 		a.Name,
 		"Detects when assignments to existing variables are not used",

--- a/pkg/golinters/ineffassign.go
+++ b/pkg/golinters/ineffassign.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewIneffassign() *goanalysis.Linter {
+	a := ineffassign.Analyzer
 	return goanalysis.NewLinter(
-		"ineffassign",
+		a.Name,
 		"Detects when assignments to existing variables are not used",
-		[]*analysis.Analyzer{ineffassign.Analyzer},
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/nakedret.go
+++ b/pkg/golinters/nakedret.go
@@ -8,8 +8,6 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-const nakedretName = "nakedret"
-
 func NewNakedret(settings *config.NakedretSettings) *goanalysis.Linter {
 	var maxLines int
 	if settings != nil {
@@ -19,7 +17,7 @@ func NewNakedret(settings *config.NakedretSettings) *goanalysis.Linter {
 	analyzer := nakedret.NakedReturnAnalyzer(uint(maxLines))
 
 	return goanalysis.NewLinter(
-		nakedretName,
+		analyzer.Name,
 		"Finds naked returns in functions greater than a specified function length",
 		[]*analysis.Analyzer{analyzer},
 		nil,

--- a/pkg/golinters/nakedret.go
+++ b/pkg/golinters/nakedret.go
@@ -14,12 +14,12 @@ func NewNakedret(settings *config.NakedretSettings) *goanalysis.Linter {
 		maxLines = settings.MaxFuncLines
 	}
 
-	analyzer := nakedret.NakedReturnAnalyzer(uint(maxLines))
+	a := nakedret.NakedReturnAnalyzer(uint(maxLines))
 
 	return goanalysis.NewLinter(
-		analyzer.Name,
-		"Finds naked returns in functions greater than a specified function length",
-		[]*analysis.Analyzer{analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/noctx.go
+++ b/pkg/golinters/noctx.go
@@ -9,9 +9,10 @@ import (
 
 func NewNoctx() *goanalysis.Linter {
 	a := noctx.Analyzer
+
 	return goanalysis.NewLinter(
 		a.Name,
-		a.Doc,
+		"Detects test helpers which is not start with t.Helper() method",
 		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)

--- a/pkg/golinters/noctx.go
+++ b/pkg/golinters/noctx.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewNoctx() *goanalysis.Linter {
+	a := noctx.Analyzer
 	return goanalysis.NewLinter(
-		"noctx",
-		"noctx finds sending http request without context.Context",
-		[]*analysis.Analyzer{noctx.Analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/paralleltest.go
+++ b/pkg/golinters/paralleltest.go
@@ -22,7 +22,7 @@ func NewParallelTest(settings *config.ParallelTestSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		"paralleltest",
+		a.Name,
 		"paralleltest detects missing usage of t.Parallel() method in your Go test",
 		[]*analysis.Analyzer{a},
 		cfg,

--- a/pkg/golinters/paralleltest.go
+++ b/pkg/golinters/paralleltest.go
@@ -23,7 +23,7 @@ func NewParallelTest(settings *config.ParallelTestSettings) *goanalysis.Linter {
 
 	return goanalysis.NewLinter(
 		a.Name,
-		"paralleltest detects missing usage of t.Parallel() method in your Go test",
+		"Detects missing usage of t.Parallel() method in your Go test",
 		[]*analysis.Analyzer{a},
 		cfg,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)

--- a/pkg/golinters/rowserrcheck.go
+++ b/pkg/golinters/rowserrcheck.go
@@ -17,7 +17,7 @@ func NewRowsErrCheck(settings *config.RowsErrCheckSettings) *goanalysis.Linter {
 	analyzer := rowserr.NewAnalyzer(pkgs...)
 
 	return goanalysis.NewLinter(
-		"rowserrcheck",
+		analyzer.Name,
 		"checks whether Err of rows is checked successfully",
 		[]*analysis.Analyzer{analyzer},
 		nil,

--- a/pkg/golinters/rowserrcheck.go
+++ b/pkg/golinters/rowserrcheck.go
@@ -14,12 +14,12 @@ func NewRowsErrCheck(settings *config.RowsErrCheckSettings) *goanalysis.Linter {
 		pkgs = settings.Packages
 	}
 
-	analyzer := rowserr.NewAnalyzer(pkgs...)
+	a := rowserr.NewAnalyzer(pkgs...)
 
 	return goanalysis.NewLinter(
-		analyzer.Name,
-		"checks whether Err of rows is checked successfully",
-		[]*analysis.Analyzer{analyzer},
+		a.Name,
+		"checks whether Rows.Err of rows is checked successfully",
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/sqlclosecheck.go
+++ b/pkg/golinters/sqlclosecheck.go
@@ -9,6 +9,7 @@ import (
 
 func NewSQLCloseCheck() *goanalysis.Linter {
 	a := analyzer.NewAnalyzer()
+
 	return goanalysis.NewLinter(
 		a.Name,
 		a.Doc,

--- a/pkg/golinters/sqlclosecheck.go
+++ b/pkg/golinters/sqlclosecheck.go
@@ -8,12 +8,11 @@ import (
 )
 
 func NewSQLCloseCheck() *goanalysis.Linter {
+	a := analyzer.NewAnalyzer()
 	return goanalysis.NewLinter(
-		"sqlclosecheck",
-		"Checks that sql.Rows and sql.Stmt are closed.",
-		[]*analysis.Analyzer{
-			analyzer.NewAnalyzer(),
-		},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/thelper.go
+++ b/pkg/golinters/thelper.go
@@ -54,8 +54,8 @@ func NewThelper(cfg *config.ThelperSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		"thelper",
-		"thelper detects Go test helpers without t.Helper() call and checks the consistency of test helpers",
+		a.Name,
+		a.Doc,
 		[]*analysis.Analyzer{a},
 		cfgMap,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)

--- a/pkg/golinters/tparallel.go
+++ b/pkg/golinters/tparallel.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewTparallel() *goanalysis.Linter {
+	a := tparallel.Analyzer
 	return goanalysis.NewLinter(
-		"tparallel",
-		"tparallel detects inappropriate usage of t.Parallel() method in your Go test codes",
-		[]*analysis.Analyzer{tparallel.Analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/wastedassign.go
+++ b/pkg/golinters/wastedassign.go
@@ -8,10 +8,11 @@ import (
 )
 
 func NewWastedAssign() *goanalysis.Linter {
+	a := wastedassign.Analyzer
 	return goanalysis.NewLinter(
-		"wastedassign",
-		"wastedassign finds wasted assignment statements.",
-		[]*analysis.Analyzer{wastedassign.Analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/wastedassign.go
+++ b/pkg/golinters/wastedassign.go
@@ -9,9 +9,10 @@ import (
 
 func NewWastedAssign() *goanalysis.Linter {
 	a := wastedassign.Analyzer
+
 	return goanalysis.NewLinter(
 		a.Name,
-		a.Doc,
+		"Finds wasted assignment statements",
 		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)

--- a/pkg/golinters/wrapcheck.go
+++ b/pkg/golinters/wrapcheck.go
@@ -8,8 +8,6 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-const wrapcheckName = "wrapcheck"
-
 func NewWrapcheck(settings *config.WrapcheckSettings) *goanalysis.Linter {
 	cfg := wrapcheck.NewDefaultConfig()
 	if settings != nil {
@@ -30,7 +28,7 @@ func NewWrapcheck(settings *config.WrapcheckSettings) *goanalysis.Linter {
 	a := wrapcheck.NewAnalyzer(cfg)
 
 	return goanalysis.NewLinter(
-		wrapcheckName,
+		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
 		nil,


### PR DESCRIPTION
This PR refactors linters constructors to use `analyzer.Name`  and `analyzer.Doc` instead of hardcoded strings.