### PR TITLE
dev: use zerologlint analyzer fields for name and doc

### DIFF
--- a/pkg/golinters/zerologlint.go
+++ b/pkg/golinters/zerologlint.go
@@ -8,10 +8,12 @@ import (
 )
 
 func NewZerologLint() *goanalysis.Linter {
+	a := zerologlint.Analyzer
+
 	return goanalysis.NewLinter(
-		"zerologlint",
-		"Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`.",
-		[]*analysis.Analyzer{zerologlint.Analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }


### PR DESCRIPTION
This PR does the same changes as in the https://github.com/golangci/golangci-lint/pull/4214 but for zerologlint.

[zerologlint 0.1.4](https://github.com/golangci/golangci-lint/pull/4222) has [necessary changes](https://github.com/ykadowak/zerologlint/commit/b7e040a44bb3339aa00853a331bd1430224fa446) for Name and Doc fields.