### PR TITLE
.golangci.reference.yml: depguard notice

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -218,6 +218,8 @@ linters-settings:
           - $gostd
           - github.com/OpenPeeDeeP
         # Packages that are not allowed where the value is a suggestion.
+        # /!\ Unlike upstream a deny list (with "pkg" and "desc" keys) must be provided
+        # (due to a viper limitation, yaml map keys can't have a dot)
         deny:
           - pkg: "github.com/sirupsen/logrus"
             desc: not allowed


### PR DESCRIPTION
When using `depguard`, special care must be taken to adjust the "Deny" key, otherwise a panic happens:
```
ERRO [runner] Panic: depguard: package "..." (isInitialPkg: true, needAnalyzeSource: true): runtime error: index out of range [-1]
```

https://github.com/OpenPeeDeeP/depguard/issues/74

