### PR TITLE
Add new linter canonicalheader

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2323,6 +2323,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - containedctx
     - contextcheck
     - cyclop
@@ -2443,6 +2444,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - containedctx
     - contextcheck
     - cyclop

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/kulti/thelper v0.6.3
 	github.com/kunwardeep/paralleltest v1.0.8
 	github.com/kyoh86/exportloopref v0.1.11
+	github.com/lasiar/canonicalheader v1.0.4
 	github.com/ldez/gomoddirectives v0.2.3
 	github.com/ldez/tagliatelle v0.5.0
 	github.com/leonklingele/grouper v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,8 @@ github.com/kunwardeep/paralleltest v1.0.8 h1:Ul2KsqtzFxTlSU7IP0JusWlLiNqQaloB9vg
 github.com/kunwardeep/paralleltest v1.0.8/go.mod h1:2C7s65hONVqY7Q5Efj5aLzRCNLjw2h4eMc9EcypGjcY=
 github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/ymEyhQ=
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
+github.com/lasiar/canonicalheader v1.0.4 h1:3SfECz18dVumm2+ly2s5XYqQqKyH9IyTGOA5w6C+DvY=
+github.com/lasiar/canonicalheader v1.0.4/go.mod h1:lfMC8RPNimePVAAmIMyPepKpK2iMe8mmkwiTTgeEuec=
 github.com/ldez/gomoddirectives v0.2.3 h1:y7MBaisZVDYmKvt9/l1mjNCiSA1BVn34U0ObUcJwlhA=
 github.com/ldez/gomoddirectives v0.2.3/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdBr6g8G04uz6d0=
 github.com/ldez/tagliatelle v0.5.0 h1:epgfuYt9v0CG3fms0pEgIMNPuFf/LpPIfjk4kyqSioo=

--- a/pkg/golinters/canonicalheader.go
+++ b/pkg/golinters/canonicalheader.go
@@ -1,0 +1,19 @@
+package golinters
+
+import (
+	"github.com/lasiar/canonicalheader"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewCanonicalheder() *goanalysis.Linter {
+	a := canonicalheader.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{canonicalheader.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -285,6 +285,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithPresets(linter.PresetPerformance, linter.PresetBugs).
 			WithURL("https://github.com/timakin/bodyclose"),
 
+		linter.NewConfig(golinters.NewCanonicalheder()).
+			WithSince("v1.56.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/lasiar/canonicalHeader"),
+
 		linter.NewConfig(golinters.NewContainedCtx()).
 			WithSince("1.44.0").
 			WithLoadForGoAnalysis().

--- a/test/testdata/canonicalheader.go
+++ b/test/testdata/canonicalheader.go
@@ -1,0 +1,19 @@
+//golangcitest:args -Ecanonicalheader
+package testdata
+
+import "net/http"
+
+func canonicalheader() {
+	v := http.Header{}
+
+	v.Get("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Set("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Add("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Del("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Values("Test-HEader")       // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+
+	v.Set("Test-Header", "value")
+	v.Add("Test-Header", "value")
+	v.Del("Test-Header")
+	v.Values("Test-Header")
+}


### PR DESCRIPTION
[canonicalheader](https://github.com/lasiar/canonicalHeader) analyzes code and reports or fixes non-canonical header key in net/http.Header, [doc](https://pkg.go.dev/net/http#CanonicalHeaderKey).

The linter suggest canonical header:

```go
http.Header{}.Get("Test-Header")
```
instead of non-canonical header:

```go
http.Header{}.Get("TeSt-HeAdEr")
```

This change also speeds up the code a little, benchmark from repo:
```
name             time/op
Canonical-10     29.7ns ± 4%
NonCanonical-10  69.0ns ± 1%

name             alloc/op
Canonical-10      0.00B     
NonCanonical-10   16.0B ± 0%

name             allocs/op
Canonical-10       0.00     
NonCanonical-10    1.00 ± 0%
```

Now, the linter works only with value net/http.Header (not pointer) and with string literal.
