### PR TITLE
misspell: add mode option

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1333,6 +1333,11 @@ linters-settings:
     # Default: []
     ignore-words:
       - someword
+    # Mode of the analysis:
+    # - default: checks all the file content.
+    # - restricted: checks only comments.
+    # Default: ""
+    mode: restricted
 
   musttag:
     # A set of custom functions to check in addition to the builtin ones.

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -659,8 +659,9 @@ type MalignedSettings struct {
 }
 
 type MisspellSettings struct {
+	Mode   string `mapstructure:"mode"`
 	Locale string
-	// TODO(ldez): v2 the options must be renamed to `IgnoredRules`.
+	// TODO(ldez): v2 the option must be renamed to `IgnoredRules`.
 	IgnoreWords []string `mapstructure:"ignore-words"`
 }
 

--- a/pkg/golinters/misspell.go
+++ b/pkg/golinters/misspell.go
@@ -29,7 +29,7 @@ func NewMisspell(settings *config.MisspellSettings) *goanalysis.Linter {
 
 	return goanalysis.NewLinter(
 		misspellName,
-		"Finds commonly misspelled English words in comments",
+		"Finds commonly misspelled English words",
 		[]*analysis.Analyzer{analyzer},
 		nil,
 	).WithContextSetter(func(lintCtx *linter.Context) {
@@ -40,7 +40,7 @@ func NewMisspell(settings *config.MisspellSettings) *goanalysis.Linter {
 				return nil, ruleErr
 			}
 
-			issues, err := runMisspell(lintCtx, pass, replacer)
+			issues, err := runMisspell(lintCtx, pass, replacer, settings.Mode)
 			if err != nil {
 				return nil, err
 			}
@@ -60,15 +60,16 @@ func NewMisspell(settings *config.MisspellSettings) *goanalysis.Linter {
 	}).WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
-func runMisspell(lintCtx *linter.Context, pass *analysis.Pass, replacer *misspell.Replacer) ([]goanalysis.Issue, error) {
+func runMisspell(lintCtx *linter.Context, pass *analysis.Pass, replacer *misspell.Replacer, mode string) ([]goanalysis.Issue, error) {
 	fileNames := getFileNames(pass)
 
 	var issues []goanalysis.Issue
 	for _, filename := range fileNames {
-		lintIssues, err := runMisspellOnFile(lintCtx, filename, replacer)
+		lintIssues, err := runMisspellOnFile(lintCtx, filename, replacer, mode)
 		if err != nil {
 			return nil, err
 		}
+
 		for i := range lintIssues {
 			issues = append(issues, goanalysis.NewIssue(&lintIssues[i], pass))
 		}
@@ -104,25 +105,36 @@ func createMisspellReplacer(settings *config.MisspellSettings) (*misspell.Replac
 	return replacer, nil
 }
 
-func runMisspellOnFile(lintCtx *linter.Context, filename string, replacer *misspell.Replacer) ([]result.Issue, error) {
-	var res []result.Issue
+func runMisspellOnFile(lintCtx *linter.Context, filename string, replacer *misspell.Replacer, mode string) ([]result.Issue, error) {
 	fileContent, err := lintCtx.FileCache.GetFileBytes(filename)
 	if err != nil {
 		return nil, fmt.Errorf("can't get file %s contents: %s", filename, err)
 	}
 
-	// use r.Replace, not r.ReplaceGo because r.ReplaceGo doesn't find
-	// issues inside strings: it searches only inside comments. r.Replace
-	// searches all words: it treats input as a plain text. A standalone misspell
-	// tool uses r.Replace by default.
-	_, diffs := replacer.Replace(string(fileContent))
+	// `r.ReplaceGo` doesn't find issues inside strings: it searches only inside comments.
+	// `r.Replace` searches all words: it treats input as a plain text.
+	// The standalone misspell tool uses `r.Replace` by default.
+	var replace func(input string) (string, []misspell.Diff)
+	switch strings.ToLower(mode) {
+	case "restricted":
+		replace = replacer.ReplaceGo
+	default:
+		replace = replacer.Replace
+	}
+
+	_, diffs := replace(string(fileContent))
+
+	var res []result.Issue
+
 	for _, diff := range diffs {
 		text := fmt.Sprintf("`%s` is a misspelling of `%s`", diff.Original, diff.Corrected)
+
 		pos := token.Position{
 			Filename: filename,
 			Line:     diff.Line,
 			Column:   diff.Column + 1,
 		}
+
 		replacement := &result.Replacement{
 			Inline: &result.InlineFix{
 				StartCol:  diff.Column,


### PR DESCRIPTION
Adds an option `mode`:
- default: checks all the file content.
- restricted: checks only comments.

This option is closed to the CLI flags `source` of `misspell` but I changed the naming and the value to have something less misleading.