### PR TITLE
docs: fix Go version fallback 

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -72,7 +72,7 @@ run:
 
   # Define the Go version limit.
   # Mainly related to generics support since go1.18.
-  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.18
+  # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
   go: '1.19'
 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,5 +67,5 @@ func DetectGoVersion() string {
 		return v
 	}
 
-	return "1.18"
+	return "1.17"
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,5 +67,5 @@ func DetectGoVersion() string {
 		return v
 	}
 
-	return "1.17"
+	return "1.18"
 }


### PR DESCRIPTION
Fix documentation to follow what code does. Reference https://github.com/golangci/golangci-lint/blob/master/pkg/config/config.go#L70