### PR TITLE
fix: make versioning inside Docker image consistent with binaries

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,9 @@ ARG DATE
 
 COPY / /golangci
 WORKDIR /golangci
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
+RUN PROGRAM_VERSION=$VERSION && \
+    PROGRAM_VERSION=${PROGRAM_VERSION#v} && \
+    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$PROGRAM_VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.21

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,9 +7,9 @@ ARG DATE
 
 COPY / /golangci
 WORKDIR /golangci
-RUN PROGRAM_VERSION=$VERSION && \
-    PROGRAM_VERSION=${PROGRAM_VERSION#v} && \
-    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$PROGRAM_VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
+RUN APP_VERSION=${VERSION#v} \
+    CGO_ENABLED=0 \
+    go build -trimpath -ldflags "-s -w -X main.version=$APP_VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.21

--- a/build/alpine.Dockerfile
+++ b/build/alpine.Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /golangci
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80
 RUN apk --no-cache add gcc musl-dev git mercurial
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
+RUN PROGRAM_VERSION=$VERSION && \
+    PROGRAM_VERSION=${PROGRAM_VERSION#v} && \
+    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$PROGRAM_VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.21-alpine

--- a/build/alpine.Dockerfile
+++ b/build/alpine.Dockerfile
@@ -12,9 +12,9 @@ WORKDIR /golangci
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80
 RUN apk --no-cache add gcc musl-dev git mercurial
-RUN PROGRAM_VERSION=$VERSION && \
-    PROGRAM_VERSION=${PROGRAM_VERSION#v} && \
-    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=$PROGRAM_VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
+RUN APP_VERSION=${VERSION#v} \
+    CGO_ENABLED=0 \
+    go build -trimpath -ldflags "-s -w -X main.version=$APP_VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2
 FROM golang:1.21-alpine


### PR DESCRIPTION
goreleaser currently strips the leading `v` off of the SemVer tag when passing to ldflags, while the container build does not remove it.

Remove the leading `v`, if present, off of the version in container builds so that the version returned by `golangci-lint --version` is consistent regardless of whether the program is running standalone or in a container.

As discussed in https://github.com/golangci/golangci-lint/discussions/4268.

Fixes #4263