### PR TITLE
doc: fix URL not available

### DIFF
--- a/docs/src/docs/contributing/website.mdx
+++ b/docs/src/docs/contributing/website.mdx
@@ -14,7 +14,7 @@ The website lives in `docs/` directory of [golangci-lint repository](https://git
 
 ## Theme
 
-Initially the site is based on [@rocketseat](https://rocketdocs.netlify.app/) theme.
+Initially the site is based on [@rocketseat](https://github.com/jpedroschmitz/rocketdocs) theme.
 Later we've merged its code into `src/@rocketseat` because we needed too much changes
 and [gatsby shadowing](https://www.gatsbyjs.org/docs/themes/shadowing/) doesn't allow shadowing `gatsby-node.js` or `gatsby-config.js`.
 


### PR DESCRIPTION
https://rocketdocs.netlify.app/ (which takes to https://rocketdocs.gatsbyjs.io/) is not available anymore. Change URL to code repository.