### PR TITLE
dev: remove unrelated flags from config and linters command

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2649,7 +2649,7 @@ linters:
     - test
     - unused
 
-  # Run only fast linters from enabled linters set (first run won't be fast)
+  # Enable only fast linters from enabled linters set (first run won't be fast)
   # Default: false
   fast: true
 

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -5,8 +5,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/exitcodes"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 )
@@ -29,9 +31,12 @@ func (e *Executor) initConfig() {
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run:               e.executePathCmd,
 	}
+
 	fs := pathCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
-	e.initConfigFileFlagSet(fs, &e.cfg.Run)
+
+	initConfigFileFlagSet(fs, &e.cfg.Run)
+
 	cmd.AddCommand(pathCmd)
 }
 
@@ -60,4 +65,9 @@ func (e *Executor) executePathCmd(_ *cobra.Command, _ []string) {
 	}
 
 	fmt.Println(usedConfigFile)
+}
+
+func initConfigFileFlagSet(fs *pflag.FlagSet, cfg *config.Run) {
+	fs.StringVarP(&cfg.Config, "config", "c", "", wh("Read config from file path `PATH`"))
+	fs.BoolVar(&cfg.NoConfig, "no-config", false, wh("Don't read config file"))
 }

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -14,7 +14,7 @@ import (
 func (e *Executor) initConfig() {
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Config",
+		Short: "Config file information",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
@@ -29,7 +29,9 @@ func (e *Executor) initConfig() {
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run:               e.executePathCmd,
 	}
-	e.initRunConfiguration(pathCmd) // allow --config
+	fs := pathCmd.Flags()
+	fs.SortFlags = false // sort them as they are defined here
+	e.initConfigFileFlagSet(fs, &e.cfg.Run)
 	cmd.AddCommand(pathCmd)
 }
 

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -2,10 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 )
 
@@ -17,11 +20,25 @@ func (e *Executor) initLinters() {
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              e.executeLinters,
 	}
+
 	fs := e.lintersCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
-	e.initConfigFileFlagSet(fs, &e.cfg.Run)
+
+	initConfigFileFlagSet(fs, &e.cfg.Run)
 	e.initLintersFlagSet(fs, &e.cfg.Linters)
+
 	e.rootCmd.AddCommand(e.lintersCmd)
+}
+
+func (e *Executor) initLintersFlagSet(fs *pflag.FlagSet, cfg *config.Linters) {
+	fs.StringSliceVarP(&cfg.Disable, "disable", "D", nil, wh("Disable specific linter"))
+	fs.BoolVar(&cfg.DisableAll, "disable-all", false, wh("Disable all linters"))
+	fs.StringSliceVarP(&cfg.Enable, "enable", "E", nil, wh("Enable specific linter"))
+	fs.BoolVar(&cfg.EnableAll, "enable-all", false, wh("Enable all linters"))
+	fs.BoolVar(&cfg.Fast, "fast", false, wh("Enable only fast linters from enabled linters set (first run won't be fast)"))
+	fs.StringSliceVarP(&cfg.Presets, "presets", "p", nil,
+		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
+			"them. This option implies option --disable-all", strings.Join(e.DBManager.AllPresets(), "|"))))
 }
 
 // executeLinters runs the 'linters' CLI command, which displays the supported linters.
@@ -46,14 +63,9 @@ func (e *Executor) executeLinters(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	enabledBy := "your configuration"
-	if e.cfg.Run.NoConfig {
-		enabledBy = "default"
-	}
-
-	color.Green("Enabled by %v linters:\n", enabledBy)
+	color.Green("Enabled by your configuration linters:\n")
 	printLinterConfigs(enabledLinters)
-	color.Red("\nDisabled by %v linters:\n", enabledBy)
+	color.Red("\nDisabled by your configuration linters:\n")
 	printLinterConfigs(disabledLCs)
 
 	return nil

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -20,6 +20,7 @@ func (e *Executor) initLinters() {
 	fs := e.lintersCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
 	e.initConfigFileFlagSet(fs, &e.cfg.Run)
+	e.initLintersFlagSet(fs, &e.cfg.Linters)
 	e.rootCmd.AddCommand(e.lintersCmd)
 }
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -63,8 +63,13 @@ func wh(text string) string {
 
 const defaultTimeout = time.Minute
 
+func (e *Executor) initConfigFileFlagSet(fs *pflag.FlagSet, cfg *config.Run) {
+	fs.StringVarP(&cfg.Config, "config", "c", "", wh("Read config from file path `PATH`"))
+	fs.BoolVar(&cfg.NoConfig, "no-config", false, wh("Don't read config file"))
+}
+
 //nolint:funlen,gomnd
-func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, isFinalInit bool) {
+func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config, isFinalInit bool) {
 	hideFlag := func(name string) {
 		if err := fs.MarkHidden(name); err != nil {
 			panic(err)
@@ -78,6 +83,10 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 			}
 		}
 	}
+
+	// Config file config
+	rc := &cfg.Run
+	e.initConfigFileFlagSet(fs, rc)
 
 	// Output config
 	oc := &cfg.Output
@@ -98,7 +107,6 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	}
 
 	// Run config
-	rc := &cfg.Run
 	fs.StringVar(&rc.ModulesDownloadMode, "modules-download-mode", "",
 		wh("Modules download mode. If not empty, passed as -mod=<mode> to go tools"))
 	fs.IntVar(&rc.ExitCodeIfIssuesFound, "issues-exit-code",
@@ -115,8 +123,6 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.BoolVar(&rc.AnalyzeTests, "tests", true, wh("Analyze tests (*_test.go)"))
 	fs.BoolVar(&rc.PrintResourcesUsage, "print-resources-usage", false,
 		wh("Print avg and max memory usage of golangci-lint and total time"))
-	fs.StringVarP(&rc.Config, "config", "c", "", wh("Read config from file path `PATH`"))
-	fs.BoolVar(&rc.NoConfig, "no-config", false, wh("Don't read config"))
 	fs.StringSliceVar(&rc.SkipDirs, "skip-dirs", nil, wh("Regexps of directories to skip"))
 	fs.BoolVar(&rc.UseDefaultSkipDirs, "skip-dirs-use-default", true, getDefaultDirectoryExcludeHelp())
 	fs.StringSliceVar(&rc.SkipFiles, "skip-files", nil, wh("Regexps of files to skip"))
@@ -207,7 +213,7 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.BoolVar(&lc.DisableAll, "disable-all", false, wh("Disable all linters"))
 	fs.StringSliceVarP(&lc.Presets, "presets", "p", nil,
 		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
-			"them. This option implies option --disable-all", strings.Join(m.AllPresets(), "|"))))
+			"them. This option implies option --disable-all", strings.Join(e.DBManager.AllPresets(), "|"))))
 	fs.BoolVar(&lc.Fast, "fast", false, wh("Run only fast linters from enabled linters set (first run won't be fast)"))
 
 	// Issues config
@@ -241,7 +247,7 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 func (e *Executor) initRunConfiguration(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
-	initFlagSet(fs, e.cfg, e.DBManager, true)
+	e.initFlagSet(fs, e.cfg, true)
 }
 
 func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
@@ -254,7 +260,7 @@ func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
 	// `changed` variable inside string slice vars will be shared.
 	// Use another config variable here, not e.cfg, to not
 	// affect main parsing by this parsing of only config option.
-	initFlagSet(fs, &cfg, e.DBManager, false)
+	e.initFlagSet(fs, &cfg, false)
 	initVersionFlagSet(fs, &cfg)
 
 	// Parse max options, even force version option: don't want

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -29,55 +29,14 @@ import (
 
 const defaultFileMode = 0644
 
+const defaultTimeout = time.Minute
+
 const (
 	// envFailOnWarnings value: "1"
 	envFailOnWarnings = "FAIL_ON_WARNINGS"
 	// envMemLogEvery value: "1"
 	envMemLogEvery = "GL_MEM_LOG_EVERY"
 )
-
-func getDefaultIssueExcludeHelp() string {
-	parts := []string{color.GreenString("Use or not use default excludes:")}
-	for _, ep := range config.DefaultExcludePatterns {
-		parts = append(parts,
-			fmt.Sprintf("  # %s %s: %s", ep.ID, ep.Linter, ep.Why),
-			fmt.Sprintf("  - %s", color.YellowString(ep.Pattern)),
-			"",
-		)
-	}
-	return strings.Join(parts, "\n")
-}
-
-func getDefaultDirectoryExcludeHelp() string {
-	parts := []string{color.GreenString("Use or not use default excluded directories:")}
-	for _, dir := range packages.StdExcludeDirRegexps {
-		parts = append(parts, fmt.Sprintf("  - %s", color.YellowString(dir)))
-	}
-	parts = append(parts, "")
-	return strings.Join(parts, "\n")
-}
-
-func wh(text string) string {
-	return color.GreenString(text)
-}
-
-const defaultTimeout = time.Minute
-
-func (e *Executor) initConfigFileFlagSet(fs *pflag.FlagSet, cfg *config.Run) {
-	fs.StringVarP(&cfg.Config, "config", "c", "", wh("Read config from file path `PATH`"))
-	fs.BoolVar(&cfg.NoConfig, "no-config", false, wh("Don't read config file"))
-}
-
-func (e *Executor) initLintersFlagSet(fs *pflag.FlagSet, cfg *config.Linters) {
-	fs.StringSliceVarP(&cfg.Disable, "disable", "D", nil, wh("Disable specific linter"))
-	fs.BoolVar(&cfg.DisableAll, "disable-all", false, wh("Disable all linters"))
-	fs.StringSliceVarP(&cfg.Enable, "enable", "E", nil, wh("Enable specific linter"))
-	fs.BoolVar(&cfg.EnableAll, "enable-all", false, wh("Enable all linters"))
-	fs.BoolVar(&cfg.Fast, "fast", false, wh("Enable only fast linters from enabled linters set (first run won't be fast)"))
-	fs.StringSliceVarP(&cfg.Presets, "presets", "p", nil,
-		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
-			"them. This option implies option --disable-all", strings.Join(e.DBManager.AllPresets(), "|"))))
-}
 
 //nolint:funlen,gomnd
 func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config, isFinalInit bool) {
@@ -97,7 +56,7 @@ func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config, isFinalIni
 
 	// Config file config
 	rc := &cfg.Run
-	e.initConfigFileFlagSet(fs, rc)
+	initConfigFileFlagSet(fs, rc)
 
 	// Output config
 	oc := &cfg.Output
@@ -647,4 +606,29 @@ func watchResources(ctx context.Context, done chan struct{}, logger logutils.Log
 		iterationsCount, avgRSSMB, maxRSSMB)
 	logger.Infof("Execution took %s", time.Since(startedAt))
 	close(done)
+}
+
+func getDefaultIssueExcludeHelp() string {
+	parts := []string{color.GreenString("Use or not use default excludes:")}
+	for _, ep := range config.DefaultExcludePatterns {
+		parts = append(parts,
+			fmt.Sprintf("  # %s %s: %s", ep.ID, ep.Linter, ep.Why),
+			fmt.Sprintf("  - %s", color.YellowString(ep.Pattern)),
+			"",
+		)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func getDefaultDirectoryExcludeHelp() string {
+	parts := []string{color.GreenString("Use or not use default excluded directories:")}
+	for _, dir := range packages.StdExcludeDirRegexps {
+		parts = append(parts, fmt.Sprintf("  - %s", color.YellowString(dir)))
+	}
+	parts = append(parts, "")
+	return strings.Join(parts, "\n")
+}
+
+func wh(text string) string {
+	return color.GreenString(text)
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -68,6 +68,17 @@ func (e *Executor) initConfigFileFlagSet(fs *pflag.FlagSet, cfg *config.Run) {
 	fs.BoolVar(&cfg.NoConfig, "no-config", false, wh("Don't read config file"))
 }
 
+func (e *Executor) initLintersFlagSet(fs *pflag.FlagSet, cfg *config.Linters) {
+	fs.StringSliceVarP(&cfg.Disable, "disable", "D", nil, wh("Disable specific linter"))
+	fs.BoolVar(&cfg.DisableAll, "disable-all", false, wh("Disable all linters"))
+	fs.StringSliceVarP(&cfg.Enable, "enable", "E", nil, wh("Enable specific linter"))
+	fs.BoolVar(&cfg.EnableAll, "enable-all", false, wh("Enable all linters"))
+	fs.BoolVar(&cfg.Fast, "fast", false, wh("Enable only fast linters from enabled linters set (first run won't be fast)"))
+	fs.StringSliceVarP(&cfg.Presets, "presets", "p", nil,
+		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
+			"them. This option implies option --disable-all", strings.Join(e.DBManager.AllPresets(), "|"))))
+}
+
 //nolint:funlen,gomnd
 func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config, isFinalInit bool) {
 	hideFlag := func(name string) {
@@ -206,15 +217,7 @@ func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config, isFinalIni
 
 	// Linters config
 	lc := &cfg.Linters
-	fs.StringSliceVarP(&lc.Enable, "enable", "E", nil, wh("Enable specific linter"))
-	fs.StringSliceVarP(&lc.Disable, "disable", "D", nil, wh("Disable specific linter"))
-	fs.BoolVar(&lc.EnableAll, "enable-all", false, wh("Enable all linters"))
-
-	fs.BoolVar(&lc.DisableAll, "disable-all", false, wh("Disable all linters"))
-	fs.StringSliceVarP(&lc.Presets, "presets", "p", nil,
-		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
-			"them. This option implies option --disable-all", strings.Join(e.DBManager.AllPresets(), "|"))))
-	fs.BoolVar(&lc.Fast, "fast", false, wh("Run only fast linters from enabled linters set (first run won't be fast)"))
+	e.initLintersFlagSet(fs, lc)
 
 	// Issues config
 	ic := &cfg.Issues

--- a/test/testshared/runner.go
+++ b/test/testshared/runner.go
@@ -163,7 +163,7 @@ func (b *RunnerBuilder) Runner() *Runner {
 		b.tb.Fatal("--no-config and -c cannot be used at the same time")
 	}
 
-	arguments := []string{}
+	var arguments []string
 
 	if b.command == "run" {
 		arguments = append(arguments, "--internal-cmd-test")

--- a/test/testshared/runner.go
+++ b/test/testshared/runner.go
@@ -163,12 +163,13 @@ func (b *RunnerBuilder) Runner() *Runner {
 		b.tb.Fatal("--no-config and -c cannot be used at the same time")
 	}
 
-	arguments := []string{
-		"--internal-cmd-test",
-	}
+	arguments := []string{}
 
-	if b.allowParallelRunners {
-		arguments = append(arguments, "--allow-parallel-runners")
+	if b.command == "run" {
+		arguments = append(arguments, "--internal-cmd-test")
+		if b.allowParallelRunners {
+			arguments = append(arguments, "--allow-parallel-runners")
+		}
 	}
 
 	if b.noConfig {

--- a/test/testshared/runner_test.go
+++ b/test/testshared/runner_test.go
@@ -28,11 +28,20 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 			},
 		},
 		{
-			desc:    "with command",
+			desc:    "with non run command",
 			builder: NewRunnerBuilder(t).WithCommand("example"),
 			expected: &Runner{
 				env:     []string(nil),
 				command: "example",
+				args:    []string{},
+			},
+		},
+		{
+			desc:    "with run command",
+			builder: NewRunnerBuilder(t).WithCommand("run"),
+			expected: &Runner{
+				env:     []string(nil),
+				command: "run",
 				args: []string{
 					"--internal-cmd-test",
 					"--allow-parallel-runners",

--- a/test/testshared/runner_test.go
+++ b/test/testshared/runner_test.go
@@ -33,7 +33,6 @@ func TestRunnerBuilder_Runner(t *testing.T) {
 			expected: &Runner{
 				env:     []string(nil),
 				command: "example",
-				args:    []string{},
 			},
 		},
 		{


### PR DESCRIPTION
`config` and `linters` command would present all flags from `run` command to users. This PR removes unnecessary flags from those commands.