### PR TITLE
feat: Documentation reference check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -129,3 +129,20 @@ jobs:
         env:
           # needed for github-action-config.json generation
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
+          go-version: ${{ env.GO_VERSION }}
+      - name: Check if documentation reference is up to date
+        run: HELP_RUN=2 go run cmd/golangci-lint/main.go -c .golangci.reference.yml

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -70,10 +70,22 @@ run:
   # Default: false
   allow-parallel-runners: false
 
+  # Allow multiple golangci-lint instances running, but serialize them around a lock.
+  # If false, golangci-lint exits with an error if it fails to acquire file lock on start.
+  # Default: false
+  allow-serial-runners: true
+
+  # Print avg and max memory usage of golangci-lint and total time.
+  # Default: false
+  print-resources-usage: true
+
   # Define the Go version limit.
   # Mainly related to generics support since go1.18.
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
   go: '1.19'
+
+  # Deprecated: use Timeout instead.
+  deadline: 5m
 
 
 # output configuration options
@@ -659,6 +671,8 @@ linters-settings:
     # Check that each sentence starts with a capital letter.
     # Default: false
     capital: true
+    # Deprecated: use `Scope` instead
+    check-all: false
 
   godox:
     # Report any comments starting with keywords, this is useful for TODO or FIXME comments that
@@ -775,6 +789,10 @@ linters-settings:
     ignored-functions:
       - '^math\.'
       - '^http\.StatusText$'
+    # Deprecated
+    settings:
+      deprecated:
+        deprecated: do not use
 
   gomoddirectives:
     # Allow local `replace` directives.
@@ -1505,6 +1523,14 @@ linters-settings:
     # Default: 0.8
     confidence: 0.1
 
+    error-code: 1
+
+    warning-code: 0
+
+    directives:
+      name: example
+      severity: example
+
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
       - name: add-constant
@@ -2146,6 +2172,9 @@ linters-settings:
     # Default: false
     check-exported: true
 
+    # Deprecated: isn't supported anymore
+    algo: cha
+
   unused:
     # Mark all struct fields that have been written to as used.
     # Default: true
@@ -2313,6 +2342,9 @@ linters-settings:
     # This logic overrides force-err-cuddling among others.
     force-short-decl-cuddling: false
 
+  structcheck:
+    exported-fields: false
+
   # The custom section can be used to define linter plugins to be loaded at runtime.
   # See README documentation for more info.
   custom:
@@ -2327,6 +2359,8 @@ linters-settings:
       # Intended to point to the repo location of the linter.
       # Optional.
       original-url: github.com/golangci/example-linter
+
+      settings: symbol
 
 
 linters:
@@ -2697,6 +2731,10 @@ issues:
   # Fix found issues (if it's supported by the linter).
   # Default: false
   fix: true
+
+  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
+  # Default: false
+  whole-files: true
 
 
 severity:

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/golangci/misspell v0.4.1
 	github.com/golangci/revgrep v0.5.2
 	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4
+	github.com/google/go-cmp v0.6.0
 	github.com/gordonklaus/ineffassign v0.1.0
 	github.com/gostaticanalysis/forcetypeassert v0.1.0
 	github.com/gostaticanalysis/nilerr v0.1.1
@@ -151,7 +152,6 @@ require (
 	github.com/go-toolsmith/typep v1.1.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/gostaticanalysis/analysisutil v0.7.1 // indirect
 	github.com/gostaticanalysis/comment v1.4.2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -87,8 +87,8 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.BoolVar(&oc.UniqByLine, "uniq-by-line", true, wh("Make issues output unique by line"))
 	fs.BoolVar(&oc.SortResults, "sort-results", false, wh("Sort linter results"))
 	fs.BoolVar(&oc.PrintWelcomeMessage, "print-welcome", false, wh("Print welcome message"))
-	fs.StringVar(&oc.PathPrefix, "path-prefix", "", wh("Path prefix to add to output"))
 	hideFlag("print-welcome") // no longer used
+	fs.StringVar(&oc.PathPrefix, "path-prefix", "", wh("Path prefix to add to output"))
 
 	fs.BoolVar(&cfg.InternalCmdTest, "internal-cmd-test", false, wh("Option is used only for testing golangci-lint command, don't use it"))
 	if err := fs.MarkHidden("internal-cmd-test"); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,19 +10,19 @@ import (
 
 // Config encapsulates the config data specified in the golangci yaml config file.
 type Config struct {
-	cfgDir string // The directory containing the golangci config file.
-	Run    Run
-
-	Output Output
-
+	Run             Run `mapstructure:"run"`
+	Output          Output
 	LintersSettings LintersSettings `mapstructure:"linters-settings"`
 	Linters         Linters
 	Issues          Issues
 	Severity        Severity
-	Version         Version
 
-	InternalCmdTest bool `mapstructure:"internal-cmd-test"` // Option is used only for testing golangci-lint command, don't use it
-	InternalTest    bool // Option is used only for testing golangci-lint code, don't use it
+	InternalTest bool // Option is used only for testing golangci-lint code, don't use it
+
+	// Internal usage options, not available to users
+	cfgDir          string  `mapstructure:"-"` // The directory containing the golangci config file.
+	Version         Version `mapstructure:"-"`
+	InternalCmdTest bool    `mapstructure:"-"` // Option is used only for testing golangci-lint command, don't use it
 }
 
 // GetConfigDir returns the directory that contains golangci config file.

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -213,7 +213,7 @@ type LintersSettings struct {
 	GoModDirectives  GoModDirectivesSettings
 	Gomodguard       GoModGuardSettings
 	Gosec            GoSecSettings
-	Gosimple         StaticCheckSettings
+	Gosimple         CommonStaticCheckSettings
 	Gosmopolitan     GosmopolitanSettings
 	Govet            GovetSettings
 	Grouper          GrouperSettings
@@ -245,7 +245,7 @@ type LintersSettings struct {
 	Revive           ReviveSettings
 	RowsErrCheck     RowsErrCheckSettings
 	SlogLint         SlogLintSettings
-	Staticcheck      StaticCheckSettings
+	Staticcheck      CommonStaticCheckSettings
 	Structcheck      StructCheckSettings
 	Stylecheck       StaticCheckSettings
 	TagAlign         TagAlignSettings
@@ -774,17 +774,34 @@ type SlogLintSettings struct {
 }
 
 type StaticCheckSettings struct {
+	CommonStaticCheckSettings `mapstructure:",squash"`
+	Initialisms               []string `mapstructure:"initialisms"`
+	DotImportWhitelist        []string `mapstructure:"dot-import-whitelist"`
+	HTTPStatusCodeWhitelist   []string `mapstructure:"http-status-code-whitelist"`
+}
+
+type CommonStaticCheckSettings struct {
 	// Deprecated: use the global `run.go` instead.
 	GoVersion string `mapstructure:"go"`
 
-	Checks                  []string `mapstructure:"checks"`
-	Initialisms             []string `mapstructure:"initialisms"`                // only for stylecheck
-	DotImportWhitelist      []string `mapstructure:"dot-import-whitelist"`       // only for stylecheck
-	HTTPStatusCodeWhitelist []string `mapstructure:"http-status-code-whitelist"` // only for stylecheck
+	Checks []string `mapstructure:"checks"`
 }
 
 func (s *StaticCheckSettings) HasConfiguration() bool {
 	return len(s.Initialisms) > 0 || len(s.HTTPStatusCodeWhitelist) > 0 || len(s.DotImportWhitelist) > 0 || len(s.Checks) > 0
+}
+
+func (s *CommonStaticCheckSettings) GetGoVersion() string {
+	var goVersion string
+	if s != nil {
+		goVersion = s.GoVersion
+	}
+
+	if goVersion != "" {
+		return goVersion
+	}
+
+	return "1.17"
 }
 
 type StructCheckSettings struct {
@@ -863,7 +880,9 @@ type UseStdlibVarsSettings struct {
 
 type UnparamSettings struct {
 	CheckExported bool `mapstructure:"check-exported"`
-	Algo          string
+
+	// Deprecated
+	Algo string
 }
 
 type UnusedSettings struct {
@@ -938,7 +957,6 @@ type CustomLinterSettings struct {
 	Description string
 	// OriginalURL The URL containing the source code for the private linter.
 	OriginalURL string `mapstructure:"original-url"`
-
 	// Settings plugin settings only work with linterdb.PluginConstructor symbol.
 	Settings any
 }

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -28,14 +28,14 @@ var OutFormats = []string{
 }
 
 type Output struct {
-	Format              string
-	PrintIssuedLine     bool   `mapstructure:"print-issued-lines"`
-	PrintLinterName     bool   `mapstructure:"print-linter-name"`
-	UniqByLine          bool   `mapstructure:"uniq-by-line"`
-	SortResults         bool   `mapstructure:"sort-results"`
-	PrintWelcomeMessage bool   `mapstructure:"print-welcome"`
-	PathPrefix          string `mapstructure:"path-prefix"`
+	Format          string
+	PrintIssuedLine bool   `mapstructure:"print-issued-lines"`
+	PrintLinterName bool   `mapstructure:"print-linter-name"`
+	UniqByLine      bool   `mapstructure:"uniq-by-line"`
+	SortResults     bool   `mapstructure:"sort-results"`
+	PathPrefix      string `mapstructure:"path-prefix"`
 
-	// only work with CLI flags because the setup of logs is done before the config file parsing.
-	Color string
+	// Internal usage options, not available to users
+	PrintWelcomeMessage bool   `mapstructure:"-"`
+	Color               string `mapstructure:"-"`
 }

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -4,37 +4,32 @@ import "time"
 
 // Run encapsulates the config options for running the linter analysis.
 type Run struct {
-	IsVerbose           bool `mapstructure:"verbose"`
-	Silent              bool
-	CPUProfilePath      string
-	MemProfilePath      string
-	TracePath           string
-	Concurrency         int
-	PrintResourcesUsage bool `mapstructure:"print-resources-usage"`
-
-	Config   string // The path to the golangci config file, as specified with the --config argument.
-	NoConfig bool
-
-	Args []string
-
-	Go string `mapstructure:"go"`
-
-	BuildTags           []string `mapstructure:"build-tags"`
-	ModulesDownloadMode string   `mapstructure:"modules-download-mode"`
-
-	ExitCodeIfIssuesFound int  `mapstructure:"issues-exit-code"`
-	AnalyzeTests          bool `mapstructure:"tests"`
+	Concurrency           int
+	PrintResourcesUsage   bool     `mapstructure:"print-resources-usage"`
+	Go                    string   `mapstructure:"go"`
+	BuildTags             []string `mapstructure:"build-tags"`
+	ModulesDownloadMode   string   `mapstructure:"modules-download-mode"`
+	ExitCodeIfIssuesFound int      `mapstructure:"issues-exit-code"`
+	AnalyzeTests          bool     `mapstructure:"tests"`
+	Timeout               time.Duration
+	SkipFiles             []string `mapstructure:"skip-files"`
+	SkipDirs              []string `mapstructure:"skip-dirs"`
+	UseDefaultSkipDirs    bool     `mapstructure:"skip-dirs-use-default"`
+	AllowParallelRunners  bool     `mapstructure:"allow-parallel-runners"`
+	AllowSerialRunners    bool     `mapstructure:"allow-serial-runners"`
 
 	// Deprecated: Deadline exists for historical compatibility
 	// and should not be used. To set run timeout use Timeout instead.
 	Deadline time.Duration
-	Timeout  time.Duration
 
-	PrintVersion       bool
-	SkipFiles          []string `mapstructure:"skip-files"`
-	SkipDirs           []string `mapstructure:"skip-dirs"`
-	UseDefaultSkipDirs bool     `mapstructure:"skip-dirs-use-default"`
-
-	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
-	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
+	// Internal usage options, not available to users
+	Config         string   `mapstructure:"-"` // The path to the golangci config file, as specified with the --config argument.
+	NoConfig       bool     `mapstructure:"-"`
+	IsVerbose      bool     `mapstructure:"-"`
+	CPUProfilePath string   `mapstructure:"-"`
+	MemProfilePath string   `mapstructure:"-"`
+	TracePath      string   `mapstructure:"-"`
+	Args           []string `mapstructure:"-"`
+	Silent         bool     `mapstructure:"-"`
+	PrintVersion   bool     `mapstructure:"-"`
 }

--- a/pkg/golinters/gosimple.go
+++ b/pkg/golinters/gosimple.go
@@ -7,10 +7,10 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-func NewGosimple(settings *config.StaticCheckSettings) *goanalysis.Linter {
-	cfg := staticCheckConfig(settings)
+func NewGosimple(settings *config.CommonStaticCheckSettings) *goanalysis.Linter {
+	cfg := commonStaticCheckConfig(settings)
 
-	analyzers := setupStaticCheckAnalyzers(simple.Analyzers, getGoVersion(settings), cfg.Checks)
+	analyzers := setupStaticCheckAnalyzers(simple.Analyzers, settings.GetGoVersion(), cfg.Checks)
 
 	return goanalysis.NewLinter(
 		"gosimple",

--- a/pkg/golinters/staticcheck.go
+++ b/pkg/golinters/staticcheck.go
@@ -7,9 +7,9 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-func NewStaticcheck(settings *config.StaticCheckSettings) *goanalysis.Linter {
-	cfg := staticCheckConfig(settings)
-	analyzers := setupStaticCheckAnalyzers(staticcheck.Analyzers, getGoVersion(settings), cfg.Checks)
+func NewStaticcheck(settings *config.CommonStaticCheckSettings) *goanalysis.Linter {
+	cfg := commonStaticCheckConfig(settings)
+	analyzers := setupStaticCheckAnalyzers(staticcheck.Analyzers, settings.GetGoVersion(), cfg.Checks)
 
 	return goanalysis.NewLinter(
 		"staticcheck",

--- a/pkg/golinters/staticcheck_common.go
+++ b/pkg/golinters/staticcheck_common.go
@@ -54,6 +54,24 @@ func setAnalyzerGoVersion(a *analysis.Analyzer, goVersion string) {
 	}
 }
 
+func commonStaticCheckConfig(settings *config.CommonStaticCheckSettings) *scconfig.Config {
+	var cfg *scconfig.Config
+
+	if settings == nil || len(settings.Checks) == 0 {
+		return &scconfig.Config{
+			Checks: []string{"*"}, // override for compatibility reason. Must drop in the next major version.
+		}
+	}
+
+	cfg = &scconfig.Config{
+		Checks: settings.Checks,
+	}
+
+	cfg.Checks = normalizeList(cfg.Checks)
+
+	return cfg
+}
+
 func staticCheckConfig(settings *config.StaticCheckSettings) *scconfig.Config {
 	var cfg *scconfig.Config
 

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -99,7 +99,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		goModDirectivesCfg  *config.GoModDirectivesSettings
 		gomodguardCfg       *config.GoModGuardSettings
 		gosecCfg            *config.GoSecSettings
-		gosimpleCfg         *config.StaticCheckSettings
+		gosimpleCfg         *config.CommonStaticCheckSettings
 		gosmopolitanCfg     *config.GosmopolitanSettings
 		govetCfg            *config.GovetSettings
 		grouperCfg          *config.GrouperSettings
@@ -131,7 +131,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		reviveCfg           *config.ReviveSettings
 		rowserrcheckCfg     *config.RowsErrCheckSettings
 		sloglintCfg         *config.SlogLintSettings
-		staticcheckCfg      *config.StaticCheckSettings
+		staticcheckCfg      *config.CommonStaticCheckSettings
 		structcheckCfg      *config.StructCheckSettings
 		stylecheckCfg       *config.StaticCheckSettings
 		tagalignCfg         *config.TagAlignSettings
@@ -868,7 +868,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/mvdan/unparam"),
 
-		linter.NewConfig(golinters.NewUnused(unusedCfg, staticcheckCfg)).
+		linter.NewConfig(golinters.NewUnused(unusedCfg, stylecheckCfg)).
 			WithEnabledByDefault().
 			WithSince("v1.20.0").
 			WithLoadForGoAnalysis().

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -475,7 +475,6 @@ func TestConfigFileIsDetected(t *testing.T) {
 			t.Parallel()
 
 			testshared.NewRunnerBuilder(t).
-				// WithNoConfig().
 				WithTargetPath(test.targetPath).
 				Runner().
 				Run().

--- a/test/testdata/configs/importas_noalias.yml
+++ b/test/testdata/configs/importas_noalias.yml
@@ -1,4 +1,3 @@
 linters-settings:
   importas:
-    fff: fmt
-    std_os: os
+    alias: []

--- a/test/testdata_etc/unused_exported/golangci.yml
+++ b/test/testdata_etc/unused_exported/golangci.yml
@@ -4,4 +4,4 @@ linters:
     - unused
 linters-settings:
   unused:
-    check-exported: true
+    exported-is-used: true


### PR DESCRIPTION
Add documentation reference check to CI. This allows `.golangci.reference.yml` file to be always up to date with code.

Related to https://github.com/golangci/golangci-lint/issues/2645