### PR TITLE
dev: replace hashicorp/go-multierror with errors.Join

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/gordonklaus/ineffassign v0.1.0
 	github.com/gostaticanalysis/forcetypeassert v0.1.0
 	github.com/gostaticanalysis/nilerr v0.1.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/jgautheron/goconst v1.7.0
@@ -154,7 +153,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/gostaticanalysis/analysisutil v0.7.1 // indirect
 	github.com/gostaticanalysis/comment v1.4.2 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kisielk/gotool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,10 +291,6 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/pkg/golinters/goanalysis/runner_action.go
+++ b/pkg/golinters/goanalysis/runner_action.go
@@ -9,7 +9,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/types/objectpath"
@@ -126,20 +125,16 @@ func (act *action) analyze() {
 	}(time.Now())
 
 	// Report an error if any dependency failures.
-	var depErrors *multierror.Error
+	var depErrors error
 	for _, dep := range act.deps {
 		if dep.err == nil {
 			continue
 		}
 
-		depErrors = multierror.Append(depErrors, errors.Unwrap(dep.err))
+		depErrors = errors.Join(depErrors, errors.Unwrap(dep.err))
 	}
 	if depErrors != nil {
-		depErrors.ErrorFormat = func(e []error) string {
-			return fmt.Sprintf("failed prerequisites: %v", e)
-		}
-
-		act.err = depErrors
+		act.err = fmt.Errorf("failed prerequisites: %v", depErrors)
 		return
 	}
 

--- a/pkg/golinters/goanalysis/runner_action.go
+++ b/pkg/golinters/goanalysis/runner_action.go
@@ -134,7 +134,7 @@ func (act *action) analyze() {
 		depErrors = errors.Join(depErrors, errors.Unwrap(dep.err))
 	}
 	if depErrors != nil {
-		act.err = fmt.Errorf("failed prerequisites: %v", depErrors)
+		act.err = fmt.Errorf("failed prerequisites: %w", depErrors)
 		return
 	}
 

--- a/pkg/lint/lintersdb/custom_linters.go
+++ b/pkg/lint/lintersdb/custom_linters.go
@@ -1,12 +1,12 @@
 package lintersdb
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"plugin"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/viper"
 	"golang.org/x/tools/go/analysis"
 
@@ -94,8 +94,7 @@ func (m *Manager) lookupPlugin(plug *plugin.Plugin, settings any) ([]*analysis.A
 	if err != nil {
 		analyzers, errP := m.lookupAnalyzerPlugin(plug)
 		if errP != nil {
-			// TODO(ldez): use `errors.Join` when we will upgrade to go1.20.
-			return nil, multierror.Append(err, errP)
+			return nil, errors.Join(err, errP)
 		}
 
 		return analyzers, nil

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -2,11 +2,11 @@ package lint
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	gopackages "golang.org/x/tools/go/packages"
 
 	"github.com/golangci/golangci-lint/internal/errorutil"
@@ -205,7 +205,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 	defer sw.Print()
 
 	var (
-		lintErrors *multierror.Error
+		lintErrors error
 		issues     []result.Issue
 	)
 
@@ -214,7 +214,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 		sw.TrackStage(lc.Name(), func() {
 			linterIssues, err := r.runLinterSafe(ctx, lintCtx, lc)
 			if err != nil {
-				lintErrors = multierror.Append(lintErrors, fmt.Errorf("can't run linter %s: %w", lc.Linter.Name(), err))
+				lintErrors = errors.Join(lintErrors, fmt.Errorf("can't run linter %s: %w", lc.Linter.Name(), err))
 				r.Log.Warnf("Can't run linter %s: %v", lc.Linter.Name(), err)
 
 				return
@@ -224,7 +224,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 		})
 	}
 
-	return r.processLintResults(issues), lintErrors.ErrorOrNil()
+	return r.processLintResults(issues), lintErrors
 }
 
 func (r *Runner) processIssues(issues []result.Issue, sw *timeutils.Stopwatch, statPerProcessor map[string]processorStat) []result.Issue {

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -214,7 +214,7 @@ func (r Runner) Run(ctx context.Context, linters []*linter.Config, lintCtx *lint
 		sw.TrackStage(lc.Name(), func() {
 			linterIssues, err := r.runLinterSafe(ctx, lintCtx, lc)
 			if err != nil {
-				lintErrors = errors.Join(lintErrors, fmt.Errorf("can't run linter %s: %w", lc.Linter.Name(), err))
+				lintErrors = errors.Join(lintErrors, fmt.Errorf("can't run linter %s", lc.Linter.Name()), err)
 				r.Log.Warnf("Can't run linter %s: %v", lc.Linter.Name(), err)
 
 				return


### PR DESCRIPTION
This PR replaces [github.com/hashicorp/go-multierror](https://pkg.go.dev/github.com/hashicorp/go-multierror) package with the native [joining errors](https://pkg.go.dev/errors#Join) mechanism.