### PR TITLE
Restore noctx description

### DIFF
--- a/pkg/golinters/noctx.go
+++ b/pkg/golinters/noctx.go
@@ -12,7 +12,7 @@ func NewNoctx() *goanalysis.Linter {
 
 	return goanalysis.NewLinter(
 		a.Name,
-		"Detects test helpers which is not start with t.Helper() method",
+		"noctx finds sending http request without context.Context",
 		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)


### PR DESCRIPTION
Looks like it there has been simple typo here: https://github.com/golangci/golangci-lint/commit/ce020c6be1b8f9da457436fa9b85f7f54f8107b7#diff-9adfeb0bdfaa45d88753221c60cd26def0b538e67d1763cbfec7b64b28539068L13