### PR TITLE
docs: fix grammar

### DIFF
--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -29,7 +29,7 @@ Config options inside the file are identical to command-line options.
 You can configure specific linters' options only within the config file (not the command-line).
 
 There is a [`.golangci.reference.yml`](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml) file with all supported options, their description, and default values.
-This file is a neither a working example nor recommended configuration, it's just a reference to display all the configuration options.
+This file is neither a working example nor a recommended configuration, it's just a reference to display all the configuration options.
 
 { .ConfigurationExample }
 


### PR DESCRIPTION
This is just a simple grammatical fix, which could have been a mishandled merge conflict. Either way, its pretty trivial. 

Fixes #4301