### PR TITLE
Improve `typecheck` docs

### DIFF
--- a/docs/src/docs/usage/faq.mdx
+++ b/docs/src/docs/usage/faq.mdx
@@ -49,5 +49,6 @@ How to troubleshoot:
 
 - [ ] Ensure the version of `golangci-lint` is built with a compatible version of Go.
 - [ ] Ensure dependencies are up-to-date with `go mod tidy`.
+- [ ] Ensure you're linting packages and not single files. I.e. `golangci-lint run ./path/to/pkg` (or `./...`), **not** `./path/to/pkg/file.go`.
 - [ ] Ensure building works with `go run ./...`/`go build ./...` - whole package.
 - [ ] If using CGO, ensure all require system libraries are installed.


### PR DESCRIPTION
Add a step in the troubleshooting guide to ensure users are not linting individual files. Even though this _might_ work, it's often the root cause of `typecheck` reports when the package consists of multiple files.

---

This seems to be a common mistake and mentioned in https://github.com/golangci/golangci-lint/discussions/3759. This step ensures users targeting single files tries to lint the whole package first (and not necessarily `./...`).