### PR TITLE
docs: improve typecheck FAQ

### DIFF
--- a/docs/src/docs/usage/faq.mdx
+++ b/docs/src/docs/usage/faq.mdx
@@ -45,7 +45,7 @@ It cannot be disabled because of that.
 
 Of course, this is just as good as the compiler itself and a lot of compilation issues will not properly show where in the code your error lies.
 
-As consequence, the code to analyze should compile.
+As a consequence, the code to analyze should compile.
 It means that if you try to run an analysis on a single file or a group of files or a package or a group of packages,
 with dependencies on other files or packages of your project, as it doesn't compile (because of the missing pieces of code),
 it also cannot be analyzed.

--- a/docs/src/docs/usage/faq.mdx
+++ b/docs/src/docs/usage/faq.mdx
@@ -57,4 +57,5 @@ How to troubleshoot:
 - [ ] Ensure the version of `golangci-lint` is built with a compatible version of Go.
 - [ ] Ensure dependencies are up-to-date with `go mod tidy`.
 - [ ] Ensure building works with `go run ./...`/`go build ./...` - whole package.
+- [ ] Ensure you are not running an analysis on code that depends on files/packages outside the scope of the analyzed elements.
 - [ ] If using CGO, ensure all require system libraries are installed.

--- a/docs/src/docs/usage/faq.mdx
+++ b/docs/src/docs/usage/faq.mdx
@@ -35,15 +35,22 @@ Usually this options is used during development on local machine and compilation
 
 ## Why do you have `typecheck` errors?
 
-`typecheck` is like the front-end of a Go compiler, parses and type-checks Go code, it manages compilation errors.
+`typecheck` is like a front-end for the Go compiler errors.
+Compilation errors are identified/labeled as reports of `typecheck` but they are not produced by a linter called `typecheck`.
+
+`typecheck` is not a linter, it doesn't perform any analysis,
+it's just a way to identify, parse, and display compiling errors (produced by the `types.Checker`) and some linter errors.
 
 It cannot be disabled because of that.
 
 Of course, this is just as good as the compiler itself and a lot of compilation issues will not properly show where in the code your error lies.
 
-`typecheck` is not a real linter, it's just a way to parse compiling errors (produced by the `types.Checker`) and some linter errors.
+As consequence, the code to analyze should compile.
+It means that if you try to run an analysis on a single file or a group of files or a package or a group of packages,
+with dependencies on other files or packages of your project, as it doesn't compile (because of the missing pieces of code),
+it also cannot be analyzed.
 
-If there are `typecheck` errors, golangci-lint will not able to produce other reports because that kind of error doesn't allow it to perform analysis.
+If there are `typecheck` errors, golangci-lint will not able to produce other reports because that kind of error doesn't allow it to perform any analysis.
 
 How to troubleshoot:
 


### PR DESCRIPTION
rephrases the doc to try to be more clear about the nature of `typecheck`.