### PR TITLE
fix: parse Go RC version

### DIFF
--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -991,7 +991,7 @@ func trimGoVersion(v string) string {
 		return ""
 	}
 
-	exp := regexp.MustCompile(`(\d\.\d+)\.\d+`)
+	exp := regexp.MustCompile(`(\d\.\d+)(?:\.\d+|[a-z]+\d)`)
 
 	if exp.MatchString(v) {
 		return exp.FindStringSubmatch(v)[1]

--- a/pkg/lint/lintersdb/manager_test.go
+++ b/pkg/lint/lintersdb/manager_test.go
@@ -29,12 +29,12 @@ func Test_trimGoVersion(t *testing.T) {
 		},
 		{
 			desc:     "alpha version",
-			version:  "1.22beta1",
+			version:  "1.22alpha1",
 			expected: "1.22",
 		},
 		{
 			desc:     "beta version",
-			version:  "1.22alpha1",
+			version:  "1.22beta1",
 			expected: "1.22",
 		},
 		{

--- a/pkg/lint/lintersdb/manager_test.go
+++ b/pkg/lint/lintersdb/manager_test.go
@@ -1,0 +1,56 @@
+package lintersdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_trimGoVersion(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		version  string
+		expected string
+	}{
+		{
+			desc:     "patched version",
+			version:  "1.22.0",
+			expected: "1.22",
+		},
+		{
+			desc:     "minor version",
+			version:  "1.22",
+			expected: "1.22",
+		},
+		{
+			desc:     "RC version",
+			version:  "1.22rc1",
+			expected: "1.22",
+		},
+		{
+			desc:     "alpha version",
+			version:  "1.22beta1",
+			expected: "1.22",
+		},
+		{
+			desc:     "beta version",
+			version:  "1.22alpha1",
+			expected: "1.22",
+		},
+		{
+			desc:     "semver RC version",
+			version:  "1.22.0-rc1",
+			expected: "1.22",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			version := trimGoVersion(test.version)
+			assert.Equal(t, test.expected, version)
+		})
+	}
+}


### PR DESCRIPTION
Related to #3995

Fixes #4318
