### PR TITLE
feat: Add output option to group results by linter name

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -117,6 +117,10 @@ output:
   # Default: false
   sort-results: true
 
+  # Group results by linter name.
+  # Default: false
+  group-results-by-linter: false
+
 
 # All available settings of specific linters.
 linters-settings:

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -86,6 +86,7 @@ func initFlagSet(fs *pflag.FlagSet, cfg *config.Config, m *lintersdb.Manager, is
 	fs.BoolVar(&oc.PrintLinterName, "print-linter-name", true, wh("Print linter name in issue line"))
 	fs.BoolVar(&oc.UniqByLine, "uniq-by-line", true, wh("Make issues output unique by line"))
 	fs.BoolVar(&oc.SortResults, "sort-results", false, wh("Sort linter results"))
+	fs.BoolVar(&oc.GroupResultsByLinter, "group-results-by-linter", false, wh("Group results by linter name"))
 	fs.BoolVar(&oc.PrintWelcomeMessage, "print-welcome", false, wh("Print welcome message"))
 	fs.StringVar(&oc.PathPrefix, "path-prefix", "", wh("Path prefix to add to output"))
 	hideFlag("print-welcome") // no longer used

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -28,13 +28,14 @@ var OutFormats = []string{
 }
 
 type Output struct {
-	Format              string
-	PrintIssuedLine     bool   `mapstructure:"print-issued-lines"`
-	PrintLinterName     bool   `mapstructure:"print-linter-name"`
-	UniqByLine          bool   `mapstructure:"uniq-by-line"`
-	SortResults         bool   `mapstructure:"sort-results"`
-	PrintWelcomeMessage bool   `mapstructure:"print-welcome"`
-	PathPrefix          string `mapstructure:"path-prefix"`
+	Format               string
+	PrintIssuedLine      bool   `mapstructure:"print-issued-lines"`
+	PrintLinterName      bool   `mapstructure:"print-linter-name"`
+	UniqByLine           bool   `mapstructure:"uniq-by-line"`
+	SortResults          bool   `mapstructure:"sort-results"`
+	GroupResultsByLinter bool   `mapstructure:"group-results-by-linter"`
+	PrintWelcomeMessage  bool   `mapstructure:"print-welcome"`
+	PathPrefix           string `mapstructure:"path-prefix"`
 
 	// only work with CLI flags because the setup of logs is done before the config file parsing.
 	Color string

--- a/pkg/result/processors/sort_results_test.go
+++ b/pkg/result/processors/sort_results_test.go
@@ -14,6 +14,7 @@ import (
 
 var issues = []result.Issue{
 	{
+		FromLinter: "linter-a",
 		Pos: token.Position{
 			Filename: "file_windows.go",
 			Column:   80,
@@ -21,6 +22,7 @@ var issues = []result.Issue{
 		},
 	},
 	{
+		FromLinter: "linter-b",
 		Pos: token.Position{
 			Filename: "file_linux.go",
 			Column:   70,
@@ -28,12 +30,14 @@ var issues = []result.Issue{
 		},
 	},
 	{
+		FromLinter: "linter-a",
 		Pos: token.Position{
 			Filename: "file_darwin.go",
 			Line:     12,
 		},
 	},
 	{
+		FromLinter: "linter-b",
 		Pos: token.Position{
 			Filename: "file_darwin.go",
 			Column:   60,
@@ -174,4 +178,31 @@ func TestSorting(t *testing.T) {
 	results, err := sr.Process(tests)
 	require.NoError(t, err)
 	assert.Equal(t, []result.Issue{issues[3], issues[2], issues[1], issues[0]}, results)
+}
+
+func TestGroupingByLinterName(t *testing.T) {
+	var tests = make([]result.Issue, len(issues))
+	copy(tests, issues)
+
+	var cfg = config.Config{}
+	cfg.Output.GroupResultsByLinter = true
+	var sr = NewSortResults(&cfg)
+
+	results, err := sr.Process(tests)
+	require.NoError(t, err)
+	assert.Equal(t, []result.Issue{issues[0], issues[2], issues[1], issues[3]}, results)
+}
+
+func TestSortingAndGroupingByLinterName(t *testing.T) {
+	var tests = make([]result.Issue, len(issues))
+	copy(tests, issues)
+
+	var cfg = config.Config{}
+	cfg.Output.SortResults = true
+	cfg.Output.GroupResultsByLinter = true
+	var sr = NewSortResults(&cfg)
+
+	results, err := sr.Process(tests)
+	require.NoError(t, err)
+	assert.Equal(t, []result.Issue{issues[2], issues[0], issues[3], issues[1]}, results)
 }


### PR DESCRIPTION
Hi! Newbie to the project here, took a stab at trying to implement the enhancement from #4197.
Hope it makes sense to you to include the grouping code in the sorting processor (made sense to me since I wanted to preserve the eventual sorting within the linter 'group' - it could be done in a separate processor adding extra processing but keeping concerns apart, so I'm obviously open to suggestions!).