### PR TITLE
docs: adjust wrapcheck ignoreSigs to new defaults

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2281,11 +2281,12 @@ linters-settings:
     # An array of strings that specify substrings of signatures to ignore.
     # If this set, it will override the default set of ignored signatures.
     # See https://github.com/tomarrell/wrapcheck#configuration for more information.
-    # Default: [".Errorf(", "errors.New(", "errors.Unwrap(", ".Wrap(", ".Wrapf(", ".WithMessage(", ".WithMessagef(", ".WithStack("]
+    # Default: [".Errorf(", "errors.New(", "errors.Unwrap(", "errors.Join(", ".Wrap(", ".Wrapf(", ".WithMessage(", ".WithMessagef(", ".WithStack("]
     ignoreSigs:
       - .Errorf(
       - errors.New(
       - errors.Unwrap(
+      - errors.Join(
       - .Wrap(
       - .Wrapf(
       - .WithMessage(


### PR DESCRIPTION
This adds `errors.Join(` to the signatures ignored by default, which has been added to the wrapcheck linter in v2.8.0 a while ago. See https://github.com/tomarrell/wrapcheck/releases/tag/v2.8.0