### PR TITLE
dev: check go.sum is up to date

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Check go mod
         run: |
           go mod tidy
-          git diff --exit-code
+          git diff --exit-code go.mod
+          git diff --exit-code go.sum
 
   # We already run the current golangci-lint in tests, but here we test
   # our GitHub action with the latest stable golangci-lint.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check go mod
         run: |
           go mod tidy
-          git diff --exit-code go.mod
+          git diff --exit-code
 
   # We already run the current golangci-lint in tests, but here we test
   # our GitHub action with the latest stable golangci-lint.

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/Antonboom/errname v0.1.12 h1:oh9ak2zUtsLp5oaEd/erjB4GPu9w19NyoIskZClD
 github.com/Antonboom/errname v0.1.12/go.mod h1:bK7todrzvlaZoQagP1orKzWXv59X/x0W0Io2XT1Ssro=
 github.com/Antonboom/nilnil v0.1.7 h1:ofgL+BA7vlA1K2wNQOsHzLJ2Pw5B5DpWRLdDAVvvTow=
 github.com/Antonboom/nilnil v0.1.7/go.mod h1:TP+ScQWVEq0eSIxqU8CbdT5DFWoHp0MbP+KMUO1BKYQ=
-github.com/Antonboom/testifylint v1.0.2 h1:WkSc4c6AcYAPrSqj/3MYrewhszk+mnwd07acH1NL9Vw=
-github.com/Antonboom/testifylint v1.0.2/go.mod h1:tGEV9t6Th7DHXFVjd8oyLOBbIxXzs4CMEIAkbQ2RuC8=
 github.com/Antonboom/testifylint v1.1.0 h1:HrgwOEqVQc5eAsWEDA6JvK7ZSzfdTBjWt0PAYHweu+o=
 github.com/Antonboom/testifylint v1.1.0/go.mod h1:m62Du5rtu7uwrWsypuLPTVeKbTB3NZgPWrxfffu2r/8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=


### PR DESCRIPTION
The PR updates "Check go mod" action step to check also `go.sum`. This reverts #1397. Additionally, the PR cleans `go.sum`.