### PR TITLE
feat: implement stats per linter with a flag

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -84,6 +84,10 @@ run:
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
   go: '1.19'
 
+  # Show statistics per linter.
+  # Default: false
+  show-stats: true
+
 
 # output configuration options
 output:

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -494,14 +494,16 @@ func (e *Executor) createPrinter(format string, w io.Writer) (printers.Printer, 
 
 func (e *Executor) printStats(issues []result.Issue) {
 	if e.cfg.Run.ShowStatsPerLinter {
-		e.runCmd.Println("Stats per linter:")
 		stats := map[string]int{}
 		for idx := range issues {
 			stats[issues[idx].FromLinter]++
 		}
-
+		e.runCmd.Println("Stats per linter:")
 		for linter, count := range stats {
 			e.runCmd.Printf("  %s: %d\n", linter, count)
+		}
+		if len(stats) == 0 {
+			e.runCmd.Println("  no issues")
 		}
 	}
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -500,7 +500,7 @@ func (e *Executor) printStats(issues []result.Issue) {
 	}
 
 	if len(issues) == 0 {
-		e.runCmd.Println("0 report.")
+		e.runCmd.Println("0 issue.")
 		return
 	}
 
@@ -509,7 +509,7 @@ func (e *Executor) printStats(issues []result.Issue) {
 		stats[issues[idx].FromLinter]++
 	}
 
-	e.runCmd.Printf("%d reports:\n", len(issues))
+	e.runCmd.Printf("%d issues:\n", len(issues))
 
 	keys := maps.Keys(stats)
 	sort.Strings(keys)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -500,7 +500,7 @@ func (e *Executor) printStats(issues []result.Issue) {
 	}
 
 	if len(issues) == 0 {
-		e.runCmd.Println("0 issue.")
+		e.runCmd.Println("0 issues.")
 		return
 	}
 

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -38,5 +38,5 @@ type Run struct {
 	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
 	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
 
-	ShowStatsPerLinter bool `mapstructure:"show-stats-per-linter"`
+	ShowStats bool `mapstructure:"show-stats"`
 }

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -37,4 +37,6 @@ type Run struct {
 
 	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
 	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
+
+	ShowStatsPerLinter bool `mapstructure:"show-stats-per-linter"`
 }


### PR DESCRIPTION
In this PR I added a flag that enables basic stats collection and printing per linter using the `--show-stats-per-linter` flag to the `run` subcommand. This only prints the stats to the terminal after running all the linters.

**Note to the reviewers:**
I tried implementing it using `e.runAnalysis` to return the stats from the `run.Run`, yet it made things more complicated. I can still do it if you prefer that approach and I'd be happy to have your feedback. Also, I can either update the `printers.Print` interface to accept the stats or add a extra field (somewhere), so that the stats are printed based on the formatter used, and not just to the terminal.

Closes #2924.