### PR TITLE
`ireturn`:  Update for nolint instruction.

### DIFF
--- a/pkg/golinters/ireturn.go
+++ b/pkg/golinters/ireturn.go
@@ -16,8 +16,9 @@ func NewIreturn(settings *config.IreturnSettings) *goanalysis.Linter {
 	cfg := map[string]map[string]any{}
 	if settings != nil {
 		cfg[a.Name] = map[string]any{
-			"allow":  strings.Join(settings.Allow, ","),
-			"reject": strings.Join(settings.Reject, ","),
+			"allow":    strings.Join(settings.Allow, ","),
+			"reject":   strings.Join(settings.Reject, ","),
+			"nonolint": true,
 		}
 	}
 


### PR DESCRIPTION
- [x] Added instruction to not check `nolint` directive (already checked) by `golangci-lint` 
- [ ] @dependabot needs to update to last version (`ireturn@v0.3.0` )