### PR TITLE
revive: add exclude option

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1534,6 +1534,7 @@ linters-settings:
       - name: add-constant
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - maxLitCount: "3"
             allowStrs: '""'
@@ -1543,41 +1544,50 @@ linters-settings:
       - name: argument-limit
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 4 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
       - name: atomic
         severity: warning
+        exclude: [""]
         disabled: false
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#banned-characters
       - name: banned-characters
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ "Ω","Σ","σ", "7" ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
       - name: bare-return
         severity: warning
+        exclude: [""]
         disabled: false
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#blank-imports
       - name: blank-imports
         severity: warning
+        exclude: [""]
         disabled: false
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
       - name: bool-literal-in-expr
         severity: warning
+        exclude: [""]
         disabled: false
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#call-to-gc
       - name: call-to-gc
         severity: warning
+        exclude: [""]
         disabled: false
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
       - name: cognitive-complexity
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 7 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
       - name: comment-spacings
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - mypragma
           - otherpragma
@@ -1585,103 +1595,125 @@ linters-settings:
       - name: confusing-naming
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-results
       - name: confusing-results
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr
       - name: constant-logical-expr
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
       - name: context-as-argument
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - allowTypesBefore: "*testing.T,*github.com/user/repo/testing.Harness"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-keys-type
       - name: context-keys-type
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
       - name: cyclomatic
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 3 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#datarace
       - name: datarace
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
       - name: deep-exit
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
       - name: defer
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - [ "call-chain", "loop" ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
       - name: dot-imports
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
       - name: duplicated-imports
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
       - name: early-return
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "preserveScope"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
       - name: empty-block
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
       - name: empty-lines
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-map-style
       - name: enforce-map-style
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "make"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style
       - name: enforce-repeated-arg-type-style
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "short"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-slice-style
       - name: enforce-slice-style
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "make"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
       - name: error-naming
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
       - name: error-return
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
       - name: error-strings
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#errorf
       - name: errorf
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
       - name: exported
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "preserveScope"
           - "checkPrivateReceivers"
@@ -1690,54 +1722,65 @@ linters-settings:
       - name: file-header
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - This is the text that must appear at the top of source files.
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
       - name: flag-parameter
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
       - name: function-result-limit
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 2 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
       - name: function-length
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 10, 0 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#get-return
       - name: get-return
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#identical-branches
       - name: identical-branches
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
       - name: if-return
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#increment-decrement
       - name: increment-decrement
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
       - name: indent-error-flow
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "preserveScope"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-alias-naming
       - name: import-alias-naming
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "^[a-z][a-z0-9]{0,}$"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#imports-blocklist
       - name: imports-blocklist
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "crypto/md5"
           - "crypto/sha1"
@@ -1745,73 +1788,90 @@ linters-settings:
       - name: import-shadowing
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
       - name: line-length-limit
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 80 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-control-nesting
       - name: max-control-nesting
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 3 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
       - name: max-public-structs
         severity: warning
         disabled: false
+        exclude: [""]
         arguments: [ 3 ]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-parameter
       - name: modifies-parameter
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-value-receiver
       - name: modifies-value-receiver
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#nested-structs
       - name: nested-structs
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#optimize-operands-order
       - name: optimize-operands-order
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
       - name: package-comments
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range
       - name: range
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure
       - name: range-val-in-closure
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
       - name: range-val-address
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#receiver-naming
       - name: receiver-naming
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
       - name: redundant-import-alias
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redefines-builtin-id
       - name: redefines-builtin-id
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-of-int
       - name: string-of-int
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
       - name: string-format
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - - 'core.WriteError[1].Message'
             - '/^([^A-Z]|$)/'
@@ -1829,24 +1889,29 @@ linters-settings:
           - "bson,outline,gnu"
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
       - name: superfluous-else
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "preserveScope"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
       - name: time-equal
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-naming
       - name: time-naming
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
       - name: var-naming
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - [ "ID" ] # AllowList
           - [ "VM" ] # DenyList
@@ -1855,22 +1920,27 @@ linters-settings:
       - name: var-declaration
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unconditional-recursion
       - name: unconditional-recursion
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
       - name: unexported-naming
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
       - name: unexported-return
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
       - name: unhandled-error
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - "fmt.Printf"
           - "myFunction"
@@ -1878,30 +1948,36 @@ linters-settings:
       - name: unnecessary-stmt
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code
       - name: unreachable-code
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
       - name: unused-parameter
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - allowRegex: "^_"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
       - name: unused-receiver
         severity: warning
         disabled: false
+        exclude: [""]
         arguments:
           - allowRegex: "^_"
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
       - name: useless-break
         severity: warning
         disabled: false
+        exclude: [""]
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
       - name: waitgroup-by-value
         severity: warning
         disabled: false
+        exclude: [""]
 
   rowserrcheck:
     # database/sql is always checked

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -751,6 +751,7 @@ type ReviveSettings struct {
 		Arguments []any
 		Severity  string
 		Disabled  bool
+		Exclude   []string
 	}
 	ErrorCode   int `mapstructure:"error-code"`
 	WarningCode int `mapstructure:"warning-code"`

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -186,7 +186,7 @@ func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
 	for k, r := range conf.Rules {
 		err := r.Initialize()
 		if err != nil {
-			return nil, fmt.Errorf("error in config of rule [%s] : [%w]", k, err)
+			return nil, fmt.Errorf("error in config of rule %q: %w", k, err)
 		}
 		conf.Rules[k] = r
 	}

--- a/pkg/golinters/revive.go
+++ b/pkg/golinters/revive.go
@@ -160,7 +160,8 @@ func reviveToIssue(pass *analysis.Pass, object *jsonObject) goanalysis.Issue {
 // This function mimics the GetConfig function of revive.
 // This allows to get default values and right types.
 // https://github.com/golangci/golangci-lint/issues/1745
-// https://github.com/mgechev/revive/blob/v1.1.4/config/config.go#L182
+// https://github.com/mgechev/revive/blob/v1.3.7/config/config.go#L217
+// https://github.com/mgechev/revive/blob/v1.3.7/config/config.go#L169-L174
 func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
 	conf := defaultConfig()
 
@@ -181,6 +182,14 @@ func getReviveConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
 	}
 
 	normalizeConfig(conf)
+
+	for k, r := range conf.Rules {
+		err := r.Initialize()
+		if err != nil {
+			return nil, fmt.Errorf("error in config of rule [%s] : [%w]", k, err)
+		}
+		conf.Rules[k] = r
+	}
 
 	reviveDebugf("revive configuration: %#v", conf)
 
@@ -214,6 +223,7 @@ func createConfigMap(cfg *config.ReviveSettings) map[string]any {
 			"severity":  s.Severity,
 			"arguments": safeTomlSlice(s.Arguments),
 			"disabled":  s.Disabled,
+			"exclude":   s.Exclude,
 		}
 	}
 


### PR DESCRIPTION
Closes #4364

<details>

To test the configuration locally, you can use this script:

```bash
#!/bin/sh -e

## setup module
rm -rf reviveexclude
mkdir reviveexclude && cd $_
go mod init helloworld

## main.go
cat > main.go  <<EOF
package main

// Foo is foo.
func Foo(a string, b string) string {
	return a
}
EOF

## main_test.go
cat > main_test.go  <<EOF
package main

// Bar is bar.
func Bar(a string, b string) string {
	return a
}
EOF

## .golangci.yml
cat > .golangci.yml  <<EOF
linters:
  disable-all: true
  enable:
    - revive

linters-settings:
  revive:
    enable-all-rules: true
    rules:
      - name: package-comments
        disabled: true
      - name: unused-parameter
#        exclude: ["~main_test.go"]
        exclude: ["TEST"]

issues:
  exclude-use-default: false
  max-issues-per-linter: 0
  max-same-issues: 0
EOF
```

</details>

