### PR TITLE
docs: improve `govet` description

### DIFF
--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -145,7 +145,8 @@ func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
 	return goanalysis.NewLinter(
 		"govet",
 		"Vet examines Go source code and reports suspicious constructs, "+
-			"such as Printf calls whose arguments do not align with the format string",
+			"such as Printf calls whose arguments do not align with the format string. "+
+			"This is the same analysis as the 'go vet' tool",
 		analyzersFromConfig(settings),
 		conf,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -144,8 +144,7 @@ func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
 
 	return goanalysis.NewLinter(
 		"govet",
-		"Vet examines Go source code and reports suspicious constructs, "+
-			"such as Printf calls whose arguments do not align with the format string. "+
+		"Vet examines Go source code and reports suspicious constructs. "+
 			"It is roughly the same as 'go vet' and uses its passes.",
 		analyzersFromConfig(settings),
 		conf,

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -146,7 +146,7 @@ func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
 		"govet",
 		"Vet examines Go source code and reports suspicious constructs, "+
 			"such as Printf calls whose arguments do not align with the format string. "+
-			"This is the same analysis as the 'go vet' tool",
+			"It is roughly the same as 'go vet' and uses its passes.",
 		analyzersFromConfig(settings),
 		conf,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)


### PR DESCRIPTION
As per https://github.com/golangci/golangci-lint/discussions/4363#discussioncomment-8413385, I think it's good to clarify this. Aim is to get this on the [docs page](https://golangci-lint.run/usage/linters/#govet). I did not add a `.` at the end of the sentence as it seems the docs build does that.