### PR TITLE
dev: fix variables incorrectly passed to 'go build'

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,8 +7,8 @@ ARG DATE
 
 COPY / /golangci
 WORKDIR /golangci
-RUN APP_VERSION=${VERSION#v} \
-    CGO_ENABLED=0 \
+RUN APP_VERSION=${VERSION#v}; \
+    CGO_ENABLED=0; \
     go build -trimpath -ldflags "-s -w -X main.version=$APP_VERSION -X main.commit=$SHORT_COMMIT -X main.date=$DATE" -o golangci-lint ./cmd/golangci-lint/main.go
 
 # stage 2


### PR DESCRIPTION
This PR aims to solve https://github.com/golangci/golangci-lint/issues/4368 by ensuring the `APP_VERSION` and `CGO_ENABLED` variables are correctly set prior to being used by `go build`:

**Before** (from d7513984d5b44c7cd49d98931a5fcb1c1a4231b8)

```sh
$ docker build --quiet -f build/Dockerfile --build-arg VERSION=9.9.9 --build-arg SHORT_COMMIT=abc123 --build-arg DATE=now . -t test/golang-ci-lint && docker run --rm -ti test/golang-ci-lint golangci-lint version
sha256:6749ff93236299ceac1d04987f3384415fa7f081cfc9ea8695412a2a86f30690
golangci-lint has version  built with go1.22.0 from abc123 on now
```

**After** (from `ashmckenzie/fix-missing-version-in-docker-build`)

```sh
$ docker build --quiet -f build/Dockerfile --build-arg VERSION=9.9.9 --build-arg SHORT_COMMIT=abc123 --build-arg DATE=now . -t test/golang-ci-lint && docker run --rm -ti test/golang-ci-lint golangci-lint version
sha256:2f2607b9836e56d75b7aca69363aa5329619bcaf8a46d2448957d450645550ce
golangci-lint has version 9.9.9 built with go1.22.0 from abc123 on now
```

Closes: https://github.com/golangci/golangci-lint/issues/4368