### PR TITLE
dev: refactor govet impl with slices.Contains

### DIFF
--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -172,17 +172,24 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 }
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
-	switch {
-	case name == loopclosure.Analyzer.Name && config.IsGreaterThanOrEqualGo122(cfg.Go):
+	// TODO(ldez) remove loopclosure when go1.23
+	if name == loopclosure.Analyzer.Name && config.IsGreaterThanOrEqualGo122(cfg.Go) {
 		return false
+	}
+
+	switch {
 	case cfg.EnableAll:
 		return !slices.Contains(cfg.Disable, name)
+
 	case slices.Contains(cfg.Enable, name):
 		return true
+
 	case slices.Contains(cfg.Disable, name):
 		return false
+
 	case cfg.DisableAll:
 		return false
+
 	default:
 		return slices.ContainsFunc(defaultAnalyzers, func(a *analysis.Analyzer) bool { return a.Name == name })
 	}

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -1,6 +1,8 @@
 package golinters
 
 import (
+	"slices"
+
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/appends"
 	"golang.org/x/tools/go/analysis/passes/asmdecl"
@@ -170,40 +172,18 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 }
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
-	if name == loopclosure.Analyzer.Name && config.IsGreaterThanOrEqualGo122(cfg.Go) {
+	switch {
+	case name == loopclosure.Analyzer.Name && config.IsGreaterThanOrEqualGo122(cfg.Go):
 		return false
-	}
-
-	if cfg.EnableAll {
-		for _, n := range cfg.Disable {
-			if n == name {
-				return false
-			}
-		}
+	case cfg.EnableAll:
+		return !slices.Contains(cfg.Disable, name)
+	case slices.Contains(cfg.Enable, name):
 		return true
-	}
-
-	// Raw for loops should be OK on small slice lengths.
-	for _, n := range cfg.Enable {
-		if n == name {
-			return true
-		}
-	}
-
-	for _, n := range cfg.Disable {
-		if n == name {
-			return false
-		}
-	}
-
-	if cfg.DisableAll {
+	case slices.Contains(cfg.Disable, name):
 		return false
+	case cfg.DisableAll:
+		return false
+	default:
+		return slices.ContainsFunc(defaultAnalyzers, func(a *analysis.Analyzer) bool { return a.Name == name })
 	}
-
-	for _, a := range defaultAnalyzers {
-		if a.Name == name {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/golinters/govet_test.go
+++ b/pkg/golinters/govet_test.go
@@ -72,6 +72,7 @@ func TestGovetAnalyzerIsEnabled(t *testing.T) {
 		Disable    []string
 		EnableAll  bool
 		DisableAll bool
+		Go         string
 
 		Name    string
 		Enabled bool
@@ -83,12 +84,14 @@ func TestGovetAnalyzerIsEnabled(t *testing.T) {
 		{Name: "unsafeptr", Enabled: true, Enable: []string{"unsafeptr"}},
 		{Name: "shift", Enabled: true, EnableAll: true},
 		{Name: "shadow", EnableAll: true, Disable: []string{"shadow"}, Enabled: false},
+		{Name: "loopclosure", EnableAll: true, Enabled: false, Go: "1.22"},
 	} {
 		cfg := &config.GovetSettings{
 			Enable:     tc.Enable,
 			Disable:    tc.Disable,
 			EnableAll:  tc.EnableAll,
 			DisableAll: tc.DisableAll,
+			Go:         tc.Go,
 		}
 		if enabled := isAnalyzerEnabled(tc.Name, cfg, defaultAnalyzers); enabled != tc.Enabled {
 			t.Errorf("%+v", tc)

--- a/pkg/golinters/govet_test.go
+++ b/pkg/golinters/govet_test.go
@@ -84,7 +84,7 @@ func TestGovetAnalyzerIsEnabled(t *testing.T) {
 		{Name: "unsafeptr", Enabled: true, Enable: []string{"unsafeptr"}},
 		{Name: "shift", Enabled: true, EnableAll: true},
 		{Name: "shadow", EnableAll: true, Disable: []string{"shadow"}, Enabled: false},
-		{Name: "loopclosure", EnableAll: true, Enabled: false, Go: "1.22"},
+		{Name: "loopclosure", EnableAll: true, Enabled: false, Go: "1.22"}, // TODO(ldez) remove loopclosure when go1.23
 	} {
 		cfg := &config.GovetSettings{
 			Enable:     tc.Enable,


### PR DESCRIPTION
The PR refactors `govet`'s `isAnalyzerEnabled` implementation by changing to `switch` and using `slices.Contains` instead of raw `for` loop.