### PR TITLE
dev: fix govet.nilness lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,6 @@ linters-settings:
       - strings.SplitN
 
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -60,6 +59,9 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    enable:
+      - nilness
+      - shadow
   errorlint:
     asserts: false
   lll:

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -236,25 +236,18 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		wrapcheckCfg = &m.cfg.LintersSettings.Wrapcheck
 		wslCfg = &m.cfg.LintersSettings.WSL
 
-		if govetCfg != nil {
-			govetCfg.Go = m.cfg.Run.Go
-		}
-
-		if gocriticCfg != nil {
-			gocriticCfg.Go = trimGoVersion(m.cfg.Run.Go)
-		}
-
-		if gofumptCfg != nil && gofumptCfg.LangVersion == "" {
+		govetCfg.Go = m.cfg.Run.Go
+		gocriticCfg.Go = trimGoVersion(m.cfg.Run.Go)
+		if gofumptCfg.LangVersion == "" {
 			gofumptCfg.LangVersion = m.cfg.Run.Go
 		}
-
-		if staticcheckCfg != nil && staticcheckCfg.GoVersion == "" {
+		if staticcheckCfg.GoVersion == "" {
 			staticcheckCfg.GoVersion = trimGoVersion(m.cfg.Run.Go)
 		}
-		if gosimpleCfg != nil && gosimpleCfg.GoVersion == "" {
+		if gosimpleCfg.GoVersion == "" {
 			gosimpleCfg.GoVersion = trimGoVersion(m.cfg.Run.Go)
 		}
-		if stylecheckCfg != nil && stylecheckCfg.GoVersion != "" {
+		if stylecheckCfg.GoVersion != "" {
 			stylecheckCfg.GoVersion = trimGoVersion(m.cfg.Run.Go)
 		}
 	}

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -237,10 +237,14 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 		wslCfg = &m.cfg.LintersSettings.WSL
 
 		govetCfg.Go = m.cfg.Run.Go
+
 		gocriticCfg.Go = trimGoVersion(m.cfg.Run.Go)
+
 		if gofumptCfg.LangVersion == "" {
 			gofumptCfg.LangVersion = m.cfg.Run.Go
 		}
+
+		// staticcheck related linters.
 		if staticcheckCfg.GoVersion == "" {
 			staticcheckCfg.GoVersion = trimGoVersion(m.cfg.Run.Go)
 		}


### PR DESCRIPTION
This PR enables `nilness` analyzer for `govet` and fixes up appearing lint issues through golangci-lint repo:

```sh
❯ golangci-lint run
pkg/lint/lintersdb/manager.go:239:15: nilness: tautological condition: non-nil != nil (govet)
                if govetCfg != nil {
                            ^
pkg/lint/lintersdb/manager.go:243:18: nilness: tautological condition: non-nil != nil (govet)
                if gocriticCfg != nil {
                               ^
pkg/lint/lintersdb/manager.go:247:17: nilness: tautological condition: non-nil != nil (govet)
                if gofumptCfg != nil && gofumptCfg.LangVersion == "" {
                              ^
```