### PR TITLE
dev: handle old TODO

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,16 @@
 linters-settings:
   depguard:
-    # new configuration
     rules:
       logger:
         deny:
           # logging is allowed only by logutils.Log,
           # logrus is allowed to use only in logutils package.
           - pkg: "github.com/sirupsen/logrus"
-            desc: logging is allowed only by logutils.Log
+            desc: logging is allowed only by logutils.Log.
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package.
+          - pkg: "github.com/instana/testify"
+            desc: It's a fork of github.com/stretchr/testify.
   dupl:
     threshold: 100
   funlen:
@@ -50,7 +53,6 @@ linters-settings:
       - '3'
     ignored-functions:
       - strings.SplitN
-
   govet:
     settings:
       printf:
@@ -118,14 +120,11 @@ linters:
 
   # don't enable:
   # - asciicheck
-  # - scopelint
   # - gochecknoglobals
   # - gocognit
   # - godot
   # - godox
   # - goerr113
-  # - interfacer
-  # - maligned
   # - nestif
   # - prealloc
   # - testpackage
@@ -155,12 +154,6 @@ issues:
       text: "rangeValCopy: each iteration copies 160 bytes \\(consider pointers or indexing\\)"
     - path: test/(fix|linters)_test.go
       text: "string `gocritic.go` has 3 occurrences, make it a constant"
-
-    # Due to a change inside go-critic v0.10.0, some reports have been removed,
-    # but as we run analysis with the previous version of golangci-lint this leads to a paradoxical situation.
-    # This exclusion will be removed when the next version of golangci-lint (v1.56.0) will be released.
-    - path: pkg/golinters/nolintlint/nolintlint.go
-      text: "hugeParam: (i|b) is heavy \\(\\d+ bytes\\); consider passing it by pointer"
 
 run:
   timeout: 5m

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -19,10 +19,12 @@ type BaseIssue struct {
 	replacement                       *result.Replacement
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (b BaseIssue) Position() token.Position {
 	return b.position
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (b BaseIssue) Replacement() *result.Replacement {
 	return b.replacement
 }
@@ -31,6 +33,7 @@ type ExtraLeadingSpace struct {
 	BaseIssue
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (i ExtraLeadingSpace) Details() string {
 	return fmt.Sprintf("directive `%s` should not have more than one leading space", i.fullDirective)
 }
@@ -41,6 +44,7 @@ type NotMachine struct {
 	BaseIssue
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (i NotMachine) Details() string {
 	expected := i.fullDirective[:2] + strings.TrimLeftFunc(i.fullDirective[2:], unicode.IsSpace)
 	return fmt.Sprintf("directive `%s` should be written without leading space as `%s`",
@@ -53,6 +57,7 @@ type NotSpecific struct {
 	BaseIssue
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (i NotSpecific) Details() string {
 	return fmt.Sprintf("directive `%s` should mention specific linter such as `%s:my-linter`",
 		i.fullDirective, i.directiveWithOptionalLeadingSpace)
@@ -64,6 +69,7 @@ type ParseError struct {
 	BaseIssue
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (i ParseError) Details() string {
 	return fmt.Sprintf("directive `%s` should match `%s[:<comma-separated-linters>] [// <explanation>]`",
 		i.fullDirective,
@@ -77,6 +83,7 @@ type NoExplanation struct {
 	fullDirectiveWithoutExplanation string
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (i NoExplanation) Details() string {
 	return fmt.Sprintf("directive `%s` should provide explanation such as `%s // this is why`",
 		i.fullDirective, i.fullDirectiveWithoutExplanation)
@@ -89,6 +96,7 @@ type UnusedCandidate struct {
 	ExpectedLinter string
 }
 
+//nolint:gocritic // TODO(ldez) must be change in the future.
 func (i UnusedCandidate) Details() string {
 	details := fmt.Sprintf("directive `%s` is unused", i.fullDirective)
 	if i.ExpectedLinter != "" {

--- a/pkg/lint/lintersdb/custom_linters.go
+++ b/pkg/lint/lintersdb/custom_linters.go
@@ -3,7 +3,6 @@ package lintersdb
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"plugin"
 
@@ -115,11 +114,8 @@ func (m *Manager) lookupAnalyzerPlugin(plug *plugin.Plugin) ([]*analysis.Analyze
 		return nil, err
 	}
 
-	// TODO(ldez): remove this env var (but keep the log) in the next minor version (v1.55.0)
-	if _, ok := os.LookupEnv("GOLANGCI_LINT_HIDE_WARNING_ABOUT_PLUGIN_API_DEPRECATION"); !ok {
-		m.log.Warnf("plugin: 'AnalyzerPlugin' plugins are deprecated, please use the new plugin signature: " +
-			"https://golangci-lint.run/contributing/new-linters/#create-a-plugin")
-	}
+	m.log.Warnf("plugin: 'AnalyzerPlugin' plugins are deprecated, please use the new plugin signature: " +
+		"https://golangci-lint.run/contributing/new-linters/#create-a-plugin")
 
 	analyzerPlugin, ok := symbol.(AnalyzerPlugin)
 	if !ok {


### PR DESCRIPTION
- #4002
- remove deprecated linters from "don't enable:" section.
- restore some `nolint` directives.