### PR TITLE
feat: add copyloopvar linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2485,6 +2485,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - cyclop
     - deadcode
     - decorder
@@ -2606,6 +2607,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - cyclop
     - deadcode
     - decorder

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/jjti/go-spancheck v0.5.2
 	github.com/julz/importas v0.1.0
-	github.com/karamaru-alpha/copyloopvar v1.0.2
+	github.com/karamaru-alpha/copyloopvar v1.0.3
 	github.com/kisielk/errcheck v1.7.0
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/jjti/go-spancheck v0.5.2
 	github.com/julz/importas v0.1.0
+	github.com/karamaru-alpha/copyloopvar v1.0.1
 	github.com/kisielk/errcheck v1.7.0
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/jjti/go-spancheck v0.5.2
 	github.com/julz/importas v0.1.0
-	github.com/karamaru-alpha/copyloopvar v1.0.3
+	github.com/karamaru-alpha/copyloopvar v1.0.4
 	github.com/kisielk/errcheck v1.7.0
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/jjti/go-spancheck v0.5.2
 	github.com/julz/importas v0.1.0
-	github.com/karamaru-alpha/copyloopvar v1.0.1
+	github.com/karamaru-alpha/copyloopvar v1.0.2
 	github.com/kisielk/errcheck v1.7.0
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
-github.com/karamaru-alpha/copyloopvar v1.0.2 h1:tmJjTFg4edmOuFTSBuxeueH8lL21kmCPTQHILQcYJWw=
-github.com/karamaru-alpha/copyloopvar v1.0.2/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
+github.com/karamaru-alpha/copyloopvar v1.0.3 h1:RqIwhmGdMFmXU2DYZhMbKl87CuDHJHD+yo/iz+UQMhE=
+github.com/karamaru-alpha/copyloopvar v1.0.3/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
 github.com/kisielk/errcheck v1.7.0 h1:+SbscKmWJ5mOK/bO1zS60F5I9WwZDWOfRsC4RwfwRV0=
 github.com/kisielk/errcheck v1.7.0/go.mod h1:1kLL+jV4e+CFfueBmI1dSK2ADDyQnlrnrY/FqKluHJQ=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
-github.com/karamaru-alpha/copyloopvar v1.0.3 h1:RqIwhmGdMFmXU2DYZhMbKl87CuDHJHD+yo/iz+UQMhE=
-github.com/karamaru-alpha/copyloopvar v1.0.3/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
+github.com/karamaru-alpha/copyloopvar v1.0.4 h1:JD6IPXo4+RawkSPe9uMKh9OtTzYKsCelAgPMUwaVxBw=
+github.com/karamaru-alpha/copyloopvar v1.0.4/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
 github.com/kisielk/errcheck v1.7.0 h1:+SbscKmWJ5mOK/bO1zS60F5I9WwZDWOfRsC4RwfwRV0=
 github.com/kisielk/errcheck v1.7.0/go.mod h1:1kLL+jV4e+CFfueBmI1dSK2ADDyQnlrnrY/FqKluHJQ=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
-github.com/karamaru-alpha/copyloopvar v1.0.1 h1:fE4aoMl3z8JJqUKozsEbTT05+qvDcuQdcUYEHlLNg0Q=
-github.com/karamaru-alpha/copyloopvar v1.0.1/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
+github.com/karamaru-alpha/copyloopvar v1.0.2 h1:tmJjTFg4edmOuFTSBuxeueH8lL21kmCPTQHILQcYJWw=
+github.com/karamaru-alpha/copyloopvar v1.0.2/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
 github.com/kisielk/errcheck v1.7.0 h1:+SbscKmWJ5mOK/bO1zS60F5I9WwZDWOfRsC4RwfwRV0=
 github.com/kisielk/errcheck v1.7.0/go.mod h1:1kLL+jV4e+CFfueBmI1dSK2ADDyQnlrnrY/FqKluHJQ=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
+github.com/karamaru-alpha/copyloopvar v1.0.1 h1:fE4aoMl3z8JJqUKozsEbTT05+qvDcuQdcUYEHlLNg0Q=
+github.com/karamaru-alpha/copyloopvar v1.0.1/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
 github.com/kisielk/errcheck v1.7.0 h1:+SbscKmWJ5mOK/bO1zS60F5I9WwZDWOfRsC4RwfwRV0=
 github.com/kisielk/errcheck v1.7.0/go.mod h1:1kLL+jV4e+CFfueBmI1dSK2ADDyQnlrnrY/FqKluHJQ=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/pkg/golinters/copyloopvar.go
+++ b/pkg/golinters/copyloopvar.go
@@ -1,0 +1,19 @@
+package golinters
+
+import (
+	"github.com/karamaru-alpha/copyloopvar"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+)
+
+func NewCopyLoopVar() *goanalysis.Linter {
+	a := copyloopvar.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/copyloopvar.go
+++ b/pkg/golinters/copyloopvar.go
@@ -15,5 +15,5 @@ func NewCopyLoopVar() *goanalysis.Linter {
 		a.Doc,
 		[]*analysis.Analyzer{a},
 		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -298,6 +298,12 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kkHAIKE/contextcheck"),
 
+		linter.NewConfig(golinters.NewCopyLoopVar()).
+			WithSince("v1.57.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/karamaru-alpha/copyloopvar"),
+
 		linter.NewConfig(golinters.NewCyclop(cyclopCfg)).
 			WithSince("v1.37.0").
 			WithLoadForGoAnalysis().

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -300,7 +300,6 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 
 		linter.NewConfig(golinters.NewCopyLoopVar()).
 			WithSince("v1.57.0").
-			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/karamaru-alpha/copyloopvar"),
 

--- a/test/testdata/copyloopvar.go
+++ b/test/testdata/copyloopvar.go
@@ -1,0 +1,34 @@
+//golangcitest:args -Ecopyloopvar
+package testdata
+
+func copyloopvarCase1() {
+	slice := []int{1, 2, 3}
+	fns := make([]func(), 0, len(slice)*2)
+	for i, v := range slice {
+		i := i // want `It's unnecessary to copy the loop variable "i"`
+		fns = append(fns, func() {
+			_ = i
+		})
+		_v := v // want `It's unnecessary to copy the loop variable "v"`
+		fns = append(fns, func() {
+			_ = _v
+		})
+	}
+	for _, fn := range fns {
+		fn()
+	}
+}
+
+func copyloopvarCase2() {
+	loopCount := 3
+	fns := make([]func(), 0, loopCount)
+	for i := 1; i <= loopCount; i++ {
+		i := i // want `It's unnecessary to copy the loop variable "i"`
+		fns = append(fns, func() {
+			_ = i
+		})
+	}
+	for _, fn := range fns {
+		fn()
+	}
+}

--- a/test/testdata/copyloopvar.go
+++ b/test/testdata/copyloopvar.go
@@ -1,17 +1,19 @@
 //golangcitest:args -Ecopyloopvar
 package testdata
 
+import "fmt"
+
 func copyloopvarCase1() {
 	slice := []int{1, 2, 3}
 	fns := make([]func(), 0, len(slice)*2)
 	for i, v := range slice {
 		i := i // want `It's unnecessary to copy the loop variable "i"`
 		fns = append(fns, func() {
-			_ = i
+			fmt.Println(i)
 		})
 		_v := v // want `It's unnecessary to copy the loop variable "v"`
 		fns = append(fns, func() {
-			_ = _v
+			fmt.Println(_v)
 		})
 	}
 	for _, fn := range fns {
@@ -25,7 +27,7 @@ func copyloopvarCase2() {
 	for i := 1; i <= loopCount; i++ {
 		i := i // want `It's unnecessary to copy the loop variable "i"`
 		fns = append(fns, func() {
-			_ = i
+			fmt.Println(i)
 		})
 	}
 	for _, fn := range fns {

--- a/test/testdata/copyloopvar.go
+++ b/test/testdata/copyloopvar.go
@@ -7,11 +7,11 @@ func copyloopvarCase1() {
 	slice := []int{1, 2, 3}
 	fns := make([]func(), 0, len(slice)*2)
 	for i, v := range slice {
-		i := i // want `It's unnecessary to copy the loop variable "i"`
+		i := i // want `The copy of the 'for' variable "i" can be deleted \(Go 1\.22\+\)`
 		fns = append(fns, func() {
 			fmt.Println(i)
 		})
-		_v := v // want `It's unnecessary to copy the loop variable "v"`
+		_v := v // want `The copy of the 'for' variable "v" can be deleted \(Go 1\.22\+\)`
 		fns = append(fns, func() {
 			fmt.Println(_v)
 		})
@@ -25,7 +25,7 @@ func copyloopvarCase2() {
 	loopCount := 3
 	fns := make([]func(), 0, loopCount)
 	for i := 1; i <= loopCount; i++ {
-		i := i // want `It's unnecessary to copy the loop variable "i"`
+		i := i // want `The copy of the 'for' variable "i" can be deleted \(Go 1\.22\+\)`
 		fns = append(fns, func() {
 			fmt.Println(i)
 		})


### PR DESCRIPTION
I'd like to add https://github.com/karamaru-alpha/copyloopvar.
This linter detects places where loop variables are copied.


For Go 1.21(set GOEXPERIMENT=loopvar) and Go 1.22~, it is unnecessary to copy loop variables because these variables have per-iteration scope instead of per-loop scope.

cf. [Fixing For Loops in Go 1.22](https://go.dev/blog/loopvar-preview)

> For Go 1.22, we plan to change for loops to make these variables have per-iteration scope instead of per-loop scope. 

> Go 1.21 includes a preview of the scoping change. If you compile your code with GOEXPERIMENT=loopvar set in your environment, then the new semantics are applied to all loops.
