### PR TITLE
dev: fix Docker image on tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,7 +157,7 @@ docker_manifests:
     image_templates:
       - 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-alpine-amd64'
       - 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-alpine-arm64'
-  - name_template: 'golangci/golangci-lint:{{ .Tag }}'
+  - name_template: 'golangci/golangci-lint:{{ .Tag }}-alpine'
     image_templates:
       - 'golangci/golangci-lint:{{ .Tag }}-alpine-amd64'
       - 'golangci/golangci-lint:{{ .Tag }}-alpine-arm64'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -139,10 +139,12 @@ docker_manifests:
     image_templates:
       - 'golangci/golangci-lint:{{ .Tag }}-amd64'
       - 'golangci/golangci-lint:{{ .Tag }}-arm64'
+
   - name_template: 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}'
     image_templates:
       - 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-amd64'
       - 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-arm64'
+
   - name_template: 'golangci/golangci-lint:{{ .Tag }}'
     image_templates:
       - 'golangci/golangci-lint:{{ .Tag }}-amd64'
@@ -153,10 +155,12 @@ docker_manifests:
     image_templates:
       - 'golangci/golangci-lint:{{ .Tag }}-alpine-amd64'
       - 'golangci/golangci-lint:{{ .Tag }}-alpine-arm64'
+
   - name_template: 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-alpine'
     image_templates:
       - 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-alpine-amd64'
       - 'golangci/golangci-lint:v{{ .Major }}.{{ .Minor }}-alpine-arm64'
+
   - name_template: 'golangci/golangci-lint:{{ .Tag }}-alpine'
     image_templates:
       - 'golangci/golangci-lint:{{ .Tag }}-alpine-amd64'


### PR DESCRIPTION
Fixes https://github.com/golangci/golangci-lint/discussions/4391

<details>

```console
$ docker run --rm -it golangci/golangci-lint:v1.56 sh  
# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
# golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a0 on 2024-02-15T18:01:51Z
# 
```

```console
$ docker run --rm -it golangci/golangci-lint:latest sh
# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
# golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a0 on 2024-02-15T18:01:51Z
# 
```

```console
$ docker run --rm -it golangci/golangci-lint:v1.56.2 sh
/app # cat /etc/os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.19.1
PRETTY_NAME="Alpine Linux v3.19"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
/ # golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a0 on 2024-02-15T18:01:51Z
/ # 
```

</details>

Note: I re-published the Docker images (based on this PR) and now the problem is fixed.