### PR TITLE
dev: clean up Executor 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,8 +141,6 @@ issues:
       text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
     - path: pkg/commands/run.go
       text: "SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead"
-    - path: pkg/commands/run.go
-      text: "SA1019: e.cfg.Run.Deadline is deprecated: Deadline exists for historical compatibility and should not be used."
 
     - path: pkg/golinters/gofumpt.go
       text: "SA1019: settings.LangVersion is deprecated: use the global `run.go` instead."

--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -66,6 +66,19 @@ func (e *Executor) executeCacheStatus(_ *cobra.Command, _ []string) {
 	}
 }
 
+func dirSizeBytes(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
+}
+
+// --- Related to cache but not used directly by the cache command.
+
 func (e *Executor) initHashSalt(version string) error {
 	binSalt, err := computeBinarySalt(version)
 	if err != nil {
@@ -127,15 +140,4 @@ func computeConfigSalt(cfg *config.Config) ([]byte, error) {
 		return nil, err
 	}
 	return h.Sum(nil), nil
-}
-
-func dirSizeBytes(path string) (int64, error) {
-	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		if err == nil && !info.IsDir() {
-			size += info.Size()
-		}
-		return err
-	})
-	return size, err
 }

--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -33,7 +33,7 @@ func (e *Executor) initCache() {
 		Short:             "Clean cache",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
-		RunE:              e.executeCleanCache,
+		RunE:              e.executeCacheClean,
 	})
 	cacheCmd.AddCommand(&cobra.Command{
 		Use:               "status",
@@ -48,7 +48,7 @@ func (e *Executor) initCache() {
 	e.rootCmd.AddCommand(cacheCmd)
 }
 
-func (e *Executor) executeCleanCache(_ *cobra.Command, _ []string) error {
+func (e *Executor) executeCacheClean(_ *cobra.Command, _ []string) error {
 	cacheDir := cache.DefaultDir()
 	if err := os.RemoveAll(cacheDir); err != nil {
 		return fmt.Errorf("failed to remove dir %s: %w", cacheDir, err)

--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -108,10 +108,11 @@ func computeBinarySalt(version string) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
+// computeConfigSalt computes configuration hash.
+// We don't hash all config fields to reduce meaningless cache invalidations.
+// At least, it has a huge impact on tests speed.
+// Fields: `LintersSettings` and `Run.BuildTags`.
 func computeConfigSalt(cfg *config.Config) ([]byte, error) {
-	// We don't hash all config fields to reduce meaningless cache
-	// invalidations. At least, it has a huge impact on tests speed.
-
 	lintersSettingsBytes, err := yaml.Marshal(cfg.LintersSettings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to json marshal config linter settings: %w", err)

--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -80,13 +80,13 @@ func dirSizeBytes(path string) (int64, error) {
 
 // --- Related to cache but not used directly by the cache command.
 
-func (e *Executor) initHashSalt(version string) error {
+func initHashSalt(version string, cfg *config.Config) error {
 	binSalt, err := computeBinarySalt(version)
 	if err != nil {
 		return fmt.Errorf("failed to calculate binary salt: %w", err)
 	}
 
-	configSalt, err := computeConfigSalt(e.cfg)
+	configSalt, err := computeConfigSalt(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to calculate config salt: %w", err)
 	}

--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -27,7 +27,6 @@ func (e *Executor) initCache() {
 			return cmd.Help()
 		},
 	}
-	e.rootCmd.AddCommand(cacheCmd)
 
 	cacheCmd.AddCommand(&cobra.Command{
 		Use:               "clean",
@@ -45,6 +44,8 @@ func (e *Executor) initCache() {
 	})
 
 	// TODO: add trim command?
+
+	e.rootCmd.AddCommand(cacheCmd)
 }
 
 func (e *Executor) executeCleanCache(_ *cobra.Command, _ []string) error {

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -34,8 +34,6 @@ func (e *Executor) initConfig() {
 	fs := pathCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
 
-	initConfigFileFlagSet(fs, &e.cfg.Run)
-
 	configCmd.AddCommand(pathCmd)
 	e.rootCmd.AddCommand(configCmd)
 }
@@ -66,6 +64,8 @@ func (e *Executor) getUsedConfig() string {
 
 	return prettyUsedConfigFile
 }
+
+// --- Related to config but not used directly by the config command.
 
 func initConfigFileFlagSet(fs *pflag.FlagSet, cfg *config.Run) {
 	fs.StringVarP(&cfg.Config, "config", "c", "", wh("Read config from file path `PATH`"))

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (e *Executor) initConfig() {
-	cmd := &cobra.Command{
+	configCmd := &cobra.Command{
 		Use:   "config",
 		Short: "Config file information",
 		Args:  cobra.NoArgs,
@@ -22,7 +22,6 @@ func (e *Executor) initConfig() {
 			return cmd.Help()
 		},
 	}
-	e.rootCmd.AddCommand(cmd)
 
 	pathCmd := &cobra.Command{
 		Use:               "path",
@@ -37,7 +36,8 @@ func (e *Executor) initConfig() {
 
 	initConfigFileFlagSet(fs, &e.cfg.Run)
 
-	cmd.AddCommand(pathCmd)
+	configCmd.AddCommand(pathCmd)
+	e.rootCmd.AddCommand(configCmd)
 }
 
 // getUsedConfig returns the resolved path to the golangci config file,

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -28,7 +28,7 @@ func (e *Executor) initConfig() {
 		Short:             "Print used config path",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
-		Run:               e.executePathCmd,
+		Run:               e.executePath,
 	}
 
 	fs := pathCmd.Flags()
@@ -38,6 +38,16 @@ func (e *Executor) initConfig() {
 
 	configCmd.AddCommand(pathCmd)
 	e.rootCmd.AddCommand(configCmd)
+}
+
+func (e *Executor) executePath(_ *cobra.Command, _ []string) {
+	usedConfigFile := e.getUsedConfig()
+	if usedConfigFile == "" {
+		e.log.Warnf("No config file detected")
+		os.Exit(exitcodes.NoConfigFileDetected)
+	}
+
+	fmt.Println(usedConfigFile)
 }
 
 // getUsedConfig returns the resolved path to the golangci config file,
@@ -55,16 +65,6 @@ func (e *Executor) getUsedConfig() string {
 	}
 
 	return prettyUsedConfigFile
-}
-
-func (e *Executor) executePathCmd(_ *cobra.Command, _ []string) {
-	usedConfigFile := e.getUsedConfig()
-	if usedConfigFile == "" {
-		e.log.Warnf("No config file detected")
-		os.Exit(exitcodes.NoConfigFileDetected)
-	}
-
-	fmt.Println(usedConfigFile)
 }
 
 func initConfigFileFlagSet(fs *pflag.FlagSet, cfg *config.Run) {

--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -40,8 +40,8 @@ func (e *Executor) initConfig() {
 	cmd.AddCommand(pathCmd)
 }
 
-// getUsedConfig returns the resolved path to the golangci config file, or the empty string
-// if no configuration could be found.
+// getUsedConfig returns the resolved path to the golangci config file,
+// or the empty string if no configuration could be found.
 func (e *Executor) getUsedConfig() string {
 	usedConfigFile := viper.ConfigFileUsed()
 	if usedConfigFile == "" {

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -22,13 +22,6 @@ import (
 	"github.com/golangci/golangci-lint/pkg/timeutils"
 )
 
-type BuildInfo struct {
-	GoVersion string `json:"goVersion"`
-	Version   string `json:"version"`
-	Commit    string `json:"commit"`
-	Date      string `json:"date"`
-}
-
 type Executor struct {
 	rootCmd    *cobra.Command
 	runCmd     *cobra.Command

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -48,9 +48,6 @@ type Executor struct {
 
 	fileCache *fsutils.FileCache
 	lineCache *fsutils.LineCache
-	pkgCache  *pkgcache.Cache
-
-	sw *timeutils.Stopwatch
 
 	flock *flock.Flock
 }
@@ -144,15 +141,15 @@ func (e *Executor) initExecutor() {
 	e.fileCache = fsutils.NewFileCache()
 	e.lineCache = fsutils.NewLineCache(e.fileCache)
 
-	e.sw = timeutils.NewStopwatch("pkgcache", e.log.Child(logutils.DebugKeyStopwatch))
+	sw := timeutils.NewStopwatch("pkgcache", e.log.Child(logutils.DebugKeyStopwatch))
 
-	e.pkgCache, err = pkgcache.NewCache(e.sw, e.log.Child(logutils.DebugKeyPkgCache))
+	pkgCache, err := pkgcache.NewCache(sw, e.log.Child(logutils.DebugKeyPkgCache))
 	if err != nil {
 		e.log.Fatalf("Failed to build packages cache: %s", err)
 	}
 
 	e.contextLoader = lint.NewContextLoader(e.cfg, e.log.Child(logutils.DebugKeyLoader), e.goenv,
-		e.lineCache, e.fileCache, e.pkgCache, load.NewGuard())
+		e.lineCache, e.fileCache, pkgCache, load.NewGuard())
 	if err = e.initHashSalt(e.buildInfo.Version); err != nil {
 		e.log.Fatalf("Failed to init hash salt: %s", err)
 	}

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -60,6 +60,22 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	// init of commands must be done before config file reading because init sets config with the default values of flags.
 	e.initCommands()
 
+	e.initExecutor()
+
+	return e
+}
+
+func (e *Executor) initCommands() {
+	e.initRoot()
+	e.initRun()
+	e.initHelp()
+	e.initLinters()
+	e.initConfig()
+	e.initVersion()
+	e.initCache()
+}
+
+func (e *Executor) initExecutor() {
 	startedAt := time.Now()
 	e.debugf("Starting execution...")
 	e.log = report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &e.reportData)
@@ -128,21 +144,10 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	e.loadGuard = load.NewGuard()
 	e.contextLoader = lint.NewContextLoader(e.cfg, e.log.Child(logutils.DebugKeyLoader), e.goenv,
 		e.lineCache, e.fileCache, e.pkgCache, e.loadGuard)
-	if err = e.initHashSalt(buildInfo.Version); err != nil {
+	if err = e.initHashSalt(e.buildInfo.Version); err != nil {
 		e.log.Fatalf("Failed to init hash salt: %s", err)
 	}
 	e.debugf("Initialized executor in %s", time.Since(startedAt))
-	return e
-}
-
-func (e *Executor) initCommands() {
-	e.initRoot()
-	e.initRun()
-	e.initHelp()
-	e.initLinters()
-	e.initConfig()
-	e.initVersion()
-	e.initCache()
 }
 
 func (e *Executor) Execute() error {

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -155,7 +155,8 @@ func (e *Executor) initExecutor() {
 
 	e.contextLoader = lint.NewContextLoader(e.cfg, e.log.Child(logutils.DebugKeyLoader), e.goenv,
 		e.lineCache, e.fileCache, pkgCache, load.NewGuard())
-	if err = e.initHashSalt(e.buildInfo.Version); err != nil {
+
+	if err = initHashSalt(e.buildInfo.Version, e.cfg); err != nil {
 		e.log.Fatalf("Failed to init hash salt: %s", err)
 	}
 }

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -156,7 +156,7 @@ func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
 	// `changed` variable inside string slice vars will be shared.
 	// Use another config variable here, not e.cfg, to not
 	// affect main parsing by this parsing of only config option.
-	e.initRunFlagSet(fs, &cfg)
+	initRunFlagSet(fs, &cfg)
 	initVersionFlagSet(fs, &cfg)
 
 	// Parse max options, even force version option: don't want

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -51,7 +51,6 @@ type Executor struct {
 
 // NewExecutor creates and initializes a new command executor.
 func NewExecutor(buildInfo BuildInfo) *Executor {
-	startedAt := time.Now()
 	e := &Executor{
 		cfg:       config.NewDefault(),
 		buildInfo: buildInfo,
@@ -59,6 +58,7 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 		debugf:    logutils.Debug(logutils.DebugKeyExec),
 	}
 
+	startedAt := time.Now()
 	e.debugf("Starting execution...")
 	e.log = report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &e.reportData)
 
@@ -83,13 +83,7 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	}
 
 	// init of commands must be done before config file reading because init sets config with the default values of flags.
-	e.initRoot()
-	e.initRun()
-	e.initHelp()
-	e.initLinters()
-	e.initConfig()
-	e.initVersion()
-	e.initCache()
+	e.initCommands()
 
 	// init e.cfg by values from config: flags parse will see these values like the default ones.
 	// It will overwrite them only if the same option is found in command-line: it's ok, command-line has higher priority.
@@ -140,6 +134,16 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	}
 	e.debugf("Initialized executor in %s", time.Since(startedAt))
 	return e
+}
+
+func (e *Executor) initCommands() {
+	e.initRoot()
+	e.initRun()
+	e.initHelp()
+	e.initLinters()
+	e.initConfig()
+	e.initVersion()
+	e.initCache()
 }
 
 func (e *Executor) Execute() error {

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -142,6 +144,36 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 
 func (e *Executor) Execute() error {
 	return e.rootCmd.Execute()
+}
+
+func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
+	// We use another pflag.FlagSet here to not set `changed` flag
+	// on cmd.Flags() options. Otherwise, string slice options will be duplicated.
+	fs := pflag.NewFlagSet("config flag set", pflag.ContinueOnError)
+
+	var cfg config.Config
+	// Don't do `fs.AddFlagSet(cmd.Flags())` because it shares flags representations:
+	// `changed` variable inside string slice vars will be shared.
+	// Use another config variable here, not e.cfg, to not
+	// affect main parsing by this parsing of only config option.
+	e.initRunFlagSet(fs, &cfg)
+	initVersionFlagSet(fs, &cfg)
+
+	// Parse max options, even force version option: don't want
+	// to get access to Executor here: it's error-prone to use
+	// cfg vs e.cfg.
+	initRootFlagSet(fs, &cfg, true)
+
+	fs.Usage = func() {} // otherwise, help text will be printed twice
+	if err := fs.Parse(os.Args); err != nil {
+		if errors.Is(err, pflag.ErrHelp) {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("can't parse args: %w", err)
+	}
+
+	return &cfg, nil
 }
 
 func fixSlicesFlags(fs *pflag.FlagSet) {

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -126,12 +126,12 @@ func (e *Executor) initExecutor() {
 		e.cfg.Run.Go = config.DetectGoVersion()
 	}
 
-	// recreate after getting config
-	e.dbManager = lintersdb.NewManager(e.cfg, e.log)
-
 	// Slice options must be explicitly set for proper merging of config and command-line options.
 	fixSlicesFlags(e.runCmd.Flags())
 	fixSlicesFlags(e.lintersCmd.Flags())
+
+	// recreate after getting config
+	e.dbManager = lintersdb.NewManager(e.cfg, e.log)
 
 	e.enabledLintersSet = lintersdb.NewEnabledSet(e.dbManager,
 		lintersdb.NewValidator(e.dbManager), e.log.Child(logutils.DebugKeyLintersDB), e.cfg)

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -30,21 +30,27 @@ type Executor struct {
 	runCmd     *cobra.Command // used by fixSlicesFlags, printStats
 	lintersCmd *cobra.Command // used by fixSlicesFlags
 
-	exitCode  int
+	exitCode int
+
 	buildInfo BuildInfo
 
-	cfg               *config.Config // cfg is the unmarshaled data from the golangci config file.
-	log               logutils.Log
-	reportData        report.Data
+	cfg *config.Config // cfg is the unmarshaled data from the golangci config file.
+
+	log        logutils.Log
+	debugf     logutils.DebugFunc
+	reportData report.Data
+
 	dbManager         *lintersdb.Manager
 	enabledLintersSet *lintersdb.EnabledSet
-	contextLoader     *lint.ContextLoader
-	goenv             *goutil.Env
-	fileCache         *fsutils.FileCache
-	lineCache         *fsutils.LineCache
-	pkgCache          *pkgcache.Cache
-	debugf            logutils.DebugFunc
-	sw                *timeutils.Stopwatch
+
+	contextLoader *lint.ContextLoader
+	goenv         *goutil.Env
+
+	fileCache *fsutils.FileCache
+	lineCache *fsutils.LineCache
+	pkgCache  *pkgcache.Cache
+
+	sw *timeutils.Stopwatch
 
 	flock *flock.Flock
 }

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -60,8 +60,7 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	e.debugf("Starting execution...")
 	e.log = report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &e.reportData)
 
-	// to setup log level early we need to parse config from command line extra time to
-	// find `-v` option
+	// to set up log level early we need to parse config from command line extra time to find `-v` option.
 	commandLineCfg, err := e.getConfigForCommandLine()
 	if err != nil && !errors.Is(err, pflag.ErrHelp) {
 		e.log.Fatalf("Can't get config for command line: %s", err)
@@ -81,8 +80,7 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 		}
 	}
 
-	// init of commands must be done before config file reading because
-	// init sets config with the default values of flags
+	// init of commands must be done before config file reading because init sets config with the default values of flags.
 	e.initRoot()
 	e.initRun()
 	e.initHelp()
@@ -91,9 +89,8 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	e.initVersion()
 	e.initCache()
 
-	// init e.cfg by values from config: flags parse will see these values
-	// like the default ones. It will overwrite them only if the same option
-	// is found in command-line: it's ok, command-line has higher priority.
+	// init e.cfg by values from config: flags parse will see these values like the default ones.
+	// It will overwrite them only if the same option is found in command-line: it's ok, command-line has higher priority.
 
 	r := config.NewFileReader(e.cfg, commandLineCfg, e.log.Child(logutils.DebugKeyConfigReader))
 	if err = r.Read(); err != nil {

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -54,7 +54,6 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	e := &Executor{
 		cfg:       config.NewDefault(),
 		buildInfo: buildInfo,
-		dbManager: lintersdb.NewManager(nil, nil),
 		debugf:    logutils.Debug(logutils.DebugKeyExec),
 	}
 

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -33,8 +33,8 @@ type Executor struct {
 	cfg               *config.Config // cfg is the unmarshaled data from the golangci config file.
 	log               logutils.Log
 	reportData        report.Data
-	DBManager         *lintersdb.Manager
-	EnabledLintersSet *lintersdb.EnabledSet
+	dbManager         *lintersdb.Manager
+	enabledLintersSet *lintersdb.EnabledSet
 	contextLoader     *lint.ContextLoader
 	goenv             *goutil.Env
 	fileCache         *fsutils.FileCache
@@ -53,7 +53,7 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	e := &Executor{
 		cfg:       config.NewDefault(),
 		buildInfo: buildInfo,
-		DBManager: lintersdb.NewManager(nil, nil),
+		dbManager: lintersdb.NewManager(nil, nil),
 		debugf:    logutils.Debug(logutils.DebugKeyExec),
 	}
 
@@ -113,14 +113,14 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 	}
 
 	// recreate after getting config
-	e.DBManager = lintersdb.NewManager(e.cfg, e.log)
+	e.dbManager = lintersdb.NewManager(e.cfg, e.log)
 
 	// Slice options must be explicitly set for proper merging of config and command-line options.
 	fixSlicesFlags(e.runCmd.Flags())
 	fixSlicesFlags(e.lintersCmd.Flags())
 
-	e.EnabledLintersSet = lintersdb.NewEnabledSet(e.DBManager,
-		lintersdb.NewValidator(e.DBManager), e.log.Child(logutils.DebugKeyLintersDB), e.cfg)
+	e.enabledLintersSet = lintersdb.NewEnabledSet(e.dbManager,
+		lintersdb.NewValidator(e.dbManager), e.log.Child(logutils.DebugKeyLintersDB), e.cfg)
 	e.goenv = goutil.NewEnv(e.log.Child(logutils.DebugKeyGoEnv))
 	e.fileCache = fsutils.NewFileCache()
 	e.lineCache = fsutils.NewLineCache(e.fileCache)

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -25,9 +25,10 @@ import (
 )
 
 type Executor struct {
-	rootCmd    *cobra.Command
-	runCmd     *cobra.Command
-	lintersCmd *cobra.Command
+	rootCmd *cobra.Command
+
+	runCmd     *cobra.Command // used by fixSlicesFlags, printStats
+	lintersCmd *cobra.Command // used by fixSlicesFlags
 
 	exitCode  int
 	buildInfo BuildInfo

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -81,7 +81,7 @@ func (e *Executor) initExecutor() {
 	e.log = report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &e.reportData)
 
 	// to set up log level early we need to parse config from command line extra time to find `-v` option.
-	commandLineCfg, err := e.getConfigForCommandLine()
+	commandLineCfg, err := getConfigForCommandLine()
 	if err != nil && !errors.Is(err, pflag.ErrHelp) {
 		e.log.Fatalf("Can't get config for command line: %s", err)
 	}
@@ -154,7 +154,7 @@ func (e *Executor) Execute() error {
 	return e.rootCmd.Execute()
 }
 
-func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
+func getConfigForCommandLine() (*config.Config, error) {
 	// We use another pflag.FlagSet here to not set `changed` flag
 	// on cmd.Flags() options. Otherwise, string slice options will be duplicated.
 	fs := pflag.NewFlagSet("config flag set", pflag.ContinueOnError)
@@ -170,7 +170,7 @@ func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
 	// Parse max options, even force version option: don't want
 	// to get access to Executor here: it's error-prone to use
 	// cfg vs e.cfg.
-	initRootFlagSet(fs, &cfg, true)
+	initRootFlagSet(fs, &cfg)
 
 	fs.Usage = func() {} // otherwise, help text will be printed twice
 	if err := fs.Parse(os.Args); err != nil {

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -57,6 +57,9 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 		debugf:    logutils.Debug(logutils.DebugKeyExec),
 	}
 
+	// init of commands must be done before config file reading because init sets config with the default values of flags.
+	e.initCommands()
+
 	startedAt := time.Now()
 	e.debugf("Starting execution...")
 	e.log = report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &e.reportData)
@@ -80,9 +83,6 @@ func NewExecutor(buildInfo BuildInfo) *Executor {
 			e.log.Fatalf("invalid value %q for --color; must be 'always', 'auto', or 'never'", commandLineCfg.Output.Color)
 		}
 	}
-
-	// init of commands must be done before config file reading because init sets config with the default values of flags.
-	e.initCommands()
 
 	// init e.cfg by values from config: flags parse will see these values like the default ones.
 	// It will overwrite them only if the same option is found in command-line: it's ok, command-line has higher priority.

--- a/pkg/commands/executor.go
+++ b/pkg/commands/executor.go
@@ -46,8 +46,7 @@ type Executor struct {
 	debugf            logutils.DebugFunc
 	sw                *timeutils.Stopwatch
 
-	loadGuard *load.Guard
-	flock     *flock.Flock
+	flock *flock.Flock
 }
 
 // NewExecutor creates and initializes a new command executor.
@@ -133,21 +132,25 @@ func (e *Executor) initExecutor() {
 
 	e.enabledLintersSet = lintersdb.NewEnabledSet(e.dbManager,
 		lintersdb.NewValidator(e.dbManager), e.log.Child(logutils.DebugKeyLintersDB), e.cfg)
+
 	e.goenv = goutil.NewEnv(e.log.Child(logutils.DebugKeyGoEnv))
+
 	e.fileCache = fsutils.NewFileCache()
 	e.lineCache = fsutils.NewLineCache(e.fileCache)
 
 	e.sw = timeutils.NewStopwatch("pkgcache", e.log.Child(logutils.DebugKeyStopwatch))
+
 	e.pkgCache, err = pkgcache.NewCache(e.sw, e.log.Child(logutils.DebugKeyPkgCache))
 	if err != nil {
 		e.log.Fatalf("Failed to build packages cache: %s", err)
 	}
-	e.loadGuard = load.NewGuard()
+
 	e.contextLoader = lint.NewContextLoader(e.cfg, e.log.Child(logutils.DebugKeyLoader), e.goenv,
-		e.lineCache, e.fileCache, e.pkgCache, e.loadGuard)
+		e.lineCache, e.fileCache, e.pkgCache, load.NewGuard())
 	if err = e.initHashSalt(e.buildInfo.Version); err != nil {
 		e.log.Fatalf("Failed to init hash salt: %s", err)
 	}
+
 	e.debugf("Initialized executor in %s", time.Since(startedAt))
 }
 

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -36,7 +36,7 @@ func (e *Executor) initHelp() {
 
 func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {
 	var enabledLCs, disabledLCs []*linter.Config
-	for _, lc := range e.DBManager.GetAllSupportedLinterConfigs() {
+	for _, lc := range e.dbManager.GetAllSupportedLinterConfigs() {
 		if lc.Internal {
 			continue
 		}
@@ -55,7 +55,7 @@ func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {
 
 	color.Green("\nLinters presets:")
 	for _, p := range lintersdb.AllPresets() {
-		linters := e.DBManager.GetAllLinterConfigsForPreset(p)
+		linters := e.dbManager.GetAllLinterConfigsForPreset(p)
 		var linterNames []string
 		for _, lc := range linters {
 			if lc.Internal {

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 	"github.com/spf13/cobra"
 
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
@@ -53,7 +54,7 @@ func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {
 	printLinterConfigs(disabledLCs)
 
 	color.Green("\nLinters presets:")
-	for _, p := range e.DBManager.AllPresets() {
+	for _, p := range lintersdb.AllPresets() {
 		linters := e.DBManager.GetAllLinterConfigsForPreset(p)
 		var linterNames []string
 		for _, lc := range linters {

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -22,7 +22,6 @@ func (e *Executor) initHelp() {
 			return cmd.Help()
 		},
 	}
-	e.rootCmd.SetHelpCommand(helpCmd)
 
 	helpCmd.AddCommand(&cobra.Command{
 		Use:               "linters",
@@ -31,6 +30,8 @@ func (e *Executor) initHelp() {
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run:               e.executeLintersHelp,
 	})
+
+	e.rootCmd.SetHelpCommand(helpCmd)
 }
 
 func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -33,33 +33,6 @@ func (e *Executor) initHelp() {
 	helpCmd.AddCommand(lintersHelpCmd)
 }
 
-func printLinterConfigs(lcs []*linter.Config) {
-	sort.Slice(lcs, func(i, j int) bool {
-		return lcs[i].Name() < lcs[j].Name()
-	})
-	for _, lc := range lcs {
-		altNamesStr := ""
-		if len(lc.AlternativeNames) != 0 {
-			altNamesStr = fmt.Sprintf(" (%s)", strings.Join(lc.AlternativeNames, ", "))
-		}
-
-		// If the linter description spans multiple lines, truncate everything following the first newline
-		linterDescription := lc.Linter.Desc()
-		firstNewline := strings.IndexRune(linterDescription, '\n')
-		if firstNewline > 0 {
-			linterDescription = linterDescription[:firstNewline]
-		}
-
-		deprecatedMark := ""
-		if lc.IsDeprecated() {
-			deprecatedMark = " [" + color.RedString("deprecated") + "]"
-		}
-
-		fmt.Fprintf(logutils.StdOut, "%s%s%s: %s [fast: %t, auto-fix: %t]\n", color.YellowString(lc.Name()),
-			altNamesStr, deprecatedMark, linterDescription, !lc.IsSlowLinter(), lc.CanAutoFix)
-	}
-}
-
 func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {
 	var enabledLCs, disabledLCs []*linter.Config
 	for _, lc := range e.DBManager.GetAllSupportedLinterConfigs() {
@@ -92,5 +65,32 @@ func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {
 		}
 		sort.Strings(linterNames)
 		fmt.Fprintf(logutils.StdOut, "%s: %s\n", color.YellowString(p), strings.Join(linterNames, ", "))
+	}
+}
+
+func printLinterConfigs(lcs []*linter.Config) {
+	sort.Slice(lcs, func(i, j int) bool {
+		return lcs[i].Name() < lcs[j].Name()
+	})
+	for _, lc := range lcs {
+		altNamesStr := ""
+		if len(lc.AlternativeNames) != 0 {
+			altNamesStr = fmt.Sprintf(" (%s)", strings.Join(lc.AlternativeNames, ", "))
+		}
+
+		// If the linter description spans multiple lines, truncate everything following the first newline
+		linterDescription := lc.Linter.Desc()
+		firstNewline := strings.IndexRune(linterDescription, '\n')
+		if firstNewline > 0 {
+			linterDescription = linterDescription[:firstNewline]
+		}
+
+		deprecatedMark := ""
+		if lc.IsDeprecated() {
+			deprecatedMark = " [" + color.RedString("deprecated") + "]"
+		}
+
+		fmt.Fprintf(logutils.StdOut, "%s%s%s: %s [fast: %t, auto-fix: %t]\n", color.YellowString(lc.Name()),
+			altNamesStr, deprecatedMark, linterDescription, !lc.IsSlowLinter(), lc.CanAutoFix)
 	}
 }

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 	"github.com/spf13/cobra"
 
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
+	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 )
 

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -28,13 +28,13 @@ func (e *Executor) initHelp() {
 		Short:             "Help about linters",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
-		Run:               e.executeLintersHelp,
+		Run:               e.executeHelp,
 	})
 
 	e.rootCmd.SetHelpCommand(helpCmd)
 }
 
-func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {
+func (e *Executor) executeHelp(_ *cobra.Command, _ []string) {
 	var enabledLCs, disabledLCs []*linter.Config
 	for _, lc := range e.dbManager.GetAllSupportedLinterConfigs() {
 		if lc.Internal {

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -24,14 +24,13 @@ func (e *Executor) initHelp() {
 	}
 	e.rootCmd.SetHelpCommand(helpCmd)
 
-	lintersHelpCmd := &cobra.Command{
+	helpCmd.AddCommand(&cobra.Command{
 		Use:               "linters",
 		Short:             "Help about linters",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Run:               e.executeLintersHelp,
-	}
-	helpCmd.AddCommand(lintersHelpCmd)
+	})
 }
 
 func (e *Executor) executeLintersHelp(_ *cobra.Command, _ []string) {

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
+	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 )
 
 func (e *Executor) initLinters() {

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -26,20 +26,9 @@ func (e *Executor) initLinters() {
 	fs.SortFlags = false // sort them as they are defined here
 
 	initConfigFileFlagSet(fs, &e.cfg.Run)
-	e.initLintersFlagSet(fs, &e.cfg.Linters)
+	initLintersFlagSet(fs, &e.cfg.Linters)
 
 	e.rootCmd.AddCommand(e.lintersCmd)
-}
-
-func (e *Executor) initLintersFlagSet(fs *pflag.FlagSet, cfg *config.Linters) {
-	fs.StringSliceVarP(&cfg.Disable, "disable", "D", nil, wh("Disable specific linter"))
-	fs.BoolVar(&cfg.DisableAll, "disable-all", false, wh("Disable all linters"))
-	fs.StringSliceVarP(&cfg.Enable, "enable", "E", nil, wh("Enable specific linter"))
-	fs.BoolVar(&cfg.EnableAll, "enable-all", false, wh("Enable all linters"))
-	fs.BoolVar(&cfg.Fast, "fast", false, wh("Enable only fast linters from enabled linters set (first run won't be fast)"))
-	fs.StringSliceVarP(&cfg.Presets, "presets", "p", nil,
-		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
-			"them. This option implies option --disable-all", strings.Join(lintersdb.AllPresets(), "|"))))
 }
 
 // executeLinters runs the 'linters' CLI command, which displays the supported linters.
@@ -70,4 +59,15 @@ func (e *Executor) executeLinters(_ *cobra.Command, _ []string) error {
 	printLinterConfigs(disabledLCs)
 
 	return nil
+}
+
+func initLintersFlagSet(fs *pflag.FlagSet, cfg *config.Linters) {
+	fs.StringSliceVarP(&cfg.Disable, "disable", "D", nil, wh("Disable specific linter"))
+	fs.BoolVar(&cfg.DisableAll, "disable-all", false, wh("Disable all linters"))
+	fs.StringSliceVarP(&cfg.Enable, "enable", "E", nil, wh("Enable specific linter"))
+	fs.BoolVar(&cfg.EnableAll, "enable-all", false, wh("Enable all linters"))
+	fs.BoolVar(&cfg.Fast, "fast", false, wh("Enable only fast linters from enabled linters set (first run won't be fast)"))
+	fs.StringSliceVarP(&cfg.Presets, "presets", "p", nil,
+		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
+			"them. This option implies option --disable-all", strings.Join(lintersdb.AllPresets(), "|"))))
 }

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -44,7 +44,7 @@ func (e *Executor) initLintersFlagSet(fs *pflag.FlagSet, cfg *config.Linters) {
 
 // executeLinters runs the 'linters' CLI command, which displays the supported linters.
 func (e *Executor) executeLinters(_ *cobra.Command, _ []string) error {
-	enabledLintersMap, err := e.EnabledLintersSet.GetEnabledLintersMap()
+	enabledLintersMap, err := e.enabledLintersSet.GetEnabledLintersMap()
 	if err != nil {
 		return fmt.Errorf("can't get enabled linters: %w", err)
 	}
@@ -52,7 +52,7 @@ func (e *Executor) executeLinters(_ *cobra.Command, _ []string) error {
 	var enabledLinters []*linter.Config
 	var disabledLCs []*linter.Config
 
-	for _, lc := range e.DBManager.GetAllSupportedLinterConfigs() {
+	for _, lc := range e.dbManager.GetAllSupportedLinterConfigs() {
 		if lc.Internal {
 			continue
 		}

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/golangci/golangci-lint/pkg/lint/lintersdb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -38,7 +39,7 @@ func (e *Executor) initLintersFlagSet(fs *pflag.FlagSet, cfg *config.Linters) {
 	fs.BoolVar(&cfg.Fast, "fast", false, wh("Enable only fast linters from enabled linters set (first run won't be fast)"))
 	fs.StringSliceVarP(&cfg.Presets, "presets", "p", nil,
 		wh(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
-			"them. This option implies option --disable-all", strings.Join(e.DBManager.AllPresets(), "|"))))
+			"them. This option implies option --disable-all", strings.Join(lintersdb.AllPresets(), "|"))))
 }
 
 // executeLinters runs the 'linters' CLI command, which displays the supported linters.

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (e *Executor) initLinters() {
-	e.lintersCmd = &cobra.Command{
+	lintersCmd := &cobra.Command{
 		Use:               "linters",
 		Short:             "List current linters configuration",
 		Args:              cobra.NoArgs,
@@ -22,13 +22,15 @@ func (e *Executor) initLinters() {
 		RunE:              e.executeLinters,
 	}
 
-	fs := e.lintersCmd.Flags()
+	fs := lintersCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
 
 	initConfigFileFlagSet(fs, &e.cfg.Run)
 	initLintersFlagSet(fs, &e.cfg.Linters)
 
-	e.rootCmd.AddCommand(e.lintersCmd)
+	e.rootCmd.AddCommand(lintersCmd)
+
+	e.lintersCmd = lintersCmd
 }
 
 // executeLinters runs the 'linters' CLI command, which displays the supported linters.

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -93,7 +93,7 @@ func (e *Executor) persistentPostRun(_ *cobra.Command, _ []string) error {
 		printMemStats(&ms, e.log)
 
 		if err := pprof.WriteHeapProfile(f); err != nil {
-			return fmt.Errorf("cCan't write heap profile: %w", err)
+			return fmt.Errorf("can't write heap profile: %w", err)
 		}
 		_ = f.Close()
 	}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -36,6 +36,7 @@ func (e *Executor) initRoot() {
 	}
 
 	initRootFlagSet(rootCmd.PersistentFlags(), e.cfg)
+
 	e.rootCmd = rootCmd
 }
 

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -35,7 +35,7 @@ func (e *Executor) initRoot() {
 		PersistentPostRunE: e.persistentPostRun,
 	}
 
-	initRootFlagSet(rootCmd.PersistentFlags(), e.cfg, e.needVersionOption())
+	initRootFlagSet(rootCmd.PersistentFlags(), e.cfg)
 	e.rootCmd = rootCmd
 }
 
@@ -106,11 +106,7 @@ func (e *Executor) persistentPostRun(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (e *Executor) needVersionOption() bool {
-	return e.buildInfo.Date != ""
-}
-
-func initRootFlagSet(fs *pflag.FlagSet, cfg *config.Config, needVersionOption bool) {
+func initRootFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
 	fs.BoolVarP(&cfg.Run.IsVerbose, "verbose", "v", false, wh("Verbose output"))
 	fs.StringVar(&cfg.Output.Color, "color", "auto", wh("Use color when printing; can be 'always', 'auto', or 'never'"))
 
@@ -121,9 +117,7 @@ func initRootFlagSet(fs *pflag.FlagSet, cfg *config.Config, needVersionOption bo
 	fs.IntVarP(&cfg.Run.Concurrency, "concurrency", "j", getDefaultConcurrency(),
 		wh("Number of CPUs to use (Default: number of logical CPUs)"))
 
-	if needVersionOption {
-		fs.BoolVar(&cfg.Run.PrintVersion, "version", false, wh("Print version"))
-	}
+	fs.BoolVar(&cfg.Run.PrintVersion, "version", false, wh("Print version"))
 }
 
 func printMemStats(ms *runtime.MemStats, logger logutils.Log) {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -150,26 +150,16 @@ func (e *Executor) needVersionOption() bool {
 
 func initRootFlagSet(fs *pflag.FlagSet, cfg *config.Config, needVersionOption bool) {
 	fs.BoolVarP(&cfg.Run.IsVerbose, "verbose", "v", false, wh("Verbose output"))
-
-	var silent bool
-	fs.BoolVarP(&silent, "silent", "s", false, wh("Disables congrats outputs"))
-	if err := fs.MarkHidden("silent"); err != nil {
-		panic(err)
-	}
-	err := fs.MarkDeprecated("silent",
-		"now golangci-lint by default is silent: it doesn't print Congrats message")
-	if err != nil {
-		panic(err)
-	}
+	fs.StringVar(&cfg.Output.Color, "color", "auto", wh("Use color when printing; can be 'always', 'auto', or 'never'"))
 
 	fs.StringVar(&cfg.Run.CPUProfilePath, "cpu-profile-path", "", wh("Path to CPU profile output file"))
 	fs.StringVar(&cfg.Run.MemProfilePath, "mem-profile-path", "", wh("Path to memory profile output file"))
 	fs.StringVar(&cfg.Run.TracePath, "trace-path", "", wh("Path to trace output file"))
+
 	fs.IntVarP(&cfg.Run.Concurrency, "concurrency", "j", getDefaultConcurrency(),
 		wh("Number of CPUs to use (Default: number of logical CPUs)"))
+
 	if needVersionOption {
 		fs.BoolVar(&cfg.Run.PrintVersion, "version", false, wh("Print version"))
 	}
-
-	fs.StringVar(&cfg.Output.Color, "color", "auto", wh("Use color when printing; can be 'always', 'auto', or 'never'"))
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -41,7 +41,7 @@ const (
 )
 
 func (e *Executor) initRun() {
-	e.runCmd = &cobra.Command{
+	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run the linters",
 		Run:   e.executeRun,
@@ -55,18 +55,18 @@ func (e *Executor) initRun() {
 			e.releaseFileLock()
 		},
 	}
-	e.rootCmd.AddCommand(e.runCmd)
 
-	e.runCmd.SetOut(logutils.StdOut) // use custom output to properly color it in Windows terminals
-	e.runCmd.SetErr(logutils.StdErr)
+	runCmd.SetOut(logutils.StdOut) // use custom output to properly color it in Windows terminals
+	runCmd.SetErr(logutils.StdErr)
 
-	e.initRunConfiguration(e.runCmd)
-}
-
-func (e *Executor) initRunConfiguration(cmd *cobra.Command) {
-	fs := cmd.Flags()
+	fs := runCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
+
 	initRunFlagSet(fs, e.cfg)
+
+	e.rootCmd.AddCommand(runCmd)
+
+	e.runCmd = runCmd
 }
 
 // runAnalysis executes the linters that have been enabled in the configuration.

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -66,11 +66,11 @@ func (e *Executor) initRun() {
 func (e *Executor) initRunConfiguration(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
-	e.initFlagSet(fs, e.cfg)
+	e.initRunFlagSet(fs, e.cfg)
 }
 
 //nolint:gomnd
-func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
+func (e *Executor) initRunFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
 	// Config file config
 	rc := &cfg.Run
 	initConfigFileFlagSet(fs, rc)
@@ -159,7 +159,7 @@ func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
 	// `changed` variable inside string slice vars will be shared.
 	// Use another config variable here, not e.cfg, to not
 	// affect main parsing by this parsing of only config option.
-	e.initFlagSet(fs, &cfg)
+	e.initRunFlagSet(fs, &cfg)
 	initVersionFlagSet(fs, &cfg)
 
 	// Parse max options, even force version option: don't want

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -66,11 +66,11 @@ func (e *Executor) initRun() {
 func (e *Executor) initRunConfiguration(cmd *cobra.Command) {
 	fs := cmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
-	e.initFlagSet(fs, e.cfg, true)
+	e.initFlagSet(fs, e.cfg)
 }
 
-//nolint:funlen,gomnd
-func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config, isFinalInit bool) {
+//nolint:gomnd
+func (e *Executor) initFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
 	// Config file config
 	rc := &cfg.Run
 	initConfigFileFlagSet(fs, rc)
@@ -159,7 +159,7 @@ func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
 	// `changed` variable inside string slice vars will be shared.
 	// Use another config variable here, not e.cfg, to not
 	// affect main parsing by this parsing of only config option.
-	e.initFlagSet(fs, &cfg, false)
+	e.initFlagSet(fs, &cfg)
 	initVersionFlagSet(fs, &cfg)
 
 	// Parse max options, even force version option: don't want

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -183,17 +183,17 @@ func (e *Executor) getConfigForCommandLine() (*config.Config, error) {
 func (e *Executor) runAnalysis(ctx context.Context, args []string) ([]result.Issue, error) {
 	e.cfg.Run.Args = args
 
-	lintersToRun, err := e.EnabledLintersSet.GetOptimizedLinters()
+	lintersToRun, err := e.enabledLintersSet.GetOptimizedLinters()
 	if err != nil {
 		return nil, err
 	}
 
-	enabledLintersMap, err := e.EnabledLintersSet.GetEnabledLintersMap()
+	enabledLintersMap, err := e.enabledLintersSet.GetEnabledLintersMap()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, lc := range e.DBManager.GetAllSupportedLinterConfigs() {
+	for _, lc := range e.dbManager.GetAllSupportedLinterConfigs() {
 		isEnabled := enabledLintersMap[lc.Name()] != nil
 		e.reportData.AddLinter(lc.Name(), isEnabled, lc.EnabledByDefault)
 	}
@@ -205,7 +205,7 @@ func (e *Executor) runAnalysis(ctx context.Context, args []string) ([]result.Iss
 	lintCtx.Log = e.log.Child(logutils.DebugKeyLintersContext)
 
 	runner, err := lint.NewRunner(e.cfg, e.log.Child(logutils.DebugKeyRunner),
-		e.goenv, e.EnabledLintersSet, e.lineCache, e.fileCache, e.DBManager, lintCtx.Packages)
+		e.goenv, e.enabledLintersSet, e.lineCache, e.fileCache, e.dbManager, lintCtx.Packages)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -358,11 +358,13 @@ func (e *Executor) releaseFileLock() {
 
 //nolint:gomnd
 func initRunFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
-	// Config file config
-	rc := &cfg.Run
-	initConfigFileFlagSet(fs, rc)
+	fs.BoolVar(&cfg.InternalCmdTest, "internal-cmd-test", false, wh("Option is used only for testing golangci-lint command, don't use it"))
+	if err := fs.MarkHidden("internal-cmd-test"); err != nil {
+		panic(err)
+	}
 
-	// Output config
+	// --- Output config
+
 	oc := &cfg.Output
 	fs.StringVar(&oc.Format, "out-format",
 		config.OutFormatColoredLineNumber,
@@ -374,12 +376,13 @@ func initRunFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
 	fs.BoolVar(&oc.PrintWelcomeMessage, "print-welcome", false, wh("Print welcome message"))
 	fs.StringVar(&oc.PathPrefix, "path-prefix", "", wh("Path prefix to add to output"))
 
-	fs.BoolVar(&cfg.InternalCmdTest, "internal-cmd-test", false, wh("Option is used only for testing golangci-lint command, don't use it"))
-	if err := fs.MarkHidden("internal-cmd-test"); err != nil {
-		panic(err)
-	}
+	// --- Run config
 
-	// Run config
+	rc := &cfg.Run
+
+	// Config file config
+	initConfigFileFlagSet(fs, rc)
+
 	fs.StringVar(&rc.ModulesDownloadMode, "modules-download-mode", "",
 		wh("Modules download mode. If not empty, passed as -mod=<mode> to go tools"))
 	fs.IntVar(&rc.ExitCodeIfIssuesFound, "issues-exit-code",
@@ -404,11 +407,13 @@ func initRunFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
 	fs.BoolVar(&rc.AllowSerialRunners, "allow-serial-runners", false, wh(allowSerialDesc))
 	fs.BoolVar(&rc.ShowStats, "show-stats", false, wh("Show statistics per linter"))
 
-	// Linters config
+	// --- Linters config
+
 	lc := &cfg.Linters
 	initLintersFlagSet(fs, lc)
 
-	// Issues config
+	// --- Issues config
+
 	ic := &cfg.Issues
 	fs.StringSliceVarP(&ic.ExcludePatterns, "exclude", "e", nil, wh("Exclude issue by regexp"))
 	fs.BoolVar(&ic.UseDefaultExcludes, "exclude-use-default", true, getDefaultIssueExcludeHelp())

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -19,19 +19,6 @@ type versionInfo struct {
 	BuildInfo *debug.BuildInfo
 }
 
-func (e *Executor) initVersionConfiguration(cmd *cobra.Command) {
-	fs := cmd.Flags()
-	fs.SortFlags = false // sort them as they are defined here
-	initVersionFlagSet(fs, e.cfg)
-}
-
-func initVersionFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
-	// Version config
-	vc := &cfg.Version
-	fs.StringVar(&vc.Format, "format", "", wh("The version's format can be: 'short', 'json'"))
-	fs.BoolVar(&vc.Debug, "debug", false, wh("Add build information"))
-}
-
 func (e *Executor) initVersion() {
 	versionCmd := &cobra.Command{
 		Use:               "version",
@@ -74,6 +61,19 @@ func (e *Executor) initVersion() {
 
 	e.rootCmd.AddCommand(versionCmd)
 	e.initVersionConfiguration(versionCmd)
+}
+
+func (e *Executor) initVersionConfiguration(cmd *cobra.Command) {
+	fs := cmd.Flags()
+	fs.SortFlags = false // sort them as they are defined here
+	initVersionFlagSet(fs, e.cfg)
+}
+
+func initVersionFlagSet(fs *pflag.FlagSet, cfg *config.Config) {
+	// Version config
+	vc := &cfg.Version
+	fs.StringVar(&vc.Format, "format", "", wh("The version's format can be: 'short', 'json'"))
+	fs.BoolVar(&vc.Debug, "debug", false, wh("Add build information"))
 }
 
 func printVersion(w io.Writer, buildInfo BuildInfo) error {

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -32,38 +32,7 @@ func (e *Executor) initVersion() {
 		Short:             "Version",
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			if e.cfg.Version.Debug {
-				info, ok := debug.ReadBuildInfo()
-				if !ok {
-					return nil
-				}
-
-				switch strings.ToLower(e.cfg.Version.Format) {
-				case "json":
-					return json.NewEncoder(os.Stdout).Encode(versionInfo{
-						Info:      e.buildInfo,
-						BuildInfo: info,
-					})
-
-				default:
-					fmt.Println(info.String())
-					return printVersion(os.Stdout, e.buildInfo)
-				}
-			}
-
-			switch strings.ToLower(e.cfg.Version.Format) {
-			case "short":
-				fmt.Println(e.buildInfo.Version)
-				return nil
-
-			case "json":
-				return json.NewEncoder(os.Stdout).Encode(e.buildInfo)
-
-			default:
-				return printVersion(os.Stdout, e.buildInfo)
-			}
-		},
+		RunE:              e.executeVersion,
 	}
 
 	fs := versionCmd.Flags()
@@ -72,6 +41,39 @@ func (e *Executor) initVersion() {
 	initVersionFlagSet(fs, e.cfg)
 
 	e.rootCmd.AddCommand(versionCmd)
+}
+
+func (e *Executor) executeVersion(_ *cobra.Command, _ []string) error {
+	if e.cfg.Version.Debug {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return nil
+		}
+
+		switch strings.ToLower(e.cfg.Version.Format) {
+		case "json":
+			return json.NewEncoder(os.Stdout).Encode(versionInfo{
+				Info:      e.buildInfo,
+				BuildInfo: info,
+			})
+
+		default:
+			fmt.Println(info.String())
+			return printVersion(os.Stdout, e.buildInfo)
+		}
+	}
+
+	switch strings.ToLower(e.cfg.Version.Format) {
+	case "short":
+		fmt.Println(e.buildInfo.Version)
+		return nil
+
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(e.buildInfo)
+
+	default:
+		return printVersion(os.Stdout, e.buildInfo)
+	}
 }
 
 func initVersionFlagSet(fs *pflag.FlagSet, cfg *config.Config) {

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -66,11 +66,12 @@ func (e *Executor) initVersion() {
 		},
 	}
 
-	e.rootCmd.AddCommand(versionCmd)
-
 	fs := versionCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
+
 	initVersionFlagSet(fs, e.cfg)
+
+	e.rootCmd.AddCommand(versionCmd)
 }
 
 func initVersionFlagSet(fs *pflag.FlagSet, cfg *config.Config) {

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -14,6 +14,13 @@ import (
 	"github.com/golangci/golangci-lint/pkg/config"
 )
 
+type BuildInfo struct {
+	GoVersion string `json:"goVersion"`
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"date"`
+}
+
 type versionInfo struct {
 	Info      BuildInfo
 	BuildInfo *debug.BuildInfo

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -67,11 +67,8 @@ func (e *Executor) initVersion() {
 	}
 
 	e.rootCmd.AddCommand(versionCmd)
-	e.initVersionConfiguration(versionCmd)
-}
 
-func (e *Executor) initVersionConfiguration(cmd *cobra.Command) {
-	fs := cmd.Flags()
+	fs := versionCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
 	initVersionFlagSet(fs, e.cfg)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,7 +20,8 @@ type Config struct {
 	Linters         Linters
 	Issues          Issues
 	Severity        Severity
-	Version         Version
+
+	Version Version
 
 	InternalCmdTest bool `mapstructure:"internal-cmd-test"` // Option is used only for testing golangci-lint command, don't use it
 	InternalTest    bool // Option is used only for testing golangci-lint code, don't use it

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,10 +8,11 @@ import (
 	"github.com/ldez/gomoddirectives"
 )
 
-// Config encapsulates the config data specified in the golangci yaml config file.
+// Config encapsulates the config data specified in the golangci-lint yaml config file.
 type Config struct {
-	cfgDir string // The directory containing the golangci config file.
-	Run    Run
+	cfgDir string // The directory containing the golangci-lint config file.
+
+	Run Run
 
 	Output Output
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,18 +12,18 @@ import (
 type Config struct {
 	cfgDir string // The directory containing the golangci-lint config file.
 
-	Run Run
+	Run Run `mapstructure:"run"`
 
-	Output Output
+	Output Output `mapstructure:"output"`
 
 	LintersSettings LintersSettings `mapstructure:"linters-settings"`
-	Linters         Linters
-	Issues          Issues
-	Severity        Severity
+	Linters         Linters         `mapstructure:"linters"`
+	Issues          Issues          `mapstructure:"issues"`
+	Severity        Severity        `mapstructure:"severity"`
 
-	Version Version
+	Version Version // Flag only. // TODO(ldez) only used by the version command.
 
-	InternalCmdTest bool `mapstructure:"internal-cmd-test"` // Option is used only for testing golangci-lint command, don't use it
+	InternalCmdTest bool // Option is used only for testing golangci-lint command, don't use it
 	InternalTest    bool // Option is used only for testing golangci-lint code, don't use it
 }
 

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -606,6 +606,7 @@ type GovetSettings struct {
 }
 
 func (cfg *GovetSettings) Validate() error {
+	// TODO(ldez) need to be move into the linter file.
 	if cfg.EnableAll && cfg.DisableAll {
 		return errors.New("enable-all and disable-all can't be combined")
 	}

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -21,6 +21,12 @@ var defaultLintersSettings = LintersSettings{
 	Dogsled: DogsledSettings{
 		MaxBlankIdentifiers: 2,
 	},
+	Dupl: DuplSettings{
+		Threshold: 150,
+	},
+	Errcheck: ErrcheckSettings{
+		Ignore: "fmt:.*",
+	},
 	ErrorLint: ErrorLintSettings{
 		Errorf:      true,
 		ErrorfMulti: true,
@@ -46,8 +52,19 @@ var defaultLintersSettings = LintersSettings{
 	Gocognit: GocognitSettings{
 		MinComplexity: 30,
 	},
+	Goconst: GoConstSettings{
+		MatchWithConstants:  true,
+		MinStringLen:        3,
+		MinOccurrencesCount: 3,
+		NumberMin:           3,
+		NumberMax:           3,
+		IgnoreCalls:         true,
+	},
 	Gocritic: GoCriticSettings{
 		SettingsPerCheck: map[string]GoCriticCheckSettings{},
+	},
+	Gocyclo: GoCycloSettings{
+		MinComplexity: 30,
 	},
 	Godox: GodoxSettings{
 		Keywords: []string{},
@@ -56,10 +73,16 @@ var defaultLintersSettings = LintersSettings{
 		Scope:  "declarations",
 		Period: true,
 	},
+	Gofmt: GoFmtSettings{
+		Simplify: true,
+	},
 	Gofumpt: GofumptSettings{
 		LangVersion: "",
 		ModulePath:  "",
 		ExtraRules:  false,
+	},
+	Golint: GoLintSettings{
+		MinConfidence: 0.8,
 	},
 	Gosec: GoSecSettings{
 		Concurrency: runtime.NumCPU(),

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -28,7 +28,7 @@ var OutFormats = []string{
 }
 
 type Output struct {
-	Format              string
+	Format              string `mapstructure:"format"`
 	PrintIssuedLine     bool   `mapstructure:"print-issued-lines"`
 	PrintLinterName     bool   `mapstructure:"print-linter-name"`
 	UniqByLine          bool   `mapstructure:"uniq-by-line"`
@@ -37,5 +37,5 @@ type Output struct {
 	PathPrefix          string `mapstructure:"path-prefix"`
 
 	// only work with CLI flags because the setup of logs is done before the config file parsing.
-	Color string
+	Color string // Flag only.
 }

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -61,7 +61,8 @@ func (r *FileReader) Read() error {
 
 func (r *FileReader) parseConfig() error {
 	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		var configFileNotFoundError viper.ConfigFileNotFoundError
+		if errors.As(err, &configFileNotFoundError) {
 			return nil
 		}
 

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -116,42 +116,41 @@ func (r *FileReader) parseConfig() error {
 }
 
 func (r *FileReader) validateConfig() error {
-	c := r.cfg
-	if len(c.Run.Args) != 0 {
+	if len(r.cfg.Run.Args) != 0 {
 		return errors.New("option run.args in config isn't supported now")
 	}
 
-	if c.Run.CPUProfilePath != "" {
+	if r.cfg.Run.CPUProfilePath != "" {
 		return errors.New("option run.cpuprofilepath in config isn't allowed")
 	}
 
-	if c.Run.MemProfilePath != "" {
+	if r.cfg.Run.MemProfilePath != "" {
 		return errors.New("option run.memprofilepath in config isn't allowed")
 	}
 
-	if c.Run.TracePath != "" {
+	if r.cfg.Run.TracePath != "" {
 		return errors.New("option run.tracepath in config isn't allowed")
 	}
 
-	if c.Run.IsVerbose {
+	if r.cfg.Run.IsVerbose {
 		return errors.New("can't set run.verbose option with config: only on command-line")
 	}
-	for i, rule := range c.Issues.ExcludeRules {
+
+	for i, rule := range r.cfg.Issues.ExcludeRules {
 		if err := rule.Validate(); err != nil {
 			return fmt.Errorf("error in exclude rule #%d: %w", i, err)
 		}
 	}
-	if len(c.Severity.Rules) > 0 && c.Severity.Default == "" {
+
+	if len(r.cfg.Severity.Rules) > 0 && r.cfg.Severity.Default == "" {
 		return errors.New("can't set severity rule option: no default severity defined")
 	}
-	for i, rule := range c.Severity.Rules {
+	for i, rule := range r.cfg.Severity.Rules {
 		if err := rule.Validate(); err != nil {
 			return fmt.Errorf("error in severity rule #%d: %w", i, err)
 		}
 	}
-	if err := c.LintersSettings.Govet.Validate(); err != nil {
-		return fmt.Errorf("error in govet config: %w", err)
-	}
+
 	return nil
 }
 

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -4,18 +4,9 @@ import "time"
 
 // Run encapsulates the config options for running the linter analysis.
 type Run struct {
-	IsVerbose           bool `mapstructure:"verbose"`
-	Silent              bool
-	CPUProfilePath      string
-	MemProfilePath      string
-	TracePath           string
-	Concurrency         int
-	PrintResourcesUsage bool `mapstructure:"print-resources-usage"`
+	Timeout time.Duration `mapstructure:"timeout"`
 
-	Config   string // The path to the golangci config file, as specified with the --config argument.
-	NoConfig bool
-
-	Args []string
+	Concurrency int `mapstructure:"concurrency"`
 
 	Go string `mapstructure:"go"`
 
@@ -25,9 +16,6 @@ type Run struct {
 	ExitCodeIfIssuesFound int  `mapstructure:"issues-exit-code"`
 	AnalyzeTests          bool `mapstructure:"tests"`
 
-	Timeout time.Duration
-
-	PrintVersion       bool
 	SkipFiles          []string `mapstructure:"skip-files"`
 	SkipDirs           []string `mapstructure:"skip-dirs"`
 	UseDefaultSkipDirs bool     `mapstructure:"skip-dirs-use-default"`
@@ -36,4 +24,21 @@ type Run struct {
 	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
 
 	ShowStats bool `mapstructure:"show-stats"`
+
+	// --- Flags only section.
+
+	IsVerbose bool `mapstructure:"verbose"` // Flag only
+
+	PrintVersion bool // Flag only. (used by the root command)
+
+	CPUProfilePath string // Flag only.
+	MemProfilePath string // Flag only.
+	TracePath      string // Flag only.
+
+	PrintResourcesUsage bool `mapstructure:"print-resources-usage"` // Flag only. // TODO(ldez) need to be enforced.
+
+	Config   string // Flag only. The path to the golangci config file, as specified with the --config argument.
+	NoConfig bool   // Flag only.
+
+	Args []string // Flag only. // TODO(ldez) identify the real need and usage.
 }

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -25,10 +25,7 @@ type Run struct {
 	ExitCodeIfIssuesFound int  `mapstructure:"issues-exit-code"`
 	AnalyzeTests          bool `mapstructure:"tests"`
 
-	// Deprecated: Deadline exists for historical compatibility
-	// and should not be used. To set run timeout use Timeout instead.
-	Deadline time.Duration
-	Timeout  time.Duration
+	Timeout time.Duration
 
 	PrintVersion       bool
 	SkipFiles          []string `mapstructure:"skip-files"`

--- a/pkg/golinters/gochecknoglobals.go
+++ b/pkg/golinters/gochecknoglobals.go
@@ -8,22 +8,19 @@ import (
 )
 
 func NewGochecknoglobals() *goanalysis.Linter {
-	gochecknoglobals := checknoglobals.Analyzer()
+	a := checknoglobals.Analyzer()
 
-	// gochecknoglobals only lints test files if the `-t` flag is passed, so we
-	// pass the `t` flag as true to the analyzer before running it. This can be
-	// turned off by using the regular golangci-lint flags such as `--tests` or
-	// `--skip-files`.
+	// gochecknoglobals only lints test files if the `-t` flag is passed,
+	// so we pass the `t` flag as true to the analyzer before running it.
+	// This can be turned off by using the regular golangci-lint flags such as `--tests` or `--skip-files`.
 	linterConfig := map[string]map[string]any{
-		gochecknoglobals.Name: {
-			"t": true,
-		},
+		a.Name: {"t": true},
 	}
 
 	return goanalysis.NewLinter(
-		gochecknoglobals.Name,
-		gochecknoglobals.Doc,
-		[]*analysis.Analyzer{gochecknoglobals},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		linterConfig,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -139,12 +139,12 @@ var (
 func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
 	var conf map[string]map[string]any
 	if settings != nil {
-		conf = settings.Settings
-	}
+		err := settings.Validate()
+		if err != nil {
+			linterLogger.Fatalf("govet configuration: %v", err)
+		}
 
-	err := settings.Validate()
-	if err != nil {
-		linterLogger.Fatalf("govet configuration: %v", err)
+		conf = settings.Settings
 	}
 
 	return goanalysis.NewLinter(

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -142,6 +142,11 @@ func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
 		conf = settings.Settings
 	}
 
+	err := settings.Validate()
+	if err != nil {
+		linterLogger.Fatalf("govet configuration: %v", err)
+	}
+
 	return goanalysis.NewLinter(
 		"govet",
 		"Vet examines Go source code and reports suspicious constructs. "+

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -984,14 +984,6 @@ func AllPresets() []string {
 	}
 }
 
-func allPresetsSet() map[string]bool {
-	ret := map[string]bool{}
-	for _, p := range AllPresets() {
-		ret[p] = true
-	}
-	return ret
-}
-
 // Trims the Go version to keep only M.m.
 // Since Go 1.21 the version inside the go.mod can be a patched version (ex: 1.21.0).
 // https://go.dev/doc/toolchain#versions

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -33,12 +33,12 @@ func NewManager(cfg *config.Config, log logutils.Log) *Manager {
 	return m
 }
 
-func (m Manager) GetLinterConfigs(name string) []*linter.Config {
+func (m *Manager) GetLinterConfigs(name string) []*linter.Config {
 	return m.nameToLCs[name]
 }
 
 //nolint:funlen
-func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
+func (m *Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	var (
 		asasalintCfg        *config.AsasalintSettings
 		bidichkCfg          *config.BiDiChkSettings
@@ -927,7 +927,7 @@ func (m Manager) GetAllSupportedLinterConfigs() []*linter.Config {
 	return linters
 }
 
-func (m Manager) GetAllEnabledByDefaultLinters() []*linter.Config {
+func (m *Manager) GetAllEnabledByDefaultLinters() []*linter.Config {
 	var ret []*linter.Config
 	for _, lc := range m.GetAllSupportedLinterConfigs() {
 		if lc.EnabledByDefault {
@@ -938,7 +938,7 @@ func (m Manager) GetAllEnabledByDefaultLinters() []*linter.Config {
 	return ret
 }
 
-func (m Manager) GetAllLinterConfigsForPreset(p string) []*linter.Config {
+func (m *Manager) GetAllLinterConfigsForPreset(p string) []*linter.Config {
 	var ret []*linter.Config
 	for _, lc := range m.GetAllSupportedLinterConfigs() {
 		if lc.IsDeprecated() {

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -33,32 +33,6 @@ func NewManager(cfg *config.Config, log logutils.Log) *Manager {
 	return m
 }
 
-func (Manager) AllPresets() []string {
-	return []string{
-		linter.PresetBugs,
-		linter.PresetComment,
-		linter.PresetComplexity,
-		linter.PresetError,
-		linter.PresetFormatting,
-		linter.PresetImport,
-		linter.PresetMetaLinter,
-		linter.PresetModule,
-		linter.PresetPerformance,
-		linter.PresetSQL,
-		linter.PresetStyle,
-		linter.PresetTest,
-		linter.PresetUnused,
-	}
-}
-
-func (m Manager) allPresetsSet() map[string]bool {
-	ret := map[string]bool{}
-	for _, p := range m.AllPresets() {
-		ret[p] = true
-	}
-	return ret
-}
-
 func (m Manager) GetLinterConfigs(name string) []*linter.Config {
 	return m.nameToLCs[name]
 }
@@ -964,16 +938,6 @@ func (m Manager) GetAllEnabledByDefaultLinters() []*linter.Config {
 	return ret
 }
 
-func linterConfigsToMap(lcs []*linter.Config) map[string]*linter.Config {
-	ret := map[string]*linter.Config{}
-	for _, lc := range lcs {
-		lc := lc // local copy
-		ret[lc.Name()] = lc
-	}
-
-	return ret
-}
-
 func (m Manager) GetAllLinterConfigsForPreset(p string) []*linter.Config {
 	var ret []*linter.Config
 	for _, lc := range m.GetAllSupportedLinterConfigs() {
@@ -989,6 +953,42 @@ func (m Manager) GetAllLinterConfigsForPreset(p string) []*linter.Config {
 		}
 	}
 
+	return ret
+}
+
+func linterConfigsToMap(lcs []*linter.Config) map[string]*linter.Config {
+	ret := map[string]*linter.Config{}
+	for _, lc := range lcs {
+		lc := lc // local copy
+		ret[lc.Name()] = lc
+	}
+
+	return ret
+}
+
+func AllPresets() []string {
+	return []string{
+		linter.PresetBugs,
+		linter.PresetComment,
+		linter.PresetComplexity,
+		linter.PresetError,
+		linter.PresetFormatting,
+		linter.PresetImport,
+		linter.PresetMetaLinter,
+		linter.PresetModule,
+		linter.PresetPerformance,
+		linter.PresetSQL,
+		linter.PresetStyle,
+		linter.PresetTest,
+		linter.PresetUnused,
+	}
+}
+
+func allPresetsSet() map[string]bool {
+	ret := map[string]bool{}
+	for _, p := range AllPresets() {
+		ret[p] = true
+	}
 	return ret
 }
 

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -39,11 +39,11 @@ func (v Validator) validateLintersNames(cfg *config.Linters) error {
 }
 
 func (v Validator) validatePresets(cfg *config.Linters) error {
-	allPresets := v.m.allPresetsSet()
+	allPresets := allPresetsSet()
 	for _, p := range cfg.Presets {
 		if !allPresets[p] {
 			return fmt.Errorf("no such preset %q: only next presets exist: (%s)",
-				p, strings.Join(v.m.AllPresets(), "|"))
+				p, strings.Join(AllPresets(), "|"))
 		}
 	}
 

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -3,6 +3,7 @@ package lintersdb
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/golangci/golangci-lint/pkg/config"
@@ -39,11 +40,12 @@ func (v Validator) validateLintersNames(cfg *config.Linters) error {
 }
 
 func (v Validator) validatePresets(cfg *config.Linters) error {
-	allPresets := allPresetsSet()
+	presets := AllPresets()
+
 	for _, p := range cfg.Presets {
-		if !allPresets[p] {
+		if !slices.Contains(presets, p) {
 			return fmt.Errorf("no such preset %q: only next presets exist: (%s)",
-				p, strings.Join(AllPresets(), "|"))
+				p, strings.Join(presets, "|"))
 		}
 	}
 

--- a/test/bench/bench_test.go
+++ b/test/bench/bench_test.go
@@ -76,7 +76,7 @@ func printCommand(cmd string, args ...string) {
 }
 
 func getGolangciLintCommonArgs() []string {
-	return []string{"run", "--no-config", "--issues-exit-code=0", "--deadline=30m", "--disable-all", "--enable=govet"}
+	return []string{"run", "--no-config", "--issues-exit-code=0", "--timeout=30m", "--disable-all", "--enable=govet"}
 }
 
 func runGolangciLintForBench(b testing.TB) {

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -54,20 +54,6 @@ func TestSymlinkLoop(t *testing.T) {
 		ExpectNoIssues()
 }
 
-// TODO(ldez): remove this in v2.
-func TestDeadline(t *testing.T) {
-	projectRoot := filepath.Join("..", "...")
-
-	testshared.NewRunnerBuilder(t).
-		WithArgs("--deadline=1ms").
-		WithTargetPath(projectRoot).
-		Runner().
-		Install().
-		Run().
-		ExpectExitCode(exitcodes.Timeout).
-		ExpectOutputContains(`Timeout exceeded: try increasing it by passing --timeout option`)
-}
-
 func TestTimeout(t *testing.T) {
 	projectRoot := filepath.Join("..", "...")
 
@@ -82,43 +68,21 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestTimeoutInConfig(t *testing.T) {
-	cases := []struct {
-		cfg string
-	}{
-		{
-			cfg: `
-				run:
-					deadline: 1ms
-			`,
-		},
-		{
-			cfg: `
-				run:
-					timeout: 1ms
-			`,
-		},
-		{
-			// timeout should override deadline
-			cfg: `
-				run:
-					deadline: 100s
-					timeout: 1ms
-			`,
-		},
-	}
-
 	testshared.InstallGolangciLint(t)
 
-	for _, c := range cases {
-		// Run with disallowed option set only in config
-		testshared.NewRunnerBuilder(t).
-			WithConfig(c.cfg).
-			WithTargetPath(testdataDir, minimalPkg).
-			Runner().
-			Run().
-			ExpectExitCode(exitcodes.Timeout).
-			ExpectOutputContains(`Timeout exceeded: try increasing it by passing --timeout option`)
-	}
+	cfg := `
+				run:
+					timeout: 1ms
+			`
+
+	// Run with disallowed option set only in config
+	testshared.NewRunnerBuilder(t).
+		WithConfig(cfg).
+		WithTargetPath(testdataDir, minimalPkg).
+		Runner().
+		Run().
+		ExpectExitCode(exitcodes.Timeout).
+		ExpectOutputContains(`Timeout exceeded: try increasing it by passing --timeout option`)
 }
 
 func TestTestsAreLintedByDefault(t *testing.T) {


### PR DESCRIPTION
This is the first part of the rewrite of the command line (the `Executor`).
I split the changes into several PRs to ease the review.

This PR mainly moves, organizes, and splits the current code.
There are no major changes, but I spent a lot of time analyzing the code to be able to make the right changes to prepare for the new step.

I also removed all the deprecated flags.
They have been deprecated for multiple years (2018), so it is safe to remove them.

I made small commits to ease the review: each commit contains one change.
I recommend reviewing each commit first instead of the full change because it's easier to follow changes.

I already have the next PR, but this PR must be merged first.

related to https://github.com/golangci/golangci-lint/pull/4397#discussion_r1494525093

FYI with changes inside this PR, I can just move one line to fix the problem related to the configuration loading, but this will not fix the core of the problem: the maintainability of the code.
Also, this PR improves a bit the performance by removing one of the multiple builds of the linters (I will also fix that in another PR).

EDIT: [--update-refs](https://git-scm.com/docs/git-rebase/2.43.0#Documentation/git-rebase.txt---update-refs) is the best rebase option ever!
