### PR TITLE
dev: install.sh fix usage message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,10 @@ usage() {
   cat <<EOF
 $this: download go binaries for golangci/golangci-lint
 
-Usage: $this [-b] bindir [-d] [tag]
+Usage: $this [-b <bindir>] [-d] [<tag>]
   -b sets bindir or installation directory, Defaults to ./bin
   -d turns on debug logging
-   [tag] is a tag from
+   <tag> is a tag from
    https://github.com/golangci/golangci-lint/releases
    If tag is missing, then the latest will be used.
 


### PR DESCRIPTION
Fix install.sh usage message:
1. Use angle brackets to mark replaceable items `<bindir>` and `<tag>`. See https://stackoverflow.com/a/23242584
2. Mark that `<bindir>` is attached to `-b` option