### PR TITLE
feat: exclude linters from severity-rules

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2892,6 +2892,14 @@ severity:
   # Default: false
   case-sensitive: true
 
+  # When a list of exclude-linters is provided, the default severity of issues will not be applied to them.
+  # This allows for more complex linters such as 'revive' to conserve their own severity rules.
+  # This takes precedence over `severity-rules`.
+  #
+  # Default: []
+  exclude-linters:
+    - revive
+
   # When a list of severity rules are provided, severity information will be added to lint issues.
   # Severity rules have the same filtering capability as exclude rules
   # except you are allowed to specify one matcher per severity rule.

--- a/pkg/config/severity.go
+++ b/pkg/config/severity.go
@@ -3,9 +3,10 @@ package config
 const severityRuleMinConditionsCount = 1
 
 type Severity struct {
-	Default       string         `mapstructure:"default-severity"`
-	CaseSensitive bool           `mapstructure:"case-sensitive"`
-	Rules         []SeverityRule `mapstructure:"rules"`
+	Default        string         `mapstructure:"default-severity"`
+	CaseSensitive  bool           `mapstructure:"case-sensitive"`
+	ExcludeLinters []string       `mapstructure:"exclude-linters"`
+	Rules          []SeverityRule `mapstructure:"rules"`
 }
 
 type SeverityRule struct {

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -30,7 +30,8 @@ type Runner struct {
 func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env,
 	es *lintersdb.EnabledSet,
 	lineCache *fsutils.LineCache, fileCache *fsutils.FileCache,
-	dbManager *lintersdb.Manager, pkgs []*gopackages.Package) (*Runner, error) {
+	dbManager *lintersdb.Manager, pkgs []*gopackages.Package,
+) (*Runner, error) {
 	// Beware that some processors need to add the path prefix when working with paths
 	// because they get invoked before the path prefixer (exclude and severity rules)
 	// or process other paths (skip files).
@@ -113,7 +114,8 @@ func NewRunner(cfg *config.Config, log logutils.Log, goenv *goutil.Env,
 }
 
 func (r *Runner) runLinterSafe(ctx context.Context, lintCtx *linter.Context,
-	lc *linter.Config) (ret []result.Issue, err error) {
+	lc *linter.Config,
+) (ret []result.Issue, err error) {
 	defer func() {
 		if panicData := recover(); panicData != nil {
 			if pe, ok := panicData.(*errorutil.PanicError); ok {
@@ -333,6 +335,7 @@ func getSeverityRulesProcessor(cfg *config.Severity, log logutils.Log, files *fs
 	if cfg.CaseSensitive {
 		severityRulesProcessor = processors.NewSeverityRulesCaseSensitive(
 			cfg.Default,
+			cfg.ExcludeLinters,
 			severityRules,
 			files,
 			log.Child(logutils.DebugKeySeverityRules),
@@ -340,6 +343,7 @@ func getSeverityRulesProcessor(cfg *config.Severity, log logutils.Log, files *fs
 	} else {
 		severityRulesProcessor = processors.NewSeverityRules(
 			cfg.Default,
+			cfg.ExcludeLinters,
 			severityRules,
 			files,
 			log.Child(logutils.DebugKeySeverityRules),

--- a/pkg/result/processors/severity_rules_test.go
+++ b/pkg/result/processors/severity_rules_test.go
@@ -17,7 +17,7 @@ func TestSeverityRulesMultiple(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
 	log := report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &report.Data{})
-	p := NewSeverityRules("error", []SeverityRule{
+	p := NewSeverityRules("error", []string{}, []SeverityRule{
 		{
 			Severity: "info",
 			BaseRule: BaseRule{
@@ -122,7 +122,7 @@ func TestSeverityRulesPathPrefix(t *testing.T) {
 	pathPrefix := path.Join("some", "dir")
 	files := fsutils.NewFiles(lineCache, pathPrefix)
 	log := report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &report.Data{})
-	p := NewSeverityRules("error", []SeverityRule{
+	p := NewSeverityRules("error", []string{}, []SeverityRule{
 		{
 			Severity: "info",
 			BaseRule: BaseRule{
@@ -159,7 +159,7 @@ func TestSeverityRulesPathPrefix(t *testing.T) {
 }
 
 func TestSeverityRulesText(t *testing.T) {
-	p := NewSeverityRules("", []SeverityRule{
+	p := NewSeverityRules("", []string{}, []SeverityRule{
 		{
 			BaseRule: BaseRule{
 				Text:    "^severity$",
@@ -190,7 +190,7 @@ func TestSeverityRulesOnlyDefault(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
 	log := report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &report.Data{})
-	p := NewSeverityRules("info", []SeverityRule{}, files, log)
+	p := NewSeverityRules("info", []string{}, []SeverityRule{}, files, log)
 
 	cases := []issueTestCase{
 		{Path: "ssl.go", Text: "ssl", Linter: "gosec"},
@@ -219,13 +219,13 @@ func TestSeverityRulesOnlyDefault(t *testing.T) {
 }
 
 func TestSeverityRulesEmpty(t *testing.T) {
-	processAssertSame(t, NewSeverityRules("", nil, nil, nil), newIssueFromTextTestCase("test"))
+	processAssertSame(t, NewSeverityRules("", []string{}, nil, nil, nil), newIssueFromTextTestCase("test"))
 }
 
 func TestSeverityRulesCaseSensitive(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
-	p := NewSeverityRulesCaseSensitive("error", []SeverityRule{
+	p := NewSeverityRulesCaseSensitive("error", []string{}, []SeverityRule{
 		{
 			Severity: "info",
 			BaseRule: BaseRule{


### PR DESCRIPTION
Currently when configuring severity-rules we lose the granularity provided by more advanced linters.

A good use case is **revive** that allows us to customize the severity per linter. Considering the configuration below all the revive issues will have `info` severity instead of the severity defined in **revive**.

I already brought this to discussion in the past, https://github.com/golangci/golangci-lint/discussions/1860, and I accepted the limitation. But now I'm trying to work on a more precise coding standard for my teams and having the ability to control this would be perfect.

```yml
linters:
  disable-all: true
  enable:
    - errcheck
    - gosimple
    - govet
    - ineffassign
    - staticcheck
    - unused
    - revive
 
linters-settings:
  revive:
    severity: error
    rules:
      - name: cognitive-complexity
        arguments: [15]
      - name: cyclomatic
        arguments: [12]
        severity: warning

severity:
  default-severity: info
  rules:
    - linters:
      - errcheck
      - gosimple
      - govet
      - ineffassign
      - staticcheck
      - unused
      severity: warning
```

<details><summary>Output before the proposal</summary>
<p>

```xml
<?xml version="1.0" encoding="UTF-8"?>

<checkstyle version="5.0">
  <file name="internal/slack/slack_test.go">
    <error column="1" line="402" message="cognitive-complexity: function okFileUpload has cognitive complexity 17 (&gt; max enabled 15)" severity="info" source="revive">
    <error column="1" line="402" message="cyclomatic: function okFileUpload has cyclomatic complexity 14 (&gt; max enabled 12)" severity="info" source="revive">
    </error>
  </file>
</checkstyle>
```
</p>
</details>

With this proposal we add an `exclude-linters` to skip the `default-severity`

```yml
linters:
  disable-all: true
  enable:
    - errcheck
    - gosimple
    - govet
    - ineffassign
    - staticcheck
    - unused
    - revive
 
linters-settings:
  revive:
    severity: error
    rules:
      - name: cognitive-complexity
        arguments: [15]
      - name: cyclomatic
        arguments: [12]
        severity: warning

severity:
  default-severity: info
  exclude-linters:
    - revive
  rules:
    - linters:
      - errcheck
      - gosimple
      - govet
      - ineffassign
      - staticcheck
      - unused
      severity: warning
```

<details><summary>Output after the proposal</summary>
<p>

```xml
<?xml version="1.0" encoding="UTF-8"?>

<checkstyle version="5.0">
  <file name="internal/slack/slack_test.go">
    <error column="1" line="402" message="cognitive-complexity: function okFileUpload has cognitive complexity 17 (&gt; max enabled 15)" severity="error" source="revive">
    <error column="1" line="402" message="cyclomatic: function okFileUpload has cyclomatic complexity 14 (&gt; max enabled 12)" severity="warning" source="revive">
    </error>
  </file>
</checkstyle>
```
</p>
</details>

I didn't write any tests for this yet, I simply tested it locally to validate the output files.

Let me know if this is something worth to put more effort and I will happily finalize the work.