### PR TITLE
feat: allow running only a specific linter without modifying the file configuration

### DIFF
--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -29,7 +29,8 @@ func setupLintersFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 		color.GreenString(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
 			"them. This option implies option --disable-all", strings.Join(lintersdb.AllPresets(), "|"))))
 
-	fs.StringSlice("enable-only", nil, color.GreenString("Override linters configuration section to only run the specific linter(s)")) // Flags only.
+	fs.StringSlice("enable-only", nil,
+		color.GreenString("Override linters configuration section to only run the specific linter(s)")) // Flags only.
 }
 
 func setupRunFlagSet(v *viper.Viper, fs *pflag.FlagSet) {

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -29,7 +29,7 @@ func setupLintersFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 		color.GreenString(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
 			"them. This option implies option --disable-all", strings.Join(lintersdb.AllPresets(), "|"))))
 
-	fs.StringSlice("only", nil, color.GreenString("Override linters configuration section to only run the specific linter(s)")) // Flags only.
+	fs.StringSlice("enable-only", nil, color.GreenString("Override linters configuration section to only run the specific linter(s)")) // Flags only.
 }
 
 func setupRunFlagSet(v *viper.Viper, fs *pflag.FlagSet) {

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -28,6 +28,8 @@ func setupLintersFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 	fs.StringSliceP("presets", "p", nil,
 		color.GreenString(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see "+
 			"them. This option implies option --disable-all", strings.Join(lintersdb.AllPresets(), "|"))))
+
+	fs.StringSlice("only", nil, color.GreenString("Override linters configuration section to only run the specific linter(s)")) // Flags only.
 }
 
 func setupRunFlagSet(v *viper.Viper, fs *pflag.FlagSet) {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -61,6 +61,27 @@ func (l *Loader) Load() error {
 
 	l.handleGoVersion()
 
+	err = l.handleOnlyOption()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *Loader) handleOnlyOption() error {
+	only, err := l.fs.GetStringSlice("only")
+	if err != nil {
+		return err
+	}
+
+	if len(only) > 0 {
+		l.cfg.Linters = Linters{
+			Enable:     only,
+			DisableAll: true,
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -94,12 +94,13 @@ func (l *Loader) handleGoVersion() {
 
 	l.cfg.LintersSettings.ParallelTest.Go = l.cfg.Run.Go
 
-	trimmedGoVersion := trimGoVersion(l.cfg.Run.Go)
-
-	l.cfg.LintersSettings.Gocritic.Go = trimmedGoVersion
 	if l.cfg.LintersSettings.Gofumpt.LangVersion == "" {
 		l.cfg.LintersSettings.Gofumpt.LangVersion = l.cfg.Run.Go
 	}
+
+	trimmedGoVersion := trimGoVersion(l.cfg.Run.Go)
+
+	l.cfg.LintersSettings.Gocritic.Go = trimmedGoVersion
 
 	// staticcheck related linters.
 	if l.cfg.LintersSettings.Staticcheck.GoVersion == "" {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -61,7 +61,7 @@ func (l *Loader) Load() error {
 
 	l.handleGoVersion()
 
-	err = l.handleOnlyOption()
+	err = l.handleEnableOnlyOption()
 	if err != nil {
 		return err
 	}
@@ -69,8 +69,8 @@ func (l *Loader) Load() error {
 	return nil
 }
 
-func (l *Loader) handleOnlyOption() error {
-	only, err := l.fs.GetStringSlice("only")
+func (l *Loader) handleEnableOnlyOption() error {
+	only, err := l.fs.GetStringSlice("enable-only")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is a proposal for a new flag (not a file configuration).

This new flag will allow running only one specific linter without modifying the file configuration.

I named this flag `--only` but I'm not sure about this name.
I think `--force` can be ambiguous :thinking:.

This flag will override all the options of the `linters` section from the file configuration (`enable`, `disable`, `enable-all`, `disable-all`, `fast`, and `presets` ).
So you can run a linter with the right `linters-settings` section from the file without modifying the file configuration.

Before:
```bash
golangci-lint run --no-config --disable-all --enable=yourlintername
```

After:
```bash
golangci-lint run --enable-only=yourlintername

# OR

golangci-lint run --no-config --enable-only=yourlintername
```

Related to #3453, #1188,  #1972