### PR TITLE
fix: move show-stats field from run to output

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -80,10 +80,6 @@ run:
   # Default: use Go version from the go.mod file, fallback on the env var `GOVERSION`, fallback on 1.17
   go: '1.19'
 
-  # Show statistics per linter.
-  # Default: false
-  show-stats: true
-
 
 # output configuration options
 output:
@@ -117,6 +113,9 @@ output:
   # Default: false
   sort-results: true
 
+  # Show statistics per linter.
+  # Default: false
+  show-stats: true
 
 # All available settings of specific linters.
 linters-settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -138,19 +138,30 @@ issues:
         - gomnd
 
     - path: pkg/golinters/errcheck.go
+      linters: [staticcheck]
       text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
     - path: pkg/commands/run.go
+      linters: [staticcheck]
       text: "SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead"
+    - path: pkg/commands/run.go
+      linters: [staticcheck]
+      text: "SA1019: c.cfg.Run.ShowStats is deprecated: use Output.ShowStats instead."
 
     - path: pkg/golinters/gofumpt.go
+      linters: [staticcheck]
       text: "SA1019: settings.LangVersion is deprecated: use the global `run.go` instead."
     - path: pkg/golinters/staticcheck_common.go
+      linters: [staticcheck]
       text: "SA1019: settings.GoVersion is deprecated: use the global `run.go` instead."
     - path: pkg/lint/lintersdb/manager.go
+      linters: [staticcheck]
       text: "SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead."
+
     - path: pkg/golinters/unused.go
+      linters: [gocritic]
       text: "rangeValCopy: each iteration copies 160 bytes \\(consider pointers or indexing\\)"
     - path: test/(fix|linters)_test.go
+      linters: [gocritic]
       text: "string `gocritic.go` has 3 occurrences, make it a constant"
 
 run:

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -55,7 +55,6 @@ func setupRunFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 	const allowSerialDesc = "Allow multiple golangci-lint instances running, but serialize them around a lock. " +
 		"If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start."
 	internal.AddFlagAndBind(v, fs, fs.Bool, "allow-serial-runners", "run.allow-serial-runners", false, color.GreenString(allowSerialDesc))
-	internal.AddFlagAndBind(v, fs, fs.Bool, "show-stats", "run.show-stats", false, color.GreenString("Show statistics per linter"))
 }
 
 func setupOutputFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
@@ -71,6 +70,7 @@ func setupOutputFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 		color.GreenString("Sort linter results"))
 	internal.AddFlagAndBind(v, fs, fs.String, "path-prefix", "output.path-prefix", "",
 		color.GreenString("Path prefix to add to output"))
+	internal.AddFlagAndBind(v, fs, fs.Bool, "show-stats", "output.show-stats", false, color.GreenString("Show statistics per linter"))
 }
 
 //nolint:gomnd

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -397,7 +397,11 @@ func (c *runCommand) setExitCodeIfIssuesFound(issues []result.Issue) {
 }
 
 func (c *runCommand) printStats(issues []result.Issue) {
-	if !c.cfg.Run.ShowStats {
+	if c.cfg.Run.ShowStats {
+		c.log.Warnf("run.show-stats is deprecated, please use output.show-stats")
+	}
+
+	if !c.cfg.Run.ShowStats && !c.cfg.Output.ShowStats {
 		return
 	}
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -398,7 +398,7 @@ func (c *runCommand) setExitCodeIfIssuesFound(issues []result.Issue) {
 
 func (c *runCommand) printStats(issues []result.Issue) {
 	if c.cfg.Run.ShowStats {
-		c.log.Warnf("run.show-stats is deprecated, please use output.show-stats")
+		c.log.Warnf("The configuration option `run.show-stats` is deprecated, please use `output.show-stats`")
 	}
 
 	if !c.cfg.Run.ShowStats && !c.cfg.Output.ShowStats {

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -34,4 +34,5 @@ type Output struct {
 	UniqByLine      bool   `mapstructure:"uniq-by-line"`
 	SortResults     bool   `mapstructure:"sort-results"`
 	PathPrefix      string `mapstructure:"path-prefix"`
+	ShowStats       bool   `mapstructure:"show-stats"`
 }

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -23,7 +23,7 @@ type Run struct {
 	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
 	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
 
-	ShowStats bool `mapstructure:"show-stats"`
+	ShowStats bool `mapstructure:"show-stats"` // Deprecated use Output.ShowStats instead.
 
 	// It's obtain by flags and use for the tests and the context loader.
 	Args []string // Internal needs.

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -23,7 +23,8 @@ type Run struct {
 	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
 	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
 
-	ShowStats bool `mapstructure:"show-stats"` // Deprecated use Output.ShowStats instead.
+	// Deprecated: use Output.ShowStats instead.
+	ShowStats bool `mapstructure:"show-stats"`
 
 	// It's obtain by flags and use for the tests and the context loader.
 	Args []string // Internal needs.


### PR DESCRIPTION
During the review of the PR about `show-stats` I missed that the value was not in the right structure.

This PR deprecated the old `run.show-stats`, and replaced it with `output.show-stats`.

The flag `--show-stats` is not impacted, it's only about the file configuration.

The old `run.show-stats` still works but with a deprecation log message.