### PR TITLE
dev: split post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -5,7 +5,46 @@ on:
       - published
 
 jobs:
-  update-docs-and-assets:
+  update-docs:
+    name: "Update readme"
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
+          go-version: '1.22'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "15"
+          check-latest: true
+
+      - name: npm install
+        working-directory: .github/contributors
+        run: npm install
+
+      - name: Update Contributors list
+        run: make update_contributors_list # may take more than 1 hour
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: master
+          token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+          branch-suffix: timestamp
+          title: "docs: update documentation"
+          team-reviewers: golangci/team
+          delete-branch: true
+
+  update-assets:
+    name: "Update GitHub Action assets"
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
@@ -23,22 +62,12 @@ jobs:
       - name: Update GitHub action config
         run: make assets/github-action-config.json
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "15"
-          check-latest: true
-      - name: npm install
-        working-directory: .github/contributors
-        run: npm install
-      - name: Update Contributors list
-        run: make update_contributors_list # may take 15 min
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
           base: master
           token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
           branch-suffix: timestamp
-          title: "docs: Update documentation and assets"
+          title: "docs: update GitHub Action assets"
           team-reviewers: golangci/team
           delete-branch: true


### PR DESCRIPTION
The post-release workflow does 2 things:
- generate contributors list for the readme
- generate GitHub Action assets

And then create a PR with all the generated content.

The generation of the contributor list takes more than 1 hour and can fail.
https://github.com/golangci/golangci-lint/actions/workflows/post-release.yml

The generation of GitHub Action assets is really quick, and those assets are required to be able to install the new version from GitHub Action.

Each time it fails, I'm forced to do the work by hand.

I changed the workflow
- to not fail on a failure of the update of the readme.
- to create 2 PRs: one for the readme, and one for the assets.

So even if the readme generation fails, the assets are updated.