### PR TITLE
dev: adjust replacement msg for nosnakecase

### DIFF
--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -477,7 +477,7 @@ func (b LinterBuilder) Build(cfg *config.Config) []*linter.Config {
 			WithSince("v1.47.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/sivchari/nosnakecase").
-			Deprecated("The repository of the linter has been deprecated by the owner.", "v1.48.1", "revive(var-naming)"),
+			Deprecated("The repository of the linter has been deprecated by the owner.", "v1.48.1", "revive 'var-naming'"),
 
 		linter.NewConfig(golinters.NewNoSprintfHostPort()).
 			WithSince("v1.46.0").


### PR DESCRIPTION
The PR changed replacement string for the deprecated `nosnakecase` linter from `revive(var-naming)` to `revive 'var-naming'` to be consistent with the replacement string `govet 'fieldalignment'` for `maligned`.

Before:
```
❯ golangci-lint run -E nosnakecase -E maligned -v --disable-all --no-config

WARN [runner] The linter 'nosnakecase' is deprecated (since v1.48.1) due to: The repository of the linter has been deprecated by the owner. Replaced by revive(var-naming). 
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner. Replaced by govet 'fieldalignment'. 
```

After:
```
❯ ./golangci-lint run -E nosnakecase -E maligned -v --disable-all --no-config

WARN [runner] The linter 'nosnakecase' is deprecated (since v1.48.1) due to: The repository of the linter has been deprecated by the owner. Replaced by revive 'var-naming'. 
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner. Replaced by govet 'fieldalignment'. 
```