### PR TITLE
build(deps): bump github.com/karamaru-alpha/copyloopvar from 1.0.4 to 1.0.8

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -149,6 +149,11 @@ linters-settings:
     first-strong-isolate: false
     pop-directional-isolate: false
 
+  copyloopvar:
+    # If true, ignore aliasing of loop variables.
+    # Default: false
+    ignore-alias: true
+
   cyclop:
     # The maximal code complexity to report.
     # Default: 10

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/jjti/go-spancheck v0.5.3
 	github.com/julz/importas v0.1.0
-	github.com/karamaru-alpha/copyloopvar v1.0.4
+	github.com/karamaru-alpha/copyloopvar v1.0.8
 	github.com/kisielk/errcheck v1.7.0
 	github.com/kkHAIKE/contextcheck v1.1.4
 	github.com/kulti/thelper v0.6.3

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julz/importas v0.1.0 h1:F78HnrsjY3cR7j0etXy5+TU1Zuy7Xt08X/1aJnH5xXY=
 github.com/julz/importas v0.1.0/go.mod h1:oSFU2R4XK/P7kNBrnL/FEQlDGN1/6WoxXEjSSXO0DV0=
-github.com/karamaru-alpha/copyloopvar v1.0.4 h1:JD6IPXo4+RawkSPe9uMKh9OtTzYKsCelAgPMUwaVxBw=
-github.com/karamaru-alpha/copyloopvar v1.0.4/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
+github.com/karamaru-alpha/copyloopvar v1.0.8 h1:gieLARwuByhEMxRwM3GRS/juJqFbLraftXIKDDNJ50Q=
+github.com/karamaru-alpha/copyloopvar v1.0.8/go.mod h1:u7CIfztblY0jZLOQZgH3oYsJzpC2A7S6u/lfgSXHy0k=
 github.com/kisielk/errcheck v1.7.0 h1:+SbscKmWJ5mOK/bO1zS60F5I9WwZDWOfRsC4RwfwRV0=
 github.com/kisielk/errcheck v1.7.0/go.mod h1:1kLL+jV4e+CFfueBmI1dSK2ADDyQnlrnrY/FqKluHJQ=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -206,6 +206,7 @@ var defaultLintersSettings = LintersSettings{
 type LintersSettings struct {
 	Asasalint        AsasalintSettings
 	BiDiChk          BiDiChkSettings
+	CopyLoopVar      CopyLoopVarSettings
 	Cyclop           Cyclop
 	Decorder         DecorderSettings
 	Depguard         DepGuardSettings
@@ -311,6 +312,10 @@ type BiDiChkSettings struct {
 	RightToLeftIsolate       bool `mapstructure:"right-to-left-isolate"`
 	FirstStrongIsolate       bool `mapstructure:"first-strong-isolate"`
 	PopDirectionalIsolate    bool `mapstructure:"pop-directional-isolate"`
+}
+
+type CopyLoopVarSettings struct {
+	IgnoreAlias bool `mapstructure:"ignore-alias"`
 }
 
 type Cyclop struct {

--- a/pkg/golinters/copyloopvar.go
+++ b/pkg/golinters/copyloopvar.go
@@ -9,20 +9,21 @@ import (
 )
 
 func NewCopyLoopVar(settings *config.CopyLoopVarSettings) *goanalysis.Linter {
-	analyzer := copyloopvar.NewAnalyzer()
+	a := copyloopvar.NewAnalyzer()
+
 	var cfg map[string]map[string]any
 	if settings != nil {
 		cfg = map[string]map[string]any{
-			analyzer.Name: {
+			a.Name: {
 				"ignore-alias": settings.IgnoreAlias,
 			},
 		}
 	}
 
 	return goanalysis.NewLinter(
-		analyzer.Name,
-		analyzer.Doc,
-		[]*analysis.Analyzer{analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/copyloopvar.go
+++ b/pkg/golinters/copyloopvar.go
@@ -4,16 +4,25 @@ import (
 	"github.com/karamaru-alpha/copyloopvar"
 	"golang.org/x/tools/go/analysis"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
 )
 
-func NewCopyLoopVar() *goanalysis.Linter {
-	a := copyloopvar.Analyzer
+func NewCopyLoopVar(settings *config.CopyLoopVarSettings) *goanalysis.Linter {
+	analyzer := copyloopvar.NewAnalyzer()
+	var cfg map[string]map[string]any
+	if settings != nil {
+		cfg = map[string]map[string]any{
+			analyzer.Name: {
+				"ignore-alias": settings.IgnoreAlias,
+			},
+		}
+	}
 
 	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
+		analyzer.Name,
+		analyzer.Doc,
+		[]*analysis.Analyzer{analyzer},
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -60,7 +60,7 @@ func (b LinterBuilder) Build(cfg *config.Config) []*linter.Config {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kkHAIKE/contextcheck"),
 
-		linter.NewConfig(golinters.NewCopyLoopVar()).
+		linter.NewConfig(golinters.NewCopyLoopVar(&cfg.LintersSettings.CopyLoopVar)).
 			WithSince("v1.57.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/karamaru-alpha/copyloopvar").

--- a/test/testdata/configs/copyloopvar.yml
+++ b/test/testdata/configs/copyloopvar.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  copyloopvar:
+    ignore-alias: true

--- a/test/testdata/copyloopvar.go
+++ b/test/testdata/copyloopvar.go
@@ -1,6 +1,7 @@
 //go:build go1.22
 
 //golangcitest:args -Ecopyloopvar
+//golangcitest:config_path testdata/configs/copyloopvar.yml
 package testdata
 
 import "fmt"
@@ -13,10 +14,12 @@ func copyloopvarCase1() {
 		fns = append(fns, func() {
 			fmt.Println(i)
 		})
-		_v := v // want `The copy of the 'for' variable "v" can be deleted \(Go 1\.22\+\)`
+		v := v // want `The copy of the 'for' variable "v" can be deleted \(Go 1\.22\+\)`
 		fns = append(fns, func() {
-			fmt.Println(_v)
+			fmt.Println(v)
 		})
+		_v := v
+		_ = _v
 	}
 	for _, fn := range fns {
 		fn()

--- a/test/testdata/copyloopvar_custom.go
+++ b/test/testdata/copyloopvar_custom.go
@@ -1,6 +1,7 @@
 //go:build go1.22
 
 //golangcitest:args -Ecopyloopvar
+//golangcitest:config_path testdata/configs/copyloopvar.yml
 package testdata
 
 import "fmt"
@@ -17,7 +18,7 @@ func copyloopvarCase1() {
 		fns = append(fns, func() {
 			fmt.Println(v)
 		})
-		_v := v // want `The copy of the 'for' variable "v" can be deleted \(Go 1\.22\+\)`
+		_v := v
 		_ = _v
 	}
 	for _, fn := range fns {


### PR DESCRIPTION
I'm pleased to announce an upgrade [copyloopvar](https://github.com/karamaru-alpha/copyloopvar), now featuring support for the `ignore-alias` option. This new option allows the assignment of loop variables to variables with different names.

The detailed implementation can be found below. Please check it at your convenience.
https://github.com/karamaru-alpha/copyloopvar/releases/tag/v1.0.8

https://github.com/karamaru-alpha/copyloopvar/compare/v1.0.4...v1.0.8