### PR TITLE
dev: flag `perfsprint` as autofixable

### DIFF
--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -494,6 +494,7 @@ func (b LinterBuilder) Build(cfg *config.Config) []*linter.Config {
 			WithSince("v1.55.0").
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetPerformance).
+			WithAutoFix().
 			WithURL("https://github.com/catenacyber/perfsprint"),
 
 		linter.NewConfig(golinters.NewPreAlloc(&cfg.LintersSettings.Prealloc)).


### PR DESCRIPTION
I can't find any documentation on this, but based on other linters it seems that if the underlying linter supports `--fix` then this is all that's needed for golangci-lint to support fixing it.

Resolves #4453