### PR TITLE
docs: don't mark dupword as autofixable

### DIFF
--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -102,7 +102,6 @@ func (b LinterBuilder) Build(cfg *config.Config) []*linter.Config {
 		linter.NewConfig(golinters.NewDupWord(&cfg.LintersSettings.DupWord)).
 			WithSince("1.50.0").
 			WithPresets(linter.PresetComment).
-			WithAutoFix().
 			WithURL("https://github.com/Abirdcfly/dupword"),
 
 		linter.NewConfig(golinters.NewDurationCheck()).


### PR DESCRIPTION
Based on the feedback from #4453, linters using `SuggestedFixes` are currently not autofixable due to #1779 which is what [`dupword` is using](https://github.com/Abirdcfly/dupword/blob/main/dupword.go#L136), so it shouldn't be marked as autofixable.