### PR TITLE
docs: fix typo in 'e.g.'

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2054,7 +2054,7 @@ linters-settings:
     # Align and sort can be used together or separately.
     #
     # Whether enable align. If true, the struct tags will be aligned.
-    # eg:
+    # e.g.:
     # type FooBar struct {
     #     Bar    string `json:"bar" validate:"required"`
     #     FooFoo int8   `json:"foo_foo" validate:"required"`
@@ -2068,7 +2068,7 @@ linters-settings:
     align: false
     # Whether enable tags sort.
     # If true, the tags will be sorted by name in ascending order.
-    # eg: `xml:"bar" json:"bar" validate:"required"` -> `json:"bar" validate:"required" xml:"bar"`
+    # e.g.: `xml:"bar" json:"bar" validate:"required"` -> `json:"bar" validate:"required" xml:"bar"`
     # Default: true
     sort: false
     # Specify the order of tags, the other tags will be sorted by name.

--- a/pkg/result/processors/cgo.go
+++ b/pkg/result/processors/cgo.go
@@ -27,7 +27,7 @@ func (p Cgo) Name() string {
 
 func (p Cgo) Process(issues []result.Issue) ([]result.Issue, error) {
 	return filterIssuesErr(issues, func(i *result.Issue) (bool, error) {
-		// some linters (.e.g gosec, deadcode) return incorrect filepaths for cgo issues,
+		// some linters (e.g. gosec, deadcode) return incorrect filepaths for cgo issues,
 		// also cgo files have strange issues looking like false positives.
 
 		// cache dir contains all preprocessed files including cgo files


### PR DESCRIPTION
The abbreviation "for example" can be written without periods as "eg" according to https://dictionary.cambridge.org/us/dictionary/english/eg. However, I chose to use the more popular variant "e.g."