### PR TITLE
dev: add GL_DEBUG=govet to see enabled analyzers

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1100,7 +1100,7 @@ linters-settings:
     #   stdmethods, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr,
     #   unusedresult
     # ).
-    # Run `go tool vet help` to see all analyzers.
+    # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
     # Default: []
     enable:
       - appends
@@ -1152,7 +1152,7 @@ linters-settings:
     #   atomicalign, deepequalerrors, fieldalignment, findcall, nilness, reflectvaluecompare, shadow, sortslice,
     #   timeformat, unusedwrite
     # ).
-    # Run `go tool vet help` to see all analyzers.
+    # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
     # Default: []
     disable:
       - appends

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -2,6 +2,7 @@ package golinters
 
 import (
 	"slices"
+	"sort"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/appends"
@@ -52,6 +53,7 @@ import (
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/golinters/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/logutils"
 )
 
 var (
@@ -136,6 +138,11 @@ var (
 	}
 )
 
+var (
+	govetDebugf  = logutils.Debug(logutils.DebugKeyGovet)
+	isGovetDebug = logutils.HaveDebugTag(logutils.DebugKeyGovet)
+)
+
 func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
 	var conf map[string]map[string]any
 	if settings != nil {
@@ -152,6 +159,9 @@ func NewGovet(settings *config.GovetSettings) *goanalysis.Linter {
 }
 
 func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
+	debugAnalyzersListf(allAnalyzers, "All available analyzers")
+	debugAnalyzersListf(defaultAnalyzers, "Default analyzers")
+
 	if settings == nil {
 		return defaultAnalyzers
 	}
@@ -167,6 +177,8 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 			enabledAnalyzers = append(enabledAnalyzers, a)
 		}
 	}
+
+	debugAnalyzersListf(enabledAnalyzers, "Enabled by config analyzers")
 
 	return enabledAnalyzers
 }
@@ -193,4 +205,17 @@ func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers 
 	default:
 		return slices.ContainsFunc(defaultAnalyzers, func(a *analysis.Analyzer) bool { return a.Name == name })
 	}
+}
+
+func debugAnalyzersListf(analyzers []*analysis.Analyzer, message string) {
+	if !isGovetDebug {
+		return
+	}
+
+	analyzerNames := make([]string, 0, len(analyzers))
+	for _, a := range analyzers {
+		analyzerNames = append(analyzerNames, a.Name)
+	}
+	sort.Strings(analyzerNames)
+	govetDebugf("%s (%d): %s", message, len(analyzerNames), analyzerNames)
 }

--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -216,6 +216,8 @@ func debugAnalyzersListf(analyzers []*analysis.Analyzer, message string) {
 	for _, a := range analyzers {
 		analyzerNames = append(analyzerNames, a.Name)
 	}
+
 	sort.Strings(analyzerNames)
+
 	govetDebugf("%s (%d): %s", message, len(analyzerNames), analyzerNames)
 }

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -57,6 +57,7 @@ const (
 
 const (
 	DebugKeyGoCritic  = "gocritic"  // Debugs `go-critic` linter.
+	DebugKeyGovet     = "govet"     // Debugs `govet` linter.
 	DebugKeyMegacheck = "megacheck" // Debugs `staticcheck` related linters.
 	DebugKeyNolint    = "nolint"    // Debugs a filter excluding issues by `//nolint` comments.
 	DebugKeyRevive    = "revive"    // Debugs `revive` linter.


### PR DESCRIPTION
The PR adds the debug key `govet` that can be used to see default, all available, and enabled `govet` analyzers:

```
GL_DEBUG=govet ./golangci-lint run --enable=govet
```

Example of debug output:
```sh
❯ GL_DEBUG=govet ./golangci-lint run --enable=govet
DEBU [govet] All available analyzers (41): [appends asmdecl assign atomic atomicalign bools buildtag cgocall composites copylocks deepequalerrors defers directive errorsas fieldalignment findcall framepointer httpresponse ifaceassert loopclosure lostcancel nilfunc nilness printf reflectvaluecompare shadow shift sigchanyzer slog sortslice stdmethods stringintconv structtag testinggoroutine tests timeformat unmarshal unreachable unsafeptr unusedresult unusedwrite] 
DEBU [govet] Default analyzers (32): [appends asmdecl assign atomic bools buildtag cgocall composites copylocks defers directive errorsas framepointer httpresponse ifaceassert loopclosure lostcancel nilfunc printf shift sigchanyzer slog stdmethods stringintconv structtag testinggoroutine tests timeformat unmarshal unreachable unsafeptr unusedresult] 
DEBU [govet] Enabled by config analyzers (35): [appends asmdecl atomicalign bools buildtag cgocall composites copylocks deepequalerrors defers directive errorsas fieldalignment findcall framepointer httpresponse ifaceassert loopclosure lostcancel nilfunc printf reflectvaluecompare shift sigchanyzer slog sortslice stdmethods stringintconv structtag testinggoroutine tests timeformat unmarshal unreachable unsafeptr] 
```

The implementation of `govet` output debugging is similar to the existing one for `gocritic` checks.

Previously, the documentation suggested using `go tool vet help` to see all analyzers. However, this might be inaccurate as we could forget to update  `govet.allAnalyzers` and `govet.defaultAnalyzers` slices. To avoid this, I changed the documentation to `GL_DEBUG=govet golangci-lint run --enable=govet`.