### PR TITLE
fix: store and read severity from linters in the cache

### DIFF
--- a/pkg/golinters/goanalysis/issue.go
+++ b/pkg/golinters/goanalysis/issue.go
@@ -23,6 +23,7 @@ func NewIssue(issue *result.Issue, pass *analysis.Pass) Issue {
 type EncodingIssue struct {
 	FromLinter           string
 	Text                 string
+	Severity             string
 	Pos                  token.Position
 	LineRange            *result.Range
 	Replacement          *result.Replacement

--- a/pkg/golinters/goanalysis/runners.go
+++ b/pkg/golinters/goanalysis/runners.go
@@ -151,6 +151,7 @@ func saveIssuesToCache(allPkgs []*packages.Package, pkgsFromCache map[*packages.
 					encodedIssues = append(encodedIssues, EncodingIssue{
 						FromLinter:           i.FromLinter,
 						Text:                 i.Text,
+						Severity:             i.Severity,
 						Pos:                  i.Pos,
 						LineRange:            i.LineRange,
 						Replacement:          i.Replacement,
@@ -222,6 +223,7 @@ func loadIssuesFromCache(pkgs []*packages.Package, lintCtx *linter.Context,
 					issues = append(issues, result.Issue{
 						FromLinter:           i.FromLinter,
 						Text:                 i.Text,
+						Severity:             i.Severity,
 						Pos:                  i.Pos,
 						LineRange:            i.LineRange,
 						Replacement:          i.Replacement,


### PR DESCRIPTION
The severity from linters needs to be stored into the cache, if not, the severity between 2 calls is not consistent.

<details><summary>To test the PR</summary>

```bash
#!/bin/sh -e

## setup module
rm -rf testexample
mkdir testexample && cd $_
go mod init helloworld

## main.go
cat > main.go  <<EOF
// this is a very very very very very very very very very very very very very very very very very very very very very very long line.
package main

func main() {
	newDnsZone()
}

func newDnsZone() error {
	return nil
}
EOF

## .golangci.yml
cat > .golangci.yml  <<EOF
linters:
  disable-all: true
  enable:
    - revive
    - errcheck
    - lll

linters-settings:
  revive:
    ignore-generated-header: false
    severity: error
    confidence: 0.8
    rules:
      - name: var-naming
        severity: warning

severity:
  default-severity: error
  keep-linter-severity: true
  case-sensitive: true
  rules:
    - linters:
        - lll
      severity: warning
EOF
```

</details>

---

<details><summary>Before (i.e. v1.56.2)</summary>

```console
$ golangci-lint cache clean

$ golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }' 
{
  "linter": "errcheck",
  "text": "Error return value is not checked",
  "severity": "error"
}
{
  "linter": "lll",
  "text": "line is 133 characters",
  "severity": "warning"
}
{
  "linter": "revive",
  "text": "var-naming: func newDnsZone should be newDNSZone",
  "severity": "error"
}

$ golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }'
{
  "linter": "errcheck",
  "text": "Error return value is not checked",
  "severity": "error"
}
{
  "linter": "lll",
  "text": "line is 133 characters",
  "severity": "warning"
}
{
  "linter": "revive",
  "text": "var-naming: func newDnsZone should be newDNSZone",
  "severity": "error"
}
```

The severity from linters is ignored.

</details>

<details><summary>After #4452</summary>

```console
$ golangci-lint cache clean

$ ./golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }' 
{
  "linter": "errcheck",
  "text": "Error return value is not checked",
  "severity": "error"
}
{
  "linter": "lll",
  "text": "line is 133 characters",
  "severity": "warning"
}
{
  "linter": "revive",
  "text": "var-naming: func newDnsZone should be newDNSZone",
  "severity": "warning"
}

$ ./golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }'
{
  "linter": "errcheck",
  "text": "Error return value is not checked",
  "severity": "error"
}
{
  "linter": "lll",
  "text": "line is 133 characters",
  "severity": "warning"
}
{
  "linter": "revive",
  "text": "var-naming: func newDnsZone should be newDNSZone",
  "severity": "error"
}

```

The severity from linters is applied but the severity from `var-naming` has changed between the 2 calls because the severity is not inside the cache.

</details>

<details><summary>With this PR</summary>

```console
$ golangci-lint cache clean

$ ./golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }'
{
  "linter": "errcheck",
  "text": "Error return value is not checked",
  "severity": "error"
}
{
  "linter": "lll",
  "text": "line is 133 characters",
  "severity": "warning"
}
{
  "linter": "revive",
  "text": "var-naming: func newDnsZone should be newDNSZone",
  "severity": "warning"
}

$ ./golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }'
{
  "linter": "errcheck",
  "text": "Error return value is not checked",
  "severity": "error"
}
{
  "linter": "lll",
  "text": "line is 133 characters",
  "severity": "warning"
}
{
  "linter": "revive",
  "text": "var-naming: func newDnsZone should be newDNSZone",
  "severity": "warning"
}

```

The severity stays consistent.

</details>
