### PR TITLE
feat: syntax to not override severity from linters

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2881,6 +2881,8 @@ severity:
   # - GitHub: https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
   # - TeamCity: https://www.jetbrains.com/help/teamcity/service-messages.html#Inspection+Instance
   #
+  # `@` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
+  #
   # Default: ""
   default-severity: error
 
@@ -2891,6 +2893,9 @@ severity:
   # When a list of severity rules are provided, severity information will be added to lint issues.
   # Severity rules have the same filtering capability as exclude rules
   # except you are allowed to specify one matcher per severity rule.
+  #
+  # `@` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
+  #
   # Only affects out formats that support setting severity information.
   #
   # Default: []

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2888,10 +2888,6 @@ severity:
   # Default: false
   case-sensitive: true
 
-  # Don't override severity defined by linters.
-  # Default: false
-  keep-linter-severity: true
-
   # When a list of severity rules are provided, severity information will be added to lint issues.
   # Severity rules have the same filtering capability as exclude rules
   # except you are allowed to specify one matcher per severity rule.

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2881,7 +2881,7 @@ severity:
   # - GitHub: https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
   # - TeamCity: https://www.jetbrains.com/help/teamcity/service-messages.html#Inspection+Instance
   #
-  # `@` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
+  # `@linter` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
   #
   # Default: ""
   default-severity: error
@@ -2894,7 +2894,7 @@ severity:
   # Severity rules have the same filtering capability as exclude rules
   # except you are allowed to specify one matcher per severity rule.
   #
-  # `@` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
+  # `@linter` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
   #
   # Only affects out formats that support setting severity information.
   #

--- a/pkg/config/severity.go
+++ b/pkg/config/severity.go
@@ -8,10 +8,9 @@ import (
 const severityRuleMinConditionsCount = 1
 
 type Severity struct {
-	Default            string         `mapstructure:"default-severity"`
-	CaseSensitive      bool           `mapstructure:"case-sensitive"`
-	Rules              []SeverityRule `mapstructure:"rules"`
-	KeepLinterSeverity bool           `mapstructure:"keep-linter-severity"` // TODO(ldez): in v2 should be changed to `Override`.
+	Default       string         `mapstructure:"default-severity"`
+	CaseSensitive bool           `mapstructure:"case-sensitive"`
+	Rules         []SeverityRule `mapstructure:"rules"`
 }
 
 func (s *Severity) Validate() error {

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -302,7 +302,6 @@ func getSeverityRulesProcessor(cfg *config.Severity, log logutils.Log, files *fs
 		Default:       cfg.Default,
 		Rules:         severityRules,
 		CaseSensitive: cfg.CaseSensitive,
-		Override:      !cfg.KeepLinterSeverity,
 	}
 
 	return processors.NewSeverity(log.Child(logutils.DebugKeySeverityRules), files, severityOpts)

--- a/pkg/result/processors/processor_test.go
+++ b/pkg/result/processors/processor_test.go
@@ -22,6 +22,7 @@ func newIssueFromIssueTestCase(c issueTestCase) result.Issue {
 	return result.Issue{
 		Text:       c.Text,
 		FromLinter: c.Linter,
+		Severity:   c.Severity,
 		Pos: token.Position{
 			Filename: c.Path,
 			Line:     c.Line,

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -66,6 +66,10 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 			rule := rule
 
 			if rule.match(issue, p.files, p.log) {
+				if rule.severity == "@" || rule.severity == "" && p.defaultSeverity == "@" {
+					return issue
+				}
+
 				issue.Severity = rule.severity
 				if issue.Severity == "" {
 					issue.Severity = p.defaultSeverity
@@ -75,7 +79,9 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 			}
 		}
 
-		issue.Severity = p.defaultSeverity
+		if p.defaultSeverity != "@" {
+			issue.Severity = p.defaultSeverity
+		}
 
 		return issue
 	}), nil

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -66,9 +66,9 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 			rule := rule
 
 			if rule.match(issue, p.files, p.log) {
-				issue.Severity = p.defaultSeverity
-				if rule.severity != "" {
-					issue.Severity = rule.severity
+				issue.Severity = rule.severity
+				if issue.Severity == "" {
+					issue.Severity = p.defaultSeverity
 				}
 
 				return issue

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -68,8 +68,6 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 
 func (p *Severity) transform(issue *result.Issue) *result.Issue {
 	for _, rule := range p.rules {
-		rule := rule
-
 		if rule.match(issue, p.files, p.log) {
 			if rule.severity == severityFromLinter || rule.severity == "" && p.defaultSeverity == severityFromLinter {
 				return issue

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -66,12 +66,11 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 			rule := rule
 
 			if rule.match(issue, p.files, p.log) {
-				ruleSeverity := p.defaultSeverity
+				issue.Severity = p.defaultSeverity
 				if rule.severity != "" {
-					ruleSeverity = rule.severity
+					issue.Severity = rule.severity
 				}
 
-				issue.Severity = ruleSeverity
 				return issue
 			}
 		}

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -65,12 +65,12 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 		for _, rule := range p.rules {
 			rule := rule
 
-			ruleSeverity := p.defaultSeverity
-			if rule.severity != "" {
-				ruleSeverity = rule.severity
-			}
-
 			if rule.match(issue, p.files, p.log) {
+				ruleSeverity := p.defaultSeverity
+				if rule.severity != "" {
+					ruleSeverity = rule.severity
+				}
+
 				issue.Severity = ruleSeverity
 				return issue
 			}

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -61,30 +61,32 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 		return issues, nil
 	}
 
-	return transformIssues(issues, func(issue *result.Issue) *result.Issue {
-		for _, rule := range p.rules {
-			rule := rule
+	return transformIssues(issues, p.transform), nil
+}
 
-			if rule.match(issue, p.files, p.log) {
-				if rule.severity == "@" || rule.severity == "" && p.defaultSeverity == "@" {
-					return issue
-				}
+func (p *Severity) transform(issue *result.Issue) *result.Issue {
+	for _, rule := range p.rules {
+		rule := rule
 
-				issue.Severity = rule.severity
-				if issue.Severity == "" {
-					issue.Severity = p.defaultSeverity
-				}
-
+		if rule.match(issue, p.files, p.log) {
+			if rule.severity == "@" || rule.severity == "" && p.defaultSeverity == "@" {
 				return issue
 			}
-		}
 
-		if p.defaultSeverity != "@" {
-			issue.Severity = p.defaultSeverity
-		}
+			issue.Severity = rule.severity
+			if issue.Severity == "" {
+				issue.Severity = p.defaultSeverity
+			}
 
-		return issue
-	}), nil
+			return issue
+		}
+	}
+
+	if p.defaultSeverity != "@" {
+		issue.Severity = p.defaultSeverity
+	}
+
+	return issue
 }
 
 func (p *Severity) Name() string { return p.name }

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -8,6 +8,8 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
+const severityFromLinter = "@linter"
+
 var _ Processor = &Severity{}
 
 type severityRule struct {
@@ -69,7 +71,7 @@ func (p *Severity) transform(issue *result.Issue) *result.Issue {
 		rule := rule
 
 		if rule.match(issue, p.files, p.log) {
-			if rule.severity == "@" || rule.severity == "" && p.defaultSeverity == "@" {
+			if rule.severity == severityFromLinter || rule.severity == "" && p.defaultSeverity == severityFromLinter {
 				return issue
 			}
 
@@ -82,7 +84,7 @@ func (p *Severity) transform(issue *result.Issue) *result.Issue {
 		}
 	}
 
-	if p.defaultSeverity != "@" {
+	if p.defaultSeverity != severityFromLinter {
 		issue.Severity = p.defaultSeverity
 	}
 

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -24,7 +24,6 @@ type SeverityOptions struct {
 	Default       string
 	Rules         []SeverityRule
 	CaseSensitive bool
-	Override      bool
 }
 
 type Severity struct {
@@ -36,7 +35,6 @@ type Severity struct {
 
 	defaultSeverity string
 	rules           []severityRule
-	override        bool
 }
 
 func NewSeverity(log logutils.Log, files *fsutils.Files, opts SeverityOptions) *Severity {
@@ -45,7 +43,6 @@ func NewSeverity(log logutils.Log, files *fsutils.Files, opts SeverityOptions) *
 		files:           files,
 		log:             log,
 		defaultSeverity: opts.Default,
-		override:        opts.Override,
 	}
 
 	prefix := caseInsensitivePrefix
@@ -65,10 +62,6 @@ func (p *Severity) Process(issues []result.Issue) ([]result.Issue, error) {
 	}
 
 	return transformIssues(issues, func(issue *result.Issue) *result.Issue {
-		if issue.Severity != "" && !p.override {
-			return issue
-		}
-
 		for _, rule := range p.rules {
 			rule := rule
 

--- a/pkg/result/processors/severity_test.go
+++ b/pkg/result/processors/severity_test.go
@@ -310,3 +310,187 @@ func TestSeverity_caseSensitive(t *testing.T) {
 
 	assert.Equal(t, expectedCases, resultingCases)
 }
+
+func TestSeverity_transform(t *testing.T) {
+	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
+	files := fsutils.NewFiles(lineCache, "")
+
+	testCases := []struct {
+		desc     string
+		opts     SeverityOptions
+		issue    *result.Issue
+		expected *result.Issue
+	}{
+		{
+			desc: "apply severity from rule",
+			opts: SeverityOptions{
+				Default: "error",
+				Rules: []SeverityRule{
+					{
+						Severity: "info",
+						BaseRule: BaseRule{
+							Linters: []string{"linter1"},
+						},
+					},
+				},
+			},
+			issue: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter1",
+			},
+			expected: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter1",
+				Severity:   "info",
+			},
+		},
+		{
+			desc: "apply severity from default",
+			opts: SeverityOptions{
+				Default: "error",
+				Rules: []SeverityRule{
+					{
+						Severity: "info",
+						BaseRule: BaseRule{
+							Linters: []string{"linter1"},
+						},
+					},
+				},
+			},
+			issue: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+			},
+			expected: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+				Severity:   "error",
+			},
+		},
+		{
+			desc: "severity from rule override severity from linter",
+			opts: SeverityOptions{
+				Default: "error",
+				Rules: []SeverityRule{
+					{
+						Severity: "info",
+						BaseRule: BaseRule{
+							Linters: []string{"linter1"},
+						},
+					},
+				},
+			},
+			issue: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter1",
+				Severity:   "huge",
+			},
+			expected: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter1",
+				Severity:   "info",
+			},
+		},
+		{
+			desc: "severity from default override severity from linter",
+			opts: SeverityOptions{
+				Default: "error",
+				Rules: []SeverityRule{
+					{
+						Severity: "info",
+						BaseRule: BaseRule{
+							Linters: []string{"linter1"},
+						},
+					},
+				},
+			},
+			issue: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+				Severity:   "huge",
+			},
+			expected: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+				Severity:   "error",
+			},
+		},
+		{
+			desc: "keep severity from linter as rule",
+			opts: SeverityOptions{
+				Default: "error",
+				Rules: []SeverityRule{
+					{
+						Severity: "@",
+						BaseRule: BaseRule{
+							Linters: []string{"linter1"},
+						},
+					},
+				},
+			},
+			issue: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter1",
+				Severity:   "huge",
+			},
+			expected: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter1",
+				Severity:   "huge",
+			},
+		},
+		{
+			desc: "keep severity from linter as default",
+			opts: SeverityOptions{
+				Default: "@",
+				Rules: []SeverityRule{
+					{
+						Severity: "info",
+						BaseRule: BaseRule{
+							Linters: []string{"linter1"},
+						},
+					},
+				},
+			},
+			issue: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+				Severity:   "huge",
+			},
+			expected: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+				Severity:   "huge",
+			},
+		},
+		{
+			desc: "keep severity from linter as default (without rule)",
+			opts: SeverityOptions{
+				Default: "@",
+			},
+			issue: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+				Severity:   "huge",
+			},
+			expected: &result.Issue{
+				Text:       "This is a report",
+				FromLinter: "linter2",
+				Severity:   "huge",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			p := NewSeverity(nil, files, test.opts)
+
+			newIssue := p.transform(test.issue)
+
+			assert.Equal(t, test.expected, newIssue)
+		})
+	}
+}

--- a/pkg/result/processors/severity_test.go
+++ b/pkg/result/processors/severity_test.go
@@ -421,7 +421,7 @@ func TestSeverity_transform(t *testing.T) {
 				Default: "error",
 				Rules: []SeverityRule{
 					{
-						Severity: "@",
+						Severity: severityFromLinter,
 						BaseRule: BaseRule{
 							Linters: []string{"linter1"},
 						},
@@ -442,7 +442,7 @@ func TestSeverity_transform(t *testing.T) {
 		{
 			desc: "keep severity from linter as default",
 			opts: SeverityOptions{
-				Default: "@",
+				Default: severityFromLinter,
 				Rules: []SeverityRule{
 					{
 						Severity: "info",
@@ -466,7 +466,7 @@ func TestSeverity_transform(t *testing.T) {
 		{
 			desc: "keep severity from linter as default (without rule)",
 			opts: SeverityOptions{
-				Default: "@",
+				Default: severityFromLinter,
 			},
 			issue: &result.Issue{
 				Text:       "This is a report",


### PR DESCRIPTION
When I created #4452, I thought that only one linter produced issues with severities.

But it's not true as you can see here #4470

The previous option was global: affects all the linters.

The first problem is that `revive` uses `warning` and `error` as severity, but `gosec` uses `low`, `medium`, and `high`.

I don't want to convert one to another because:
- 2 severities vs 3 severities
- some tools allow only the usage of specific severity
- it's not possible to say what is the best set of values for severities

The second problem is related to the fact that some tools allow only the usage of specific severity.
The current option will keep the severity value from all linters, then the values will be a mix of the different sets.

If you need to use only one set of severities, you need to override/replace the severities from the unsupported set of values.

Then, I reverted the previous PR #4452 (first commit) and replaced it with the usage of a specific wildcard value (`@linter`) as severity.

~~The value `@` is inspired by some DNS convention, but we can use another character (`*` is ambiguous).~~

This value can be used as a default severity or as a rule severity.

One commit, one change.

---

The following examples illustrate the behavior.

<details><summary>the code sample</summary>

```go
package main

import (
	"fmt"
	"os"
	"os/exec"
)

func main() {
	exec.Command("go", "help", os.Args[0])
}

func foo(s string) {
	fmt.Println("test")

}
```

</details>

<details><summary>no custom severities</summary>


```yaml
linters:
  disable-all: true
  enable:
    - gosec
    - revive
    - wsl

linters-settings:
  revive:
    severity: error
    rules:
      - name: unexported-return
        disabled: true
      - name: unused-parameter
        severity: warning

```

```console
$ ./golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }'
{
  "linter": "gosec",
  "text": "G204: Subprocess launched with a potential tainted input or cmd arguments",
  "severity": "medium"
}
{
  "linter": "revive",
  "text": "unused-parameter: parameter 's' seems to be unused, consider removing or renaming it as _",
  "severity": "warning"
}
{
  "linter": "wsl",
  "text": "block should not end with a whitespace (or comment)",
  "severity": ""
}
```

</details>


<details><summary>`@linter` as rule severity</summary>

```yaml
linters:
  disable-all: true
  enable:
    - gosec
    - revive
    - wsl

linters-settings:
  revive:
    severity: error
    rules:
      - name: unexported-return
        disabled: true
      - name: unused-parameter
        severity: warning

severity:
  default-severity: tomato
  rules:
    - linters:
        - gosec
      severity: '@linter'

```

```console
$ ./golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }'
{
  "linter": "gosec",
  "text": "G204: Subprocess launched with a potential tainted input or cmd arguments",
  "severity": "medium"
}
{
  "linter": "revive",
  "text": "unused-parameter: parameter 's' seems to be unused, consider removing or renaming it as _",
  "severity": "tomato"
}
{
  "linter": "wsl",
  "text": "block should not end with a whitespace (or comment)",
  "severity": "tomato"
}
```

</details>

<details><summary>`@linter` as default value</summary>

```yaml
linters:
  disable-all: true
  enable:
    - gosec
    - revive
    - wsl

linters-settings:
  revive:
    severity: error
    rules:
      - name: unexported-return
        disabled: true
      - name: unused-parameter
        severity: warning

severity:
  default-severity: '@linter'
  rules:
    - linters:
        - gosec
      severity: carrot
```

```console
$ ./golangci-lint run --out-format json | jq  '.Issues[] | {linter: .FromLinter, text: .Text, severity: .Severity }'
{
  "linter": "gosec",
  "text": "G204: Subprocess launched with a potential tainted input or cmd arguments",
  "severity": "carrot"
}
{
  "linter": "revive",
  "text": "unused-parameter: parameter 's' seems to be unused, consider removing or renaming it as _",
  "severity": "warning"
}
{
  "linter": "wsl",
  "text": "block should not end with a whitespace (or comment)",
  "severity": ""
}

```

</details>

Fixes #3111
