### PR TITLE
docs: define linter deprecated cycle

### DIFF
--- a/docs/src/docs/usage/install/index.mdx
+++ b/docs/src/docs/usage/install/index.mdx
@@ -151,6 +151,32 @@ As such, we recommend using the fixed minor version and fixed or the latest patc
 For example, in our [GitHub Action](https://github.com/golangci/golangci-lint-action) we require users to explicitly set the minor version of `golangci-lint`
 and we always use the latest patch version.
 
+## Linter Deprecation Cycle
+
+Sometimes a linter can be deprecated because:
+
+- The linter stops working with a newer version of Go.
+- The author has abandoned its linter.
+
+The deprecation of a linter will follow 3 phases:
+
+1. A warning message will be displayed: you can still use it (except if it doesn't work at all anymore), but it's recommended to remove it from your configuration.
+2. An error message will be displayed: now you should remove the linter. The implementation is replaced by a fake linter that does nothing.
+3. The linter is removed from golangci-lint.
+
+Each phase corresponds to a minor version:
+
+- v1.100.0 -> warning message
+- v1.101.0 -> error message
+- v1.102.0 -> linter removed
+
+Otherwise, the deprecated linters are removed from presets immediately when they are deprecated (phase 1).
+
+We will provide clear information about those changes on different supports: changelog, logs, social network, etc.
+
+We consider the removal of a linter as non-breaking changes for golangci-lint itself.
+No major version will be created when a linter is removed.
+
 ## Next
 
 [Quick Start: how to use `golangci-lint`](/usage/quick-start).


### PR DESCRIPTION
I feel like we agree on my [proposal](https://github.com/golangci/golangci-lint/issues/1987#issuecomment-1975245633), and then I propose to explain it in the documentation.

Fixes #1987