### PR TITLE
Revise fallback on Go1.18

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,7 +86,7 @@ func detectGoVersion() string {
 		return v
 	}
 
-	return "1.17"
+	return "1.18"
 }
 
 // Trims the Go version to keep only M.m.


### PR DESCRIPTION
go option of [run configuration](https://golangci-lint.run/usage/configuration/) describes that if both go.mod file and GOVERSION doesn't exists, it fallbacks on Go1.18. So I've modified it.