### PR TITLE
fix: panic when concurrency=0

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -6,7 +6,8 @@
 
 # Options for analysis running.
 run:
-  # Number of CPUs to use when running golangci-lint.
+  # Number of operating system threads  (`GOMAXPROCS`) that can execute golangci-lint simultaneously.
+  # If it is explicitly set to 0 (i.e. not the default) then golangci-lint will automatically set the value to match Linux container CPU quota.
   # Default: the number of logical CPUs in the machine
   concurrency: 4
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -157,7 +157,7 @@ func (c *runCommand) persistentPreRunE(cmd *cobra.Command, _ []string) error {
 
 	if c.cfg.Run.Concurrency == 0 {
 		// Automatically set GOMAXPROCS to match Linux container CPU quota.
-		_, _ = maxprocs.Set(nil)
+		_, _ = maxprocs.Set(maxprocs.Logger(c.log.Infof))
 	} else {
 		runtime.GOMAXPROCS(c.cfg.Run.Concurrency)
 	}


### PR DESCRIPTION
When I created #4441, I tested the PR but I forgot that the default value is not `0` but the number of CPUs.

But when you set explicitly the default to `0`, it panics:
```console
$ go run ./cmd/golangci-lint run -j 0
c.cfg.Run.Concurrency 0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1536a36]

goroutine 1 [running]:
go.uber.org/automaxprocs/maxprocs.Set({0xc000295c00, 0x1, 0xc000295c00?})
        /home/ldez/sources/go/pkg/mod/go.uber.org/automaxprocs@v1.5.3/maxprocs/maxprocs.go:89 +0x76
github.com/golangci/golangci-lint/pkg/commands.(*runCommand).persistentPreRunE(0xc0002a0ea0, 0xc00038c908, {0x93f76a?, 0xc0003c2600?, 0xc0003c2600?})
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/commands/run.go:164 +0x1b5
github.com/spf13/cobra.(*Command).execute(0xc00038c908, {0xc000f11a80, 0x2, 0x2})
        /home/ldez/sources/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:915 +0x764
github.com/spf13/cobra.(*Command).ExecuteC(0xc00038c308)
        /home/ldez/sources/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5
github.com/spf13/cobra.(*Command).Execute(...)
        /home/ldez/sources/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/golangci/golangci-lint/pkg/commands.(*rootCommand).Execute(0xc0001f7590)
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/commands/root.go:83 +0x3d
github.com/golangci/golangci-lint/pkg/commands.Execute({{0x1a921f8, 0x8}, {0x1aeb0af, 0x7}, {0xc00030e330, 0x16}, {0x1817868, 0x9}})
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/commands/root.go:18 +0x5a
main.main()
        /home/ldez/sources/go/src/github.com/golangci/golangci-lint/cmd/golangci-lint/main.go:39 +0x1d1
exit status 2
```

I also updated the documentation based on the Go official doc about `GOMAXPROCS`: https://pkg.go.dev/runtime
