### PR TITLE
dev: clean up command contructors

### DIFF
--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -30,10 +30,10 @@ type lintersCommand struct {
 	dbManager *lintersdb.Manager
 }
 
-func newLintersCommand(logger logutils.Log, cfg *config.Config) *lintersCommand {
+func newLintersCommand(logger logutils.Log) *lintersCommand {
 	c := &lintersCommand{
 		viper: viper.New(),
-		cfg:   cfg,
+		cfg:   config.NewDefault(),
 		log:   logger,
 	}
 

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/logutils"
-	"github.com/golangci/golangci-lint/pkg/report"
 )
 
 func Execute(info BuildInfo) error {
@@ -56,13 +55,12 @@ func newRootCommand(info BuildInfo) *rootCommand {
 
 	setupRootPersistentFlags(rootCmd.PersistentFlags(), &c.opts)
 
-	reportData := &report.Data{}
-	log := report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), reportData)
+	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
 	// Dedicated configuration for each command to avoid side effects of bindings.
 	rootCmd.AddCommand(
 		newLintersCommand(log, config.NewDefault()).cmd,
-		newRunCommand(log, config.NewDefault(), reportData, info).cmd,
+		newRunCommand(log, config.NewDefault(), info).cmd,
 		newCacheCommand().cmd,
 		newConfigCommand(log).cmd,
 		newVersionCommand(info).cmd,

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 )
 
@@ -57,10 +56,10 @@ func newRootCommand(info BuildInfo) *rootCommand {
 
 	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
-	// Dedicated configuration for each command to avoid side effects of bindings.
+	// Each command uses a dedicated configuration structure to avoid side effects of bindings.
 	rootCmd.AddCommand(
-		newLintersCommand(log, config.NewDefault()).cmd,
-		newRunCommand(log, config.NewDefault(), info).cmd,
+		newLintersCommand(log).cmd,
+		newRunCommand(log, info).cmd,
 		newCacheCommand().cmd,
 		newConfigCommand(log).cmd,
 		newVersionCommand(info).cmd,

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -98,10 +98,12 @@ type runCommand struct {
 	exitCode int
 }
 
-func newRunCommand(logger logutils.Log, cfg *config.Config, reportData *report.Data, info BuildInfo) *runCommand {
+func newRunCommand(logger logutils.Log, cfg *config.Config, info BuildInfo) *runCommand {
+	reportData := &report.Data{}
+
 	c := &runCommand{
 		viper:      viper.New(),
-		log:        logger,
+		log:        report.NewLogWrapper(logger, reportData),
 		debugf:     logutils.Debug(logutils.DebugKeyExec),
 		cfg:        cfg,
 		reportData: reportData,

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -98,14 +98,14 @@ type runCommand struct {
 	exitCode int
 }
 
-func newRunCommand(logger logutils.Log, cfg *config.Config, info BuildInfo) *runCommand {
+func newRunCommand(logger logutils.Log, info BuildInfo) *runCommand {
 	reportData := &report.Data{}
 
 	c := &runCommand{
 		viper:      viper.New(),
 		log:        report.NewLogWrapper(logger, reportData),
 		debugf:     logutils.Debug(logutils.DebugKeyExec),
-		cfg:        cfg,
+		cfg:        config.NewDefault(),
 		reportData: reportData,
 		buildInfo:  info,
 	}
@@ -128,7 +128,7 @@ func newRunCommand(logger logutils.Log, cfg *config.Config, info BuildInfo) *run
 
 	// Only for testing purpose.
 	// Don't add other flags here.
-	fs.BoolVar(&cfg.InternalCmdTest, "internal-cmd-test", false,
+	fs.BoolVar(&c.cfg.InternalCmdTest, "internal-cmd-test", false,
 		color.GreenString("Option is used only for testing golangci-lint command, don't use it"))
 	_ = fs.MarkHidden("internal-cmd-test")
 

--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -9,7 +9,7 @@ import (
 )
 
 type JSON struct {
-	rd *report.Data
+	rd *report.Data // TODO(ldez) should be drop in v2. Only use by JSON reporter.
 	w  io.Writer
 }
 

--- a/pkg/result/processors/severity_test.go
+++ b/pkg/result/processors/severity_test.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/logutils"
-	"github.com/golangci/golangci-lint/pkg/report"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
 func TestSeverity_multiple(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
-	log := report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &report.Data{})
+	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
 	opts := SeverityOptions{
 		Default: "error",
@@ -132,7 +131,7 @@ func TestSeverity_pathPrefix(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	pathPrefix := path.Join("some", "dir")
 	files := fsutils.NewFiles(lineCache, pathPrefix)
-	log := report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &report.Data{})
+	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
 	opts := SeverityOptions{
 		Default: "error",
@@ -217,7 +216,7 @@ func TestSeverity_text(t *testing.T) {
 func TestSeverity_onlyDefault(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
-	log := report.NewLogWrapper(logutils.NewStderrLog(logutils.DebugKeyEmpty), &report.Data{})
+	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
 	opts := SeverityOptions{
 		Default: "info",


### PR DESCRIPTION
- the logger wrapper is only used by the `run` command
- the configuration doesn't need to be a command constructor argument.
- the base logger should be created inside the `root` command to be able to set `verbose` option.
