### PR TITLE
dev: improve version output

### DIFF
--- a/cmd/golangci-lint/main.go
+++ b/cmd/golangci-lint/main.go
@@ -13,31 +13,64 @@ var (
 	goVersion = "unknown"
 
 	// Populated by goreleaser during build
-	version = "master"
+	version = "unknown"
 	commit  = "?"
 	date    = ""
 )
 
 func main() {
-	if buildInfo, available := debug.ReadBuildInfo(); available {
-		goVersion = buildInfo.GoVersion
-
-		if date == "" {
-			version = buildInfo.Main.Version
-			commit = fmt.Sprintf("(unknown, mod sum: %q)", buildInfo.Main.Sum)
-			date = "(unknown)"
-		}
-	}
-
-	info := commands.BuildInfo{
-		GoVersion: goVersion,
-		Version:   version,
-		Commit:    commit,
-		Date:      date,
-	}
+	info := createBuildInfo()
 
 	if err := commands.Execute(info); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "failed executing command with error %v\n", err)
 		os.Exit(exitcodes.Failure)
 	}
+}
+
+func createBuildInfo() commands.BuildInfo {
+	info := commands.BuildInfo{
+		Commit:    commit,
+		Version:   version,
+		GoVersion: goVersion,
+		Date:      date,
+	}
+
+	if buildInfo, available := debug.ReadBuildInfo(); available {
+		info.GoVersion = buildInfo.GoVersion
+
+		if date == "" {
+			info.Version = buildInfo.Main.Version
+
+			var revision string
+			var modified string
+			for _, setting := range buildInfo.Settings {
+				// The `vcs.xxx` information is only available with `go build`.
+				// This information is are not available with `go install` or `go run`.
+				switch setting.Key {
+				case "vcs.time":
+					info.Date = setting.Value
+				case "vcs.revision":
+					revision = setting.Value
+				case "vcs.modified":
+					modified = setting.Value
+				}
+			}
+
+			if revision == "" {
+				revision = "unknown"
+			}
+
+			if modified == "" {
+				modified = "?"
+			}
+
+			if info.Date == "" {
+				info.Date = "(unknown)"
+			}
+
+			info.Commit = fmt.Sprintf("(%s, modified: %s, mod sum: %q)", revision, modified, buildInfo.Main.Sum)
+		}
+	}
+
+	return info
 }


### PR DESCRIPTION
<details><summary>Before</summary>

```console
$ make build
go build -o golangci-lint ./cmd/golangci-lint
$ ./golangci-lint version                    
golangci-lint has version (devel) built with go1.22.0 from (unknown, mod sum: "") on (unknown)
```

```console
$ go run ./cmd/golangci-lint version
golangci-lint has version (devel) built with go1.22.0 from (unknown, mod sum: "") on (unknown)
```

```console
$ go install ./cmd/golangci-lint
...
$ golangci-lint version
golangci-lint has version (devel) built with go1.22.0 from (unknown, mod sum: "") on (unknown)
```
</details>


<details><summary>With the PR</summary>

```console
$ make build                                 
go build -o golangci-lint ./cmd/golangci-lint
$ ./golangci-lint version
golangci-lint has version (devel) built with go1.22.0 from (701d8c7a665dce7d3fec69e5c9f1efc3283c2ffb, modified: false, mod sum: "") on 2024-03-11T16:05:26Z
```

```console
$ go run ./cmd/golangci-lint version         
golangci-lint has version (devel) built with go1.22.0 from (unknown, modified: ?, mod sum: "") on (unknown)
```

```console
$ go install ./cmd/golangci-lint
...
$ golangci-lint version
golangci-lint has version (devel) built with go1.22.0 from (unknown, modified: ?, mod sum: "") on (unknown)
```

</details>
