### PR TITLE
build(deps): downgrade github.com/daixiang0/gci from 0.13.0 to 0.12.3

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -451,7 +451,7 @@ linters-settings:
 
     # Section configuration to compare against.
     # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
+    # The default order of sections is `standard > default > custom > blank > dot > alias`,
     # If `custom-order` is `true`, it follows the order of `sections` option.
     # Default: ["standard", "default"]
     sections:
@@ -461,7 +461,6 @@ linters-settings:
       - blank                          # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
       - dot                            # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
       - alias                          # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
-      - localmodule                    # Local module section: contains all local packages. This section is not present unless explicitly enabled.
 
     # Skip generated files.
     # Default: true

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/charithe/durationcheck v0.0.10
 	github.com/ckaznocha/intrange v0.1.0
 	github.com/curioswitch/go-reassign v0.2.0
-	github.com/daixiang0/gci v0.13.0
+	github.com/daixiang0/gci v0.12.3
 	github.com/denis-tingaikin/go-header v0.5.0
 	github.com/fatih/color v1.16.0
 	github.com/firefart/nonamedreturns v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/curioswitch/go-reassign v0.2.0 h1:G9UZyOcpk/d7Gd6mqYgd8XYWFMw/znxwGDUstnC9DIo=
 github.com/curioswitch/go-reassign v0.2.0/go.mod h1:x6OpXuWvgfQaMGks2BZybTngWjT84hqJfKoO8Tt/Roc=
-github.com/daixiang0/gci v0.13.0 h1:pSA5Wb05cWbGpKAgs1yGZcc8IEDRLTZcpa4n8FhyWuU=
-github.com/daixiang0/gci v0.13.0/go.mod h1:xtHP9N7AHdNvtRNfcx9gwTDfw7FRJx4bZUsiEfiNNAI=
+github.com/daixiang0/gci v0.12.3 h1:yOZI7VAxAGPQmkb1eqt5g/11SUlwoat1fSblGLmdiQc=
+github.com/daixiang0/gci v0.12.3/go.mod h1:xtHP9N7AHdNvtRNfcx9gwTDfw7FRJx4bZUsiEfiNNAI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
This reverts commit 9c492afc8396d16bb640661afecf8e2968f04c60 (#4429).

Related to https://github.com/daixiang0/gci/issues/193