### PR TITLE
docs: publish JSON schema on golangci-lint.run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ go.mod: FORCE
 	go mod verify
 go.sum: go.mod
 
+website_copy_jsonschema:
+	 cp -r ./jsonschema ./docs/static
+.PHONY: website_copy_jsonschema
+
 website_expand_templates:
 	go run ./scripts/website/expand_templates/
 .PHONY: website_expand_templates

--- a/docs/package.json
+++ b/docs/package.json
@@ -51,7 +51,7 @@
     "gatsby-plugin-netlify": "^5.1.0"
   },
   "scripts": {
-    "build": "make -C .. website_expand_templates && gatsby build",
+    "build": "make -C .. website_expand_templates website_copy_jsonschema && gatsby build",
     "start": "gatsby develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean"

--- a/docs/static/.gitignore
+++ b/docs/static/.gitignore
@@ -1,0 +1,1 @@
+/jsonschema/

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1308,6 +1308,7 @@
         },
         "goheader": {
           "type": "object",
+          "additionalProperties": false,
           "allOf": [
             {
               "properties": {
@@ -1393,45 +1394,6 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "settings": {
-              "type": "object",
-              "properties": {
-                "mnd": {
-                  "type": "object",
-                  "properties": {
-                    "ignored-files": {
-                      "description": "Comma-separated list of file patterns to exclude from the analysis.",
-                      "examples": ["magic1_.*.go"],
-                      "type": "string"
-                    },
-                    "ignored-functions": {
-                      "description": "Comma-separated list of function patterns to exclude from the analysis.",
-                      "examples": ["math.*,http.StatusText,make"],
-                      "type": "string"
-                    },
-                    "ignored-numbers": {
-                      "description": "Comma-separated list of numbers to exclude from the analysis.",
-                      "examples": ["1000,1234_567_890,3.14159264"],
-                      "type": "string"
-                    },
-                    "checks": {
-                      "description": "The list of enabled checks.",
-                      "type": "array",
-                      "items": {
-                        "enum": [
-                          "argument",
-                          "case",
-                          "condition",
-                          "operation",
-                          "return",
-                          "assign"
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            },
             "ignored-files": {
               "description": "List of file patterns to exclude from analysis.",
               "examples": [["magic1_.*.go"]],


### PR DESCRIPTION
I was expecting that the store would be a proxy, but that's not the case.
I think that relying on GitHub repo and a specific branch is not a good idea.

The new URLs:

- https://golangci-lint.run/jsonschema/golangci.jsonschema.json
- https://golangci-lint.run/jsonschema/golangci.next.jsonschema.json
- https://golangci-lint.run/jsonschema/custom-gcl.next.jsonschema.json

Related to https://github.com/SchemaStore/schemastore/pull/3634
Related to #4487