### PR TITLE
docs: improve grammar in the custom linter article

### DIFF
--- a/.custom-gcl.reference.yml
+++ b/.custom-gcl.reference.yml
@@ -2,7 +2,7 @@
 # Require.
 version: v1.56.2
 
-# the name of the custom binary.
+# The name of the custom binary.
 # Optional.
 # Default: custom-gcl
 name: custom-golangci-lint

--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -48,5 +48,5 @@ Typically, these linters can't be open-sourced or too specific.
 
 Such linters can be added through 2 plugin systems:
 
-- [Go Plugin System](/plugins/module-plugins)
-- [Module Plugin System](/plugins/go-plugins)
+1. [Go Plugin System](/plugins/module-plugins)
+2. [Module Plugin System](/plugins/go-plugins)

--- a/docs/src/docs/plugins/module-plugins.mdx
+++ b/docs/src/docs/plugins/module-plugins.mdx
@@ -6,10 +6,10 @@ An example linter can be found at [here](https://github.com/golangci/example-plu
 
 ## The Automatic Way
 
-- define your building configuration into `.custom-gcl.yml`
-- run the command `golangci-lint custom` ( or `golangci-lint custom -v` to have logs)
-- define the plugin inside the  `linters-settings.custom` section with the type `module`.
-- run your custom version of golangci-lint
+- Define your building configuration into `.custom-gcl.yml`.
+- Run the command `golangci-lint custom` (or `golangci-lint custom -v` to have logs).
+- Define the plugin inside the `linters-settings.custom` section with the type `module`.
+- Run your custom version of golangci-lint.
 
 Requirements:
 - Go
@@ -47,11 +47,11 @@ linters:
 
 ## The Manual Way
 
-- add a blank-import of your module inside `cmd/golangci-lint/plugins.go`
-- run `go mod tidy`. (the module containing the plugin will be imported)
-- run `make build`
-- define the plugin inside the configuration `linters-settings.custom` section with the type `module`.
-- run your custom version of golangci-lint
+- Add a blank-import of your module inside `cmd/golangci-lint/plugins.go`.
+- Run `go mod tidy` (the module containing the plugin will be imported).
+- Run `make build`.
+- Define the plugin inside the configuration `linters-settings.custom` section with the type `module`.
+- Run your custom version of golangci-lint.
 
 ### Configuration Example
 

--- a/pkg/commands/internal/builder.go
+++ b/pkg/commands/internal/builder.go
@@ -37,35 +37,35 @@ func NewBuilder(logger logutils.Log, cfg *Configuration, root string) *Builder {
 
 // Build builds the custom binary.
 func (b Builder) Build(ctx context.Context) error {
-	b.log.Infof("Cloning golangci-lint repository.")
+	b.log.Infof("Cloning golangci-lint repository")
 
 	err := b.clone(ctx)
 	if err != nil {
 		return fmt.Errorf("clone golangci-lint: %w", err)
 	}
 
-	b.log.Infof("Adding plugin imports.")
+	b.log.Infof("Adding plugin imports")
 
 	err = b.updatePluginsFile()
 	if err != nil {
 		return fmt.Errorf("update plugin file: %w", err)
 	}
 
-	b.log.Infof("Adding replace directives.")
+	b.log.Infof("Adding replace directives")
 
 	err = b.addReplaceDirectives(ctx)
 	if err != nil {
 		return fmt.Errorf("add replace directives: %w", err)
 	}
 
-	b.log.Infof("Running go mod tidy.")
+	b.log.Infof("Running go mod tidy")
 
 	err = b.goModTidy(ctx)
 	if err != nil {
 		return fmt.Errorf("go mod tidy: %w", err)
 	}
 
-	b.log.Infof("Building golangci-lint binary.")
+	b.log.Infof("Building golangci-lint binary")
 
 	binaryName := b.getBinaryName()
 
@@ -74,7 +74,7 @@ func (b Builder) Build(ctx context.Context) error {
 		return fmt.Errorf("build golangci-lint binary: %w", err)
 	}
 
-	b.log.Infof("Moving golangci-lint binary.")
+	b.log.Infof("Moving golangci-lint binary")
 
 	err = b.copyBinary(binaryName)
 	if err != nil {


### PR DESCRIPTION
The PR improves https://github.com/golangci/golangci-lint/pull/4437 and it's doc:

- Change to use numeric list instead of bullet list due to the previous sentence "can be added through 2 plugin systems".
- Start each line with a capital letter and end with the period for consistency.
- Remove `.` at the end of log messages for consistency with the rest of the [codebase](https://github.com/search?q=repo%3Agolangci%2Fgolangci-lint+Infof%28&type=code).