### PR TITLE
dev: fix a typo in the log about preserving temp

### DIFF
--- a/pkg/commands/custom.go
+++ b/pkg/commands/custom.go
@@ -64,7 +64,7 @@ func (c *customCommand) runE(_ *cobra.Command, _ []string) error {
 
 	defer func() {
 		if os.Getenv(envKeepTempFiles) != "" {
-			log.Printf("WARN: The env var %s has been dectected: the temporary directory is preserved: %s", envKeepTempFiles, tmp)
+			log.Printf("WARN: The env var %s has been detected: the temporary directory is preserved: %s", envKeepTempFiles, tmp)
 
 			return
 		}


### PR DESCRIPTION
In the future, we might extend [misspell.extra-words](https://github.com/golangci/golangci-lint/blob/59202b196d4e212fda84e5a7419ebab54df3fec5/.golangci.next.reference.yml#L1364) in .golangci.yml with this typo.