### PR TITLE
dev: use `cmd.Context` inside custom command

### DIFF
--- a/cmd/golangci-lint/main.go
+++ b/cmd/golangci-lint/main.go
@@ -22,7 +22,7 @@ func main() {
 	info := createBuildInfo()
 
 	if err := commands.Execute(info); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "failed executing command with error %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Failed executing command with error: %v\n", err)
 		os.Exit(exitcodes.Failure)
 	}
 }

--- a/pkg/commands/custom.go
+++ b/pkg/commands/custom.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -27,7 +26,7 @@ func newCustomCommand(logger logutils.Log) *customCommand {
 
 	customCmd := &cobra.Command{
 		Use:     "custom",
-		Short:   "Build a version of golangci-lint with custom linters.",
+		Short:   "Build a version of golangci-lint with custom linters",
 		Args:    cobra.NoArgs,
 		PreRunE: c.preRunE,
 		RunE:    c.runE,
@@ -54,9 +53,7 @@ func (c *customCommand) preRunE(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (c *customCommand) runE(_ *cobra.Command, _ []string) error {
-	ctx := context.Background()
-
+func (c *customCommand) runE(cmd *cobra.Command, _ []string) error {
 	tmp, err := os.MkdirTemp(os.TempDir(), "custom-gcl")
 	if err != nil {
 		return fmt.Errorf("create temporary directory: %w", err)
@@ -72,7 +69,7 @@ func (c *customCommand) runE(_ *cobra.Command, _ []string) error {
 		_ = os.RemoveAll(tmp)
 	}()
 
-	err = internal.NewBuilder(c.log, c.cfg, tmp).Build(ctx)
+	err = internal.NewBuilder(c.log, c.cfg, tmp).Build(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}


### PR DESCRIPTION
- Use `cmd.Context()` instead of `context.Background`. Currently, they are the same but this might change in the future.
- Remove the space from the `custom` command short description for consistency with other commands in this repo.
- Capitalize the stderr output message and add a semicolon for clarity:
  - before:
	```
	> ./custom-golangci-lint run
	...
	failed executing command with error build linters: plugin(someplugin): plugin "someplugin" not found
	```
  - after: 
	```
	> ./custom-golangci-lint run
	...
	Failed executing command with error: build linters: plugin(someplugin): plugin "someplugin" not found
	```