### PR TITLE
dev: display help message with green color

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -20,7 +20,6 @@ func Execute(info BuildInfo) error {
 type rootOptions struct {
 	PrintVersion bool // Flag only.
 
-	Help    bool   // Flag only.
 	Verbose bool   // Flag only.
 	Color   string // Flag only.
 }
@@ -85,7 +84,7 @@ func (c *rootCommand) Execute() error {
 }
 
 func setupRootPersistentFlags(fs *pflag.FlagSet, opts *rootOptions) {
-	fs.BoolVarP(&opts.Help, "help", "h", false, color.GreenString("Help for a command"))
+	fs.BoolP("help", "h", false, color.GreenString("Help for a command"))
 	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, color.GreenString("Verbose output"))
 	fs.StringVar(&opts.Color, "color", "auto", color.GreenString("Use color when printing; can be 'always', 'auto', or 'never'"))
 }

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -20,6 +20,7 @@ func Execute(info BuildInfo) error {
 type rootOptions struct {
 	PrintVersion bool // Flag only.
 
+	Help    bool   // Flag only.
 	Verbose bool   // Flag only.
 	Color   string // Flag only.
 }
@@ -84,6 +85,7 @@ func (c *rootCommand) Execute() error {
 }
 
 func setupRootPersistentFlags(fs *pflag.FlagSet, opts *rootOptions) {
+	fs.BoolVarP(&opts.Help, "help", "h", false, color.GreenString("Help for a command"))
 	fs.BoolVarP(&opts.Verbose, "verbose", "v", false, color.GreenString("Verbose output"))
 	fs.StringVar(&opts.Color, "color", "auto", color.GreenString("Use color when printing; can be 'always', 'auto', or 'never'"))
 }


### PR DESCRIPTION
The PR defines the global flag `help (h)` to override the default help flag from [the cobra](https://github.com/spf13/cobra/blob/v1.7.0/command.go#L1136C1-L1151C1).

1. Root:
- Before:
<img width="898" alt="image" src="https://github.com/golangci/golangci-lint/assets/3228886/c893bc7b-03a0-4eb1-a3f9-ad85fbf5e33e">

- After:
<img width="833" alt="image" src="https://github.com/golangci/golangci-lint/assets/3228886/d297f72f-dd52-42ec-a46d-17a6fb36c1f7">

2. Nested command:
- Before:
<img width="922" alt="image" src="https://github.com/golangci/golangci-lint/assets/3228886/3d9f217c-4382-4710-bb79-932d9e25e32f">

- After:
<img width="829" alt="image" src="https://github.com/golangci/golangci-lint/assets/3228886/9adfa2b7-8654-45b2-bd62-43fbfde75292">
