### PR TITLE
docs: improve "about golangci-lint" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ---
 
 `golangci-lint` is a fast Go linters runner. It runs linters in parallel, uses caching, supports YAML configuration,
-integrates with all major IDEs, and includes dozens of linters.
+integrates with all major IDEs, and includes over a hundred linters.
 
 ## Install `golangci-lint`
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ---
 
-`golangci-lint` is a fast Go linters runner. It runs linters in parallel, uses caching, supports `yaml` config, has integrations
-with all major IDE and has dozens of linters included.
+`golangci-lint` is a fast Go linters runner. It runs linters in parallel, uses caching, supports YAML configuration,
+integrates with all major IDEs, and includes dozens of linters.
 
 ## Install `golangci-lint`
 


### PR DESCRIPTION
This PR improves the second sentence in README:
- fixes the grammar `IDE` -> `IDEs`;
- slightly rewrite the whole sentence.