### PR TITLE
docs: use XTwitter logo for Twitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Follow the news and releases on [Mastodon](https://fosstodon.org/@golangcilint) and on [Twitter](https://twitter.com/golangci).
+Follow the news and releases on [Mastodon](https://fosstodon.org/@golangcilint) and on [X/Twitter](https://twitter.com/golangci).
 
 There is the most valuable changes log:
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -46,7 +46,7 @@
         "react-dom": "^18.2.0",
         "react-headroom": "^3.2.1",
         "react-helmet": "^6.1.0",
-        "react-icons": "^4.7.1",
+        "react-icons": "^4.11.0",
         "react-live": "^3.1.1",
         "url-join": "^5.0.0"
       },
@@ -19104,9 +19104,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
-      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
       "peerDependencies": {
         "react": "*"
       }
@@ -38033,9 +38033,9 @@
       }
     },
     "react-icons": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
-      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
       "requires": {}
     },
     "react-is": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^18.2.0",
     "react-headroom": "^3.2.1",
     "react-helmet": "^6.1.0",
-    "react-icons": "^4.7.1",
+    "react-icons": "^4.11.0",
     "react-live": "^3.1.1",
     "url-join": "^5.0.0"
   },

--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -2,7 +2,7 @@
 title: Introduction
 ---
 
-import { FaTwitter, FaSlack } from "react-icons/fa";
+import { FaSlack, FaXTwitter } from "react-icons/fa6";
 import { IconContainer } from "lib/icons";
 
 ![Build Status](https://github.com/golangci/golangci-lint/workflows/CI/badge.svg)
@@ -16,7 +16,7 @@ import { IconContainer } from "lib/icons";
 Join our slack <IconContainer color="#1DA1F2"><FaSlack /></IconContainer> channel by [joining Gophers workspace](https://invite.slack.golangbridge.org/)
 and then [joining](https://gophers.slack.com/archives/CS0TBRKPC) channel [`#golangci-lint`](https://gophers.slack.com/archives/CS0TBRKPC).
 
-Follow the news and releases on our twitter <IconContainer color="#1DA1F2"><FaTwitter /></IconContainer> [`@golangci`](https://twitter.com/golangci).
+Follow the news and releases on our X/Twitter <IconContainer color="#1DA1F2"><FaXTwitter /></IconContainer> [`@golangci`](https://twitter.com/golangci).
 
 ## Features
 


### PR DESCRIPTION
The PR replaces the old Twitter logo with a [rebranded](https://en.wikipedia.org/wiki/Twitter#Rebrand_to_X) one on the website. The X/Twitter logo was added in the [`react-icons@v4.11.0`](https://github.com/react-icons/react-icons/pull/807).

<details>
<summary>Before:</summary>
<img width="743" alt="image" src="https://github.com/golangci/golangci-lint/assets/3228886/407501b0-4187-423f-a03e-c128e01dd1cd">
</details>

<details>
<summary>After:</summary>
<img width="729" alt="image" src="https://github.com/golangci/golangci-lint/assets/3228886/ababa5f3-50a6-47a3-9bd0-11f701c85d46">
</details>