### PR TITLE
docs: shorten description for gochecknoglobals linter

### DIFF
--- a/pkg/golinters/gochecknoglobals.go
+++ b/pkg/golinters/gochecknoglobals.go
@@ -19,7 +19,7 @@ func NewGochecknoglobals() *goanalysis.Linter {
 
 	return goanalysis.NewLinter(
 		a.Name,
-		a.Doc,
+		"Check that no global variables exist.",
 		[]*analysis.Analyzer{a},
 		linterConfig,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)


### PR DESCRIPTION
The description of the `gochecknoglobals` is currently verbose:
<img width="870" alt="image" src="https://github.com/golangci/golangci-lint/assets/3228886/3a6efd30-2fad-4a79-af75-8e071cc0de6e">

I propose to condense it in this PR.