### PR TITLE
dev: review config path usage inside gocritic

### DIFF
--- a/pkg/golinters/gocritic.go
+++ b/pkg/golinters/gocritic.go
@@ -32,13 +32,12 @@ var (
 	isGoCriticDebug = logutils.HaveDebugTag(logutils.DebugKeyGoCritic)
 )
 
-func NewGoCritic(settings *config.GoCriticSettings, cfg *config.Config) *goanalysis.Linter {
+func NewGoCritic(settings *config.GoCriticSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	wrapper := &goCriticWrapper{
-		configDir: cfg.GetConfigDir(),
-		sizes:     types.SizesFor("gc", runtime.GOARCH),
+		sizes: types.SizesFor("gc", runtime.GOARCH),
 	}
 
 	analyzer := &analysis.Analyzer{
@@ -71,6 +70,8 @@ Dynamic rules are written declaratively with AST patterns, filters, report messa
 		nil,
 	).
 		WithContextSetter(func(context *linter.Context) {
+			wrapper.configDir = context.Cfg.GetConfigDir()
+
 			wrapper.init(context.Log, settings)
 		}).
 		WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -228,7 +228,7 @@ func (b LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/jgautheron/goconst"),
 
-		linter.NewConfig(golinters.NewGoCritic(&cfg.LintersSettings.Gocritic, cfg)).
+		linter.NewConfig(golinters.NewGoCritic(&cfg.LintersSettings.Gocritic)).
 			WithSince("v1.12.0").
 			WithPresets(linter.PresetStyle, linter.PresetMetaLinter).
 			WithLoadForGoAnalysis().


### PR DESCRIPTION
Since the previous refactor of the commands, the configuration is fully loaded before the build of the linters, so we don't need a closure.

The configuration is inside the linter context, we can use it instead of passing it as a parameter.
