### PR TITLE
docs: fix website broken links

### DIFF
--- a/docs/src/docs/contributing/workflow.mdx
+++ b/docs/src/docs/contributing/workflow.mdx
@@ -51,7 +51,7 @@ Also, we run a few checks in CI by using GitHub actions, you can see them [here]
 
 ## New releases
 
-First, see [our versioning policy](/usage/install/#versioning-policy).
+First, see [our versioning policy](/product/roadmap/#versioning-policy).
 
 To make a new release create a tag `vx.y.z`. Don't forget to add zero patch version for a new minor release, e.g. `v1.99.0`.
 A GitHub action [workflow](https://github.com/golangci/golangci-lint/blob/master/.github/workflows/tag.yml) will start building and publishing release after that.

--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -20,14 +20,14 @@ Follow the news and releases on our twitter <IconContainer color="#1DA1F2"><FaTw
 
 ## Features
 
-- ⚡ [Very fast](/usage/performance): runs linters in parallel, reuses Go build cache and caches analysis results.
+- ⚡ [Very fast](/product/performance): runs linters in parallel, reuses Go build cache and caches analysis results.
 - ⚙️ YAML-based [configuration](/usage/configuration).
-- 🖥 [Integrations](/usage/integrations) with VS Code, Sublime Text, GoLand, GNU Emacs, Vim, Atom, GitHub Actions.
+- 🖥 [Integrations](/welcome/integrations) with VS Code, Sublime Text, GoLand, GNU Emacs, Vim, Atom, GitHub Actions.
 - 🥇 [A lot of linters](/usage/linters) included, no need to install them.
 - 📈 Minimum number of [false positives](/usage/false-positives) because of tuned default settings.
 - 🔥 Nice output with colors, source code lines and marked `identifiers`.
 
-[Get started now!](/usage/install)
+[Get started now!](/welcome/install)
 
 ## Demo
 
@@ -36,7 +36,7 @@ Follow the news and releases on our twitter <IconContainer color="#1DA1F2"><FaTw
 Short 1.5 min video demo of analyzing [beego](https://github.com/astaxie/beego).
 [![asciicast](https://asciinema.org/a/183662.svg)](https://asciinema.org/a/183662)
 
-[Get started now!](/usage/install)
+[Get started now!](/welcome/install)
 
 ## License Scan
 

--- a/docs/src/docs/welcome/faq.mdx
+++ b/docs/src/docs/welcome/faq.mdx
@@ -10,7 +10,7 @@ The same as the Go team (the 2 latest minor versions).
 
 Run `golangci-lint` in CI and check the exit code. If it's non-zero - fail the build.
 
-See [how to properly install `golangci-lint` in CI](/usage/install#ci-installation)
+See [how to properly install `golangci-lint` in CI](/welcome/install/#ci-installation)
 
 ## `golangci-lint` doesn't work
 

--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -126,4 +126,4 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@{.LatestVersion}
 
 ## Next
 
-[Quick Start: how to use `golangci-lint`](/usage/quick-start).
+[Quick Start: how to use `golangci-lint`](/welcome/quick-start/).

--- a/docs/src/docs/welcome/integrations.mdx
+++ b/docs/src/docs/welcome/integrations.mdx
@@ -80,4 +80,4 @@ See the instructions on `golangci-lint completion <YOUR_SHELL> --help` (replace 
 
 ## CI Integration
 
-See our [GitHub Action](/usage/install#github-actions).
+See our [GitHub Action](/welcome/install/#github-actions).


### PR DESCRIPTION
This PR fixes broken links on the https://golangci-lint.run/ found by the [linkchecker](https://linkchecker.github.io/linkchecker/).

<details>
<summary>linkchecker output</summary>

```
❯ linkchecker --no-warnings https://golangci-lint.run/
INFO linkcheck.cmdline 2024-03-15 21:14:06,351 MainThread Checking intern URLs only; use --check-extern to check extern URLs.
LinkChecker 10.4.0
Copyright (C) 2000-2016 Bastian Kleineidam, 2010-2023 LinkChecker Authors
LinkChecker comes with ABSOLUTELY NO WARRANTY!
This is free software, and you are welcome to redistribute it under
certain conditions. Look at the file `COPYING' within this distribution.
Read the documentation at https://linkchecker.github.io/linkchecker/
Write comments and bugs to https://github.com/linkchecker/linkchecker/issues

Start checking at 2024-03-15 21:14:06+003
 2 threads active,     0 links queued,    0 links in   2 URLs checked, runtime 1 seconds
10 threads active,    24 links queued,   36 links in  70 URLs checked, runtime 6 seconds
10 threads active,    15 links queued,  396 links in 421 URLs checked, runtime 11 seconds

URL        `/usage/performance'
Name       `Very fast'
Parent URL https://golangci-lint.run/, line 154, col 2101
Real URL   https://golangci-lint.run/usage/performance
Check time 3.668 seconds
Size       8KB
Result     Error: 404 Not Found

URL        `/usage/integrations'
Name       `Integrations'
Parent URL https://golangci-lint.run/, line 154, col 2304
Real URL   https://golangci-lint.run/usage/integrations
Check time 3.275 seconds
Size       8KB
Result     Error: 404 Not Found
10 threads active,     7 links queued,  446 links in 463 URLs checked, runtime 16 seconds

URL        `/usage/install'
Name       `Get started now!'
Parent URL https://golangci-lint.run/, line 154, col 2754
Real URL   https://golangci-lint.run/usage/install
Check time 3.587 seconds
Size       8KB
Result     Error: 404 Not Found

URL        `/usage/quick-start'
Name       `Quick Start: how to use golangci-lint'
Parent URL https://golangci-lint.run/welcome/install/, line 169, col 3303
Real URL   https://golangci-lint.run/usage/quick-start
Check time 2.998 seconds
Size       8KB
Result     Error: 404 Not Found

URL        `/usage/install/#versioning-policy'
Name       `our versioning policy'
Parent URL https://golangci-lint.run/contributing/workflow/, line 150, col 1896
Real URL   https://golangci-lint.run/usage/install/#versioning-policy
Check time 3.370 seconds
Size       8KB
Result     Error: 404 Not Found
 1 thread active,     0 links queued,  462 links in 464 URLs checked, runtime 21 seconds

Statistics:
Downloaded: 3.19MB.
Content types: 11 image, 33 text, 0 video, 0 audio, 10 application, 0 mail and 409 other.
URL lengths: min=14, max=508, avg=45.

That's it. 463 links in 464 URLs checked. 0 warnings found (6 ignored or duplicates not printed). 5 errors found.
Stopped checking at 2024-03-15 21:14:28+003 (22 seconds)
```

</details>
