### PR TITLE
dev: remove Run.Args

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -369,8 +369,6 @@ func (c *runCommand) runAndPrint(ctx context.Context, args []string) error {
 
 // runAnalysis executes the linters that have been enabled in the configuration.
 func (c *runCommand) runAnalysis(ctx context.Context, args []string) ([]result.Issue, error) {
-	c.cfg.Run.Args = args
-
 	lintersToRun, err := c.dbManager.GetOptimizedLinters()
 	if err != nil {
 		return nil, err
@@ -381,8 +379,8 @@ func (c *runCommand) runAnalysis(ctx context.Context, args []string) ([]result.I
 		return nil, fmt.Errorf("context loading failed: %w", err)
 	}
 
-	runner, err := lint.NewRunner(c.log.Child(logutils.DebugKeyRunner),
-		c.cfg, c.goenv, c.lineCache, c.fileCache, c.dbManager, lintCtx)
+	runner, err := lint.NewRunner(c.log.Child(logutils.DebugKeyRunner), c.cfg, args,
+		c.goenv, c.lineCache, c.fileCache, c.dbManager, lintCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -33,9 +33,6 @@ type Run struct {
 
 	// Deprecated: use Output.ShowStats instead.
 	ShowStats bool `mapstructure:"show-stats"`
-
-	// Only used by skipDirs processor. TODO(ldez) remove it in next PR.
-	Args []string // Internal needs.
 }
 
 func (r *Run) Validate() error {

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -32,7 +32,7 @@ type Runner struct {
 	Processors []processors.Processor
 }
 
-func NewRunner(log logutils.Log, cfg *config.Config, goenv *goutil.Env,
+func NewRunner(log logutils.Log, cfg *config.Config, args []string, goenv *goutil.Env,
 	lineCache *fsutils.LineCache, fileCache *fsutils.FileCache,
 	dbManager *lintersdb.Manager, lintCtx *linter.Context,
 ) (*Runner, error) {
@@ -51,7 +51,7 @@ func NewRunner(log logutils.Log, cfg *config.Config, goenv *goutil.Env,
 		skipDirs = append(skipDirs, packages.StdExcludeDirRegexps...)
 	}
 
-	skipDirsProcessor, err := processors.NewSkipDirs(skipDirs, log.Child(logutils.DebugKeySkipDirs), cfg.Run.Args, cfg.Output.PathPrefix)
+	skipDirsProcessor, err := processors.NewSkipDirs(skipDirs, log.Child(logutils.DebugKeySkipDirs), args, cfg.Output.PathPrefix)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After #4516, this PR removes completely the usage of `cfg.Run.Args`.

Now, the `Run` structure contains only real configuration.