### PR TITLE
fix: use GOTOOLCHAIN=auto inside the Docker images

### DIFF
--- a/build/buildx-alpine.Dockerfile
+++ b/build/buildx-alpine.Dockerfile
@@ -4,6 +4,11 @@ FROM golang:1.22-alpine
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
 
+# Allow to download a more recent version of Go.
+# https://go.dev/doc/toolchain
+# GOTOOLCHAIN=auto is shorthand for GOTOOLCHAIN=local+auto
+ENV GOTOOLCHAIN auto
+
 # gcc is required to support cgo;
 # git and mercurial are needed most times for go get`, etc.
 # See https://github.com/docker-library/golang/issues/80

--- a/build/buildx.Dockerfile
+++ b/build/buildx.Dockerfile
@@ -4,6 +4,11 @@ FROM golang:1.22
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go
 
+# Allow to download a more recent version of Go.
+# https://go.dev/doc/toolchain
+# GOTOOLCHAIN=auto is shorthand for GOTOOLCHAIN=local+auto
+ENV GOTOOLCHAIN auto
+
 # Set all directories as safe
 RUN git config --global --add safe.directory '*'
 


### PR DESCRIPTION
The mode `auto` to download and use a Go version higher than the version inside the Docker image.

https://go.dev/doc/toolchain

Fixes #4239