### PR TITLE
govet: fix check-shadowing

### DIFF
--- a/pkg/golinters/govet.go
+++ b/pkg/golinters/govet.go
@@ -166,11 +166,6 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 		return defaultAnalyzers
 	}
 
-	if settings.CheckShadowing {
-		// Keeping for backward compatibility.
-		settings.Enable = append(settings.Enable, shadow.Analyzer.Name)
-	}
-
 	var enabledAnalyzers []*analysis.Analyzer
 	for _, a := range allAnalyzers {
 		if isAnalyzerEnabled(a.Name, settings, defaultAnalyzers) {
@@ -187,6 +182,11 @@ func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers 
 	// TODO(ldez) remove loopclosure when go1.23
 	if name == loopclosure.Analyzer.Name && config.IsGoGreaterThanOrEqual(cfg.Go, "1.22") {
 		return false
+	}
+
+	// Keeping for backward compatibility.
+	if cfg.CheckShadowing && name == shadow.Analyzer.Name {
+		return true
 	}
 
 	switch {


### PR DESCRIPTION
If you are using this kind of configuration:

```yml
linters-settings:
  govet:
    check-shadowing: true
    enable-all: true
    disable:
      - fieldalignment

linters:
  disable-all: true
  enable:
    - govet
```

An error will appear:
```console
$ ./golangci-lint run ./...                                                     
Error: govet: enable-all and enable can't be combined
Failed executing command with error: govet: enable-all and enable can't be combined
```

This a new problem related to the previous refactor: the validation doesn't happen at the same time as before (and it's a good thing).

Inside the `govet` implementation, the pass `shadow` is added to `enable` when `check-shadowing` is true, but as it's a pointer to the configuration, then the real configuration is also modified.

Note: `check-shadowing` is deprecated inside the code but not with a warning since 2019.
I will create another PR to deprecate this option.