### PR TITLE
govet: add a warning about the deprecation of check-shadowing

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1074,10 +1074,6 @@ linters-settings:
       - Katakana
 
   govet:
-    # Report about shadowed variables.
-    # Default: false
-    check-shadowing: true
-
     # Settings per analyzer.
     settings:
       # Analyzer name, run `go tool vet help` to see all analyzers.

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1074,36 +1074,6 @@ linters-settings:
       - Katakana
 
   govet:
-    # Settings per analyzer.
-    settings:
-      # Analyzer name, run `go tool vet help` to see all analyzers.
-      printf:
-        # Comma-separated list of print function names to check (in addition to default, see `go tool vet help printf`).
-        # Default: []
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-      shadow:
-        # Whether to be strict about shadowing; can be noisy.
-        # Default: false
-        strict: true
-      unusedresult:
-        # Comma-separated list of functions whose results must be used
-        # (in addition to default:
-        #   context.WithCancel, context.WithDeadline, context.WithTimeout, context.WithValue, errors.New, fmt.Errorf,
-        #   fmt.Sprint, fmt.Sprintf, sort.Reverse
-        # ).
-        # Default: []
-        funcs:
-          - pkg.MyFunc
-        # Comma-separated list of names of methods of type func() string whose results must be used
-        # (in addition to default Error,String)
-        # Default: []
-        stringmethods:
-          - MyMethod
-
     # Disable all analyzers.
     # Default: false
     disable-all: true
@@ -1209,6 +1179,36 @@ linters-settings:
       - unsafeptr
       - unusedresult
       - unusedwrite
+
+    # Settings per analyzer.
+    settings:
+      # Analyzer name, run `go tool vet help` to see all analyzers.
+      printf:
+        # Comma-separated list of print function names to check (in addition to default, see `go tool vet help printf`).
+        # Default: []
+        funcs:
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+      shadow:
+        # Whether to be strict about shadowing; can be noisy.
+        # Default: false
+        strict: true
+      unusedresult:
+        # Comma-separated list of functions whose results must be used
+        # (in addition to default:
+        #   context.WithCancel, context.WithDeadline, context.WithTimeout, context.WithValue, errors.New, fmt.Errorf,
+        #   fmt.Sprint, fmt.Sprintf, sort.Reverse
+        # ).
+        # Default: []
+        funcs:
+          - pkg.MyFunc
+        # Comma-separated list of names of methods of type func() string whose results must be used
+        # (in addition to default Error,String)
+        # Default: []
+        stringmethods:
+          - MyMethod
 
   grouper:
     # Require the use of a single global 'const' declaration only.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,6 +155,8 @@ issues:
     - path: pkg/commands/run.go
       linters: [staticcheck]
       text: "SA1019: c.cfg.Run.ShowStats is deprecated: use Output.ShowStats instead."
+    - path: pkg/golinters/govet.go
+      text: "SA1019: settings.CheckShadowing is deprecated: the linter should be enabled inside `Enable`."
 
     - path: pkg/golinters/gofumpt.go
       linters: [staticcheck]

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1661,11 +1661,6 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "check-shadowing": {
-              "description": "Report shadowed variables.",
-              "type": "boolean",
-              "default": true
-            },
             "settings": {
               "description": "Settings per analyzer. Map of analyzer name to specific settings.\nRun `go tool vet help` to find out more.",
               "type": "object",

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -598,13 +598,14 @@ type GosmopolitanSettings struct {
 }
 
 type GovetSettings struct {
-	Go       string `mapstructure:"-"`
-	Settings map[string]map[string]any
+	Go string `mapstructure:"-"`
 
 	Enable     []string
 	Disable    []string
 	EnableAll  bool `mapstructure:"enable-all"`
 	DisableAll bool `mapstructure:"disable-all"`
+
+	Settings map[string]map[string]any
 
 	// Deprecated: the linter should be enabled inside `Enable`.
 	CheckShadowing bool `mapstructure:"check-shadowing"`

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -598,14 +598,16 @@ type GosmopolitanSettings struct {
 }
 
 type GovetSettings struct {
-	Go             string `mapstructure:"-"`
-	CheckShadowing bool   `mapstructure:"check-shadowing"`
-	Settings       map[string]map[string]any
+	Go       string `mapstructure:"-"`
+	Settings map[string]map[string]any
 
 	Enable     []string
 	Disable    []string
 	EnableAll  bool `mapstructure:"enable-all"`
 	DisableAll bool `mapstructure:"disable-all"`
+
+	// Deprecated: the linter should be enabled inside `Enable`.
+	CheckShadowing bool `mapstructure:"check-shadowing"`
 }
 
 func (cfg *GovetSettings) Validate() error {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -322,6 +322,13 @@ func (l *Loader) handleDeprecation() error {
 		l.cfg.Output.Formats = f
 	}
 
+	// Deprecated since v1.57.0,
+	// but it was unofficially deprecated since v1.19 (2019) (https://github.com/golangci/golangci-lint/pull/697).
+	if l.cfg.LintersSettings.Govet.CheckShadowing {
+		l.warn("The configuration option `govet.check-shadowing` is deprecated. " +
+			"Please enable `shadow` instead, if you are not using `enable-all`.")
+	}
+
 	return nil
 }
 

--- a/test/testdata/configs/govet.yml
+++ b/test/testdata/configs/govet.yml
@@ -1,3 +1,4 @@
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow


### PR DESCRIPTION
It was "unofficially" deprecated since v1.19 (2019) (inside #697).

https://github.com/golangci/golangci-lint/pull/697/files#diff-5144159bbaf9571c0fb12b9077a23f5dd046eda75d10c4d02c8317d071b54019R124

I think it's time to add a warning to deprecate it.

The deprecation message is complex because there are several possible configurations:
- `check-shadowing` + `enable-all`
- `check-shadowing` + `disable-all`
- `check-shadowing` + `enable`
- `check-shadowing` + `disable`