### PR TITLE
feat: improve 'no go files to analyze' message

### DIFF
--- a/pkg/lint/context.go
+++ b/pkg/lint/context.go
@@ -43,7 +43,7 @@ func (cl *ContextBuilder) Build(ctx context.Context, log logutils.Log, linters [
 	}
 
 	if len(deduplicatedPkgs) == 0 {
-		return nil, exitcodes.ErrNoGoFiles
+		return nil, fmt.Errorf("%w: running `go mod tidy` may solve the problem", exitcodes.ErrNoGoFiles)
 	}
 
 	ret := &linter.Context{


### PR DESCRIPTION
90% of the contexts that lead to `no go files to analyze` error are related to missing `go mod tidy`.

A sample of issues on the topic:
- https://github.com/golangci/golangci-lint/issues/4168
- https://github.com/golangci/golangci-lint/discussions/3371
- https://github.com/golangci/golangci-lint/issues/3335
- https://github.com/golangci/golangci-lint/issues/1855
- https://github.com/golangci/golangci-lint/issues/1833
- https://github.com/golangci/golangci-lint/issues/1784
- https://github.com/golangci/golangci-lint/issues/870
- https://github.com/golangci/golangci-lint/issues/825

Before:
```console
$ golangci-lint run ./...                           
ERRO Running error: context loading failed: no go files to analyze 
```

After:
```console
$ ./golangci-lint run ./...                                                     
ERRO Running error: context loading failed: no go files to analyze: running `go mod tidy` may solve the problem 
```


Fixes #3335
Fixes #825
