### PR TITLE
dev: refactor .golangci.yml configuration and fix up nolintlint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -160,6 +160,10 @@ issues:
     - path: pkg/golinters/govet.go
       text: "SA1019: cfg.CheckShadowing is deprecated: the linter should be enabled inside `Enable`."
 
+    - path: pkg/golinters
+      linters:
+        - dupl
+
     - path: pkg/golinters/gofumpt.go
       linters: [staticcheck]
       text: "SA1019: settings.LangVersion is deprecated: use the global `run.go` instead."

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,13 +17,15 @@ linters-settings:
       logger:
         deny:
           # logging is allowed only by logutils.Log,
-          # logrus is allowed to use only in logutils package.
           - pkg: "github.com/sirupsen/logrus"
             desc: logging is allowed only by logutils.Log.
           - pkg: "github.com/pkg/errors"
             desc: Should be replaced by standard lib errors package.
           - pkg: "github.com/instana/testify"
             desc: It's a fork of github.com/stretchr/testify.
+        files:
+          # logrus is allowed to use only in logutils package.
+          - "!**/pkg/logutils/**.go"
   dupl:
     threshold: 100
   funlen:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,8 @@ linters-settings:
     line-length: 140
   misspell:
     locale: US
+    ignore-words:
+      - "importas" # linter name
   nolintlint:
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -144,7 +144,9 @@ issues:
   exclude-rules:
     - path: _test\.go
       linters:
+        - dupl
         - gomnd
+        - lll
 
     - path: pkg/golinters/errcheck.go
       linters: [staticcheck]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,8 +92,8 @@ linters-settings:
       - "importas" # linter name
   nolintlint:
     allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
   revive:
     rules:
       - name: unexported-return

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -80,7 +80,7 @@ func setupOutputFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 	internal.AddFlagAndBind(v, fs, fs.Bool, "show-stats", "output.show-stats", false, color.GreenString("Show statistics per linter"))
 }
 
-//nolint:gomnd
+//nolint:gomnd // magic numbers here is ok
 func setupIssuesFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 	internal.AddHackedStringSliceP(fs, "exclude", "e", color.GreenString("Exclude issue by regexp"))
 	internal.AddFlagAndBind(v, fs, fs.Bool, "exclude-use-default", "issues.exclude-use-default", true,

--- a/pkg/golinters/dogsled.go
+++ b/pkg/golinters/dogsled.go
@@ -16,7 +16,6 @@ import (
 
 const dogsledName = "dogsled"
 
-//nolint:dupl
 func NewDogsled(settings *config.DogsledSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/dupl.go
+++ b/pkg/golinters/dupl.go
@@ -17,7 +17,6 @@ import (
 
 const duplName = "dupl"
 
-//nolint:dupl
 func NewDupl(settings *config.DuplSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/forbidigo.go
+++ b/pkg/golinters/forbidigo.go
@@ -16,7 +16,6 @@ import (
 
 const forbidigoName = "forbidigo"
 
-//nolint:dupl
 func NewForbidigo(settings *config.ForbidigoSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/funlen.go
+++ b/pkg/golinters/funlen.go
@@ -16,7 +16,6 @@ import (
 
 const funlenName = "funlen"
 
-//nolint:dupl
 func NewFunlen(settings *config.FunlenSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/goanalysis/runner.go
+++ b/pkg/golinters/goanalysis/runner.go
@@ -281,7 +281,6 @@ func (r *runner) analyze(pkgs []*packages.Package, analyzers []*analysis.Analyze
 	return rootActions
 }
 
-//nolint:nakedret
 func extractDiagnostics(roots []*action) (retDiags []Diagnostic, retErrors []error) {
 	extracted := make(map[*action]bool)
 	var extract func(*action)
@@ -338,5 +337,5 @@ func extractDiagnostics(roots []*action) (retDiags []Diagnostic, retErrors []err
 		}
 	}
 	visitAll(roots)
-	return
+	return retDiags, retErrors
 }

--- a/pkg/golinters/goanalysis/runner.go
+++ b/pkg/golinters/goanalysis/runner.go
@@ -177,10 +177,9 @@ func (r *runner) buildActionFactDeps(act *action, a *analysis.Analyzer, pkg *pac
 	}
 }
 
-//nolint:gocritic
 func (r *runner) prepareAnalysis(pkgs []*packages.Package,
 	analyzers []*analysis.Analyzer,
-) (map[*packages.Package]bool, []*action, []*action) {
+) (initialPkgs map[*packages.Package]bool, allActions, roots []*action) {
 	// Construct the action graph.
 
 	// Each graph node (action) is one unit of analysis.
@@ -200,13 +199,13 @@ func (r *runner) prepareAnalysis(pkgs []*packages.Package,
 	actions := make(map[actKey]*action, totalActionsCount)
 	actAlloc := newActionAllocator(totalActionsCount)
 
-	initialPkgs := make(map[*packages.Package]bool, len(pkgs))
+	initialPkgs = make(map[*packages.Package]bool, len(pkgs))
 	for _, pkg := range pkgs {
 		initialPkgs[pkg] = true
 	}
 
 	// Build nodes for initial packages.
-	roots := make([]*action, 0, len(pkgs)*len(analyzers))
+	roots = make([]*action, 0, len(pkgs)*len(analyzers))
 	for _, a := range analyzers {
 		for _, pkg := range pkgs {
 			root := r.makeAction(a, pkg, initialPkgs, actions, actAlloc)
@@ -215,7 +214,7 @@ func (r *runner) prepareAnalysis(pkgs []*packages.Package,
 		}
 	}
 
-	allActions := maps.Values(actions)
+	allActions = maps.Values(actions)
 
 	debugf("Built %d actions", len(actions))
 

--- a/pkg/golinters/gocognit.go
+++ b/pkg/golinters/gocognit.go
@@ -16,7 +16,6 @@ import (
 
 const gocognitName = "gocognit"
 
-//nolint:dupl
 func NewGocognit(settings *config.GocognitSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/goconst.go
+++ b/pkg/golinters/goconst.go
@@ -15,7 +15,6 @@ import (
 
 const goconstName = "goconst"
 
-//nolint:dupl
 func NewGoconst(settings *config.GoConstSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/gocyclo.go
+++ b/pkg/golinters/gocyclo.go
@@ -15,7 +15,6 @@ import (
 
 const gocycloName = "gocyclo"
 
-//nolint:dupl
 func NewGocyclo(settings *config.GoCycloSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/godox.go
+++ b/pkg/golinters/godox.go
@@ -16,7 +16,6 @@ import (
 
 const godoxName = "godox"
 
-//nolint:dupl
 func NewGodox(settings *config.GodoxSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/gofmt_common.go
+++ b/pkg/golinters/gofmt_common.go
@@ -133,8 +133,8 @@ func (p *hunkChangesParser) handleDeletedLines(deletedLines []diffLine, addedLin
 	}
 
 	if len(addedLines) != 0 {
-		//nolint:gocritic
-		change.Replacement.NewLines = append(p.replacementLinesToPrepend, addedLines...)
+		change.Replacement.NewLines = append([]string{}, p.replacementLinesToPrepend...)
+		change.Replacement.NewLines = append(change.Replacement.NewLines, addedLines...)
 		if len(p.replacementLinesToPrepend) != 0 {
 			p.replacementLinesToPrepend = nil
 		}

--- a/pkg/golinters/importas.go
+++ b/pkg/golinters/importas.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/julz/importas" //nolint:misspell
+	"github.com/julz/importas"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
@@ -26,7 +26,7 @@ func NewImportAs(settings *config.ImportAsSettings) *goanalysis.Linter {
 			return
 		}
 		if len(settings.Alias) == 0 {
-			lintCtx.Log.Infof("importas settings found, but no aliases listed. List aliases under alias: key.") //nolint:misspell
+			lintCtx.Log.Infof("importas settings found, but no aliases listed. List aliases under alias: key.")
 		}
 
 		if err := analyzer.Flags.Set("no-unaliased", strconv.FormatBool(settings.NoUnaliased)); err != nil {

--- a/pkg/golinters/lll.go
+++ b/pkg/golinters/lll.go
@@ -22,7 +22,6 @@ const lllName = "lll"
 
 const goCommentDirectivePrefix = "//go:"
 
-//nolint:dupl
 func NewLLL(settings *config.LllSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/makezero.go
+++ b/pkg/golinters/makezero.go
@@ -15,7 +15,6 @@ import (
 
 const makezeroName = "makezero"
 
-//nolint:dupl
 func NewMakezero(settings *config.MakezeroSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/nestif.go
+++ b/pkg/golinters/nestif.go
@@ -15,7 +15,6 @@ import (
 
 const nestifName = "nestif"
 
-//nolint:dupl
 func NewNestif(settings *config.NestifSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/nolintlint.go
+++ b/pkg/golinters/nolintlint.go
@@ -16,7 +16,6 @@ import (
 
 const NoLintLintName = "nolintlint"
 
-//nolint:dupl
 func NewNoLintLint(settings *config.NoLintLintSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -156,7 +156,7 @@ var (
 	trailingBlankExplanation = regexp.MustCompile(`\s*(//\s*)?$`)
 )
 
-//nolint:funlen,gocyclo
+//nolint:funlen,gocyclo // the function is going to be refactored in the future
 func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 	var issues []Issue
 

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -131,7 +131,7 @@ func foo() {
   good() //nolint: linter1, linter2
 }`,
 			expected: []issueWithReplacement{
-				{issue: "directive `//nolint:linter1 linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9"}, //nolint:lll // this is a string
+				{issue: "directive `//nolint:linter1 linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9"},
 			},
 		},
 		{

--- a/pkg/golinters/prealloc.go
+++ b/pkg/golinters/prealloc.go
@@ -15,7 +15,6 @@ import (
 
 const preallocName = "prealloc"
 
-//nolint:dupl
 func NewPreAlloc(settings *config.PreallocSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/golinters/unconvert.go
+++ b/pkg/golinters/unconvert.go
@@ -14,7 +14,6 @@ import (
 
 const unconvertName = "unconvert"
 
-//nolint:dupl // This is not a duplicate of dogsled.
 func NewUnconvert(settings *config.UnconvertSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue

--- a/pkg/logutils/stderr_log.go
+++ b/pkg/logutils/stderr_log.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus" //nolint:depguard
+	"github.com/sirupsen/logrus"
 
 	"github.com/golangci/golangci-lint/pkg/exitcodes"
 )

--- a/pkg/packages/util_test.go
+++ b/pkg/packages/util_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//nolint:lll
 func Test_stackCrusher(t *testing.T) {
 	testCases := []struct {
 		desc     string

--- a/pkg/printers/checkstyle_test.go
+++ b/pkg/printers/checkstyle_test.go
@@ -49,7 +49,6 @@ func TestCheckstyle_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	//nolint:lll
 	expected := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<checkstyle version=\"5.0\">\n  <file name=\"path/to/filea.go\">\n    <error column=\"4\" line=\"10\" message=\"some issue\" severity=\"warning\" source=\"linter-a\"></error>\n  </file>\n  <file name=\"path/to/fileb.go\">\n    <error column=\"9\" line=\"300\" message=\"another issue\" severity=\"error\" source=\"linter-b\"></error>\n  </file>\n</checkstyle>\n"
 
 	assert.Equal(t, expected, strings.ReplaceAll(buf.String(), "\r", ""))

--- a/pkg/printers/codeclimate_test.go
+++ b/pkg/printers/codeclimate_test.go
@@ -63,7 +63,6 @@ func TestCodeClimate_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	//nolint:lll
 	expected := `[{"description":"linter-a: some issue","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"linter-b: another issue","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"linter-c: issue c","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]
 `
 

--- a/pkg/printers/github_test.go
+++ b/pkg/printers/github_test.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package printers
 
 import (

--- a/pkg/printers/html_test.go
+++ b/pkg/printers/html_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-//nolint:lll
 const expectedHTML = `<!doctype html>
 <html lang="en">
 <head>

--- a/pkg/printers/json_test.go
+++ b/pkg/printers/json_test.go
@@ -49,7 +49,6 @@ func TestJSON_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	//nolint:lll
 	expected := `{"Issues":[{"FromLinter":"linter-a","Text":"some issue","Severity":"warning","SourceLines":null,"Replacement":null,"Pos":{"Filename":"path/to/filea.go","Offset":2,"Line":10,"Column":4},"ExpectNoLint":false,"ExpectedNoLintLinter":""},{"FromLinter":"linter-b","Text":"another issue","Severity":"error","SourceLines":["func foo() {","\tfmt.Println(\"bar\")","}"],"Replacement":null,"Pos":{"Filename":"path/to/fileb.go","Offset":5,"Line":300,"Column":9},"ExpectNoLint":false,"ExpectedNoLintLinter":""}],"Report":null}
 `
 

--- a/pkg/printers/junitxml_test.go
+++ b/pkg/printers/junitxml_test.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package printers
 
 import (

--- a/pkg/printers/tab_test.go
+++ b/pkg/printers/tab_test.go
@@ -77,8 +77,7 @@ path/to/fileb.go:300:9  another issue
 			desc:            "enable all options",
 			printLinterName: true,
 			useColors:       true,
-			//nolint:lll // color characters must be in a simple string.
-			expected: "\x1b[1mpath/to/filea.go:10\x1b[22m:4   linter-a  \x1b[31msome issue\x1b[0m\n\x1b[1mpath/to/fileb.go:300\x1b[22m:9  linter-b  \x1b[31manother issue\x1b[0m\n",
+			expected:        "\x1b[1mpath/to/filea.go:10\x1b[22m:4   linter-a  \x1b[31msome issue\x1b[0m\n\x1b[1mpath/to/fileb.go:300\x1b[22m:9  linter-b  \x1b[31manother issue\x1b[0m\n",
 		},
 	}
 

--- a/pkg/printers/text_test.go
+++ b/pkg/printers/text_test.go
@@ -96,8 +96,7 @@ func foo() {
 			printIssuedLine: true,
 			printLinterName: true,
 			useColors:       true,
-			//nolint:lll // color characters must be in a simple string.
-			expected: "\x1b[1mpath/to/filea.go:10\x1b[22m:4: \x1b[31msome issue\x1b[0m (linter-a)\n\x1b[1mpath/to/fileb.go:300\x1b[22m:9: \x1b[31manother issue\x1b[0m (linter-b)\nfunc foo() {\n\tfmt.Println(\"bar\")\n}\n",
+			expected:        "\x1b[1mpath/to/filea.go:10\x1b[22m:4: \x1b[31msome issue\x1b[0m (linter-a)\n\x1b[1mpath/to/fileb.go:300\x1b[22m:9: \x1b[31manother issue\x1b[0m (linter-b)\nfunc foo() {\n\tfmt.Println(\"bar\")\n}\n",
 		},
 		{
 			desc:            "disable all options",

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -1,7 +1,7 @@
 package result
 
 import (
-	"crypto/md5" //nolint:gosec
+	"crypto/md5" //nolint:gosec // for md5 hash
 	"fmt"
 	"go/token"
 
@@ -91,7 +91,7 @@ func (i *Issue) Fingerprint() string {
 		firstLine = i.SourceLines[0]
 	}
 
-	hash := md5.New() //nolint:gosec
+	hash := md5.New() //nolint:gosec // we don't need a strong hash here
 	_, _ = fmt.Fprintf(hash, "%s%s%s", i.Pos.Filename, i.Text, firstLine)
 
 	return fmt.Sprintf("%X", hash.Sum(nil))

--- a/pkg/result/processors/base_rule.go
+++ b/pkg/result/processors/base_rule.go
@@ -65,7 +65,7 @@ func (r *baseRule) matchLinter(issue *result.Issue) bool {
 	return false
 }
 
-func (r *baseRule) matchSource(issue *result.Issue, lineCache *fsutils.LineCache, log logutils.Log) bool { //nolint:interfacer
+func (r *baseRule) matchSource(issue *result.Issue, lineCache *fsutils.LineCache, log logutils.Log) bool {
 	sourceLine, errSourceLine := lineCache.GetLine(issue.FilePath(), issue.Line())
 	if errSourceLine != nil {
 		log.Warnf("Failed to get line %s:%d from line cache: %s", issue.FilePath(), issue.Line(), errSourceLine)

--- a/pkg/result/processors/exclude_rules_test.go
+++ b/pkg/result/processors/exclude_rules_test.go
@@ -50,7 +50,6 @@ func TestExcludeRules_multiple(t *testing.T) {
 
 	p := NewExcludeRules(nil, files, opts)
 
-	//nolint:dupl
 	cases := []issueTestCase{
 		{Path: "e.go", Text: "exclude", Linter: "linter"},
 		{Path: "e.go", Text: "some", Linter: "linter"},
@@ -210,7 +209,6 @@ func TestExcludeRules_caseSensitive_multiple(t *testing.T) {
 
 	p := NewExcludeRules(nil, files, opts)
 
-	//nolint:dupl
 	cases := []issueTestCase{
 		{Path: "e.go", Text: "exclude", Linter: "linter"},
 		{Path: "e.go", Text: "excLude", Linter: "linter"},

--- a/pkg/result/processors/fixer.go
+++ b/pkg/result/processors/fixer.go
@@ -164,7 +164,7 @@ func (f Fixer) applyInlineFixes(lineIssues []result.Issue, origLine []byte, line
 	var newLineBuf bytes.Buffer
 	newLineBuf.Grow(len(origLine))
 
-	//nolint:misspell
+	//nolint:misspell // misspelling is intentional
 	// example: origLine="it's becouse of them", StartCol=5, Length=7, NewString="because"
 
 	curOrigLinePos := 0

--- a/pkg/result/processors/identifier_marker_test.go
+++ b/pkg/result/processors/identifier_marker_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestIdentifierMarker(t *testing.T) {
-	//nolint:lll
 	cases := []struct{ in, out string }{
 		{"unknown field Address in struct literal", "unknown field `Address` in struct literal"},
 		{

--- a/pkg/result/processors/sort_results_test.go
+++ b/pkg/result/processors/sort_results_test.go
@@ -104,7 +104,7 @@ func TestCompareByLine(t *testing.T) {
 	})
 }
 
-func TestCompareByFileName(t *testing.T) { //nolint:dupl
+func TestCompareByFileName(t *testing.T) {
 	testCompareValues(t, byFileName(), "Compare By File Name", []compareTestCase{
 		{issues[0], issues[1], greater}, // file_windows.go vs file_linux.go
 		{issues[1], issues[2], greater}, // file_linux.go vs file_darwin.go
@@ -119,7 +119,7 @@ func TestCompareByFileName(t *testing.T) { //nolint:dupl
 	})
 }
 
-func TestCompareByColumn(t *testing.T) { //nolint:dupl
+func TestCompareByColumn(t *testing.T) {
 	testCompareValues(t, byColumn(), "Compare By Column", []compareTestCase{
 		{issues[0], issues[1], greater}, // 80 vs 70
 		{issues[1], issues[2], none},    // 70 vs zero value
@@ -134,7 +134,7 @@ func TestCompareByColumn(t *testing.T) { //nolint:dupl
 	})
 }
 
-func TestCompareByLinter(t *testing.T) { //nolint:dupl
+func TestCompareByLinter(t *testing.T) {
 	testCompareValues(t, byLinter(), "Compare By Linter", []compareTestCase{
 		{issues[0], issues[1], greater}, // b vs a
 		{issues[1], issues[2], less},    // a vs c

--- a/scripts/website/expand_templates/main.go
+++ b/scripts/website/expand_templates/main.go
@@ -96,7 +96,7 @@ type latestRelease struct {
 func getLatestVersion() (string, error) {
 	endpoint := "https://api.github.com/repos/golangci/golangci-lint/releases/latest"
 
-	//nolint:noctx
+	//nolint:noctx // request timeout handled by the client
 	req, err := http.NewRequest(http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
 		return "", fmt.Errorf("prepare a HTTP request: %w", err)

--- a/test/output_test.go
+++ b/test/output_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golangci/golangci-lint/test/testshared"
 )
 
-//nolint:misspell,lll
+//nolint:misspell
 const expectedJSONOutput = `{"Issues":[{"FromLinter":"misspell","Text":"` + "`" + `occured` + "`" + ` is a misspelling of ` + "`" + `occurred` + "`" + `","Severity":"","SourceLines":["\t// comment with incorrect spelling: occured // want \"` + "`" + `occured` + "`" + ` is a misspelling of ` + "`" + `occurred` + "`" + `\""],"Replacement":{"NeedOnlyDelete":false,"NewLines":null,"Inline":{"StartCol":37,"Length":7,"NewString":"occurred"}},"Pos":{"Filename":"testdata/misspell.go","Offset":0,"Line":6,"Column":38},"ExpectNoLint":false,"ExpectedNoLintLinter":""}]`
 
 func TestOutput_lineNumber(t *testing.T) {

--- a/test/output_test.go
+++ b/test/output_test.go
@@ -30,7 +30,7 @@ func TestOutput_lineNumber(t *testing.T) {
 		Runner().
 		Install().
 		Run().
-		//nolint:misspell
+		//nolint:misspell // misspelling is intentional
 		ExpectHasIssue("testdata/misspell.go:6:38: `occured` is a misspelling of `occurred`")
 }
 
@@ -91,7 +91,7 @@ func TestOutput_Multiple(t *testing.T) {
 		Runner().
 		Install().
 		Run().
-		//nolint:misspell
+		//nolint:misspell // misspelling is intentional
 		ExpectHasIssue("testdata/misspell.go:6:38: `occured` is a misspelling of `occurred`").
 		ExpectOutputContains(testshared.NormalizeFilePathInJSON(expectedJSONOutput))
 }

--- a/test/output_test.go
+++ b/test/output_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golangci/golangci-lint/test/testshared"
 )
 
-//nolint:misspell
+//nolint:misspell // misspelling is intentional
 const expectedJSONOutput = `{"Issues":[{"FromLinter":"misspell","Text":"` + "`" + `occured` + "`" + ` is a misspelling of ` + "`" + `occurred` + "`" + `","Severity":"","SourceLines":["\t// comment with incorrect spelling: occured // want \"` + "`" + `occured` + "`" + ` is a misspelling of ` + "`" + `occurred` + "`" + `\""],"Replacement":{"NeedOnlyDelete":false,"NewLines":null,"Inline":{"StartCol":37,"Length":7,"NewString":"occurred"}},"Pos":{"Filename":"testdata/misspell.go","Offset":0,"Line":6,"Column":38},"ExpectNoLint":false,"ExpectedNoLintLinter":""}]`
 
 func TestOutput_lineNumber(t *testing.T) {

--- a/test/testshared/directives.go
+++ b/test/testshared/directives.go
@@ -25,7 +25,7 @@ type RunContext struct {
 
 // ParseTestDirectives parses test directives from sources files.
 //
-//nolint:gocyclo,funlen
+//nolint:funlen,gocyclo // can't be simplified without losing readability
 func ParseTestDirectives(tb testing.TB, sourcePath string) *RunContext {
 	tb.Helper()
 
@@ -108,7 +108,9 @@ func ParseTestDirectives(tb testing.TB, sourcePath string) *RunContext {
 	if rc.ExpectedLinter == "" {
 		for _, arg := range rc.Args {
 			if strings.HasPrefix(arg, "-E") && !strings.Contains(arg, ",") {
-				require.Empty(tb, rc.ExpectedLinter, "could not infer expected linter for errors because multiple linters are enabled. Please use the `//golangcitest:expected_linter ` directive in your test to indicate the linter-under-test.") //nolint:lll
+				require.Empty(tb, rc.ExpectedLinter,
+					"could not infer expected linter for errors because multiple linters are enabled. "+
+						"Please use the `//golangcitest:expected_linter ` directive in your test to indicate the linter-under-test.")
 				rc.ExpectedLinter = arg[2:]
 			}
 		}

--- a/test/testshared/runner.go
+++ b/test/testshared/runner.go
@@ -267,7 +267,7 @@ func (r *Runner) Command() *exec.Cmd {
 
 	runArgs := append([]string{r.command}, r.args...)
 
-	//nolint:gosec
+	//nolint:gosec // we don't use user input here
 	cmd := exec.Command(r.binPath, runArgs...)
 	cmd.Env = append(os.Environ(), r.env...)
 


### PR DESCRIPTION
The PR fixes `nolintlint` issues and refactors `nolintlint` configuration for `golangci-lint` repo.

Main changes:
- Ignore `dupl` and `lll` for tests and remove `//nolint:dupl`, `//nolint:lll`. Usually, it's OK to have duplicated code and long lines in tests.
- Ignore `dupl` for the `pkg/golinters` package and remove `//nolint:dupl`. Because the logic of creating linters is similar between linters.
- Ignore `misspell`ed `importas` because it's a linter.
- Fix easy-to-fix `gocritic` issues and remove `//nolint:gocritic` comments.
- Add explanation comments for `//nolint:<linter>`.

One commit one change.