### PR TITLE
dev: silence help on some commands usage on error

### DIFF
--- a/pkg/commands/custom.go
+++ b/pkg/commands/custom.go
@@ -25,11 +25,12 @@ func newCustomCommand(logger logutils.Log) *customCommand {
 	c := &customCommand{log: logger}
 
 	customCmd := &cobra.Command{
-		Use:     "custom",
-		Short:   "Build a version of golangci-lint with custom linters",
-		Args:    cobra.NoArgs,
-		PreRunE: c.preRunE,
-		RunE:    c.runE,
+		Use:          "custom",
+		Short:        "Build a version of golangci-lint with custom linters",
+		Args:         cobra.NoArgs,
+		PreRunE:      c.preRunE,
+		RunE:         c.runE,
+		SilenceUsage: true,
 	}
 
 	c.cmd = customCmd

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -44,6 +44,7 @@ func newLintersCommand(logger logutils.Log) *lintersCommand {
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              c.execute,
 		PreRunE:           c.preRunE,
+		SilenceUsage:      true,
 	}
 
 	fs := lintersCmd.Flags()

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -118,6 +118,7 @@ func newRunCommand(logger logutils.Log, info BuildInfo) *runCommand {
 		PostRun:            c.postRun,
 		PersistentPreRunE:  c.persistentPreRunE,
 		PersistentPostRunE: c.persistentPostRunE,
+		SilenceUsage:       true,
 	}
 
 	runCmd.SetOut(logutils.StdOut) // use custom output to properly color it in Windows terminals


### PR DESCRIPTION
Some help displays are huge (e.g. `run`), and so it's too big to be useful when an error occurs.

I silenced some verbose help commands.

```go
// SilenceUsage is an option to silence usage when an error occurs.
SilenceUsage bool
```