### PR TITLE
nolintlint: enforce directive and linter list formatting

### DIFF
--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -64,8 +64,9 @@ type NoExplanation struct {
 
 //nolint:gocritic // TODO(ldez) must be change in the future.
 func (i NoExplanation) Details() string {
-	return fmt.Sprintf("directive `%s` is missing an explanation; it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>`",
-		i.fullDirective)
+	baseMsg := "directive `%s` is missing an explanation; "
+	explanationMsg := "it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>`"
+	return fmt.Sprintf(baseMsg+explanationMsg, i.fullDirective)
 }
 
 func (i NoExplanation) String() string { return toString(i) }

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -113,7 +113,7 @@ const (
 var commentPattern = regexp.MustCompile(`^//\s*(nolint)(:\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*)?\b`)
 
 // matches a complete nolint directive
-var fullDirectivePattern = regexp.MustCompile(`^//nolint(?::([\w-]+(?:,[\w-]+)*))?(?: (//.*))?\n?$`)
+var fullDirectivePattern = regexp.MustCompile(`^//nolint(?::(\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*))?\s*(//.*)?\s*\n?$`)
 
 type Linter struct {
 	needs           Needs // indicates which linter checks to perform

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -113,7 +113,7 @@ const (
 var commentPattern = regexp.MustCompile(`^//\s*(nolint)(:\s*[\w-]+\s*(?:,\s*[\w-]+\s*)*)?\b`)
 
 // matches a complete nolint directive
-var fullDirectivePattern = regexp.MustCompile(`^//\s*nolint(?::([\w-]+(?:,[\w-]+)*))?(?: (//.*))?\n?$`)
+var fullDirectivePattern = regexp.MustCompile(`^//nolint(?::([\w-]+(?:,[\w-]+)*))?(?: (//.*))?\n?$`)
 
 type Linter struct {
 	needs           Needs // indicates which linter checks to perform

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -64,8 +64,8 @@ type NoExplanation struct {
 
 //nolint:gocritic // TODO(ldez) must be change in the future.
 func (i NoExplanation) Details() string {
-	return fmt.Sprintf("directive `%s` should provide explanation such as `%s // this is why`",
-		i.fullDirective, i.fullDirectiveWithoutExplanation)
+	return fmt.Sprintf("directive `%s` is missing an explanation; it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>`",
+		i.fullDirective)
 }
 
 func (i NoExplanation) String() string { return toString(i) }

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -11,22 +11,22 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-type baseIssue struct {
+type BaseIssue struct {
 	fullDirective string
 	position      token.Position
 	replacement   *result.Replacement
 }
 
-func (b baseIssue) Position() token.Position {
+func (b BaseIssue) Position() token.Position {
 	return b.position
 }
 
-func (b baseIssue) Replacement() *result.Replacement {
+func (b BaseIssue) Replacement() *result.Replacement {
 	return b.replacement
 }
 
 type ExtraLeadingSpace struct {
-	baseIssue
+	BaseIssue
 }
 
 func (i ExtraLeadingSpace) Details() string {
@@ -36,7 +36,7 @@ func (i ExtraLeadingSpace) Details() string {
 func (i ExtraLeadingSpace) String() string { return toString(i) }
 
 type NotSpecific struct {
-	baseIssue
+	BaseIssue
 }
 
 func (i NotSpecific) Details() string {
@@ -47,7 +47,7 @@ func (i NotSpecific) Details() string {
 func (i NotSpecific) String() string { return toString(i) }
 
 type ParseError struct {
-	baseIssue
+	BaseIssue
 }
 
 func (i ParseError) Details() string {
@@ -58,7 +58,7 @@ func (i ParseError) Details() string {
 func (i ParseError) String() string { return toString(i) }
 
 type NoExplanation struct {
-	baseIssue
+	BaseIssue
 	fullDirectiveWithoutExplanation string
 }
 
@@ -71,7 +71,7 @@ func (i NoExplanation) Details() string {
 func (i NoExplanation) String() string { return toString(i) }
 
 type UnusedCandidate struct {
-	baseIssue
+	BaseIssue
 	ExpectedLinter string
 }
 
@@ -165,14 +165,14 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 				pos := fset.Position(comment.Pos())
 				end := fset.Position(comment.End())
 
-				base := baseIssue{
+				base := BaseIssue{
 					fullDirective: comment.Text,
 					position:      pos,
 				}
 
 				fullMatches := fullDirectivePattern.FindStringSubmatch(comment.Text)
 				if len(fullMatches) == 0 {
-					issues = append(issues, ParseError{baseIssue: base})
+					issues = append(issues, ParseError{BaseIssue: base})
 					continue
 				}
 
@@ -198,7 +198,7 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 
 				if (l.needs & NeedsSpecific) != 0 {
 					if len(linters) == 0 {
-						issues = append(issues, NotSpecific{baseIssue: base})
+						issues = append(issues, NotSpecific{BaseIssue: base})
 					}
 				}
 
@@ -213,12 +213,12 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 					}
 
 					if len(linters) == 0 {
-						issue := UnusedCandidate{baseIssue: base}
+						issue := UnusedCandidate{BaseIssue: base}
 						issue.replacement = removeNolintCompletely
 						issues = append(issues, issue)
 					} else {
 						for _, linter := range linters {
-							issue := UnusedCandidate{baseIssue: base, ExpectedLinter: linter}
+							issue := UnusedCandidate{BaseIssue: base, ExpectedLinter: linter}
 							// only offer replacement if there is a single linter
 							// because of issues around commas and the possibility of all
 							// linters being removed
@@ -243,7 +243,7 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 					if needsExplanation {
 						fullDirectiveWithoutExplanation := trailingBlankExplanation.ReplaceAllString(comment.Text, "")
 						issues = append(issues, NoExplanation{
-							baseIssue:                       base,
+							BaseIssue:                       base,
 							fullDirectiveWithoutExplanation: fullDirectiveWithoutExplanation,
 						})
 					}

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -7,7 +7,6 @@ import (
 	"go/token"
 	"regexp"
 	"strings"
-	"unicode"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -35,18 +34,6 @@ func (i ExtraLeadingSpace) Details() string {
 }
 
 func (i ExtraLeadingSpace) String() string { return toString(i) }
-
-type NotMachine struct {
-	baseIssue
-}
-
-func (i NotMachine) Details() string {
-	expected := i.fullDirective[:2] + strings.TrimLeftFunc(i.fullDirective[2:], unicode.IsSpace)
-	return fmt.Sprintf("directive `%s` should be written without leading space as `%s`",
-		i.fullDirective, expected)
-}
-
-func (i NotMachine) String() string { return toString(i) }
 
 type NotSpecific struct {
 	baseIssue
@@ -181,20 +168,6 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 				base := baseIssue{
 					fullDirective: comment.Text,
 					position:      pos,
-				}
-
-				// check for, report and eliminate leading spaces, so we can check for other issues
-				if leadingSpace != "" {
-					removeWhitespace := &result.Replacement{
-						Inline: &result.InlineFix{
-							StartCol:  pos.Column + 1,
-							Length:    len(leadingSpace),
-							NewString: "",
-						},
-					}
-					issue := NotMachine{baseIssue: base}
-					issue.baseIssue.replacement = removeWhitespace
-					issues = append(issues, issue)
 				}
 
 				fullMatches := fullDirectivePattern.FindStringSubmatch(comment.Text)

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -127,11 +127,17 @@ package bar
 func foo() {
   good() //nolint:linter1,linter-two
   bad() //nolint:linter1 linter2
-  good() //nolint: linter1,linter2
-  good() //nolint: linter1, linter2
+  bad() //nolint: linter1,linter2
+  bad() //nolint: linter1, linter2
+  bad() //nolint / description
+  bad() //nolint, // hi
 }`,
 			expected: []issueWithReplacement{
 				{issue: "directive `//nolint:linter1 linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9"},
+				{issue: "directive `//nolint: linter1,linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:7:9"},
+				{issue: "directive `//nolint: linter1, linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:8:9"},
+				{issue: "directive `//nolint / description` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:9:9"},
+				{issue: "directive `//nolint, // hi` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:10:9"},
 			},
 		},
 		{

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -102,22 +102,20 @@ func foo() {
 			},
 		},
 		{
-			desc: "spaces are not allowed in comma-separated list of linters",
+			desc: "spaces are allowed in comma-separated list of linters",
 			contents: `
 package bar
 
 func foo() {
   good() //nolint:linter1,linter-two
   bad() //nolint:linter1 linter2
-  bad() //nolint: linter1,linter2
-  bad() //nolint: linter1, linter2
+  good() //nolint: linter1,linter2
+  good() //nolint: linter1, linter2
   bad() //nolint / description
   bad() //nolint, // hi
 }`,
 			expected: []issueWithReplacement{
 				{issue: "directive `//nolint:linter1 linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9"},
-				{issue: "directive `//nolint: linter1,linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:7:9"},
-				{issue: "directive `//nolint: linter1, linter2` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:8:9"},
 				{issue: "directive `//nolint / description` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:9:9"},
 				{issue: "directive `//nolint, // hi` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:10:9"},
 			},

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -39,10 +39,10 @@ func foo() {
 	other() //nolintother
 }`,
 			expected: []issueWithReplacement{
-				{issue: "directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:5:1"},
-				{issue: "directive `//nolint` should provide explanation such as `//nolint // this is why` at testing.go:7:9"},
-				{issue: "directive `//nolint //` should provide explanation such as `//nolint // this is why` at testing.go:8:9"},
-				{issue: "directive `//nolint // ` should provide explanation such as `//nolint // this is why` at testing.go:9:9"},
+				{issue: "directive `//nolint` is missing an explanation; it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>` at testing.go:5:1"},
+				{issue: "directive `//nolint` is missing an explanation; it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>` at testing.go:7:9"},
+				{issue: "directive `//nolint //` is missing an explanation; it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>` at testing.go:8:9"},
+				{issue: "directive `//nolint // ` is missing an explanation; it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>` at testing.go:9:9"},
 			},
 		},
 		{
@@ -56,7 +56,7 @@ package bar
 //nolint:dupl
 func foo() {}`,
 			expected: []issueWithReplacement{
-				{issue: "directive `//nolint:dupl` should provide explanation such as `//nolint:dupl // this is why` at testing.go:6:1"},
+				{issue: "directive `//nolint:dupl` is missing an explanation; it should follow the format `//nolint[:<comma-separated-linters>] // <explanation>` at testing.go:6:1"},
 			},
 		},
 		{

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -102,7 +102,7 @@ func foo() {
 			},
 		},
 		{
-			desc: "spaces are allowed in comma-separated list of linters",
+			desc: "spaces are not allowed in comma-separated list of linters",
 			contents: `
 package bar
 

--- a/pkg/golinters/nolintlint/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/nolintlint_test.go
@@ -97,26 +97,8 @@ func foo() {
   good() //nolint
 }`,
 			expected: []issueWithReplacement{
-				{
-					issue: "directive `// nolint` should be written without leading space as `//nolint` at testing.go:5:9",
-					replacement: &result.Replacement{
-						Inline: &result.InlineFix{
-							StartCol:  10,
-							Length:    1,
-							NewString: "",
-						},
-					},
-				},
-				{
-					issue: "directive `//   nolint` should be written without leading space as `//nolint` at testing.go:6:9",
-					replacement: &result.Replacement{
-						Inline: &result.InlineFix{
-							StartCol:  10,
-							Length:    3,
-							NewString: "",
-						},
-					},
-				},
+				{issue: "directive `// nolint` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:5:9"},
+				{issue: "directive `//   nolint` should match `//nolint[:<comma-separated-linters>] [// <explanation>]` at testing.go:6:9"},
 			},
 		},
 		{


### PR DESCRIPTION
The rationale for this PR is to provide more helpful error messages in the nolintlint linter for nolint directives that have leading whitespace. The syntax of a Go directive [should roughly conform to the following format](https://github.com/golangci/golangci-lint/issues/1658): ^[a-z]+:[a-z]+. For nolint directive comments that have leading whitespace, the nolintlint linter currently gives a warning of the form “directive `// nolint: lll // ignore line length warnings` should be written without leading space as `//nolint: lll // ignore line length warnings`", whereas the correct directive comment would actually be `//nolint:lll // ignore line length warnings` (with no space between `nolint:` and `lll`). Broadly, this PR avoids providing inaccurate suggestions such as the aforementioned, instead providing a more generic directive template, resulting in an error message such as, "directive `// nolint: lll // ignore line length warnings` should match `//nolint[:<comma-separated-linters>] [// <explanation>]`". This should reduce confusion for developers and should make it easier to conform to the requirements of `go fmt` as of go1.19. However, this PR is non-breaking - it does not result in an error for nolint directives that have no leading whitespace but that do have spaces in the linter lists, which follows the existing behavior of nolintlint.

Change list:
- Remove `directiveWithOptionalLeadingSpace` field - leading spaces in the directive are [no longer allowed as of go1.19](https://github.com/golangci/golangci-lint/pull/3002), so the directive will now always be `//nolint`. It cannot be any directive other than `nolint` (e.g., `go:generate`) due to the guarantee provided by matching the comment against the `commentPattern` regular expression in the `Run` function. Therefore, we can just hardcode `//nolint` as the directive. (The directive, as the term is generally used in Go, *could* be something like `//nolint:lll` or `//nolint:all` with a colon and specific linter(s) after `nolint`, but the `directiveWithOptionalLeadingSpace` variable would not currently include the optional colon and anything following it, so for the purposes of this field, the directive will always be `//nolint`).
- Update the `fullDirectivePattern` to disallow spaces at the beginning of the string in order to avoid providing an error message that could potentially contain an inaccurate suggestion for how to update the `nolint` directive, as would have previously been done by the `NotMachine` issue. The regular expression continues to allow empty explanation comments because they will be caught by the `NoExplanation` issue if the `NeedsExplanation` flag is set.
- Deprecate `NeedsMachineOnly` and remove all references in code.
- Remove the `NotMachine` issue, since it has been superseded by the `ParseError`, which gives a more accurate error message (specifically, it does not provide a suggestion for how to update the `nolint` directive that could potentially still have spaces in the linter list, but rather a more generic suggestion of the format of a well-formed `nolint` comment).
- Update `NoExplanation` details to provide a generic directive template rather than a specific suggestion; update unit tests accordingly. Similar to the previous bullet point, this avoids inadvertently providing an inaccurate error message.
- Remove unused `//nolint:gocritic` comments.
- Update test cases in the unit test file that previously resulted in the `NotMachine` issue to reflect that they now result in the `ParseError` issue instead.
- Add test cases that would have previously erroneously resulted in `directiveWithOptionalLeadingSpace` values not equal to `//nolint` or `// nolint` (namely, `directiveWithOptionalLeadingSpace` values containing additional characters after the directive, such as `//nolint / description`).