### PR TITLE
feat: Add `.config` directories to `configSearchPaths`

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -138,6 +138,13 @@ func (l *Loader) setupConfigFileSearch() {
 	for {
 		configSearchPaths = append(configSearchPaths, curDir)
 
+		dotConfig := filepath.Join(curDir, ".config")
+
+		info, err := os.Stat(dotConfig)
+		if err == nil && info.IsDir() {
+			configSearchPaths = append(configSearchPaths, dotConfig)
+		}
+
 		newCurDir := filepath.Dir(curDir)
 		if curDir == newCurDir || newCurDir == "" {
 			break


### PR DESCRIPTION
Support for `.config` proposal from https://github.com/pi0/config-dir. While walking the tree, check if a directory named `.config` exist. If so, add it to `configSearchPaths` to include when searching for `.golangci.yaml`.

Fixes #4554