### PR TITLE
dev: clean code arround CLI args usage

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -77,7 +77,7 @@ func newConfigCommand(log logutils.Log, info BuildInfo) *configCommand {
 	return c
 }
 
-func (c *configCommand) preRunE(cmd *cobra.Command, _ []string) error {
+func (c *configCommand) preRunE(cmd *cobra.Command, args []string) error {
 	// The command doesn't depend on the real configuration.
 	// It only needs to know the path of the configuration file.
 	cfg := config.NewDefault()
@@ -89,7 +89,7 @@ func (c *configCommand) preRunE(cmd *cobra.Command, _ []string) error {
 	// TODO(ldez) add an option (check deprecation) to `Loader.Load()` but this require a dedicated PR.
 	cfg.Run.UseDefaultSkipDirs = true
 
-	loader := config.NewLoader(c.log.Child(logutils.DebugKeyConfigReader), c.viper, cmd.Flags(), c.opts, cfg)
+	loader := config.NewLoader(c.log.Child(logutils.DebugKeyConfigReader), c.viper, cmd.Flags(), c.opts, cfg, args)
 
 	if err := loader.Load(); err != nil {
 		return fmt.Errorf("can't load config: %w", err)

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -58,7 +58,7 @@ func newLintersCommand(logger logutils.Log) *lintersCommand {
 	return c
 }
 
-func (c *lintersCommand) preRunE(cmd *cobra.Command, _ []string) error {
+func (c *lintersCommand) preRunE(cmd *cobra.Command, args []string) error {
 	// Hack to hide deprecation messages related to `--skip-dirs-use-default`:
 	// Flags are not bound then the default values, defined only through flags, are not applied.
 	// In this command, linters information are the only requirements, i.e. it don't need flag values.
@@ -66,7 +66,7 @@ func (c *lintersCommand) preRunE(cmd *cobra.Command, _ []string) error {
 	// TODO(ldez) add an option (check deprecation) to `Loader.Load()` but this require a dedicated PR.
 	c.cfg.Run.UseDefaultSkipDirs = true
 
-	loader := config.NewLoader(c.log.Child(logutils.DebugKeyConfigReader), c.viper, cmd.Flags(), c.opts.LoaderOptions, c.cfg)
+	loader := config.NewLoader(c.log.Child(logutils.DebugKeyConfigReader), c.viper, cmd.Flags(), c.opts.LoaderOptions, c.cfg, args)
 
 	if err := loader.Load(); err != nil {
 		return fmt.Errorf("can't load config: %w", err)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -147,12 +147,12 @@ func newRunCommand(logger logutils.Log, info BuildInfo) *runCommand {
 	return c
 }
 
-func (c *runCommand) persistentPreRunE(cmd *cobra.Command, _ []string) error {
+func (c *runCommand) persistentPreRunE(cmd *cobra.Command, args []string) error {
 	if err := c.startTracing(); err != nil {
 		return err
 	}
 
-	loader := config.NewLoader(c.log.Child(logutils.DebugKeyConfigReader), c.viper, cmd.Flags(), c.opts.LoaderOptions, c.cfg)
+	loader := config.NewLoader(c.log.Child(logutils.DebugKeyConfigReader), c.viper, cmd.Flags(), c.opts.LoaderOptions, c.cfg, args)
 
 	if err := loader.Load(); err != nil {
 		return fmt.Errorf("can't load config: %w", err)

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -116,7 +116,7 @@ func (l *Loader) evaluateOptions() (string, error) {
 }
 
 func (l *Loader) setupConfigFileSearch() {
-	firstArg := extractFirstPathArg()
+	firstArg := extractFirstPathArg(os.Args)
 
 	absStartPath, err := filepath.Abs(firstArg)
 	if err != nil {
@@ -417,9 +417,7 @@ func customDecoderHook() viper.DecoderConfigOption {
 	))
 }
 
-func extractFirstPathArg() string {
-	args := os.Args
-
+func extractFirstPathArg(args []string) string {
 	// skip all args ([golangci-lint, run/linters]) before files/dirs list
 	for len(args) != 0 {
 		if args[0] == "run" {

--- a/pkg/lint/package.go
+++ b/pkg/lint/package.go
@@ -238,9 +238,14 @@ func buildArgs(args []string) []string {
 
 	var retArgs []string
 	for _, arg := range args {
-		if strings.HasPrefix(arg, ".") || filepath.IsAbs(arg) {
+		if strings.HasPrefix(arg, ".") {
+			println("HasPrefix", arg)
+			retArgs = append(retArgs, arg)
+		} else if filepath.IsAbs(arg) {
+			println("IsAbs", arg)
 			retArgs = append(retArgs, arg)
 		} else {
+			println("ELSE", arg)
 			// go/packages doesn't work well if we don't have the prefix ./ for local packages
 			retArgs = append(retArgs, fmt.Sprintf(".%c%s", filepath.Separator, arg))
 		}

--- a/pkg/lint/package.go
+++ b/pkg/lint/package.go
@@ -238,14 +238,9 @@ func buildArgs(args []string) []string {
 
 	var retArgs []string
 	for _, arg := range args {
-		if strings.HasPrefix(arg, ".") {
-			println("HasPrefix", arg)
-			retArgs = append(retArgs, arg)
-		} else if filepath.IsAbs(arg) {
-			println("IsAbs", arg)
+		if strings.HasPrefix(arg, ".") || filepath.IsAbs(arg) {
 			retArgs = append(retArgs, arg)
 		} else {
-			println("ELSE", arg)
 			// go/packages doesn't work well if we don't have the prefix ./ for local packages
 			retArgs = append(retArgs, fmt.Sprintf(".%c%s", filepath.Separator, arg))
 		}

--- a/pkg/lint/package_test.go
+++ b/pkg/lint/package_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_buildArgs(t *testing.T) {
@@ -30,8 +31,8 @@ func Test_buildArgs(t *testing.T) {
 		},
 		{
 			desc:     "absolute path",
-			args:     []string{filepath.FromSlash("/tmp/foo")},
-			expected: []string{filepath.FromSlash("/tmp/foo")},
+			args:     []string{mustAbs(t, "/tmp/foo")},
+			expected: []string{mustAbs(t, "/tmp/foo")},
 		},
 	}
 
@@ -45,4 +46,13 @@ func Test_buildArgs(t *testing.T) {
 			assert.Equal(t, test.expected, results)
 		})
 	}
+}
+
+func mustAbs(t *testing.T, p string) string {
+	t.Helper()
+
+	abs, err := filepath.Abs(filepath.FromSlash(p))
+	require.NoError(t, err)
+
+	return abs
 }

--- a/pkg/lint/package_test.go
+++ b/pkg/lint/package_test.go
@@ -1,0 +1,48 @@
+package lint
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_buildArgs(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		args     []string
+		expected []string
+	}{
+		{
+			desc:     "empty",
+			args:     nil,
+			expected: []string{"./..."},
+		},
+		{
+			desc:     "start with a dot",
+			args:     []string{filepath.FromSlash("./foo")},
+			expected: []string{filepath.FromSlash("./foo")},
+		},
+		{
+			desc:     "start without a dot",
+			args:     []string{"foo"},
+			expected: []string{filepath.FromSlash("./foo")},
+		},
+		{
+			desc:     "absolute path",
+			args:     []string{filepath.FromSlash("/tmp/foo")},
+			expected: []string{filepath.FromSlash("/tmp/foo")},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			results := buildArgs(test.args)
+
+			assert.Equal(t, test.expected, results)
+		})
+	}
+}

--- a/pkg/result/processors/autogenerated_exclude.go
+++ b/pkg/result/processors/autogenerated_exclude.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -156,8 +155,4 @@ func getComments(filePath string) (string, error) {
 	}
 
 	return strings.Join(docLines, "\n"), nil
-}
-
-func isGoFile(name string) bool {
-	return filepath.Ext(name) == ".go"
 }

--- a/pkg/result/processors/invalid_issue.go
+++ b/pkg/result/processors/invalid_issue.go
@@ -7,6 +7,8 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
+const goFileExtension = ".go"
+
 var _ Processor = InvalidIssue{}
 
 type InvalidIssue struct {
@@ -49,4 +51,8 @@ func (p InvalidIssue) shouldPassIssue(issue *result.Issue) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func isGoFile(name string) bool {
+	return filepath.Ext(name) == goFileExtension
 }

--- a/pkg/result/processors/invalid_issue.go
+++ b/pkg/result/processors/invalid_issue.go
@@ -7,8 +7,6 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const goFileExtension = ".go"
-
 var _ Processor = InvalidIssue{}
 
 type InvalidIssue struct {
@@ -54,5 +52,5 @@ func (p InvalidIssue) shouldPassIssue(issue *result.Issue) (bool, error) {
 }
 
 func isGoFile(name string) bool {
-	return filepath.Ext(name) == goFileExtension
+	return filepath.Ext(name) == ".go"
 }

--- a/pkg/result/processors/skip_dirs.go
+++ b/pkg/result/processors/skip_dirs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/logutils"
@@ -38,21 +37,9 @@ func NewSkipDirs(patterns []string, log logutils.Log, runArgs []string, pathPref
 		patternsRe = append(patternsRe, patternRe)
 	}
 
-	if len(runArgs) == 0 {
-		runArgs = append(runArgs, "./...")
-	}
-	var absArgsDirs []string
-	for _, arg := range runArgs {
-		base := filepath.Base(arg)
-		if base == "..." || strings.HasSuffix(base, goFileExtension) {
-			arg = filepath.Dir(arg)
-		}
-
-		absArg, err := filepath.Abs(arg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to abs-ify arg %q: %w", arg, err)
-		}
-		absArgsDirs = append(absArgsDirs, absArg)
+	absArgsDirs, err := absDirs(runArgs)
+	if err != nil {
+		return nil, err
 	}
 
 	return &SkipDirs{
@@ -141,4 +128,27 @@ func (p *SkipDirs) Finish() {
 	for dir, stat := range p.skippedDirs {
 		p.log.Infof("Skipped %d issues from dir %s by pattern %s", stat.count, dir, stat.pattern)
 	}
+}
+
+func absDirs(args []string) ([]string, error) {
+	if len(args) == 0 {
+		args = append(args, "./...")
+	}
+
+	var absArgsDirs []string
+	for _, arg := range args {
+		base := filepath.Base(arg)
+		if base == "..." || isGoFile(base) {
+			arg = filepath.Dir(arg)
+		}
+
+		absArg, err := filepath.Abs(arg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to abs-ify arg %q: %w", arg, err)
+		}
+
+		absArgsDirs = append(absArgsDirs, absArg)
+	}
+
+	return absArgsDirs, nil
 }

--- a/pkg/result/processors/skip_dirs.go
+++ b/pkg/result/processors/skip_dirs.go
@@ -26,7 +26,7 @@ type SkipDirs struct {
 
 var _ Processor = (*SkipDirs)(nil)
 
-func NewSkipDirs(patterns []string, log logutils.Log, runArgs []string, pathPrefix string) (*SkipDirs, error) {
+func NewSkipDirs(patterns []string, log logutils.Log, args []string, pathPrefix string) (*SkipDirs, error) {
 	var patternsRe []*regexp.Regexp
 	for _, p := range patterns {
 		p = fsutils.NormalizePathInRegex(p)
@@ -37,7 +37,7 @@ func NewSkipDirs(patterns []string, log logutils.Log, runArgs []string, pathPref
 		patternsRe = append(patternsRe, patternRe)
 	}
 
-	absArgsDirs, err := absDirs(runArgs)
+	absArgsDirs, err := absDirs(args)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/result/processors/skip_dirs.go
+++ b/pkg/result/processors/skip_dirs.go
@@ -27,8 +27,6 @@ type SkipDirs struct {
 
 var _ Processor = (*SkipDirs)(nil)
 
-const goFileSuffix = ".go"
-
 func NewSkipDirs(patterns []string, log logutils.Log, runArgs []string, pathPrefix string) (*SkipDirs, error) {
 	var patternsRe []*regexp.Regexp
 	for _, p := range patterns {
@@ -46,7 +44,7 @@ func NewSkipDirs(patterns []string, log logutils.Log, runArgs []string, pathPref
 	var absArgsDirs []string
 	for _, arg := range runArgs {
 		base := filepath.Base(arg)
-		if base == "..." || strings.HasSuffix(base, goFileSuffix) {
+		if base == "..." || strings.HasSuffix(base, goFileExtension) {
 			arg = filepath.Dir(arg)
 		}
 

--- a/pkg/result/processors/skip_dirs_test.go
+++ b/pkg/result/processors/skip_dirs_test.go
@@ -1,0 +1,68 @@
+package processors
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_absDirs(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		args     []string
+		expected []string
+	}{
+		{
+			desc:     "empty",
+			expected: []string{mustAbs(t, ".")},
+		},
+		{
+			desc:     "wildcard",
+			args:     []string{"./..."},
+			expected: []string{mustAbs(t, ".")},
+		},
+		{
+			desc:     "wildcard directory",
+			args:     []string{"foo/..."},
+			expected: []string{mustAbs(t, "foo")},
+		},
+		{
+			desc:     "Go file",
+			args:     []string{"./foo/bar.go"},
+			expected: []string{mustAbs(t, "foo")},
+		},
+		{
+			desc:     "relative directory",
+			args:     []string{filepath.FromSlash("./foo")},
+			expected: []string{mustAbs(t, "foo")},
+		},
+		{
+			desc:     "absolute directory",
+			args:     []string{mustAbs(t, "foo")},
+			expected: []string{mustAbs(t, "foo")},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			results, err := absDirs(test.args)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, results)
+		})
+	}
+}
+
+func mustAbs(t *testing.T, p string) string {
+	t.Helper()
+
+	abs, err := filepath.Abs(p)
+	require.NoError(t, err)
+
+	return abs
+}


### PR DESCRIPTION
There is a mix between args from `os.Args` and args from Cobra.

The PR removes the usage `os.Args`, cleans the related functions, and adds tests.
