### PR TITLE
feat: deprecate usage of linter alternative names

### DIFF
--- a/pkg/golinters/internal/diff_test.go
+++ b/pkg/golinters/internal/diff_test.go
@@ -128,8 +128,8 @@ index 0000000..6399915
 +// line
 `
 
-	log := logutils.NewMockLog()
-	log.On("Infof", "The diff contains only additions: no original or deleted lines: %#v", mock.Anything)
+	log := logutils.NewMockLog().
+		OnInfof("The diff contains only additions: no original or deleted lines: %#v", mock.Anything)
 
 	var noChanges []Change
 	testDiffProducesChanges(t, log, diff, noChanges...)

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -102,7 +102,7 @@ func (v Validator) alternativeNamesDeprecation(cfg *config.Linters) error {
 		}
 
 		if len(lc) > 1 {
-			v.m.log.Warnf("The linter name %q is deprecated. It has been splited into: %s.", name, strings.Join(lc, ", "))
+			v.m.log.Warnf("The linter name %q is deprecated. It has been split into: %s.", name, strings.Join(lc, ", "))
 		} else {
 			v.m.log.Warnf("The linter name %q is deprecated. It has been renamed to: %s.", name, lc[0])
 		}

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -43,7 +43,7 @@ func (v Validator) Validate(cfg *config.Config) error {
 }
 
 func (v Validator) validateLintersNames(cfg *config.Linters) error {
-	allNames := append([]string{}, cfg.Enable...)
+	allNames := cfg.Enable
 	allNames = append(allNames, cfg.Disable...)
 
 	var unknownNames []string
@@ -91,7 +91,7 @@ func (v Validator) alternativeNamesDeprecation(cfg *config.Linters) error {
 		}
 	}
 
-	names := append([]string{}, cfg.Enable...)
+	names := cfg.Enable
 	names = append(names, cfg.Disable...)
 
 	for _, name := range names {

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -91,8 +91,7 @@ func (v Validator) alternativeNamesDeprecation(cfg *config.Linters) error {
 		}
 	}
 
-	var names []string
-	names = append(names, cfg.Enable...)
+	names := append([]string{}, cfg.Enable...)
 	names = append(names, cfg.Disable...)
 
 	for _, name := range names {

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -3,10 +3,12 @@ package lintersdb
 import (
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
 	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/logutils"
 )
 
 type Validator struct {
@@ -28,6 +30,7 @@ func (v Validator) Validate(cfg *config.Config) error {
 	validators := []func(cfg *config.Linters) error{
 		v.validateLintersNames,
 		v.validatePresets,
+		v.alternativeNamesDeprecation,
 	}
 
 	for _, v := range validators {
@@ -71,6 +74,38 @@ func (v Validator) validatePresets(cfg *config.Linters) error {
 
 	if len(cfg.Presets) != 0 && cfg.EnableAll {
 		return errors.New("--presets is incompatible with --enable-all")
+	}
+
+	return nil
+}
+
+func (v Validator) alternativeNamesDeprecation(cfg *config.Linters) error {
+	if v.m.cfg.InternalTest || v.m.cfg.InternalCmdTest || os.Getenv(logutils.EnvTestRun) == "1" {
+		return nil
+	}
+
+	altNames := map[string][]string{}
+	for _, lc := range v.m.GetAllSupportedLinterConfigs() {
+		for _, alt := range lc.AlternativeNames {
+			altNames[alt] = append(altNames[alt], lc.Name())
+		}
+	}
+
+	var names []string
+	names = append(names, cfg.Enable...)
+	names = append(names, cfg.Disable...)
+
+	for _, name := range names {
+		lc, ok := altNames[name]
+		if !ok {
+			continue
+		}
+
+		if len(lc) > 1 {
+			v.m.log.Warnf("The linter name %q is deprecated. It has been splited into: %s.", name, strings.Join(lc, ", "))
+		} else {
+			v.m.log.Warnf("The linter name %q is deprecated. It has been renamed to: %s.", name, lc[0])
+		}
 	}
 
 	return nil

--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -102,9 +102,9 @@ func (v Validator) alternativeNamesDeprecation(cfg *config.Linters) error {
 		}
 
 		if len(lc) > 1 {
-			v.m.log.Warnf("The linter name %q is deprecated. It has been split into: %s.", name, strings.Join(lc, ", "))
+			v.m.log.Warnf("The linter named %q is deprecated. It has been split into: %s.", name, strings.Join(lc, ", "))
 		} else {
-			v.m.log.Warnf("The linter name %q is deprecated. It has been renamed to: %s.", name, lc[0])
+			v.m.log.Warnf("The name %q is deprecated. The linter has been renamed to: %s.", name, lc[0])
 		}
 	}
 

--- a/pkg/lint/lintersdb/validator_test.go
+++ b/pkg/lint/lintersdb/validator_test.go
@@ -222,7 +222,7 @@ func TestValidator_alternativeNamesDeprecation(t *testing.T) {
 		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vet", "govet").
 		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vetshadow", "govet").
 		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "logrlint", "loggercheck").
-		OnWarnf("The linter name %q is deprecated. It has been splited into: %s.", "megacheck", "gosimple, staticcheck, unused").
+		OnWarnf("The linter name %q is deprecated. It has been split into: %s.", "megacheck", "gosimple, staticcheck, unused").
 		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "gas", "gosec")
 
 	m, err := NewManager(log, nil, NewLinterBuilder())

--- a/pkg/lint/lintersdb/validator_test.go
+++ b/pkg/lint/lintersdb/validator_test.go
@@ -217,15 +217,15 @@ func TestValidator_validatePresets_error(t *testing.T) {
 	}
 }
 
-func TestValidator_alternativeNames(t *testing.T) {
+func TestValidator_alternativeNamesDeprecation(t *testing.T) {
 	t.Setenv(logutils.EnvTestRun, "0")
 
 	log := logutils.NewMockLog().
-		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vet", "govet").
-		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vetshadow", "govet").
-		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "logrlint", "loggercheck").
-		OnWarnf("The linter name %q is deprecated. It has been split into: %s.", "megacheck", "gosimple, staticcheck, unused").
-		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "gas", "gosec")
+		OnWarnf("The name %q is deprecated. The linter has been renamed to: %s.", "vet", "govet").
+		OnWarnf("The name %q is deprecated. The linter has been renamed to: %s.", "vetshadow", "govet").
+		OnWarnf("The name %q is deprecated. The linter has been renamed to: %s.", "logrlint", "loggercheck").
+		OnWarnf("The linter named %q is deprecated. It has been split into: %s.", "megacheck", "gosimple, staticcheck, unused").
+		OnWarnf("The name %q is deprecated. The linter has been renamed to: %s.", "gas", "gosec")
 
 	m, err := NewManager(log, nil, NewLinterBuilder())
 	require.NoError(t, err)

--- a/pkg/lint/lintersdb/validator_test.go
+++ b/pkg/lint/lintersdb/validator_test.go
@@ -218,12 +218,12 @@ func TestValidator_validatePresets_error(t *testing.T) {
 }
 
 func TestValidator_alternativeNamesDeprecation(t *testing.T) {
-	log := logutils.NewMockLog()
-	log.On("Warnf", "The linter name %q is deprecated. It has been renamed to: %s.", "vet", "govet")
-	log.On("Warnf", "The linter name %q is deprecated. It has been renamed to: %s.", "vetshadow", "govet")
-	log.On("Warnf", "The linter name %q is deprecated. It has been renamed to: %s.", "logrlint", "loggercheck")
-	log.On("Warnf", "The linter name %q is deprecated. It has been splited into: %s.", "megacheck", "gosimple, staticcheck, unused")
-	log.On("Warnf", "The linter name %q is deprecated. It has been renamed to: %s.", "gas", "gosec")
+	log := logutils.NewMockLog().
+		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vet", "govet").
+		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vetshadow", "govet").
+		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "logrlint", "loggercheck").
+		OnWarnf("The linter name %q is deprecated. It has been splited into: %s.", "megacheck", "gosimple, staticcheck, unused").
+		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "gas", "gosec")
 
 	m, err := NewManager(log, nil, NewLinterBuilder())
 	require.NoError(t, err)

--- a/pkg/lint/lintersdb/validator_test.go
+++ b/pkg/lint/lintersdb/validator_test.go
@@ -217,7 +217,9 @@ func TestValidator_validatePresets_error(t *testing.T) {
 	}
 }
 
-func TestValidator_alternativeNamesDeprecation(t *testing.T) {
+func TestValidator_alternativeNames(t *testing.T) {
+	t.Setenv(logutils.EnvTestRun, "0")
+
 	log := logutils.NewMockLog().
 		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vet", "govet").
 		OnWarnf("The linter name %q is deprecated. It has been renamed to: %s.", "vetshadow", "govet").

--- a/pkg/logutils/mock.go
+++ b/pkg/logutils/mock.go
@@ -45,3 +45,48 @@ func (m *MockLog) Child(name string) Log {
 func (m *MockLog) SetLevel(level LogLevel) {
 	m.Called(level)
 }
+
+func (m *MockLog) OnFatalf(format string, args ...any) *MockLog {
+	arguments := []any{format}
+	arguments = append(arguments, args...)
+
+	m.On("Fatalf", arguments...)
+
+	return m
+}
+
+func (m *MockLog) OnPanicf(format string, args ...any) *MockLog {
+	arguments := []any{format}
+	arguments = append(arguments, args...)
+
+	m.On("Panicf", arguments...)
+
+	return m
+}
+
+func (m *MockLog) OnErrorf(format string, args ...any) *MockLog {
+	arguments := []any{format}
+	arguments = append(arguments, args...)
+
+	m.On("Errorf", arguments...)
+
+	return m
+}
+
+func (m *MockLog) OnWarnf(format string, args ...any) *MockLog {
+	arguments := []any{format}
+	arguments = append(arguments, args...)
+
+	m.On("Warnf", arguments...)
+
+	return m
+}
+
+func (m *MockLog) OnInfof(format string, args ...any) *MockLog {
+	arguments := []any{format}
+	arguments = append(arguments, args...)
+
+	m.On("Infof", arguments...)
+
+	return m
+}

--- a/pkg/logutils/mock.go
+++ b/pkg/logutils/mock.go
@@ -47,8 +47,7 @@ func (m *MockLog) SetLevel(level LogLevel) {
 }
 
 func (m *MockLog) OnFatalf(format string, args ...any) *MockLog {
-	arguments := []any{format}
-	arguments = append(arguments, args...)
+	arguments := append([]any{format}, args...)
 
 	m.On("Fatalf", arguments...)
 

--- a/pkg/logutils/mock.go
+++ b/pkg/logutils/mock.go
@@ -13,28 +13,23 @@ func NewMockLog() *MockLog {
 }
 
 func (m *MockLog) Fatalf(format string, args ...any) {
-	mArgs := []any{format}
-	m.Called(append(mArgs, args...)...)
+	m.Called(append([]any{format}, args...)...)
 }
 
 func (m *MockLog) Panicf(format string, args ...any) {
-	mArgs := []any{format}
-	m.Called(append(mArgs, args...)...)
+	m.Called(append([]any{format}, args...)...)
 }
 
 func (m *MockLog) Errorf(format string, args ...any) {
-	mArgs := []any{format}
-	m.Called(append(mArgs, args...)...)
+	m.Called(append([]any{format}, args...)...)
 }
 
 func (m *MockLog) Warnf(format string, args ...any) {
-	mArgs := []any{format}
-	m.Called(append(mArgs, args...)...)
+	m.Called(append([]any{format}, args...)...)
 }
 
 func (m *MockLog) Infof(format string, args ...any) {
-	mArgs := []any{format}
-	m.Called(append(mArgs, args...)...)
+	m.Called(append([]any{format}, args...)...)
 }
 
 func (m *MockLog) Child(name string) Log {
@@ -55,8 +50,7 @@ func (m *MockLog) OnFatalf(format string, args ...any) *MockLog {
 }
 
 func (m *MockLog) OnPanicf(format string, args ...any) *MockLog {
-	arguments := []any{format}
-	arguments = append(arguments, args...)
+	arguments := append([]any{format}, args...)
 
 	m.On("Panicf", arguments...)
 
@@ -64,8 +58,7 @@ func (m *MockLog) OnPanicf(format string, args ...any) *MockLog {
 }
 
 func (m *MockLog) OnErrorf(format string, args ...any) *MockLog {
-	arguments := []any{format}
-	arguments = append(arguments, args...)
+	arguments := append([]any{format}, args...)
 
 	m.On("Errorf", arguments...)
 
@@ -73,8 +66,7 @@ func (m *MockLog) OnErrorf(format string, args ...any) *MockLog {
 }
 
 func (m *MockLog) OnWarnf(format string, args ...any) *MockLog {
-	arguments := []any{format}
-	arguments = append(arguments, args...)
+	arguments := append([]any{format}, args...)
 
 	m.On("Warnf", arguments...)
 
@@ -82,8 +74,7 @@ func (m *MockLog) OnWarnf(format string, args ...any) *MockLog {
 }
 
 func (m *MockLog) OnInfof(format string, args ...any) *MockLog {
-	arguments := []any{format}
-	arguments = append(arguments, args...)
+	arguments := append([]any{format}, args...)
 
 	m.On("Infof", arguments...)
 


### PR DESCRIPTION
Displays a warning when using alternative names.

I used the `Validator` because the linter names and alternative names are required for the analysis, then it cannot be done inside the `Loader`.

FYI: `unused`, `gosimple`, `staticcheck` cannot be merged as one "linter" because their requirements are completely different.

Fixes #357
Related #3746