### PR TITLE
docs: remove invalid example about mixing files and directory

### DIFF
--- a/docs/src/docs/welcome/quick-start.mdx
+++ b/docs/src/docs/welcome/quick-start.mdx
@@ -14,13 +14,16 @@ It's an equivalent of executing:
 golangci-lint run ./...
 ```
 
-You can choose which directories and files to analyze:
+You can choose which directories or files to analyze:
 
 ```sh
-golangci-lint run dir1 dir2/... dir3/file1.go
+golangci-lint run dir1 dir2/...
+golangci-lint run file1.go
 ```
 
-Directories are NOT analyzed recursively. To analyze them recursively append `/...` to their path.
+Directories are NOT analyzed recursively.
+To analyze them recursively append `/...` to their path.
+It's not possible to mix files and packages/directories, and files must come from the same package.
 
 GolangCI-Lint can be used with zero configuration. By default, the following linters are enabled:
 


### PR DESCRIPTION
The mix of file and package/directory (as documented inside the [quick start](https://golangci-lint.run/welcome/quick-start/)) doesn't work as expected.

Same thing for the usage of multiple files from different packages.

<details><summary>Examples</summary>

```console
$ golangci-lint run main.go          
main.go:11:5: Error return value is not checked (errcheck)
        Bar()
           ^
```

```console
$ golangci-lint run pkga/... main.go
ERRO Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: -: named files must be .go files: ./pkga/...
```

```console
$ golangci-lint run pkga main.go 
ERRO Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: -: named files must be .go files: ./pkga
```

```console
$ golangci-lint run pkga/file1.go pkgb/file1.go 
ERRO [linters_context] typechecking error: named files must all be in one directory; have pkga and pkgb
```

</details>

This limitation is related to the package loader of `x/tools`.

There is a hack: the usage of the prefix `file=` allows to mix files and packages but this has a major side effect.

The usage of `file=`, despite what the name of the query suggests, will not limit the loading to the file but to the package that contains the file.
In other words, instead of the analysis of one file, all the sibling files will be analyzed.
So this is not an acceptable solution.

In this context, I edited the documentation to remove this invalid example.

<details><summary>To reproduce</summary>

```bash
#!/bin/sh -e

## setup module
rm -rf sandbox
mkdir sandbox && cd $_
go mod init github.com/golangci/sandbox

## main.go
cat > main.go  <<EOF
package main

import (
	"github.com/golangci/sandbox/pkga"
	"github.com/golangci/sandbox/pkgb"
)

func main() {
	pkga.Foo()
	pkgb.Foo()
	Bar()
}

func Bar() error {
	return nil
}

EOF

## pkga/file1.go
cat > pkga/file1.go  <<EOF
package pkga

func Foo() {
	foo()
	return
}

func foo() error {
	return nil
}
EOF

## pkgb/file1.go
cat > pkgb/file1.go  <<EOF
package pkgb

func Foo() {
	foo()
	return
}

func foo() error {
	return nil
}
EOF

## .golangci.yml
cat > .golangci.yml  <<EOF
linters:
  disable-all: true
  enable:
    - errcheck
EOF
```

</details>

Fixes #3200
Fixes #1081
Fixes #942
