### PR TITLE
fix: display warnings on deprecated linter options

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,7 +143,6 @@ linters:
   # See the comment on top of this file.
 
 issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: (.+)_test\.go
       linters:
@@ -151,28 +150,39 @@ issues:
         - gomnd
         - lll
 
+    # The logic of creating a linter is similar between linters, it's not duplication.
     - path: pkg/golinters
       linters:
         - dupl
 
+    # Deprecated configuration options.
+    - path: pkg/commands/run.go
+      linters: [staticcheck]
+      text: "SA1019: c.cfg.Run.ShowStats is deprecated: use Output.ShowStats instead."
+    - path: pkg/commands/config.go
+      text: "SA1019: cfg.Run.UseDefaultSkipDirs is deprecated: use Issues.UseDefaultExcludeDirs instead."
+
+    # Deprecated linter options.
     - path: pkg/golinters/errcheck.go
       linters: [staticcheck]
       text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
     - path: pkg/commands/run.go
       linters: [staticcheck]
       text: "SA1019: lsc.Errcheck.Exclude is deprecated: use ExcludeFunctions instead"
-    - path: pkg/commands/run.go
-      linters: [staticcheck]
-      text: "SA1019: c.cfg.Run.ShowStats is deprecated: use Output.ShowStats instead."
     - path: pkg/golinters/govet.go
-      text: "SA1019: cfg.CheckShadowing is deprecated: the linter should be enabled inside `Enable`."
-    - path: pkg/commands/config.go
-      text: "SA1019: cfg.Run.UseDefaultSkipDirs is deprecated: use Issues.UseDefaultExcludeDirs instead."
-
+      linters: [staticcheck]
+      text: "SA1019: cfg.CheckShadowing is deprecated: the linter should be enabled inside Enable."
     - path: pkg/golinters/godot.go
       linters: [staticcheck]
-      text: "SA1019: settings.CheckAll is deprecated: use `Scope` instead"
+      text: "SA1019: settings.CheckAll is deprecated: use Scope instead"
+    - path: pkg/golinters/gci.go
+      linters: [staticcheck]
+      text: "SA1019: settings.LocalPrefixes is deprecated: use Sections instead."
+    - path: pkg/golinters/gomnd.go
+      linters: [staticcheck]
+      text: "SA1019: settings.Settings is deprecated: use root level settings instead."
 
+    # Related to `run.go`, it cannot be removed.
     - path: pkg/golinters/gofumpt.go
       linters: [staticcheck]
       text: "SA1019: settings.LangVersion is deprecated: use the global `run.go` instead."
@@ -183,6 +193,7 @@ issues:
       linters: [staticcheck]
       text: "SA1019: (.+).(GoVersion|LangVersion) is deprecated: use the global `run.go` instead."
 
+    # Based on existing code, the modifications should be limited to make maintenance easier.
     - path: pkg/golinters/unused.go
       linters: [gocritic]
       text: "rangeValCopy: each iteration copies 160 bytes \\(consider pointers or indexing\\)"

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -452,10 +452,12 @@ type FunlenSettings struct {
 }
 
 type GciSettings struct {
-	LocalPrefixes string   `mapstructure:"local-prefixes"` // Deprecated
 	Sections      []string `mapstructure:"sections"`
 	SkipGenerated bool     `mapstructure:"skip-generated"`
 	CustomOrder   bool     `mapstructure:"custom-order"`
+
+	// Deprecated: use Sections instead.
+	LocalPrefixes string `mapstructure:"local-prefixes"`
 }
 
 type GinkgoLinterSettings struct {
@@ -511,7 +513,7 @@ type GodotSettings struct {
 	Capital bool     `mapstructure:"capital"`
 	Period  bool     `mapstructure:"period"`
 
-	// Deprecated: use `Scope` instead
+	// Deprecated: use Scope instead
 	CheckAll bool `mapstructure:"check-all"`
 }
 
@@ -548,11 +550,13 @@ type GoImportsSettings struct {
 }
 
 type GoMndSettings struct {
-	Settings         map[string]map[string]any // Deprecated
-	Checks           []string                  `mapstructure:"checks"`
-	IgnoredNumbers   []string                  `mapstructure:"ignored-numbers"`
-	IgnoredFiles     []string                  `mapstructure:"ignored-files"`
-	IgnoredFunctions []string                  `mapstructure:"ignored-functions"`
+	Checks           []string `mapstructure:"checks"`
+	IgnoredNumbers   []string `mapstructure:"ignored-numbers"`
+	IgnoredFiles     []string `mapstructure:"ignored-files"`
+	IgnoredFunctions []string `mapstructure:"ignored-functions"`
+
+	// Deprecated: use root level settings instead.
+	Settings map[string]map[string]any
 }
 
 type GoModDirectivesSettings struct {
@@ -607,7 +611,7 @@ type GovetSettings struct {
 
 	Settings map[string]map[string]any
 
-	// Deprecated: the linter should be enabled inside `Enable`.
+	// Deprecated: the linter should be enabled inside Enable.
 	CheckShadowing bool `mapstructure:"check-shadowing"`
 }
 
@@ -814,13 +818,13 @@ type SpancheckSettings struct {
 }
 
 type StaticCheckSettings struct {
-	// Deprecated: use the global `run.go` instead.
-	GoVersion string `mapstructure:"go"`
-
 	Checks                  []string `mapstructure:"checks"`
 	Initialisms             []string `mapstructure:"initialisms"`                // only for stylecheck
 	DotImportWhitelist      []string `mapstructure:"dot-import-whitelist"`       // only for stylecheck
 	HTTPStatusCodeWhitelist []string `mapstructure:"http-status-code-whitelist"` // only for stylecheck
+
+	// Deprecated: use the global `run.go` instead.
+	GoVersion string `mapstructure:"go"`
 }
 
 func (s *StaticCheckSettings) HasConfiguration() bool {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -325,29 +325,29 @@ func (l *Loader) handleDeprecation() error {
 	// Deprecated since v1.57.0,
 	// but it was unofficially deprecated since v1.19 (2019) (https://github.com/golangci/golangci-lint/pull/697).
 	if l.cfg.LintersSettings.Govet.CheckShadowing {
-		l.warn("The configuration option `govet.check-shadowing` is deprecated. " +
+		l.warn("The configuration option `linters.govet.check-shadowing` is deprecated. " +
 			"Please enable `shadow` instead, if you are not using `enable-all`.")
 	}
 
 	// Deprecated since v1.42.0.
 	if l.cfg.LintersSettings.Errcheck.Exclude != "" {
-		l.warn("The configuration option `errcheck.exclude` is deprecated, please use `errcheck.exclude-functions`.")
+		l.warn("The configuration option `linters.errcheck.exclude` is deprecated, please use `linters.errcheck.exclude-functions`.")
 	}
 
 	// Deprecated since v1.44.0.
 	if l.cfg.LintersSettings.Gci.LocalPrefixes != "" {
-		l.warn("The configuration option `gci.local-prefixes` is deprecated, please use `prefix()` inside `gci.sections`.")
+		l.warn("The configuration option `linters.gci.local-prefixes` is deprecated, please use `prefix()` inside `linters.gci.sections`.")
 	}
 
 	// Deprecated since v1.33.0.
 	if l.cfg.LintersSettings.Godot.CheckAll {
-		l.warn("The configuration option `godot.check-all` is deprecated, please use `godot.scope: all`.")
+		l.warn("The configuration option `linters.godot.check-all` is deprecated, please use `linters.godot.scope: all`.")
 	}
 
 	// Deprecated since v1.44.0.
 	if len(l.cfg.LintersSettings.Gomnd.Settings) > 0 {
-		l.warn("The configuration option `gomnd.settings` is deprecated. " +
-			"Please use the options `gomnd.checks`,`gomnd.ignored-numbers`,`gomnd.ignored-files`,`gomnd.ignored-functions`.")
+		l.warn("The configuration option `linters.gomnd.settings` is deprecated. Please use the options " +
+			"`linters.gomnd.checks`,`linters.gomnd.ignored-numbers`,`linters.gomnd.ignored-files`,`linters.gomnd.ignored-functions`.")
 	}
 
 	return nil

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -277,7 +277,7 @@ func (l *Loader) handleGoVersion() {
 	if l.cfg.LintersSettings.Gosimple.GoVersion == "" {
 		l.cfg.LintersSettings.Gosimple.GoVersion = trimmedGoVersion
 	}
-	if l.cfg.LintersSettings.Stylecheck.GoVersion != "" {
+	if l.cfg.LintersSettings.Stylecheck.GoVersion == "" {
 		l.cfg.LintersSettings.Stylecheck.GoVersion = trimmedGoVersion
 	}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -322,6 +322,12 @@ func (l *Loader) handleDeprecation() error {
 		l.cfg.Output.Formats = f
 	}
 
+	l.handleLinterOptionDeprecations()
+
+	return nil
+}
+
+func (l *Loader) handleLinterOptionDeprecations() {
 	// Deprecated since v1.57.0,
 	// but it was unofficially deprecated since v1.19 (2019) (https://github.com/golangci/golangci-lint/pull/697).
 	if l.cfg.LintersSettings.Govet.CheckShadowing {
@@ -369,8 +375,6 @@ func (l *Loader) handleDeprecation() error {
 	if l.cfg.LintersSettings.Stylecheck.GoVersion != "" {
 		l.warn("The configuration option `linters.stylecheck.go` is deprecated, please use global `run.go`.")
 	}
-
-	return nil
 }
 
 func (l *Loader) handleEnableOnlyOption() error {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -329,6 +329,27 @@ func (l *Loader) handleDeprecation() error {
 			"Please enable `shadow` instead, if you are not using `enable-all`.")
 	}
 
+	// Deprecated since v1.42.0.
+	if l.cfg.LintersSettings.Errcheck.Exclude != "" {
+		l.warn("The configuration option `errcheck.exclude` is deprecated, please use `errcheck.exclude-functions`.")
+	}
+
+	// Deprecated since v1.44.0.
+	if l.cfg.LintersSettings.Gci.LocalPrefixes != "" {
+		l.warn("The configuration option `gci.local-prefixes` is deprecated, please use `prefix()` inside `gci.sections`.")
+	}
+
+	// Deprecated since v1.33.0.
+	if l.cfg.LintersSettings.Godot.CheckAll {
+		l.warn("The configuration option `godot.check-all` is deprecated, please use `godot.scope: all`.")
+	}
+
+	// Deprecated since v1.44.0.
+	if len(l.cfg.LintersSettings.Gomnd.Settings) > 0 {
+		l.warn("The configuration option `gomnd.settings` is deprecated. " +
+			"Please use the options `gomnd.checks`,`gomnd.ignored-numbers`,`gomnd.ignored-files`,`gomnd.ignored-functions`.")
+	}
+
 	return nil
 }
 

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -59,12 +59,12 @@ func (l *Loader) Load() error {
 
 	l.applyStringSliceHack()
 
-	l.handleGoVersion()
-
 	err = l.handleDeprecation()
 	if err != nil {
 		return err
 	}
+
+	l.handleGoVersion()
 
 	err = l.handleEnableOnlyOption()
 	if err != nil {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -350,6 +350,26 @@ func (l *Loader) handleDeprecation() error {
 			"`linters.gomnd.checks`,`linters.gomnd.ignored-numbers`,`linters.gomnd.ignored-files`,`linters.gomnd.ignored-functions`.")
 	}
 
+	// Deprecated since v1.47.0
+	if l.cfg.LintersSettings.Gofumpt.LangVersion != "" {
+		l.warn("The configuration option `linters.gofumpt.lang-version` is deprecated, please use global `run.go`.")
+	}
+
+	// Deprecated since v1.47.0
+	if l.cfg.LintersSettings.Staticcheck.GoVersion != "" {
+		l.warn("The configuration option `linters.staticcheck.go` is deprecated, please use global `run.go`.")
+	}
+
+	// Deprecated since v1.47.0
+	if l.cfg.LintersSettings.Gosimple.GoVersion != "" {
+		l.warn("The configuration option `linters.gosimple.go` is deprecated, please use global `run.go`.")
+	}
+
+	// Deprecated since v1.47.0
+	if l.cfg.LintersSettings.Stylecheck.GoVersion != "" {
+		l.warn("The configuration option `linters.stylecheck.go` is deprecated, please use global `run.go`.")
+	}
+
 	return nil
 }
 

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -21,15 +21,15 @@ type Run struct {
 	ExitCodeIfIssuesFound int  `mapstructure:"issues-exit-code"`
 	AnalyzeTests          bool `mapstructure:"tests"`
 
+	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
+	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
+
 	// Deprecated: use Issues.ExcludeFiles instead.
 	SkipFiles []string `mapstructure:"skip-files"`
 	// Deprecated: use Issues.ExcludeDirs instead.
 	SkipDirs []string `mapstructure:"skip-dirs"`
 	// Deprecated: use Issues.UseDefaultExcludeDirs instead.
 	UseDefaultSkipDirs bool `mapstructure:"skip-dirs-use-default"`
-
-	AllowParallelRunners bool `mapstructure:"allow-parallel-runners"`
-	AllowSerialRunners   bool `mapstructure:"allow-serial-runners"`
 
 	// Deprecated: use Output.ShowStats instead.
 	ShowStats bool `mapstructure:"show-stats"`

--- a/pkg/golinters/godot.go
+++ b/pkg/golinters/godot.go
@@ -29,7 +29,6 @@ func NewGodot(settings *config.GodotSettings) *goanalysis.Linter {
 		}
 
 		// Convert deprecated setting
-		// todo(butuzov): remove on v2 release
 		if settings.CheckAll {
 			dotSettings.Scope = godot.AllScope
 		}


### PR DESCRIPTION
Currently, there are no warnings related to deprecated linter options.
