### PR TITLE
docs: improve linters page

### DIFF
--- a/docs/src/docs/usage/linters.mdx
+++ b/docs/src/docs/usage/linters.mdx
@@ -2,6 +2,8 @@
 title: Linters
 ---
 
+import { FaGithub, FaGitlab } from "react-icons/fa";
+
 To see a list of supported linters and which linters are enabled/disabled:
 
 ```sh

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -75,12 +75,17 @@ func getLintersListMarkdown(enabled bool) string {
 func getName(lc *types.LinterWrapper) string {
 	name := lc.Name
 
-	if lc.OriginalURL != "" {
-		name = fmt.Sprintf("[%s](%s)", name, lc.OriginalURL)
+	if hasSettings(lc.Name) {
+		name = fmt.Sprintf("[%[1]s](#%[2]s \"%[1]s configuration\")", name, lc.Name)
 	}
 
-	if hasSettings(lc.Name) {
-		name = fmt.Sprintf("%s&nbsp;[%s](#%s)", name, spanWithID(listItemPrefix+lc.Name, "Configuration", "⚙️"), lc.Name)
+	if lc.OriginalURL != "" {
+		icon := "<FaGithub size={'0.8rem'} />"
+		if strings.Contains(lc.OriginalURL, "gitlab") {
+			icon = "<FaGitlab size={'0.8rem'} />"
+		}
+
+		name = fmt.Sprintf("%s&nbsp;[%s](%s)", name, spanWithID(listItemPrefix+lc.Name, lc.Name+" repository", icon), lc.OriginalURL)
 	}
 
 	if lc.Deprecation == nil {


### PR DESCRIPTION
Change the links around linter names.

Before:
- the link on the linter name was targeting the linter repository.
- the link on the gear was targeting the linter settings.

<details>
<summary>screenshot</summary>

![before](https://github.com/golangci/golangci-lint/assets/5674651/17ffe0f5-58a9-4d6e-ab9b-faea2d10f208)

</details>

After:
- the link on the linter name targets the linter settings.
- the icon targets the repository.

<details>
<summary>screenshot</summary>

![after](https://github.com/golangci/golangci-lint/assets/5674651/780d19f3-7ae1-4308-8694-52f1583fced6)

</details>


