### PR TITLE
fix: the TeamCity inspectionType service message

### DIFF
--- a/pkg/printers/teamcity.go
+++ b/pkg/printers/teamcity.go
@@ -88,7 +88,7 @@ type InspectionType struct {
 }
 
 func (i InspectionType) Print(w io.Writer, escaper *strings.Replacer) (int, error) {
-	return fmt.Fprintf(w, "##teamcity[InspectionType id='%s' name='%s' description='%s' category='%s']\n",
+	return fmt.Fprintf(w, "##teamcity[inspectionType id='%s' name='%s' description='%s' category='%s']\n",
 		limit(i.id, smallLimit), limit(i.name, smallLimit), limit(escaper.Replace(i.description), largeLimit), limit(i.category, smallLimit))
 }
 

--- a/pkg/printers/teamcity_test.go
+++ b/pkg/printers/teamcity_test.go
@@ -56,10 +56,10 @@ func TestTeamCity_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	expected := `##teamcity[InspectionType id='linter-a' name='linter-a' description='linter-a' category='Golangci-lint reports']
+	expected := `##teamcity[inspectionType id='linter-a' name='linter-a' description='linter-a' category='Golangci-lint reports']
 ##teamcity[inspection typeId='linter-a' message='warning issue' file='path/to/filea.go' line='10' SEVERITY='']
 ##teamcity[inspection typeId='linter-a' message='error issue' file='path/to/filea.go' line='10' SEVERITY='ERROR']
-##teamcity[InspectionType id='linter-b' name='linter-b' description='linter-b' category='Golangci-lint reports']
+##teamcity[inspectionType id='linter-b' name='linter-b' description='linter-b' category='Golangci-lint reports']
 ##teamcity[inspection typeId='linter-b' message='info issue' file='path/to/fileb.go' line='300' SEVERITY='']
 `
 


### PR DESCRIPTION
The [Inspection Type](https://www.jetbrains.com/help/teamcity/service-messages.html#Inspection+Type) is used in the TeamCity printer. The message type should be `inspectionType` as the doc specified, but the golangci-lint uses `InspectionType`(capitalized "I").

I'm not sure if it works with previous TeamCity versions, I'm currenly on "TeamCity Enterprise 2023.11.3 (build 147512)" and it doesn't work for me. Changing the `InspectionType` to `inspectionType` did the trick.

Update the TeamCity printer to have it align with the specification, and avoid any surprise in the future.