### PR TITLE
fix: missing output format

### DIFF
--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -22,10 +22,11 @@ const (
 )
 
 var AllOutputFormats = []string{
-	OutFormatColoredLineNumber,
-	OutFormatLineNumber,
 	OutFormatJSON,
+	OutFormatLineNumber,
+	OutFormatColoredLineNumber,
 	OutFormatTab,
+	OutFormatColoredTab,
 	OutFormatCheckstyle,
 	OutFormatCodeClimate,
 	OutFormatHTML,


### PR DESCRIPTION
One format was missing inside `AllOutputFormats` list.

```console
$ golangci-lint run --out-format=colored-tab                                                                                                                                                         
Error: unsupported output format "colored-tab"
Failed executing command with error: unsupported output format "colored-tab"
```

