### PR TITLE
dev: remove unused markdownlint config file

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,2 +1,0 @@
-MD013: false
-MD033: false


### PR DESCRIPTION
The [markdownlint](https://github.com/DavidAnson/markdownlint) is not used in golangci-lint GitHub workflows for linting Markdown files, thus the `markdownlint.yaml` can be deleted.