### PR TITLE
feat: add fatcontext linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2532,6 +2532,7 @@ linters:
     - exhaustive
     - exhaustruct
     - exportloopref
+    - fatcontext
     - forbidigo
     - forcetypeassert
     - funlen
@@ -2645,6 +2646,7 @@ linters:
     - exhaustive
     - exhaustruct
     - exportloopref
+    - fatcontext
     - forbidigo
     - forcetypeassert
     - funlen

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Antonboom/nilnil v0.1.7
 	github.com/Antonboom/testifylint v1.2.0
 	github.com/BurntSushi/toml v1.3.2
+	github.com/Crocmagnon/fatcontext v0.2.2
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.2.0
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Crocmagnon/fatcontext v0.2.2 h1:OrFlsDdOj9hW/oBEJBNSuH7QWf+E9WPVHw+x52bXVbk=
+github.com/Crocmagnon/fatcontext v0.2.2/go.mod h1:WSn/c/+MMNiD8Pri0ahRj0o9jVpeowzavOQplBJw6u0=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.2.0 h1:sATXp1x6/axKxz2Gjxv8MALP0bXaNRfQinEwyfMcx8c=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -235,6 +235,7 @@
             "exhaustivestruct",
             "exhaustruct",
             "exportloopref",
+            "fatcontext",
             "forbidigo",
             "forcetypeassert",
             "funlen",

--- a/pkg/golinters/fatcontext.go
+++ b/pkg/golinters/fatcontext.go
@@ -8,10 +8,12 @@ import (
 )
 
 func NewFatContext() *goanalysis.Linter {
+	a := analyzer.Analyzer
+
 	return goanalysis.NewLinter(
-		"fatcontext",
-		"Detects potential fat contexts in loops",
-		[]*analysis.Analyzer{analyzer.Analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/fatcontext.go
+++ b/pkg/golinters/fatcontext.go
@@ -1,0 +1,17 @@
+package golinters
+
+import (
+	"github.com/Crocmagnon/fatcontext/pkg/analyzer"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func NewFatContext() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		"fatcontext",
+		"Detects potential fat contexts in loops",
+		[]*analysis.Analyzer{analyzer.Analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -181,6 +181,12 @@ func (b LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/gostaticanalysis/forcetypeassert"),
 
+		linter.NewConfig(golinters.NewFatContext()).
+			WithSince("1.58.0").
+			WithPresets(linter.PresetPerformance).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/Crocmagnon/fatcontext"),
+
 		linter.NewConfig(golinters.NewFunlen(&cfg.LintersSettings.Funlen)).
 			WithSince("v1.18.0").
 			WithPresets(linter.PresetComplexity).

--- a/test/testdata/fatcontext.go
+++ b/test/testdata/fatcontext.go
@@ -1,0 +1,33 @@
+//golangcitest:args -Efatcontext
+package testdata
+
+import "context"
+
+func example() {
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		ctx := context.WithValue(ctx, "key", i)
+		ctx = context.WithValue(ctx, "other", "val")
+	}
+
+	for i := 0; i < 10; i++ {
+		ctx = context.WithValue(ctx, "key", i) // want "nested context in loop"
+		ctx = context.WithValue(ctx, "other", "val")
+	}
+
+	for item := range []string{"one", "two", "three"} {
+		ctx = wrapContext(ctx) // want "nested context in loop"
+		ctx := context.WithValue(ctx, "key", item)
+		ctx = wrapContext(ctx)
+	}
+
+	for {
+		ctx = wrapContext(ctx) // want "nested context in loop"
+		break
+	}
+}
+
+func wrapContext(ctx context.Context) context.Context {
+	return context.WithoutCancel(ctx)
+}


### PR DESCRIPTION
As described in a blog post I wrote (https://gabnotes.org/fat-contexts/), we've been bitten by contexts not shadowed inside loops.
This linter addresses this issue.

Github repo: https://github.com/Crocmagnon/fatcontext