### PR TITLE
dev: add fix test for tagalign linter

### DIFF
--- a/test/testdata/fix/in/tagalign.go
+++ b/test/testdata/fix/in/tagalign.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Etagalign
+//golangcitest:config_path testdata/configs/tagalign_strict.yml
+//golangcitest:expected_exitcode 0
+package p
+
+import "time"
+
+type TagAlignExampleStrictKO struct {
+	Foo    time.Time `json:"foo,omitempty" validate:"required" zip:"foo"`
+	FooBar struct{}  `gorm:"column:fooBar" validate:"required" zip:"fooBar" xml:"fooBar" json:"fooBar,omitempty" yaml:"fooBar"`
+}

--- a/test/testdata/fix/out/tagalign.go
+++ b/test/testdata/fix/out/tagalign.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Etagalign
+//golangcitest:config_path testdata/configs/tagalign_strict.yml
+//golangcitest:expected_exitcode 0
+package p
+
+import "time"
+
+type TagAlignExampleStrictKO struct {
+	Foo    time.Time `                     json:"foo,omitempty"    validate:"required"                            zip:"foo"`
+	FooBar struct{}  `gorm:"column:fooBar" json:"fooBar,omitempty" validate:"required" xml:"fooBar" yaml:"fooBar" zip:"fooBar"`
+}


### PR DESCRIPTION
This PR adds a fix integration test for `tagalign`:

```
T=tagalign.go make test_fix
```