### PR TITLE
dev: enable testifylint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,6 +133,7 @@ linters:
     - revive
     - staticcheck
     - stylecheck
+    - testifylint
     - unconvert
     - unparam
     - unused
@@ -213,4 +214,3 @@ issues:
 
 run:
   timeout: 5m
-

--- a/pkg/golinters/misspell_test.go
+++ b/pkg/golinters/misspell_test.go
@@ -29,7 +29,7 @@ func Test_appendExtraWords(t *testing.T) {
 
 	expected := []string{"iff", "if", "cancelation", "cancellation"}
 
-	assert.Equal(t, replacer.Replacements, expected)
+	assert.Equal(t, expected, replacer.Replacements)
 }
 
 func Test_appendExtraWords_error(t *testing.T) {

--- a/pkg/result/processors/autogenerated_exclude_test.go
+++ b/pkg/result/processors/autogenerated_exclude_test.go
@@ -252,7 +252,7 @@ func Test_shouldPassIssue_error(t *testing.T) {
 
 			pass, err := p.shouldPassIssue(test.issue)
 
-			assert.EqualError(t, err, test.expected)
+			require.EqualError(t, err, test.expected)
 			assert.False(t, pass)
 		})
 	}

--- a/pkg/result/processors/autogenerated_exclude_test.go
+++ b/pkg/result/processors/autogenerated_exclude_test.go
@@ -252,7 +252,8 @@ func Test_shouldPassIssue_error(t *testing.T) {
 
 			pass, err := p.shouldPassIssue(test.issue)
 
-			require.EqualError(t, err, test.expected)
+			//nolint:testifylint // It's a loop and the main expectation is the error message.
+			assert.EqualError(t, err, test.expected)
 			assert.False(t, pass)
 		})
 	}

--- a/pkg/result/processors/skip_files_test.go
+++ b/pkg/result/processors/skip_files_test.go
@@ -49,6 +49,6 @@ func TestSkipFiles(t *testing.T) {
 
 func TestSkipFilesInvalidPattern(t *testing.T) {
 	p, err := NewSkipFiles([]string{"\\o"}, "")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, p)
 }


### PR DESCRIPTION
The PR enables `testifylint` for this repo.

<details>
<summary>golangci-lint run</summary>

```
pkg/golinters/misspell_test.go:32:2: expected-actual: need to reverse actual and expected values (testifylint)
        assert.Equal(t, replacer.Replacements, expected)
        ^
pkg/result/processors/autogenerated_exclude_test.go:255:4: require-error: for error assertions use require (testifylint)
                        assert.EqualError(t, err, test.expected)
                        ^
pkg/result/processors/skip_files_test.go:52:2: require-error: for error assertions use require (testifylint)
        assert.Error(t, err)
        ^
```

</details>