### PR TITLE
dev: add fix test for mirror linter

### DIFF
--- a/test/testdata/fix/in/mirror.go
+++ b/test/testdata/fix/in/mirror.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Emirror
+//golangcitest:expected_exitcode 0
+package testdata
+
+import (
+	"unicode/utf8"
+)
+
+func foobar() {
+	_ = utf8.RuneCount([]byte("foobar"))
+}

--- a/test/testdata/fix/out/mirror.go
+++ b/test/testdata/fix/out/mirror.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Emirror
+//golangcitest:expected_exitcode 0
+package testdata
+
+import (
+	"unicode/utf8"
+)
+
+func foobar() {
+	_ = utf8.RuneCountInString("foobar")
+}


### PR DESCRIPTION
This PR adds a fix integration test for `mirror`:

```
T=mirror.go make test_fix
```