### PR TITLE
Add `pre-commit` hook to run `config verify`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,3 +14,10 @@
   language: golang
   require_serial: true
   pass_filenames: false
+- id: golangci-lint-config-verify
+  name: golangci-lint-config-verify
+  description: Verifies the configuration file
+  entry: golangci-lint config verify
+  files: '\.golangci\.(?:yml|yaml|toml|json)'
+  language: golang
+  pass_filenames: false


### PR DESCRIPTION
Add this as a way to easily ensure configs stay valid. Filenames are not passed to the hook, this means For the default case (config in one of the default searched files), the config is picked up automatically and there's nothing extra to configure. For the case of a non-standard config setup the hook can be configured like

    repos:
    -   repo: https://github.com/golangci/golangci-lint
        rev: v1.57.2
        hooks:
        -   id: golangci-lint-config-verify
            # config is kept at '.golangci-config.yaml'
            files: \.golangci-config\.yaml
            args: ['--config', '.golangci-config.yaml']