### PR TITLE
dev: set timeout for loading JSON schema

### DIFF
--- a/pkg/commands/config_verify.go
+++ b/pkg/commands/config_verify.go
@@ -100,10 +100,10 @@ func createSchemaURL(flags *pflag.FlagSet, buildInfo BuildInfo) (string, error) 
 }
 
 func validateConfiguration(schemaPath, targetFile string) error {
+	httploader.Client = &http.Client{Timeout: 2 * time.Second}
+
 	compiler := jsonschema.NewCompiler()
 	compiler.Draft = jsonschema.Draft7
-	const loadSchemaTimeout = 2 * time.Second
-	httploader.Client = &http.Client{Timeout: loadSchemaTimeout}
 
 	schema, err := compiler.Compile(schemaPath)
 	if err != nil {

--- a/pkg/commands/config_verify.go
+++ b/pkg/commands/config_verify.go
@@ -3,14 +3,16 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	hcversion "github.com/hashicorp/go-version"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/santhosh-tekuri/jsonschema/v5"
-	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
+	"github.com/santhosh-tekuri/jsonschema/v5/httploader"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
@@ -100,6 +102,8 @@ func createSchemaURL(flags *pflag.FlagSet, buildInfo BuildInfo) (string, error) 
 func validateConfiguration(schemaPath, targetFile string) error {
 	compiler := jsonschema.NewCompiler()
 	compiler.Draft = jsonschema.Draft7
+	const loadSchemaTimeout = 2 * time.Second
+	httploader.Client = &http.Client{Timeout: loadSchemaTimeout}
 
 	schema, err := compiler.Compile(schemaPath)
 	if err != nil {


### PR DESCRIPTION
`jsonschema` uses [the default HTTP client](https://github.com/santhosh-tekuri/jsonschema/blob/v5.3.1/httploader/httploader.go#L20) for loading JSON schemas, which doesn't have request timeouts. This PR overrides the global HTTP client from the library with a client that includes a timeout.