### PR TITLE
docs: fix links to Module and Go Plugins

### DIFF
--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -48,5 +48,5 @@ Typically, these linters can't be open-sourced or too specific.
 
 Such linters can be added through 2 plugin systems:
 
-1. [Go Plugin System](/plugins/module-plugins)
-2. [Module Plugin System](/plugins/go-plugins)
+1. [Module Plugin System](/plugins/module-plugins)
+2. [Go Plugin System](/plugins/go-plugins)


### PR DESCRIPTION
The text was not corresponding to the link.

Opening "Go Plugin System" was loading "Module Plugin System", and vice-versa .