### PR TITLE
feat: add linereturn linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	4d63.com/gochecknoglobals v0.2.1
 	github.com/4meepo/tagalign v1.3.3
 	github.com/Abirdcfly/dupword v0.0.14
+	github.com/Ak-Army/linereturn v0.0.0-20240402133102-9b651aa9b3c7
 	github.com/Antonboom/errname v0.1.12
 	github.com/Antonboom/nilnil v0.1.7
 	github.com/Antonboom/testifylint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/4meepo/tagalign v1.3.3 h1:ZsOxcwGD/jP4U/aw7qeWu58i7dwYemfy5Y+IF1ACoNw
 github.com/4meepo/tagalign v1.3.3/go.mod h1:Q9c1rYMZJc9dPRkbQPpcBNCLEmY2njbAsXhQOZFE2dE=
 github.com/Abirdcfly/dupword v0.0.14 h1:3U4ulkc8EUo+CaT105/GJ1BQwtgyj6+VaBVbAX11Ba8=
 github.com/Abirdcfly/dupword v0.0.14/go.mod h1:VKDAbxdY8YbKUByLGg8EETzYSuC4crm9WwI6Y3S0cLI=
+github.com/Ak-Army/linereturn v0.0.0-20240402133102-9b651aa9b3c7 h1:tOyfA98mr0IF0fR2RzeFemoOCz7xTIs1E4YYfDZlmPs=
+github.com/Ak-Army/linereturn v0.0.0-20240402133102-9b651aa9b3c7/go.mod h1:WQDbuP7wEuCz3+RpHxzrWg3OsXNh0CfIUjikko72UdA=
 github.com/Antonboom/errname v0.1.12 h1:oh9ak2zUtsLp5oaEd/erjB4GPu9w19NyoIskZClDcQY=
 github.com/Antonboom/errname v0.1.12/go.mod h1:bK7todrzvlaZoQagP1orKzWXv59X/x0W0Io2XT1Ssro=
 github.com/Antonboom/nilnil v0.1.7 h1:ofgL+BA7vlA1K2wNQOsHzLJ2Pw5B5DpWRLdDAVvvTow=

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -273,6 +273,7 @@
             "interfacer",
             "intrange",
             "ireturn",
+            "linereturn",
             "lll",
             "loggercheck",
             "maintidx",
@@ -1870,6 +1871,18 @@
               "description": "Allow only slices initialized with a length of zero.",
               "type": "boolean",
               "default": false
+            }
+          }
+        },
+        "linereturn": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "block-size": {
+              "description": "set block size that is still ok",
+              "type": "number",
+              "default": 1,
+              "minimum": 1
             }
           }
         },

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -273,6 +273,7 @@
             "interfacer",
             "intrange",
             "ireturn",
+            "linereturn",
             "lll",
             "loggercheck",
             "maintidx",
@@ -1841,6 +1842,18 @@
               "description": "Allow only slices initialized with a length of zero.",
               "type": "boolean",
               "default": false
+            }
+          }
+        },
+        "linereturn": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "block-size": {
+              "description": "set block size that is still ok",
+              "type": "number",
+              "default": 1,
+              "minimum": 1
             }
           }
         },

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -238,6 +238,7 @@ type LintersSettings struct {
 	Inamedparam     INamedParamSettings
 	InterfaceBloat  InterfaceBloatSettings
 	Ireturn         IreturnSettings
+	Linereturn      LinereturnSettings
 	Lll             LllSettings
 	LoggerCheck     LoggerCheckSettings
 	MaintIdx        MaintIdxSettings
@@ -660,6 +661,10 @@ type InterfaceBloatSettings struct {
 type IreturnSettings struct {
 	Allow  []string `mapstructure:"allow"`
 	Reject []string `mapstructure:"reject"`
+}
+
+type LinereturnSettings struct {
+	BlockSize int `mapstructure:"block-size"`
 }
 
 type LllSettings struct {

--- a/pkg/golinters/linereturn.go
+++ b/pkg/golinters/linereturn.go
@@ -1,0 +1,26 @@
+package golinters
+
+import (
+	"github.com/Ak-Army/linereturn/pkg/linereturn"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func NewLineReturn(settings *config.LinereturnSettings) *goanalysis.Linter {
+	a := linereturn.NewAnalyzer()
+
+	cfg := map[string]map[string]any{}
+	if settings != nil {
+		cfg[a.Name] = map[string]any{
+			"block-size": settings.BlockSize,
+		}
+	}
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		cfg,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -402,6 +402,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/butuzov/ireturn"),
 
+		linter.NewConfig(golinters.NewLineReturn(&cfg.LintersSettings.Linereturn)).
+			WithSince("v1.58.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("github.com/Ak-Army/linereturn"),
+
 		linter.NewConfig(golinters.NewLLL(&cfg.LintersSettings.Lll)).
 			WithSince("v1.8.0").
 			WithPresets(linter.PresetStyle),
@@ -429,7 +434,9 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetPerformance).
 			WithURL("https://github.com/mdempsky/maligned").
-			Deprecated("The repository of the linter has been archived by the owner.", "v1.38.0", "govet 'fieldalignment'"),
+			Deprecated("The repository of the linter has been archived by the owner.",
+				"v1.38.0",
+				"govet 'fieldalignment'"),
 
 		linter.NewConfig(golinters.NewMirror()).
 			WithSince("v1.53.0").
@@ -493,7 +500,9 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.47.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/sivchari/nosnakecase").
-			Deprecated("The repository of the linter has been deprecated by the owner.", "v1.48.1", "revive 'var-naming'"),
+			Deprecated("The repository of the linter has been deprecated by the owner.",
+				"v1.48.1",
+				"revive 'var-naming'"),
 
 		linter.NewConfig(golinters.NewNoSprintfHostPort()).
 			WithSince("v1.46.0").

--- a/test/testdata/linereturn.go
+++ b/test/testdata/linereturn.go
@@ -1,0 +1,43 @@
+//golangcitest:args -Elinereturn
+package testdata
+
+type a struct {
+	a string
+}
+
+func fooa() int {
+	o := []int{0, 1}
+	return o[0] // want "no blank line before"
+}
+
+func foob(s string) *a {
+	o := &a{
+		a: s,
+	}
+	return o
+}
+
+func fooc() int {
+	defer fooa()
+
+	return 0
+}
+
+func food(s string) interface{} {
+	o := foob(
+		s,
+	)
+	return o
+}
+
+func fooe() interface{} {
+	o := food(
+		"a",
+	)
+	switch s := o.(type) {
+	case *a:
+		return s
+	default:
+	}
+	return o
+}


### PR DESCRIPTION
Add [linereturn](https://github.com/Ak-Army/linereturn) linter.

Linter requires a new line before return statements if the previous line in a block is a real statement.