### PR TITLE
chore: add chocolatey

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,18 +7,29 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # https://github.com/actions/setup-go#supported-version-syntax
+      # ex:
+      # - 1.18beta1 -> 1.18.0-beta.1
+      # - 1.18rc1 -> 1.18.0-rc.1
+      GO_VERSION: '1.22'
+      CHOCOLATEY_VERSION: 2.2.0
     steps:
       - uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.22'
+          go-version: ${{ env.GO_VERSION }}
       - name: Unshallow
         run: git fetch --prune --unshallow
+
+      - name: Install chocolatey
+        run: |
+          mkdir -p /opt/chocolatey
+          wget -q -O - "https://github.com/chocolatey/choco/releases/download/${CHOCOLATEY_VERSION}/chocolatey.v${CHOCOLATEY_VERSION}.tar.gz" | tar -xz -C "/opt/chocolatey"
+          echo '#!/bin/bash' >> /usr/local/bin/choco
+          echo 'mono /opt/chocolatey/choco.exe $@' >> /usr/local/bin/choco
+          chmod +x /usr/local/bin/choco
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -35,4 +46,5 @@ jobs:
           version: latest
           args: release --clean --timeout=90m
         env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,6 +111,7 @@ chocolateys:
     license_url: https://github.com/golangci/golangci-lint/blob/master/LICENSE
     require_license_acceptance: false
     project_source_url: https://github.com/golangci/golangci-lint
+    package_source_url: https://github.com/golangci/golangci-lint
     docs_url: https://golangci-lint.run
     bug_tracker_url: https://github.com/golangci/golangci-lint/issues
     tags: "go golang lint linter"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,6 +99,33 @@ brews:
     test: |
       system "#{bin}/golangci-lint --version"
 
+chocolateys:
+  - name: golangci-lint
+    ids:
+      - windows
+    owners: golangci
+    title: Golangci-lint
+    authors: golangci
+    project_url: https://golangci-lint.run
+    url_template: "https://github.com/golangci/golangci-lint/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    icon_url: "https://cdn.rawgit.com/golangci/golangci-lint/master/assets/go.png"
+    copyright: 2024 GolangCI
+    license_url: https://github.com/golangci/golangci-lint/blob/master/LICENSE
+    require_license_acceptance: false
+    project_source_url: https://github.com/golangci/golangci-lint
+    docs_url: https://golangci-lint.run
+    bug_tracker_url: https://github.com/golangci/golangci-lint/issues
+    tags: "go golang lint linter"
+    summary: Fast linters Runner for Go
+    description: |
+      {{ .ProjectName }} installer package.
+      Fast linters Runner for Go .
+    release_notes: "https://github.com/golangci/golangci-lint/releases/tag/v{{ .Version }}"
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+    source_repo: "https://push.chocolatey.org/"
+    skip_publish: false
+    goamd64: v1
+
 nfpms:
   -
     id: golangci-lint-nfpms

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,8 +101,6 @@ brews:
 
 chocolateys:
   - name: golangci-lint
-    ids:
-      - windows
     owners: golangci
     title: Golangci-lint
     authors: golangci

--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -9,7 +9,7 @@ Most installations of `golangci-lint` are performed for CI.
 ### GitHub Actions
 
 We recommend using [our GitHub Action](https://github.com/golangci/golangci-lint-action) for running `golangci-lint` in CI for GitHub projects.
-It's [fast and uses smart caching](https://github.com/golangci/golangci-lint-action#performance) inside
+It's [fast and uses smart caching](https://github.com/golangci/golangci-lint-action#performance) inside,
 and it can be much faster than the simple binary installation.
 
 Also, the action creates GitHub annotations for found issues: you don't need to dig into build log to see found by `golangci-lint` issues:
@@ -97,6 +97,14 @@ The macports installation mode is community driven, and not officially maintaine
 
 ```sh
 sudo port install golangci-lint
+```
+
+### Windows
+
+You can install a binary on Windows using [chocolatey](https://community.chocolatey.org/packages/golangci-lint):
+
+```sh
+choco install golangci-lint
 ```
 
 ### Install from Source


### PR DESCRIPTION
Inspired by:
- https://github.com/algolia/cli/blob/01a0555a0fc4f2678204f25013724245c9106ba6/.goreleaser.yml#L108
- https://github.com/algolia/cli/blob/01a0555a0fc4f2678204f25013724245c9106ba6/.github/workflows/releases.yml#L23

There is not a lot of usage of this goreleaser feature (about 35 repo): https://github.com/search?q=path%3A%2F%5C.goreleaser.yml%2F+chocolateys&type=code

I tried to publish previous versions by using goreleaser locally (it's not trivial to set up a stack on Docker/Linux).

- [1.56.2](https://community.chocolatey.org/packages/golangci-lint/1.56.2) -> failure because the verification bot doesn't use the right archive (`.nupkg`) even if I update it.
- [1.57.0](https://community.chocolatey.org/packages/golangci-lint/1.57.0) -> success
- [1.57.2](https://community.chocolatey.org/packages/golangci-lint/1.57.2) -> success

Closes #2861