### PR TITLE
docs: remove deprecated Atom from Editor Integrations

### DIFF
--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -22,7 +22,7 @@ Follow the news and releases on our twitter <IconContainer color="#1DA1F2"><FaTw
 
 - ⚡ [Very fast](/product/performance): runs linters in parallel, reuses Go build cache and caches analysis results.
 - ⚙️ YAML-based [configuration](/usage/configuration).
-- 🖥 [Integrations](/welcome/integrations) with VS Code, Sublime Text, GoLand, GNU Emacs, Vim, Atom, GitHub Actions.
+- 🖥 [Integrations](/welcome/integrations) with VS Code, Sublime Text, GoLand, GNU Emacs, Vim, GitHub Actions.
 - 🥇 [A lot of linters](/usage/linters) included, no need to install them.
 - 📈 Minimum number of [false positives](/usage/false-positives) because of tuned default settings.
 - 🔥 Nice output with colors, source code lines and marked `identifiers`.

--- a/docs/src/docs/welcome/integrations.mdx
+++ b/docs/src/docs/welcome/integrations.mdx
@@ -45,10 +45,6 @@ The following plugins support `golangci-lint`:
 - [ALE](https://github.com/w0rp/ale);
 - [Syntastic](https://github.com/vim-syntastic/syntastic).
 
-### Atom
-
-[go-plus](https://atom.io/packages/go-plus) supports golangci-lint.
-
 ## Shell Completion
 
 `golangci-lint` can generate bash, fish, powershell, and zsh completion files.


### PR DESCRIPTION
See https://github.blog/2022-06-08-sunsetting-atom/