### PR TITLE
dev: improve formatting and description in flagsets

### DIFF
--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -26,9 +26,11 @@ func setupLintersFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 		color.GreenString("Enable only fast linters from enabled linters set (first run won't be fast)"))
 
 	internal.AddHackedStringSliceP(fs, "presets", "p",
-		color.GreenString(fmt.Sprintf("Enable presets (%s) of linters.\n", strings.Join(lintersdb.AllPresets(), "|"))+
-			"Run 'golangci-lint help linters' to see them. This option implies option --disable-all",
-		))
+		color.GreenString(fmt.Sprintf("Enable presets (%s) of linters.\n"+
+			"Run 'golangci-lint help linters' to see them.\n"+
+			"This option implies option --disable-all",
+			strings.Join(lintersdb.AllPresets(), "|"),
+		)))
 
 	fs.StringSlice("enable-only", nil,
 		color.GreenString("Override linters configuration section to only run the specific linter(s)")) // Flags only.

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -26,8 +26,9 @@ func setupLintersFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 		color.GreenString("Enable only fast linters from enabled linters set (first run won't be fast)"))
 
 	internal.AddHackedStringSliceP(fs, "presets", "p",
-		color.GreenString(fmt.Sprintf("Enable presets (%s) of linters. Run 'golangci-lint help linters' to see them. "+
-			"This option implies option --disable-all", strings.Join(lintersdb.AllPresets(), "|"))))
+		color.GreenString(fmt.Sprintf("Enable presets (%s) of linters.\n", strings.Join(lintersdb.AllPresets(), "|"))+
+			"Run 'golangci-lint help linters' to see them. This option implies option --disable-all",
+		))
 
 	fs.StringSlice("enable-only", nil,
 		color.GreenString("Override linters configuration section to only run the specific linter(s)")) // Flags only.
@@ -53,11 +54,11 @@ func setupRunFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 	internal.AddDeprecatedFlagAndBind(v, fs, fs.Bool, "skip-dirs-use-default", "run.skip-dirs-use-default", true,
 		getDefaultDirectoryExcludeHelp())
 
-	const allowParallelDesc = "Allow multiple parallel golangci-lint instances running. " +
+	const allowParallelDesc = "Allow multiple parallel golangci-lint instances running.\n" +
 		"If false (default) - golangci-lint acquires file lock on start."
 	internal.AddFlagAndBind(v, fs, fs.Bool, "allow-parallel-runners", "run.allow-parallel-runners", false,
 		color.GreenString(allowParallelDesc))
-	const allowSerialDesc = "Allow multiple golangci-lint instances running, but serialize them around a lock. " +
+	const allowSerialDesc = "Allow multiple golangci-lint instances running, but serialize them around a lock.\n" +
 		"If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start."
 	internal.AddFlagAndBind(v, fs, fs.Bool, "allow-serial-runners", "run.allow-serial-runners", false, color.GreenString(allowSerialDesc))
 }


### PR DESCRIPTION
```diff
--- 1.txt       2024-04-11 22:35:51
+++ 2.txt       2024-04-11 22:36:24
@@ -11,7 +11,8 @@
   -E, --enable strings                 Enable specific linter
       --enable-all                     Enable all linters
       --fast                           Enable only fast linters from enabled linters set (first run won't be fast)
-  -p, --presets strings                Enable presets (bugs|comment|complexity|error|format|import|metalinter|module|performance|sql|style|test|unused) of linters. Run 'golangci-lint help linters' to see them. This option implies option --disable-all
+  -p, --presets strings                Enable presets (bugs|comment|complexity|error|format|import|metalinter|module|performance|sql|style|test|unused) of linters.
+                                       Run 'golangci-lint help linters' to see them. This option implies option --disable-all
       --enable-only strings            Override linters configuration section to only run the specific linter(s)
   -j, --concurrency int                Number of CPUs to use (Default: number of logical CPUs) (default 12)
       --modules-download-mode string   Modules download mode. If not empty, passed as -mod=<mode> to go tools
@@ -20,8 +21,10 @@
       --build-tags strings             Build tags
       --timeout duration               Timeout for total work (default 1m0s)
       --tests                          Analyze tests (*_test.go) (default true)
-      --allow-parallel-runners         Allow multiple parallel golangci-lint instances running. If false (default) - golangci-lint acquires file lock on start.
-      --allow-serial-runners           Allow multiple golangci-lint instances running, but serialize them around a lock. If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start.
+      --allow-parallel-runners         Allow multiple parallel golangci-lint instances running.
+                                       If false (default) - golangci-lint acquires file lock on start.
+      --allow-serial-runners           Allow multiple golangci-lint instances running, but serialize them around a lock.
+                                       If false (default) - golangci-lint exits with an error if it fails to acquire file lock on start.
       --out-format string              Formats of output: json|line-number|colored-line-number|tab|colored-tab|checkstyle|code-climate|html|junit-xml|github-actions|teamcity (default "colored-line-number")
       --print-issued-lines             Print lines of code with issue (default true)
       --print-linter-name              Print linter name in issue line (default true)

```

Added line breaks to make it more readable than before
