### PR TITLE
docs: use proper templates when creating GitHub issues

### DIFF
--- a/docs/src/docs/welcome/faq.mdx
+++ b/docs/src/docs/welcome/faq.mdx
@@ -16,7 +16,7 @@ See [how to properly install `golangci-lint` in CI](/welcome/install/#ci-install
 
 1. Please, ensure you are using the latest binary release.
 2. Run it with `-v` option and check the output.
-3. If it doesn't help create a [GitHub issue](https://github.com/golangci/golangci-lint/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) with the output from the error and #2 above.
+3. If it doesn't help create a [GitHub issue](https://github.com/golangci/golangci-lint/issues/new) with the output from the error and #2 above.
 
 ## Why do you have `typecheck` errors?
 

--- a/docs/src/docs/welcome/faq.mdx
+++ b/docs/src/docs/welcome/faq.mdx
@@ -16,7 +16,7 @@ See [how to properly install `golangci-lint` in CI](/welcome/install/#ci-install
 
 1. Please, ensure you are using the latest binary release.
 2. Run it with `-v` option and check the output.
-3. If it doesn't help create a [GitHub issue](https://github.com/golangci/golangci-lint/issues/new) with the output from the error and #2 above.
+3. If it doesn't help create a [GitHub issue](https://github.com/golangci/golangci-lint/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) with the output from the error and #2 above.
 
 ## Why do you have `typecheck` errors?
 
@@ -53,7 +53,7 @@ Usually this options is used during development on local machine and compilation
 ## How do you add a custom linter?
 
 You can integrate it yourself, see this [manual](/contributing/new-linters/).
-Or you can create a [GitHub Issue](https://github.com/golangci/golangci-lint/issues/new) and we will integrate when time permits.
+Or you can create a [GitHub Issue](https://github.com/golangci/golangci-lint/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.yml) and we will integrate when time permits.
 
 ## How to integrate `golangci-lint` into large project with thousands of issues
 

--- a/docs/src/docs/welcome/faq.mdx
+++ b/docs/src/docs/welcome/faq.mdx
@@ -16,7 +16,7 @@ See [how to properly install `golangci-lint` in CI](/welcome/install/#ci-install
 
 1. Please, ensure you are using the latest binary release.
 2. Run it with `-v` option and check the output.
-3. If it doesn't help create a [GitHub issue](https://github.com/golangci/golangci-lint/issues/new) with the output from the error and #2 above.
+3. If it doesn't help create a [GitHub issue](https://github.com/golangci/golangci-lint/issues/new/choose) with the output from the error and #2 above.
 
 ## Why do you have `typecheck` errors?
 


### PR DESCRIPTION
This PR improves links for creating GitHub issues when a user opens it from:

- https://golangci-lint.run/welcome/faq/#golangci-lint-doesnt-work
- https://golangci-lint.run/welcome/faq/#how-do-you-add-a-custom-linter