### PR TITLE
dev: clean DefaultExcludePatterns and improve CLI render

### DIFF
--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -120,13 +120,14 @@ func setupIssuesFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 
 func getDefaultIssueExcludeHelp() string {
 	parts := []string{color.GreenString("Use or not use default excludes:")}
+
 	for _, ep := range config.DefaultExcludePatterns {
 		parts = append(parts,
-			fmt.Sprintf("  # %s %s: %s", ep.ID, ep.Linter, ep.Why),
-			fmt.Sprintf("  - %s", color.YellowString(ep.Pattern)),
-			"",
+			fmt.Sprintf("  - %s (%s): %s", color.BlueString(ep.ID), color.CyanString(ep.Linter), ep.Why),
+			fmt.Sprintf(`    Pattern: %s`, color.YellowString(`'`+ep.Pattern+`'`)),
 		)
 	}
+
 	return strings.Join(parts, "\n")
 }
 

--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -14,93 +14,92 @@ var DefaultExcludePatterns = []ExcludePattern{
 		Pattern: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close" +
 			"|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked",
 		Linter: "errcheck",
-		Why:    "Almost all programs ignore errors on these functions and in most cases it's ok",
+		Why:    "Almost all programs ignore errors on these functions and in most cases it's ok.",
 	},
 	{
-		ID: "EXC0002",
+		ID: "EXC0002", // TODO(ldez): should be remove in v2
 		Pattern: "(comment on exported (method|function|type|const)|" +
 			"should have( a package)? comment|comment should be of the form)",
 		Linter: "golint",
-		Why:    "Annoying issue about not having a comment. The rare codebase has such comments",
+		Why:    "Annoying issue about not having a comment. The rare codebase has such comments.",
 	},
 	{
-		ID:      "EXC0003",
+		ID:      "EXC0003", // TODO(ldez): should be remove in v2
 		Pattern: "func name will be used as test\\.Test.* by other packages, and that stutters; consider calling this",
 		Linter:  "golint",
-		Why:     "False positive when tests are defined in package 'test'",
+		Why:     "False positive when tests are defined in package 'test'.",
 	},
 	{
 		ID:      "EXC0004",
 		Pattern: "(possible misuse of unsafe.Pointer|should have signature)",
 		Linter:  "govet",
-		Why:     "Common false positives",
+		Why:     "Common false positives.",
 	},
 	{
 		ID:      "EXC0005",
-		Pattern: "ineffective break statement. Did you mean to break out of the outer loop",
+		Pattern: "SA4011", // CheckScopedBreak
 		Linter:  "staticcheck",
-		Why:     "Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore",
+		Why:     "Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore.",
 	},
 	{
 		ID:      "EXC0006",
-		Pattern: "Use of unsafe calls should be audited",
+		Pattern: "G103: Use of unsafe calls should be audited",
 		Linter:  "gosec",
-		Why:     "Too many false-positives on 'unsafe' usage",
+		Why:     "Too many false-positives on 'unsafe' usage.",
 	},
 	{
 		ID:      "EXC0007",
-		Pattern: "Subprocess launch(ed with variable|ing should be audited)",
+		Pattern: "G204: Subprocess launched with variable",
 		Linter:  "gosec",
-		Why:     "Too many false-positives for parametrized shell calls",
+		Why:     "Too many false-positives for parametrized shell calls.",
 	},
 	{
 		ID:      "EXC0008",
-		Pattern: "(G104)",
+		Pattern: "G104", // Errors unhandled.
 		Linter:  "gosec",
-		Why:     "Duplicated errcheck checks",
+		Why:     "Duplicated errcheck checks.",
 	},
 	{
 		ID:      "EXC0009",
-		Pattern: "(Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)",
+		Pattern: "(G301|G302|G307): Expect (directory permissions to be 0750|file permissions to be 0600) or less",
 		Linter:  "gosec",
-		Why:     "Too many issues in popular repos",
+		Why:     "Too many issues in popular repos.",
 	},
 	{
 		ID:      "EXC0010",
-		Pattern: "Potential file inclusion via variable",
+		Pattern: "G304: Potential file inclusion via variable",
 		Linter:  "gosec",
-		Why:     "False positive is triggered by 'src, err := ioutil.ReadFile(filename)'",
+		Why:     "False positive is triggered by 'src, err := ioutil.ReadFile(filename)'.",
 	},
 	{
-		ID: "EXC0011",
-		Pattern: "(comment on exported (method|function|type|const)|" +
-			"should have( a package)? comment|comment should be of the form)",
-		Linter: "stylecheck",
-		Why:    "Annoying issue about not having a comment. The rare codebase has such comments",
+		ID:      "EXC0011",
+		Pattern: "(ST1000|ST1020|ST1021|ST1022)", // CheckPackageComment, CheckExportedFunctionDocs, CheckExportedTypeDocs, CheckExportedVarDocs
+		Linter:  "stylecheck",
+		Why:     "Annoying issue about not having a comment. The rare codebase has such comments.",
 	},
 	{
 		ID:      "EXC0012",
-		Pattern: `exported (.+) should have comment( \(or a comment on this block\))? or be unexported`,
+		Pattern: `exported (.+) should have comment( \(or a comment on this block\))? or be unexported`, // rule: exported
 		Linter:  "revive",
-		Why:     "Annoying issue about not having a comment. The rare codebase has such comments",
+		Why:     "Annoying issue about not having a comment. The rare codebase has such comments.",
 	},
 	{
 		ID:      "EXC0013",
-		Pattern: `package comment should be of the form "(.+)...`,
+		Pattern: `package comment should be of the form "(.+)..."`, // rule: package-comments
 		Linter:  "revive",
-		Why:     "Annoying issue about not having a comment. The rare codebase has such comments",
+		Why:     "Annoying issue about not having a comment. The rare codebase has such comments.",
 	},
 	{
 		ID:      "EXC0014",
-		Pattern: `comment on exported (.+) should be of the form "(.+)..."`,
+		Pattern: `comment on exported (.+) should be of the form "(.+)..."`, // rule: exported
 		Linter:  "revive",
-		Why:     "Annoying issue about not having a comment. The rare codebase has such comments",
+		Why:     "Annoying issue about not having a comment. The rare codebase has such comments.",
 	},
 	{
 		ID:      "EXC0015",
-		Pattern: `should have a package comment`,
+		Pattern: `should have a package comment`, // rule: package-comments
 		Linter:  "revive",
-		Why:     "Annoying issue about not having a comment. The rare codebase has such comments",
+		Why:     "Annoying issue about not having a comment. The rare codebase has such comments.",
 	},
 }
 


### PR DESCRIPTION
Uses more explicit patterns, and improves the CLI render of the exclusions.

<details>
<summary>before</summary>

![Screenshot_20240412_012620](https://github.com/golangci/golangci-lint/assets/5674651/20435427-a37a-443d-9392-74d1afa571dd)

</details>

<details>
<summary>with the PR</summary>

![Screenshot_20240412_022539](https://github.com/golangci/golangci-lint/assets/5674651/fd48365a-809a-45eb-a1aa-a936dfaada37)

</details>