### PR TITLE
dev: sorts deprecated linters at the end of lists

### DIFF
--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -106,8 +107,20 @@ func (c *helpCommand) printPresets() {
 }
 
 func printLinters(lcs []*linter.Config) {
-	sort.Slice(lcs, func(i, j int) bool {
-		return lcs[i].Name() < lcs[j].Name()
+	slices.SortFunc(lcs, func(a, b *linter.Config) int {
+		if a.IsDeprecated() && b.IsDeprecated() {
+			return strings.Compare(a.Name(), b.Name())
+		}
+
+		if a.IsDeprecated() {
+			return 1
+		}
+
+		if b.IsDeprecated() {
+			return -1
+		}
+
+		return strings.Compare(a.Name(), b.Name())
 	})
 
 	for _, lc := range lcs {

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -51,6 +52,22 @@ func getLintersListMarkdown(enabled bool) string {
 
 	sort.Slice(neededLcs, func(i, j int) bool {
 		return neededLcs[i].Name < neededLcs[j].Name
+	})
+
+	slices.SortFunc(neededLcs, func(a, b *types.LinterWrapper) int {
+		if a.IsDeprecated() && b.IsDeprecated() {
+			return strings.Compare(a.Name, b.Name)
+		}
+
+		if a.IsDeprecated() {
+			return 1
+		}
+
+		if b.IsDeprecated() {
+			return -1
+		}
+
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	lines := []string{

--- a/scripts/website/types/types.go
+++ b/scripts/website/types/types.go
@@ -45,3 +45,7 @@ type LinterWrapper struct {
 	Since       string       `json:"since,omitempty"`
 	Deprecation *Deprecation `json:"deprecation,omitempty"`
 }
+
+func (l *LinterWrapper) IsDeprecated() bool {
+	return l.Deprecation != nil
+}


### PR DESCRIPTION
Sorts deprecated linters at the end of lists.

```
usestdlibvars: A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
varnamelen: checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
wastedassign: Finds wasted assignment statements [fast: false, auto-fix: false]
wrapcheck: Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
wsl: add or remove empty lines [fast: true, auto-fix: false]
zerologlint: Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg` [fast: false, auto-fix: false]
deadcode [deprecated]: Deprecated [fast: false, auto-fix: false]
exhaustivestruct [deprecated]: Deprecated [fast: false, auto-fix: false]
golint [deprecated]: Deprecated [fast: false, auto-fix: false]
ifshort [deprecated]: Deprecated [fast: true, auto-fix: false]
interfacer [deprecated]: Deprecated [fast: false, auto-fix: false]
maligned [deprecated]: Deprecated [fast: false, auto-fix: false]
nosnakecase [deprecated]: Deprecated [fast: true, auto-fix: false]
scopelint [deprecated]: Deprecated [fast: true, auto-fix: false]
structcheck [deprecated]: Deprecated [fast: false, auto-fix: false]
varcheck [deprecated]: Deprecated [fast: false, auto-fix: false]
```

![Screenshot 2024-04-13 at 17-20-16 Linters golangci-lint](https://github.com/golangci/golangci-lint/assets/5674651/b3ee43c7-1f13-4fb0-984c-696c236e0aae)
