### PR TITLE
dev: close errcheck exclude file

### DIFF
--- a/pkg/golinters/errcheck/errcheck.go
+++ b/pkg/golinters/errcheck/errcheck.go
@@ -254,6 +254,7 @@ func readExcludeFile(name string) ([]string, error) {
 	if fh == nil {
 		return nil, fmt.Errorf("failed reading exclude file: %s: %w", name, err)
 	}
+	defer func() { _ = fh.Close() }()
 
 	scanner := bufio.NewScanner(fh)
 


### PR DESCRIPTION
It's the same fix as in the https://github.com/golangci/golangci-lint/commit/7ad7949ca9bf236ee4f349de2cb384d5f7c90b08.