### PR TITLE
dev: eliminate redundant indentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,7 @@ linters-settings:
     require-specific: true # require nolint directives to be specific about which linter is being skipped
   revive:
     rules:
+      - name: indent-error-flow
       - name: unexported-return
         disabled: true
       - name: unused-parameter

--- a/pkg/lint/lintersdb/builder_plugin_go.go
+++ b/pkg/lint/lintersdb/builder_plugin_go.go
@@ -48,9 +48,8 @@ func (b *PluginGoBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		lc, err := b.loadConfig(cfg, name, &settings)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load custom analyzer %q: %s, %w", name, settings.Path, err)
-		} else {
-			linters = append(linters, lc)
 		}
+		linters = append(linters, lc)
 	}
 
 	return linters, nil


### PR DESCRIPTION
`revive` is already included in `.golangci.yaml`. This PR only enables one revive's rule:


```
Updated 1 path from the index
❯ golangci-lint run
pkg/lint/lintersdb/builder_plugin_go.go:51:10: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
                } else {
                        linters = append(linters, lc)
                }
```