### PR TITLE
dev: fix broken links to the website

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
           required: true
         - label: Yes, I've searched similar issues on GitHub and didn't find any.
           required: true
-        - label: Yes, I've read the typecheck section of the FAQ (https://golangci-lint.run/usage/faq/#why-do-you-have-typecheck-errors).
+        - label: Yes, I've read the typecheck section of the FAQ (https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors).
           required: true
         - label: Yes, I've tried with the standalone linter if available (e.g., gocritic, go vet, etc.). (https://golangci-lint.run/usage/linters/)
           required: true

--- a/pkg/lint/lintersdb/builder_plugin_go.go
+++ b/pkg/lint/lintersdb/builder_plugin_go.go
@@ -127,7 +127,7 @@ func (b *PluginGoBuilder) lookupAnalyzerPlugin(plug *plugin.Plugin) ([]*analysis
 	}
 
 	b.log.Warnf("plugin: 'AnalyzerPlugin' plugins are deprecated, please use the new plugin signature: " +
-		"https://golangci-lint.run/contributing/new-linters/#create-a-plugin")
+		"https://golangci-lint.run/plugins/go-plugins#create-a-plugin")
 
 	analyzerPlugin, ok := symbol.(AnalyzerPlugin)
 	if !ok {


### PR DESCRIPTION
This PR fixes the website links in the bug issue template and the warning log for the deprecated analyzer plugin.