### PR TITLE
dev: fix shellcheck lint issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ EOF
 }
 
 parse_args() {
-  #BINDIR is ./bin unless set be ENV
-  # over-ridden by flag below
+  # BINDIR is ./bin unless set be ENV
+  # overridden by flag below
 
   BINDIR=${BINDIR:-./bin}
   while getopts "b:dh?x" arg; do
@@ -150,9 +150,6 @@ is_command() {
 echoerr() {
   echo "$@" 1>&2
 }
-log_prefix() {
-  echo "$0"
-}
 _logp=6
 log_set_priority() {
   _logp="$1"
@@ -200,7 +197,7 @@ uname_os() {
     mingw*) os="windows" ;;
     cygwin*) os="windows" ;;
     win*) os="windows" ;;
-    sunos) [ $(uname -o) == "illumos" ] && os=illumos ;;
+    sunos) [ "$(uname -o)" = "illumos" ] && os=illumos ;;
   esac
   echo "$os"
 }
@@ -218,7 +215,7 @@ uname_arch() {
     armv7*) arch="armv7" ;;
     loongarch64) arch="loong64" ;;
   esac
-  echo ${arch}
+  echo "${arch}"
 }
 uname_os_check() {
   os=$(uname_os)


### PR DESCRIPTION
This PR fixes [shellcheck](https://www.shellcheck.net/) linter issues:

- [Quote this to prevent word splitting](https://www.shellcheck.net/wiki/SC2046)
- [In POSIX sh, == in place of = is undefined](https://www.shellcheck.net/wiki/SC3014)
- [Double quote to prevent globbing and word splitting](https://www.shellcheck.net/wiki/SC2086)

The function `log_prefix()` is removed because it's redefined below.

<details>
<summary>Details</summary>

```
❯ shellcheck install.sh

In install.sh line 154:
  echo "$0"
  ^-------^ SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).


In install.sh line 203:
    sunos) [ $(uname -o) == "illumos" ] && os=illumos ;;
             ^---------^ SC2046 (warning): Quote this to prevent word splitting.
                         ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.


In install.sh line 221:
  echo ${arch}
       ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  echo "${arch}"

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC3014 -- In POSIX sh, == in place of = is ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

</details>