### PR TITLE
Add new linter canonicalheader

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2519,6 +2519,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - containedctx
     - contextcheck
     - copyloopvar
@@ -2633,6 +2634,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - containedctx
     - contextcheck
     - copyloopvar

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/kulti/thelper v0.6.3
 	github.com/kunwardeep/paralleltest v1.0.10
 	github.com/kyoh86/exportloopref v0.1.11
+	github.com/lasiar/canonicalheader v1.0.5
 	github.com/ldez/gomoddirectives v0.2.4
 	github.com/ldez/tagliatelle v0.5.0
 	github.com/leonklingele/grouper v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,8 @@ github.com/kunwardeep/paralleltest v1.0.10 h1:wrodoaKYzS2mdNVnc4/w31YaXFtsc21PCT
 github.com/kunwardeep/paralleltest v1.0.10/go.mod h1:2C7s65hONVqY7Q5Efj5aLzRCNLjw2h4eMc9EcypGjcY=
 github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/ymEyhQ=
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
+github.com/lasiar/canonicalheader v1.0.5 h1:KKRZMuCuD9ZEithvm5LMW840uT7ziYWLGKS/Yuf965M=
+github.com/lasiar/canonicalheader v1.0.5/go.mod h1:vlPb89W3yQgrXIydpYZiiwcq/vKIIf5WdyOrVr9Q7F4=
 github.com/ldez/gomoddirectives v0.2.4 h1:j3YjBIjEBbqZ0NKtBNzr8rtMHTOrLPeiwTkfUJZ3alg=
 github.com/ldez/gomoddirectives v0.2.4/go.mod h1:oWu9i62VcQDYp9EQ0ONTfqLNh+mDLWWDO+SO0qSQw5g=
 github.com/ldez/tagliatelle v0.5.0 h1:epgfuYt9v0CG3fms0pEgIMNPuFf/LpPIfjk4kyqSioo=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -215,6 +215,7 @@
             "asciicheck",
             "bidichk",
             "bodyclose",
+            "canonicalheader",
             "containedctx",
             "contextcheck",
             "copyloopvar",

--- a/pkg/golinters/canonicalheader/canonicalheader.go
+++ b/pkg/golinters/canonicalheader/canonicalheader.go
@@ -1,0 +1,19 @@
+package canonicalheader
+
+import (
+	"github.com/lasiar/canonicalheader"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	a := canonicalheader.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/canonicalheader/canonicalheader_test.go
+++ b/pkg/golinters/canonicalheader/canonicalheader_test.go
@@ -1,0 +1,11 @@
+package canonicalheader_test
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/canonicalheader/testdata/canonicalheader.go
+++ b/pkg/golinters/canonicalheader/testdata/canonicalheader.go
@@ -1,0 +1,19 @@
+//golangcitest:args -Ecanonicalheader
+package testdata
+
+import "net/http"
+
+func canonicalheader() {
+	v := http.Header{}
+
+	v.Get("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Set("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Add("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Del("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Values("Test-HEader")       // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+
+	v.Set("Test-Header", "value")
+	v.Add("Test-Header", "value")
+	v.Del("Test-Header")
+	v.Values("Test-Header")
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/asciicheck"
 	"github.com/golangci/golangci-lint/pkg/golinters/bidichk"
 	"github.com/golangci/golangci-lint/pkg/golinters/bodyclose"
+	"github.com/golangci/golangci-lint/pkg/golinters/canonicalheader"
 	"github.com/golangci/golangci-lint/pkg/golinters/containedctx"
 	"github.com/golangci/golangci-lint/pkg/golinters/contextcheck"
 	"github.com/golangci/golangci-lint/pkg/golinters/copyloopvar"
@@ -153,6 +154,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetPerformance, linter.PresetBugs).
 			WithURL("https://github.com/timakin/bodyclose"),
+
+		linter.NewConfig(canonicalheader.New()).
+			WithSince("v1.58.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/lasiar/canonicalHeader"),
 
 		linter.NewConfig(containedctx.New()).
 			WithSince("1.44.0").


### PR DESCRIPTION
[canonicalheader](https://github.com/lasiar/canonicalHeader) analyzes code and reports or fixes non-canonical header key in `net/http.Header`, [doc](https://pkg.go.dev/net/http#CanonicalHeaderKey).

The linter suggest canonical header:

```go
http.Header{}.Get("Test-Header")
```
instead of non-canonical header:

```go
http.Header{}.Get("TeSt-HeAdEr")
```

This change also speeds up the code a little, benchmark from repo:
```
name             time/op
Canonical-10     29.7ns ± 4%
NonCanonical-10  69.0ns ± 1%

name             alloc/op
Canonical-10      0.00B     
NonCanonical-10   16.0B ± 0%

name             allocs/op
Canonical-10       0.00     
NonCanonical-10    1.00 ± 0%
```

Now, the linter works only with value `net/http.Header` (not pointer) and with string literal.

----
The reason I created this PR:

I tried to add this linter at https://github.com/golangci/golangci-lint/pull/4241. But the PR was closed, because duplicate linter (https://github.com/golangci/golangci-lint/pull/4241#issuecomment-1853771375).

So this not fully duplicate, [SA1008](https://staticcheck.dev/docs/checks/#SA1008) checks direct write to map.
 `staticcheck` doesn't want to add checks for methods calls https://github.com/dominikh/go-tools/issues/1519#issuecomment-2067816842.


