### PR TITLE
dev: removes BaseRule, ExcludeRule, SeverityRule duplications

### DIFF
--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -91,7 +91,7 @@ func NewRunner(log logutils.Log, cfg *config.Config, args []string, goenv *gouti
 			processors.NewMaxFromLinter(cfg.Issues.MaxIssuesPerLinter, log.Child(logutils.DebugKeyMaxFromLinter), cfg),
 			processors.NewSourceCode(lineCache, log.Child(logutils.DebugKeySourceCode)),
 			processors.NewPathShortener(),
-			getSeverityRulesProcessor(&cfg.Severity, log, files),
+			processors.NewSeverity(log.Child(logutils.DebugKeySeverityRules), files, &cfg.Severity),
 
 			// The fixer still needs to see paths for the issues that are relative to the current directory.
 			processors.NewFixer(cfg, log, fileCache),
@@ -275,14 +275,4 @@ func getExcludeRulesProcessor(cfg *config.Issues, log logutils.Log, files *fsuti
 	}
 
 	return processors.NewExcludeRules(log.Child(logutils.DebugKeyExcludeRules), files, opts)
-}
-
-func getSeverityRulesProcessor(cfg *config.Severity, log logutils.Log, files *fsutils.Files) processors.Processor {
-	severityOpts := processors.SeverityOptions{
-		Default:       cfg.Default,
-		Rules:         cfg.Rules,
-		CaseSensitive: cfg.CaseSensitive,
-	}
-
-	return processors.NewSeverity(log.Child(logutils.DebugKeySeverityRules), files, severityOpts)
 }

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -80,7 +80,7 @@ func NewRunner(log logutils.Log, cfg *config.Config, args []string, goenv *gouti
 			// Must be before exclude because users see already marked output and configure excluding by it.
 			processors.NewIdentifierMarker(),
 
-			getExcludeProcessor(&cfg.Issues),
+			processors.NewExclude(&cfg.Issues),
 			processors.NewExcludeRules(log.Child(logutils.DebugKeyExcludeRules), files, &cfg.Issues),
 			processors.NewNolint(log.Child(logutils.DebugKeyNolint), dbManager, enabledLinters),
 
@@ -241,16 +241,4 @@ func (r *Runner) processIssues(issues []result.Issue, sw *timeutils.Stopwatch, s
 	}
 
 	return issues
-}
-
-func getExcludeProcessor(cfg *config.Issues) processors.Processor {
-	opts := processors.ExcludeOptions{
-		CaseSensitive: cfg.ExcludeCaseSensitive,
-	}
-
-	if len(cfg.ExcludePatterns) != 0 {
-		opts.Pattern = fmt.Sprintf("(%s)", strings.Join(cfg.ExcludePatterns, "|"))
-	}
-
-	return processors.NewExclude(opts)
 }

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -256,23 +256,12 @@ func getExcludeProcessor(cfg *config.Issues) processors.Processor {
 }
 
 func getExcludeRulesProcessor(cfg *config.Issues, log logutils.Log, files *fsutils.Files) processors.Processor {
-	var excludeRules []processors.ExcludeRule
-	for _, r := range cfg.ExcludeRules {
-		excludeRules = append(excludeRules, processors.ExcludeRule{
-			BaseRule: processors.BaseRule{
-				Text:       r.Text,
-				Source:     r.Source,
-				Path:       r.Path,
-				PathExcept: r.PathExcept,
-				Linters:    r.Linters,
-			},
-		})
-	}
+	excludeRules := cfg.ExcludeRules
 
 	if cfg.UseDefaultExcludes {
 		for _, r := range config.GetExcludePatterns(cfg.IncludeDefaultExcludes) {
-			excludeRules = append(excludeRules, processors.ExcludeRule{
-				BaseRule: processors.BaseRule{
+			excludeRules = append(excludeRules, config.ExcludeRule{
+				BaseRule: config.BaseRule{
 					Text:    r.Pattern,
 					Linters: []string{r.Linter},
 				},
@@ -289,23 +278,9 @@ func getExcludeRulesProcessor(cfg *config.Issues, log logutils.Log, files *fsuti
 }
 
 func getSeverityRulesProcessor(cfg *config.Severity, log logutils.Log, files *fsutils.Files) processors.Processor {
-	var severityRules []processors.SeverityRule
-	for _, r := range cfg.Rules {
-		severityRules = append(severityRules, processors.SeverityRule{
-			Severity: r.Severity,
-			BaseRule: processors.BaseRule{
-				Text:       r.Text,
-				Source:     r.Source,
-				Path:       r.Path,
-				PathExcept: r.PathExcept,
-				Linters:    r.Linters,
-			},
-		})
-	}
-
 	severityOpts := processors.SeverityOptions{
 		Default:       cfg.Default,
-		Rules:         severityRules,
+		Rules:         cfg.Rules,
 		CaseSensitive: cfg.CaseSensitive,
 	}
 

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -81,7 +81,7 @@ func NewRunner(log logutils.Log, cfg *config.Config, args []string, goenv *gouti
 			processors.NewIdentifierMarker(),
 
 			getExcludeProcessor(&cfg.Issues),
-			getExcludeRulesProcessor(&cfg.Issues, log, files),
+			processors.NewExcludeRules(log.Child(logutils.DebugKeyExcludeRules), files, &cfg.Issues),
 			processors.NewNolint(log.Child(logutils.DebugKeyNolint), dbManager, enabledLinters),
 
 			processors.NewUniqByLine(cfg),
@@ -253,26 +253,4 @@ func getExcludeProcessor(cfg *config.Issues) processors.Processor {
 	}
 
 	return processors.NewExclude(opts)
-}
-
-func getExcludeRulesProcessor(cfg *config.Issues, log logutils.Log, files *fsutils.Files) processors.Processor {
-	excludeRules := cfg.ExcludeRules
-
-	if cfg.UseDefaultExcludes {
-		for _, r := range config.GetExcludePatterns(cfg.IncludeDefaultExcludes) {
-			excludeRules = append(excludeRules, config.ExcludeRule{
-				BaseRule: config.BaseRule{
-					Text:    r.Pattern,
-					Linters: []string{r.Linter},
-				},
-			})
-		}
-	}
-
-	opts := processors.ExcludeRulesOptions{
-		Rules:         excludeRules,
-		CaseSensitive: cfg.ExcludeCaseSensitive,
-	}
-
-	return processors.NewExcludeRules(log.Child(logutils.DebugKeyExcludeRules), files, opts)
 }

--- a/pkg/result/processors/base_rule.go
+++ b/pkg/result/processors/base_rule.go
@@ -10,14 +10,6 @@ import (
 
 const caseInsensitivePrefix = "(?i)"
 
-type BaseRule struct {
-	Text       string
-	Source     string
-	Path       string
-	PathExcept string
-	Linters    []string
-}
-
 type baseRule struct {
 	text       *regexp.Regexp
 	source     *regexp.Regexp

--- a/pkg/result/processors/exclude.go
+++ b/pkg/result/processors/exclude.go
@@ -1,8 +1,11 @@
 package processors
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
@@ -14,22 +17,22 @@ type Exclude struct {
 	pattern *regexp.Regexp
 }
 
-type ExcludeOptions struct {
-	Pattern       string
-	CaseSensitive bool
-}
-
-func NewExclude(opts ExcludeOptions) *Exclude {
+func NewExclude(cfg *config.Issues) *Exclude {
 	p := &Exclude{name: "exclude"}
 
+	var pattern string
+	if len(cfg.ExcludePatterns) != 0 {
+		pattern = fmt.Sprintf("(%s)", strings.Join(cfg.ExcludePatterns, "|"))
+	}
+
 	prefix := caseInsensitivePrefix
-	if opts.CaseSensitive {
+	if cfg.ExcludeCaseSensitive {
 		p.name = "exclude-case-sensitive"
 		prefix = ""
 	}
 
-	if opts.Pattern != "" {
-		p.pattern = regexp.MustCompile(prefix + opts.Pattern)
+	if pattern != "" {
+		p.pattern = regexp.MustCompile(prefix + pattern)
 	}
 
 	return p

--- a/pkg/result/processors/exclude_rules.go
+++ b/pkg/result/processors/exclude_rules.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"regexp"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
@@ -12,10 +13,6 @@ var _ Processor = (*ExcludeRules)(nil)
 
 type excludeRule struct {
 	baseRule
-}
-
-type ExcludeRule struct {
-	BaseRule
 }
 
 type ExcludeRules struct {
@@ -28,7 +25,7 @@ type ExcludeRules struct {
 }
 
 type ExcludeRulesOptions struct {
-	Rules         []ExcludeRule
+	Rules         []config.ExcludeRule
 	CaseSensitive bool
 }
 
@@ -71,7 +68,7 @@ func (p ExcludeRules) Process(issues []result.Issue) ([]result.Issue, error) {
 
 func (ExcludeRules) Finish() {}
 
-func createRules(rules []ExcludeRule, prefix string) []excludeRule {
+func createRules(rules []config.ExcludeRule, prefix string) []excludeRule {
 	parsedRules := make([]excludeRule, 0, len(rules))
 
 	for _, rule := range rules {

--- a/pkg/result/processors/exclude_rules_test.go
+++ b/pkg/result/processors/exclude_rules_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -15,33 +16,33 @@ func TestExcludeRules_multiple(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
 
-	opts := ExcludeRulesOptions{Rules: []ExcludeRule{
+	opts := ExcludeRulesOptions{Rules: []config.ExcludeRule{
 		{
-			BaseRule: BaseRule{
+			BaseRule: config.BaseRule{
 				Text:    "^exclude$",
 				Linters: []string{"linter"},
 			},
 		},
 		{
-			BaseRule: BaseRule{
+			BaseRule: config.BaseRule{
 				Linters: []string{"testlinter"},
 				Path:    `_test\.go`,
 			},
 		},
 		{
-			BaseRule: BaseRule{
+			BaseRule: config.BaseRule{
 				Text: "^testonly$",
 				Path: `_test\.go`,
 			},
 		},
 		{
-			BaseRule: BaseRule{
+			BaseRule: config.BaseRule{
 				Text:       "^nontestonly$",
 				PathExcept: `_test\.go`,
 			},
 		},
 		{
-			BaseRule: BaseRule{
+			BaseRule: config.BaseRule{
 				Source:  "^//go:generate ",
 				Linters: []string{"lll"},
 			},
@@ -95,9 +96,9 @@ func TestExcludeRules_pathPrefix(t *testing.T) {
 	files := fsutils.NewFiles(lineCache, pathPrefix)
 
 	opts := ExcludeRulesOptions{
-		Rules: []ExcludeRule{
+		Rules: []config.ExcludeRule{
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Path: `some/dir/e\.go`,
 				},
 			},
@@ -137,9 +138,9 @@ func TestExcludeRules_pathPrefix(t *testing.T) {
 
 func TestExcludeRules_text(t *testing.T) {
 	opts := ExcludeRulesOptions{
-		Rules: []ExcludeRule{
+		Rules: []config.ExcludeRule{
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text:    "^exclude$",
 					Linters: []string{"linter"},
 				},
@@ -179,27 +180,27 @@ func TestExcludeRules_caseSensitive_multiple(t *testing.T) {
 
 	opts := ExcludeRulesOptions{
 		CaseSensitive: true,
-		Rules: []ExcludeRule{
+		Rules: []config.ExcludeRule{
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text:    "^exclude$",
 					Linters: []string{"linter"},
 				},
 			},
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Linters: []string{"testlinter"},
 					Path:    `_test\.go`,
 				},
 			},
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text: "^testonly$",
 					Path: `_test\.go`,
 				},
 			},
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Source:  "^//go:generate ",
 					Linters: []string{"lll"},
 				},
@@ -253,9 +254,9 @@ func TestExcludeRules_caseSensitive_multiple(t *testing.T) {
 func TestExcludeRules_caseSensitive_text(t *testing.T) {
 	opts := ExcludeRulesOptions{
 		CaseSensitive: true,
-		Rules: []ExcludeRule{
+		Rules: []config.ExcludeRule{
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text:    "^exclude$",
 					Linters: []string{"linter"},
 				},

--- a/pkg/result/processors/exclude_rules_test.go
+++ b/pkg/result/processors/exclude_rules_test.go
@@ -16,7 +16,7 @@ func TestExcludeRules_multiple(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
 
-	opts := ExcludeRulesOptions{Rules: []config.ExcludeRule{
+	opts := &config.Issues{ExcludeRules: []config.ExcludeRule{
 		{
 			BaseRule: config.BaseRule{
 				Text:    "^exclude$",
@@ -95,8 +95,8 @@ func TestExcludeRules_pathPrefix(t *testing.T) {
 	pathPrefix := path.Join("some", "dir")
 	files := fsutils.NewFiles(lineCache, pathPrefix)
 
-	opts := ExcludeRulesOptions{
-		Rules: []config.ExcludeRule{
+	opts := &config.Issues{
+		ExcludeRules: []config.ExcludeRule{
 			{
 				BaseRule: config.BaseRule{
 					Path: `some/dir/e\.go`,
@@ -137,8 +137,8 @@ func TestExcludeRules_pathPrefix(t *testing.T) {
 }
 
 func TestExcludeRules_text(t *testing.T) {
-	opts := ExcludeRulesOptions{
-		Rules: []config.ExcludeRule{
+	opts := &config.Issues{
+		ExcludeRules: []config.ExcludeRule{
 			{
 				BaseRule: config.BaseRule{
 					Text:    "^exclude$",
@@ -171,16 +171,16 @@ func TestExcludeRules_text(t *testing.T) {
 }
 
 func TestExcludeRules_empty(t *testing.T) {
-	processAssertSame(t, NewExcludeRules(nil, nil, ExcludeRulesOptions{}), newIssueFromTextTestCase("test"))
+	processAssertSame(t, NewExcludeRules(nil, nil, &config.Issues{}), newIssueFromTextTestCase("test"))
 }
 
 func TestExcludeRules_caseSensitive_multiple(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
 
-	opts := ExcludeRulesOptions{
-		CaseSensitive: true,
-		Rules: []config.ExcludeRule{
+	opts := &config.Issues{
+		ExcludeCaseSensitive: true,
+		ExcludeRules: []config.ExcludeRule{
 			{
 				BaseRule: config.BaseRule{
 					Text:    "^exclude$",
@@ -252,9 +252,9 @@ func TestExcludeRules_caseSensitive_multiple(t *testing.T) {
 }
 
 func TestExcludeRules_caseSensitive_text(t *testing.T) {
-	opts := ExcludeRulesOptions{
-		CaseSensitive: true,
-		Rules: []config.ExcludeRule{
+	opts := &config.Issues{
+		ExcludeCaseSensitive: true,
+		ExcludeRules: []config.ExcludeRule{
 			{
 				BaseRule: config.BaseRule{
 					Text:    "^exclude$",
@@ -288,5 +288,5 @@ func TestExcludeRules_caseSensitive_text(t *testing.T) {
 }
 
 func TestExcludeRules_caseSensitive_empty(t *testing.T) {
-	processAssertSame(t, NewExcludeRules(nil, nil, ExcludeRulesOptions{CaseSensitive: true}), newIssueFromTextTestCase("test"))
+	processAssertSame(t, NewExcludeRules(nil, nil, &config.Issues{ExcludeCaseSensitive: true}), newIssueFromTextTestCase("test"))
 }

--- a/pkg/result/processors/exclude_test.go
+++ b/pkg/result/processors/exclude_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
 func TestExclude(t *testing.T) {
-	p := NewExclude(ExcludeOptions{Pattern: "^exclude$"})
+	p := NewExclude(&config.Issues{ExcludePatterns: []string{"^exclude$"}})
 
 	texts := []string{"excLude", "1", "", "exclud", "notexclude"}
 
@@ -30,11 +31,11 @@ func TestExclude(t *testing.T) {
 }
 
 func TestExclude_empty(t *testing.T) {
-	processAssertSame(t, NewExclude(ExcludeOptions{}), newIssueFromTextTestCase("test"))
+	processAssertSame(t, NewExclude(&config.Issues{}), newIssueFromTextTestCase("test"))
 }
 
 func TestExclude_caseSensitive(t *testing.T) {
-	p := NewExclude(ExcludeOptions{Pattern: "^exclude$", CaseSensitive: true})
+	p := NewExclude(&config.Issues{ExcludePatterns: []string{"^exclude$"}, ExcludeCaseSensitive: true})
 
 	texts := []string{"excLude", "1", "", "exclud", "exclude"}
 

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -18,12 +18,6 @@ type severityRule struct {
 	severity string
 }
 
-type SeverityOptions struct {
-	Default       string
-	Rules         []config.SeverityRule
-	CaseSensitive bool
-}
-
 type Severity struct {
 	name string
 
@@ -35,21 +29,21 @@ type Severity struct {
 	rules           []severityRule
 }
 
-func NewSeverity(log logutils.Log, files *fsutils.Files, opts SeverityOptions) *Severity {
+func NewSeverity(log logutils.Log, files *fsutils.Files, cfg *config.Severity) *Severity {
 	p := &Severity{
 		name:            "severity-rules",
 		files:           files,
 		log:             log,
-		defaultSeverity: opts.Default,
+		defaultSeverity: cfg.Default,
 	}
 
 	prefix := caseInsensitivePrefix
-	if opts.CaseSensitive {
+	if cfg.CaseSensitive {
 		prefix = ""
 		p.name = "severity-rules-case-sensitive"
 	}
 
-	p.rules = createSeverityRules(opts.Rules, prefix)
+	p.rules = createSeverityRules(cfg.Rules, prefix)
 
 	return p
 }

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"regexp"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
@@ -17,14 +18,9 @@ type severityRule struct {
 	severity string
 }
 
-type SeverityRule struct {
-	BaseRule
-	Severity string
-}
-
 type SeverityOptions struct {
 	Default       string
-	Rules         []SeverityRule
+	Rules         []config.SeverityRule
 	CaseSensitive bool
 }
 
@@ -93,7 +89,7 @@ func (p *Severity) transform(issue *result.Issue) *result.Issue {
 	return issue
 }
 
-func createSeverityRules(rules []SeverityRule, prefix string) []severityRule {
+func createSeverityRules(rules []config.SeverityRule, prefix string) []severityRule {
 	parsedRules := make([]severityRule, 0, len(rules))
 
 	for _, rule := range rules {

--- a/pkg/result/processors/severity_test.go
+++ b/pkg/result/processors/severity_test.go
@@ -18,7 +18,7 @@ func TestSeverity_multiple(t *testing.T) {
 	files := fsutils.NewFiles(lineCache, "")
 	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
-	opts := SeverityOptions{
+	opts := &config.Severity{
 		Default: "error",
 		Rules: []config.SeverityRule{
 			{
@@ -134,7 +134,7 @@ func TestSeverity_pathPrefix(t *testing.T) {
 	files := fsutils.NewFiles(lineCache, pathPrefix)
 	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
-	opts := SeverityOptions{
+	opts := &config.Severity{
 		Default: "error",
 		Rules: []config.SeverityRule{
 			{
@@ -181,7 +181,7 @@ func TestSeverity_pathPrefix(t *testing.T) {
 }
 
 func TestSeverity_text(t *testing.T) {
-	opts := SeverityOptions{
+	opts := &config.Severity{
 		Rules: []config.SeverityRule{
 			{
 				BaseRule: config.BaseRule{
@@ -219,12 +219,12 @@ func TestSeverity_onlyDefault(t *testing.T) {
 	files := fsutils.NewFiles(lineCache, "")
 	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
 
-	opts := SeverityOptions{
+	opts := config.Severity{
 		Default: "info",
 		Rules:   []config.SeverityRule{},
 	}
 
-	p := NewSeverity(log, files, opts)
+	p := NewSeverity(log, files, &opts)
 
 	cases := []issueTestCase{
 		{Path: "ssl.go", Text: "ssl", Linter: "gosec"},
@@ -258,7 +258,7 @@ func TestSeverity_onlyDefault(t *testing.T) {
 }
 
 func TestSeverity_empty(t *testing.T) {
-	p := NewSeverity(nil, nil, SeverityOptions{})
+	p := NewSeverity(nil, nil, &config.Severity{})
 
 	processAssertSame(t, p, newIssueFromTextTestCase("test"))
 }
@@ -267,7 +267,7 @@ func TestSeverity_caseSensitive(t *testing.T) {
 	lineCache := fsutils.NewLineCache(fsutils.NewFileCache())
 	files := fsutils.NewFiles(lineCache, "")
 
-	opts := SeverityOptions{
+	opts := &config.Severity{
 		Default: "error",
 		Rules: []config.SeverityRule{
 			{
@@ -318,13 +318,13 @@ func TestSeverity_transform(t *testing.T) {
 
 	testCases := []struct {
 		desc     string
-		opts     SeverityOptions
+		opts     *config.Severity
 		issue    *result.Issue
 		expected *result.Issue
 	}{
 		{
 			desc: "apply severity from rule",
-			opts: SeverityOptions{
+			opts: &config.Severity{
 				Default: "error",
 				Rules: []config.SeverityRule{
 					{
@@ -347,7 +347,7 @@ func TestSeverity_transform(t *testing.T) {
 		},
 		{
 			desc: "apply severity from default",
-			opts: SeverityOptions{
+			opts: &config.Severity{
 				Default: "error",
 				Rules: []config.SeverityRule{
 					{
@@ -370,7 +370,7 @@ func TestSeverity_transform(t *testing.T) {
 		},
 		{
 			desc: "severity from rule override severity from linter",
-			opts: SeverityOptions{
+			opts: &config.Severity{
 				Default: "error",
 				Rules: []config.SeverityRule{
 					{
@@ -394,7 +394,7 @@ func TestSeverity_transform(t *testing.T) {
 		},
 		{
 			desc: "severity from default override severity from linter",
-			opts: SeverityOptions{
+			opts: &config.Severity{
 				Default: "error",
 				Rules: []config.SeverityRule{
 					{
@@ -418,7 +418,7 @@ func TestSeverity_transform(t *testing.T) {
 		},
 		{
 			desc: "keep severity from linter as rule",
-			opts: SeverityOptions{
+			opts: &config.Severity{
 				Default: "error",
 				Rules: []config.SeverityRule{
 					{
@@ -442,7 +442,7 @@ func TestSeverity_transform(t *testing.T) {
 		},
 		{
 			desc: "keep severity from linter as default",
-			opts: SeverityOptions{
+			opts: &config.Severity{
 				Default: severityFromLinter,
 				Rules: []config.SeverityRule{
 					{
@@ -466,7 +466,7 @@ func TestSeverity_transform(t *testing.T) {
 		},
 		{
 			desc: "keep severity from linter as default (without rule)",
-			opts: SeverityOptions{
+			opts: &config.Severity{
 				Default: severityFromLinter,
 			},
 			issue: &result.Issue{

--- a/pkg/result/processors/severity_test.go
+++ b/pkg/result/processors/severity_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
@@ -19,56 +20,56 @@ func TestSeverity_multiple(t *testing.T) {
 
 	opts := SeverityOptions{
 		Default: "error",
-		Rules: []SeverityRule{
+		Rules: []config.SeverityRule{
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text:    "^ssl$",
 					Linters: []string{"gosec"},
 				},
 			},
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Linters: []string{"linter"},
 					Path:    "e.go",
 				},
 			},
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text: "^testonly$",
 					Path: `_test\.go`,
 				},
 			},
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text:       "^nontestonly$",
 					PathExcept: `_test\.go`,
 				},
 			},
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Source:  "^//go:generate ",
 					Linters: []string{"lll"},
 				},
 			},
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Source: "^//go:dosomething",
 				},
 			},
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Linters: []string{"someotherlinter"},
 				},
 			},
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Linters: []string{"somelinter"},
 				},
 			},
@@ -135,10 +136,10 @@ func TestSeverity_pathPrefix(t *testing.T) {
 
 	opts := SeverityOptions{
 		Default: "error",
-		Rules: []SeverityRule{
+		Rules: []config.SeverityRule{
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text: "some",
 					Path: `some/dir/e\.go`,
 				},
@@ -181,9 +182,9 @@ func TestSeverity_pathPrefix(t *testing.T) {
 
 func TestSeverity_text(t *testing.T) {
 	opts := SeverityOptions{
-		Rules: []SeverityRule{
+		Rules: []config.SeverityRule{
 			{
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text:    "^severity$",
 					Linters: []string{"linter"},
 				},
@@ -220,7 +221,7 @@ func TestSeverity_onlyDefault(t *testing.T) {
 
 	opts := SeverityOptions{
 		Default: "info",
-		Rules:   []SeverityRule{},
+		Rules:   []config.SeverityRule{},
 	}
 
 	p := NewSeverity(log, files, opts)
@@ -268,10 +269,10 @@ func TestSeverity_caseSensitive(t *testing.T) {
 
 	opts := SeverityOptions{
 		Default: "error",
-		Rules: []SeverityRule{
+		Rules: []config.SeverityRule{
 			{
 				Severity: "info",
-				BaseRule: BaseRule{
+				BaseRule: config.BaseRule{
 					Text:    "^ssl$",
 					Linters: []string{"gosec", "someotherlinter"},
 				},
@@ -325,10 +326,10 @@ func TestSeverity_transform(t *testing.T) {
 			desc: "apply severity from rule",
 			opts: SeverityOptions{
 				Default: "error",
-				Rules: []SeverityRule{
+				Rules: []config.SeverityRule{
 					{
 						Severity: "info",
-						BaseRule: BaseRule{
+						BaseRule: config.BaseRule{
 							Linters: []string{"linter1"},
 						},
 					},
@@ -348,10 +349,10 @@ func TestSeverity_transform(t *testing.T) {
 			desc: "apply severity from default",
 			opts: SeverityOptions{
 				Default: "error",
-				Rules: []SeverityRule{
+				Rules: []config.SeverityRule{
 					{
 						Severity: "info",
-						BaseRule: BaseRule{
+						BaseRule: config.BaseRule{
 							Linters: []string{"linter1"},
 						},
 					},
@@ -371,10 +372,10 @@ func TestSeverity_transform(t *testing.T) {
 			desc: "severity from rule override severity from linter",
 			opts: SeverityOptions{
 				Default: "error",
-				Rules: []SeverityRule{
+				Rules: []config.SeverityRule{
 					{
 						Severity: "info",
-						BaseRule: BaseRule{
+						BaseRule: config.BaseRule{
 							Linters: []string{"linter1"},
 						},
 					},
@@ -395,10 +396,10 @@ func TestSeverity_transform(t *testing.T) {
 			desc: "severity from default override severity from linter",
 			opts: SeverityOptions{
 				Default: "error",
-				Rules: []SeverityRule{
+				Rules: []config.SeverityRule{
 					{
 						Severity: "info",
-						BaseRule: BaseRule{
+						BaseRule: config.BaseRule{
 							Linters: []string{"linter1"},
 						},
 					},
@@ -419,10 +420,10 @@ func TestSeverity_transform(t *testing.T) {
 			desc: "keep severity from linter as rule",
 			opts: SeverityOptions{
 				Default: "error",
-				Rules: []SeverityRule{
+				Rules: []config.SeverityRule{
 					{
 						Severity: severityFromLinter,
-						BaseRule: BaseRule{
+						BaseRule: config.BaseRule{
 							Linters: []string{"linter1"},
 						},
 					},
@@ -443,10 +444,10 @@ func TestSeverity_transform(t *testing.T) {
 			desc: "keep severity from linter as default",
 			opts: SeverityOptions{
 				Default: severityFromLinter,
-				Rules: []SeverityRule{
+				Rules: []config.SeverityRule{
 					{
 						Severity: "info",
-						BaseRule: BaseRule{
+						BaseRule: config.BaseRule{
 							Linters: []string{"linter1"},
 						},
 					},


### PR DESCRIPTION
Removes `BaseRule`, `ExcludeRule`, `SeverityRule` duplications.

This deduplication allows simplification of the construction of severity processor, exclude processor, and exclude rules processor.
