### PR TITLE
fix: gochecknoinits shadow name

### DIFF
--- a/pkg/golinters/dogsled/dogsled.go
+++ b/pkg/golinters/dogsled/dogsled.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "dogsled"
+const linterName = "dogsled"
 
 func New(settings *config.DogsledSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runDogsled(pass, settings)
@@ -39,7 +39,7 @@ func New(settings *config.DogsledSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -100,7 +100,7 @@ func (v *returnsVisitor) Visit(node ast.Node) ast.Visitor {
 
 		if numBlank > v.maxBlanks {
 			v.issues = append(v.issues, result.Issue{
-				FromLinter: name,
+				FromLinter: linterName,
 				Text:       fmt.Sprintf("declaration has %v blank identifiers", numBlank),
 				Pos:        v.f.Position(assgnStmt.Pos()),
 			})

--- a/pkg/golinters/dupl/dupl.go
+++ b/pkg/golinters/dupl/dupl.go
@@ -16,14 +16,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "dupl"
+const linterName = "dupl"
 
 func New(settings *config.DuplSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runDupl(pass, settings)
@@ -44,7 +44,7 @@ func New(settings *config.DuplSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Tool for code clone detection",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -88,7 +88,7 @@ func runDupl(pass *analysis.Pass, settings *config.DuplSettings) ([]goanalysis.I
 				To:   i.From.LineEnd(),
 			},
 			Text:       text,
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/errcheck/errcheck.go
+++ b/pkg/golinters/errcheck/errcheck.go
@@ -22,20 +22,20 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "errcheck"
+const linterName = "errcheck"
 
 func New(settings *config.ErrcheckSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run:  goanalysis.DummyRun,
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"errcheck is a program for checking for unchecked errors in Go code. "+
 			"These unchecked errors can be critical bugs in some cases",
 		[]*analysis.Analyzer{analyzer},
@@ -100,7 +100,7 @@ func runErrCheck(lintCtx *linter.Context, pass *analysis.Pass, checker *errcheck
 
 		issues[i] = goanalysis.NewIssue(
 			&result.Issue{
-				FromLinter: name,
+				FromLinter: linterName,
 				Text:       text,
 				Pos:        err.Pos,
 			},

--- a/pkg/golinters/forbidigo/forbidigo.go
+++ b/pkg/golinters/forbidigo/forbidigo.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "forbidigo"
+const linterName = "forbidigo"
 
 func New(settings *config.ForbidigoSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runForbidigo(pass, settings)
@@ -44,7 +44,7 @@ func New(settings *config.ForbidigoSettings) *goanalysis.Linter {
 	// But we cannot make this depend on the settings and have to mirror the mode chosen in GetAllSupportedLinterConfigs,
 	// therefore we have to use LoadModeTypesInfo in all cases.
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Forbids identifiers",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -73,7 +73,7 @@ func runForbidigo(pass *analysis.Pass, settings *config.ForbidigoSettings) ([]go
 
 	forbid, err := forbidigo.NewLinter(patterns, options...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create linter %q: %w", name, err)
+		return nil, fmt.Errorf("failed to create linter %q: %w", linterName, err)
 	}
 
 	var issues []goanalysis.Issue
@@ -94,7 +94,7 @@ func runForbidigo(pass *analysis.Pass, settings *config.ForbidigoSettings) ([]go
 			issues = append(issues, goanalysis.NewIssue(&result.Issue{
 				Pos:        hint.Position(),
 				Text:       hint.Details(),
-				FromLinter: name,
+				FromLinter: linterName,
 			}, pass))
 		}
 	}

--- a/pkg/golinters/funlen/funlen.go
+++ b/pkg/golinters/funlen/funlen.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "funlen"
+const linterName = "funlen"
 
 func New(settings *config.FunlenSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runFunlen(pass, settings)
@@ -39,7 +39,7 @@ func New(settings *config.FunlenSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Tool for detection of long functions",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -67,7 +67,7 @@ func runFunlen(pass *analysis.Pass, settings *config.FunlenSettings) []goanalysi
 				Line:     i.Pos.Line,
 			},
 			Text:       strings.TrimRight(i.Message, "\n"),
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass)
 	}
 

--- a/pkg/golinters/gci/gci.go
+++ b/pkg/golinters/gci/gci.go
@@ -23,14 +23,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 )
 
-const name = "gci"
+const linterName = "gci"
 
 func New(settings *config.GciSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run:  goanalysis.DummyRun,
 		Requires: []*analysis.Analyzer{
@@ -63,7 +63,7 @@ func New(settings *config.GciSettings) *goanalysis.Linter {
 	var lock sync.Mutex
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Gci controls Go package import order and makes it always deterministic.",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -111,7 +111,7 @@ func runGci(pass *analysis.Pass, lintCtx *linter.Context, cfg *gcicfg.Config, lo
 			continue
 		}
 
-		is, err := internal.ExtractIssuesFromPatch(diff, lintCtx, name, getIssuedTextGci)
+		is, err := internal.ExtractIssuesFromPatch(diff, lintCtx, linterName, getIssuedTextGci)
 		if err != nil {
 			return nil, fmt.Errorf("can't extract issues from gci diff output %s: %w", diff, err)
 		}

--- a/pkg/golinters/gochecknoinits/gochecknoinits.go
+++ b/pkg/golinters/gochecknoinits/gochecknoinits.go
@@ -61,11 +61,11 @@ func checkFileForInits(f *ast.File, fset *token.FileSet) []result.Issue {
 			continue
 		}
 
-		name := funcDecl.Name.Name
-		if name == "init" && funcDecl.Recv.NumFields() == 0 {
+		fnName := funcDecl.Name.Name
+		if fnName == "init" && funcDecl.Recv.NumFields() == 0 {
 			res = append(res, result.Issue{
 				Pos:        fset.Position(funcDecl.Pos()),
-				Text:       fmt.Sprintf("don't use %s function", internal.FormatCode(name, nil)),
+				Text:       fmt.Sprintf("don't use %s function", internal.FormatCode(fnName, nil)),
 				FromLinter: name,
 			})
 		}

--- a/pkg/golinters/gochecknoinits/gochecknoinits.go
+++ b/pkg/golinters/gochecknoinits/gochecknoinits.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "gochecknoinits"
+const linterName = "gochecknoinits"
 
 func New() *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			var res []goanalysis.Issue
@@ -44,7 +44,7 @@ func New() *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Checks that no init functions are present in Go code",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -66,7 +66,7 @@ func checkFileForInits(f *ast.File, fset *token.FileSet) []result.Issue {
 			res = append(res, result.Issue{
 				Pos:        fset.Position(funcDecl.Pos()),
 				Text:       fmt.Sprintf("don't use %s function", internal.FormatCode(fnName, nil)),
-				FromLinter: name,
+				FromLinter: linterName,
 			})
 		}
 	}

--- a/pkg/golinters/gochecksumtype/gochecksumtype.go
+++ b/pkg/golinters/gochecksumtype/gochecksumtype.go
@@ -13,14 +13,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "gochecksumtype"
+const linterName = "gochecksumtype"
 
 func New() *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoCheckSumType(pass)
@@ -41,7 +41,7 @@ func New() *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		`Run exhaustiveness checks on Go "sum types"`,
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -70,7 +70,7 @@ func runGoCheckSumType(pass *analysis.Pass) ([]goanalysis.Issue, error) {
 		}
 
 		resIssues = append(resIssues, goanalysis.NewIssue(&result.Issue{
-			FromLinter: name,
+			FromLinter: linterName,
 			Text:       strings.TrimPrefix(err.Error(), err.Pos().String()+": "),
 			Pos:        err.Pos(),
 		}, pass))

--- a/pkg/golinters/gocognit/gocognit.go
+++ b/pkg/golinters/gocognit/gocognit.go
@@ -15,7 +15,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "gocognit"
+const linterName = "gocognit"
 
 func New(settings *config.GocognitSettings) *goanalysis.Linter {
 	var mu sync.Mutex
@@ -40,7 +40,7 @@ func New(settings *config.GocognitSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Computes and checks the cognitive complexity of functions",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -72,7 +72,7 @@ func runGocognit(pass *analysis.Pass, settings *config.GocognitSettings) []goana
 			Pos: s.Pos,
 			Text: fmt.Sprintf("cognitive complexity %d of func %s is high (> %d)",
 				s.Complexity, internal.FormatCode(s.FuncName, nil), settings.MinComplexity),
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/goconst/goconst.go
+++ b/pkg/golinters/goconst/goconst.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "goconst"
+const linterName = "goconst"
 
 func New(settings *config.GoConstSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoconst(pass, settings)
@@ -42,7 +42,7 @@ func New(settings *config.GoConstSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Finds repeated strings that could be replaced by a constant",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -90,7 +90,7 @@ func runGoconst(pass *analysis.Pass, settings *config.GoConstSettings) ([]goanal
 		res = append(res, goanalysis.NewIssue(&result.Issue{
 			Pos:        i.Pos,
 			Text:       text,
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "gocritic"
+const linterName = "gocritic"
 
 var (
 	debugf  = logutils.Debug(logutils.DebugKeyGoCritic)
@@ -42,7 +42,7 @@ func New(settings *config.GoCriticSettings) *goanalysis.Linter {
 	}
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := wrapper.run(pass)
@@ -63,7 +63,7 @@ func New(settings *config.GoCriticSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		`Provides diagnostics that check for bugs, performance and style issues.
 Extensible without recompilation through dynamic rules.
 Dynamic rules are written declaratively with AST patterns, filters, report message and optional suggestion.`,
@@ -96,7 +96,7 @@ func (w *goCriticWrapper) init(logger logutils.Log, settings *config.GoCriticSet
 	w.once.Do(func() {
 		err := checkers.InitEmbeddedRules()
 		if err != nil {
-			logger.Fatalf("%s: %v: setting an explicit GOROOT can fix this problem", name, err)
+			logger.Fatalf("%s: %v: setting an explicit GOROOT can fix this problem", linterName, err)
 		}
 	})
 
@@ -105,7 +105,7 @@ func (w *goCriticWrapper) init(logger logutils.Log, settings *config.GoCriticSet
 	// Validate must be after InferEnabledChecks, not before.
 	// Because it uses gathered information about tags set and finally enabled checks.
 	if err := settingsWrapper.Validate(); err != nil {
-		logger.Fatalf("%s: invalid settings: %s", name, err)
+		logger.Fatalf("%s: invalid settings: %s", linterName, err)
 	}
 
 	w.settingsWrapper = settingsWrapper
@@ -237,7 +237,7 @@ func runOnFile(linterCtx *gocriticlinter.Context, f *ast.File, checks []*gocriti
 			issue := result.Issue{
 				Pos:        pos,
 				Text:       fmt.Sprintf("%s: %s", c.Info.Name, warn.Text),
-				FromLinter: name,
+				FromLinter: linterName,
 			}
 
 			if warn.HasQuickFix() {
@@ -358,7 +358,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 
 		for _, check := range s.EnabledChecks {
 			if enabledChecks.has(check) {
-				s.logger.Warnf("%s: no need to enable check %q: it's already enabled", name, check)
+				s.logger.Warnf("%s: no need to enable check %q: it's already enabled", linterName, check)
 				continue
 			}
 			enabledChecks[check] = struct{}{}
@@ -379,7 +379,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 
 		for _, check := range s.DisabledChecks {
 			if !enabledChecks.has(check) {
-				s.logger.Warnf("%s: no need to disable check %q: it's already disabled", name, check)
+				s.logger.Warnf("%s: no need to disable check %q: it's already disabled", linterName, check)
 				continue
 			}
 			delete(enabledChecks, check)
@@ -498,13 +498,13 @@ func (s *settingsWrapper) validateOptionsCombinations() error {
 func (s *settingsWrapper) validateCheckerTags() error {
 	for _, tag := range s.EnabledTags {
 		if !s.allChecksByTag.has(tag) {
-			return fmt.Errorf("enabled tag %q doesn't exist, see %s's documentation", tag, name)
+			return fmt.Errorf("enabled tag %q doesn't exist, see %s's documentation", tag, linterName)
 		}
 	}
 
 	for _, tag := range s.DisabledTags {
 		if !s.allChecksByTag.has(tag) {
-			return fmt.Errorf("disabled tag %q doesn't exist, see %s's documentation", tag, name)
+			return fmt.Errorf("disabled tag %q doesn't exist, see %s's documentation", tag, linterName)
 		}
 	}
 
@@ -514,23 +514,23 @@ func (s *settingsWrapper) validateCheckerTags() error {
 func (s *settingsWrapper) validateCheckerNames() error {
 	for _, check := range s.EnabledChecks {
 		if !s.allChecks.has(check) {
-			return fmt.Errorf("enabled check %q doesn't exist, see %s's documentation", check, name)
+			return fmt.Errorf("enabled check %q doesn't exist, see %s's documentation", check, linterName)
 		}
 	}
 
 	for _, check := range s.DisabledChecks {
 		if !s.allChecks.has(check) {
-			return fmt.Errorf("disabled check %q doesn't exist, see %s documentation", check, name)
+			return fmt.Errorf("disabled check %q doesn't exist, see %s documentation", check, linterName)
 		}
 	}
 
 	for check := range s.SettingsPerCheck {
 		lcName := strings.ToLower(check)
 		if !s.allChecksLowerCased.has(lcName) {
-			return fmt.Errorf("invalid check settings: check %q doesn't exist, see %s documentation", check, name)
+			return fmt.Errorf("invalid check settings: check %q doesn't exist, see %s documentation", check, linterName)
 		}
 		if !s.inferredEnabledChecksLowerCased.has(lcName) {
-			s.logger.Warnf("%s: settings were provided for disabled check %q", check, name)
+			s.logger.Warnf("%s: settings were provided for disabled check %q", check, linterName)
 		}
 	}
 

--- a/pkg/golinters/gocyclo/gocyclo.go
+++ b/pkg/golinters/gocyclo/gocyclo.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "gocyclo"
+const linterName = "gocyclo"
 
 func New(settings *config.GoCycloSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runGoCyclo(pass, settings)
@@ -39,7 +39,7 @@ func New(settings *config.GoCycloSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Computes and checks the cyclomatic complexity of functions",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -68,7 +68,7 @@ func runGoCyclo(pass *analysis.Pass, settings *config.GoCycloSettings) []goanaly
 		issues = append(issues, goanalysis.NewIssue(&result.Issue{
 			Pos:        s.Pos,
 			Text:       text,
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/godot/godot.go
+++ b/pkg/golinters/godot/godot.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "godot"
+const linterName = "godot"
 
 func New(settings *config.GodotSettings) *goanalysis.Linter {
 	var mu sync.Mutex
@@ -39,7 +39,7 @@ func New(settings *config.GodotSettings) *goanalysis.Linter {
 	}
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGodot(pass, dotSettings)
@@ -60,7 +60,7 @@ func New(settings *config.GodotSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Check if comments end in a period",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -88,7 +88,7 @@ func runGodot(pass *analysis.Pass, settings godot.Settings) ([]goanalysis.Issue,
 		issue := result.Issue{
 			Pos:        i.Pos,
 			Text:       i.Message,
-			FromLinter: name,
+			FromLinter: linterName,
 			Replacement: &result.Replacement{
 				NewLines: []string{i.Replacement},
 			},

--- a/pkg/golinters/godox/godox.go
+++ b/pkg/golinters/godox/godox.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "godox"
+const linterName = "godox"
 
 func New(settings *config.GodoxSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runGodox(pass, settings)
@@ -39,7 +39,7 @@ func New(settings *config.GodoxSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Tool for detection of FIXME, TODO and other comment keywords",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -67,7 +67,7 @@ func runGodox(pass *analysis.Pass, settings *config.GodoxSettings) []goanalysis.
 				Line:     i.Pos.Line,
 			},
 			Text:       strings.TrimRight(i.Message, "\n"),
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass)
 	}
 

--- a/pkg/golinters/gofmt/gofmt.go
+++ b/pkg/golinters/gofmt/gofmt.go
@@ -13,20 +13,20 @@ import (
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 )
 
-const name = "gofmt"
+const linterName = "gofmt"
 
 func New(settings *config.GoFmtSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run:  goanalysis.DummyRun,
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Gofmt checks whether code was gofmt-ed. By default "+
 			"this tool runs with -s option to check for code simplification",
 		[]*analysis.Analyzer{analyzer},
@@ -72,7 +72,7 @@ func runGofmt(lintCtx *linter.Context, pass *analysis.Pass, settings *config.GoF
 			continue
 		}
 
-		is, err := internal.ExtractIssuesFromPatch(string(diff), lintCtx, name, getIssuedTextGoFmt)
+		is, err := internal.ExtractIssuesFromPatch(string(diff), lintCtx, linterName, getIssuedTextGoFmt)
 		if err != nil {
 			return nil, fmt.Errorf("can't extract issues from gofmt diff output %q: %w", string(diff), err)
 		}

--- a/pkg/golinters/gofumpt/gofumpt.go
+++ b/pkg/golinters/gofumpt/gofumpt.go
@@ -17,7 +17,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 )
 
-const name = "gofumpt"
+const linterName = "gofumpt"
 
 type differ interface {
 	Diff(out io.Writer, a io.ReadSeeker, b io.ReadSeeker) error
@@ -40,13 +40,13 @@ func New(settings *config.GofumptSettings) *goanalysis.Linter {
 	}
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run:  goanalysis.DummyRun,
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Gofumpt checks whether code was gofumpt-ed.",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -97,7 +97,7 @@ func runGofumpt(lintCtx *linter.Context, pass *analysis.Pass, diff differ, optio
 			}
 
 			diff := out.String()
-			is, err := internal.ExtractIssuesFromPatch(diff, lintCtx, name, getIssuedTextGoFumpt)
+			is, err := internal.ExtractIssuesFromPatch(diff, lintCtx, linterName, getIssuedTextGoFumpt)
 			if err != nil {
 				return nil, fmt.Errorf("can't extract issues from gofumpt diff output %q: %w", diff, err)
 			}

--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "goheader"
+const linterName = "goheader"
 
 func New(settings *config.GoHeaderSettings) *goanalysis.Linter {
 	var mu sync.Mutex
@@ -29,7 +29,7 @@ func New(settings *config.GoHeaderSettings) *goanalysis.Linter {
 	}
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runGoHeader(pass, conf)
@@ -50,7 +50,7 @@ func New(settings *config.GoHeaderSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Checks is file header matches to pattern",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -94,7 +94,7 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) ([]goanalysi
 				Filename: path,
 			},
 			Text:       i.Message(),
-			FromLinter: name,
+			FromLinter: linterName,
 		}
 
 		if fix := i.Fix(); fix != nil {

--- a/pkg/golinters/goimports/goimports.go
+++ b/pkg/golinters/goimports/goimports.go
@@ -14,20 +14,20 @@ import (
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 )
 
-const name = "goimports"
+const linterName = "goimports"
 
 func New(settings *config.GoImportsSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run:  goanalysis.DummyRun,
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Check import statements are formatted according to the 'goimport' command. "+
 			"Reformat imports in autofix mode.",
 		[]*analysis.Analyzer{analyzer},
@@ -70,7 +70,7 @@ func runGoImports(lintCtx *linter.Context, pass *analysis.Pass) ([]goanalysis.Is
 			continue
 		}
 
-		is, err := internal.ExtractIssuesFromPatch(string(diff), lintCtx, name, getIssuedTextGoImports)
+		is, err := internal.ExtractIssuesFromPatch(string(diff), lintCtx, linterName, getIssuedTextGoImports)
 		if err != nil {
 			return nil, fmt.Errorf("can't extract issues from gofmt diff output %q: %w", string(diff), err)
 		}

--- a/pkg/golinters/gomoddirectives/gomoddirectives.go
+++ b/pkg/golinters/gomoddirectives/gomoddirectives.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "gomoddirectives"
+const linterName = "gomoddirectives"
 
 func New(settings *config.GoModDirectivesSettings) *goanalysis.Linter {
 	var issues []goanalysis.Issue
@@ -33,7 +33,7 @@ func New(settings *config.GoModDirectivesSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -43,13 +43,13 @@ func New(settings *config.GoModDirectivesSettings) *goanalysis.Linter {
 				results, err := gomoddirectives.Analyze(opts)
 				if err != nil {
 					lintCtx.Log.Warnf("running %s failed: %s: "+
-						"if you are not using go modules it is suggested to disable this linter", name, err)
+						"if you are not using go modules it is suggested to disable this linter", linterName, err)
 					return
 				}
 
 				for _, p := range results {
 					issues = append(issues, goanalysis.NewIssue(&result.Issue{
-						FromLinter: name,
+						FromLinter: linterName,
 						Pos:        p.Start,
 						Text:       p.Reason,
 					}, pass))

--- a/pkg/golinters/gosec/gosec.go
+++ b/pkg/golinters/gosec/gosec.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "gosec"
+const linterName = "gosec"
 
 func New(settings *config.GoSecSettings) *goanalysis.Linter {
 	var mu sync.Mutex
@@ -39,13 +39,13 @@ func New(settings *config.GoSecSettings) *goanalysis.Linter {
 	ruleDefinitions := rules.Generate(false, filters...)
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run:  goanalysis.DummyRun,
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Inspects source code for security problems",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -126,7 +126,7 @@ func runGoSec(lintCtx *linter.Context, pass *analysis.Pass, settings *config.GoS
 			},
 			Text:       text,
 			LineRange:  r,
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/lll/lll.go
+++ b/pkg/golinters/lll/lll.go
@@ -19,7 +19,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "lll"
+const linterName = "lll"
 
 const goCommentDirectivePrefix = "//go:"
 
@@ -28,7 +28,7 @@ func New(settings *config.LllSettings) *goanalysis.Linter {
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runLll(pass, settings)
@@ -49,7 +49,7 @@ func New(settings *config.LllSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Reports long lines",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -122,7 +122,7 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 					Line:     lineNumber,
 				},
 				Text:       fmt.Sprintf("line is %d characters", lineLen),
-				FromLinter: name,
+				FromLinter: linterName,
 			})
 		}
 	}
@@ -146,7 +146,7 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 					Column:   1,
 				},
 				Text:       fmt.Sprintf("line is more than %d characters", bufio.MaxScanTokenSize),
-				FromLinter: name,
+				FromLinter: linterName,
 			})
 		} else {
 			return nil, fmt.Errorf("can't scan file %s: %w", filename, err)

--- a/pkg/golinters/makezero/makezero.go
+++ b/pkg/golinters/makezero/makezero.go
@@ -13,14 +13,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "makezero"
+const linterName = "makezero"
 
 func New(settings *config.MakezeroSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runMakeZero(pass, settings)
@@ -41,7 +41,7 @@ func New(settings *config.MakezeroSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Finds slice declarations with non-zero initial length",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -65,7 +65,7 @@ func runMakeZero(pass *analysis.Pass, settings *config.MakezeroSettings) ([]goan
 			issues = append(issues, goanalysis.NewIssue(&result.Issue{
 				Pos:        hint.Position(),
 				Text:       hint.Details(),
-				FromLinter: name,
+				FromLinter: linterName,
 			}, pass))
 		}
 	}

--- a/pkg/golinters/misspell/misspell.go
+++ b/pkg/golinters/misspell/misspell.go
@@ -17,20 +17,20 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "misspell"
+const linterName = "misspell"
 
 func New(settings *config.MisspellSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run:  goanalysis.DummyRun,
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Finds commonly misspelled English words",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -153,7 +153,7 @@ func runMisspellOnFile(lintCtx *linter.Context, filename string, replacer *missp
 		res = append(res, result.Issue{
 			Pos:         pos,
 			Text:        text,
-			FromLinter:  name,
+			FromLinter:  linterName,
 			Replacement: replacement,
 		})
 	}

--- a/pkg/golinters/nestif/nestif.go
+++ b/pkg/golinters/nestif/nestif.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "nestif"
+const linterName = "nestif"
 
 func New(settings *config.NestifSettings) *goanalysis.Linter {
 	var mu sync.Mutex
@@ -38,7 +38,7 @@ func New(settings *config.NestifSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Reports deeply nested if statements",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -70,7 +70,7 @@ func runNestIf(pass *analysis.Pass, settings *config.NestifSettings) []goanalysi
 		issues = append(issues, goanalysis.NewIssue(&result.Issue{
 			Pos:        i.Pos,
 			Text:       i.Message,
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const Name = "nolintlint"
+const LinterName = "nolintlint"
 
 func New(settings *config.NoLintLintSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: Name,
+		Name: LinterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues, err := runNoLintLint(pass, settings)
@@ -42,7 +42,7 @@ func New(settings *config.NoLintLintSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		Name,
+		LinterName,
 		"Reports ill-formed or insufficient nolint directives",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -89,7 +89,7 @@ func runNoLintLint(pass *analysis.Pass, settings *config.NoLintLintSettings) ([]
 		}
 
 		issue := &result.Issue{
-			FromLinter:           Name,
+			FromLinter:           LinterName,
 			Text:                 i.Details(),
 			Pos:                  i.Position(),
 			ExpectNoLint:         expectNoLint,

--- a/pkg/golinters/prealloc/prealloc.go
+++ b/pkg/golinters/prealloc/prealloc.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "prealloc"
+const linterName = "prealloc"
 
 func New(settings *config.PreallocSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runPreAlloc(pass, settings)
@@ -39,7 +39,7 @@ func New(settings *config.PreallocSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Finds slice declarations that could potentially be pre-allocated",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -57,7 +57,7 @@ func runPreAlloc(pass *analysis.Pass, settings *config.PreallocSettings) []goana
 		issues = append(issues, goanalysis.NewIssue(&result.Issue{
 			Pos:        pass.Fset.Position(hint.Pos),
 			Text:       fmt.Sprintf("Consider pre-allocating %s", internal.FormatCode(hint.DeclaredSliceName, nil)),
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/promlinter/promlinter.go
+++ b/pkg/golinters/promlinter/promlinter.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "promlinter"
+const linterName = "promlinter"
 
 func New(settings *config.PromlinterSettings) *goanalysis.Linter {
 	var mu sync.Mutex
@@ -28,7 +28,7 @@ func New(settings *config.PromlinterSettings) *goanalysis.Linter {
 	}
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runPromLinter(pass, promSettings)
@@ -46,7 +46,7 @@ func New(settings *config.PromlinterSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Check Prometheus metrics naming via promlint",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -67,7 +67,7 @@ func runPromLinter(pass *analysis.Pass, promSettings promlinter.Setting) []goana
 		issue := result.Issue{
 			Pos:        i.Pos,
 			Text:       fmt.Sprintf("Metric: %s Error: %s", i.Metric, i.Text),
-			FromLinter: name,
+			FromLinter: linterName,
 		}
 
 		issues[k] = goanalysis.NewIssue(&issue, pass)

--- a/pkg/golinters/revive/revive.go
+++ b/pkg/golinters/revive/revive.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "revive"
+const linterName = "revive"
 
 var debugf = logutils.Debug(logutils.DebugKeyRevive)
 
@@ -44,7 +44,7 @@ func New(settings *config.ReviveSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -151,7 +151,7 @@ func reviveToIssue(pass *analysis.Pass, object *jsonObject) goanalysis.Issue {
 			From: object.Position.Start.Line,
 			To:   lineRangeTo,
 		},
-		FromLinter: name,
+		FromLinter: linterName,
 	}, pass)
 }
 

--- a/pkg/golinters/unconvert/unconvert.go
+++ b/pkg/golinters/unconvert/unconvert.go
@@ -12,14 +12,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "unconvert"
+const linterName = "unconvert"
 
 func New(settings *config.UnconvertSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name: name,
+		Name: linterName,
 		Doc:  goanalysis.TheOnlyanalyzerDoc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			issues := runUnconvert(pass, settings)
@@ -37,7 +37,7 @@ func New(settings *config.UnconvertSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Remove unnecessary type conversions",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -54,7 +54,7 @@ func runUnconvert(pass *analysis.Pass, settings *config.UnconvertSettings) []goa
 		issues = append(issues, goanalysis.NewIssue(&result.Issue{
 			Pos:        position,
 			Text:       "unnecessary conversion",
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/unparam/unparam.go
+++ b/pkg/golinters/unparam/unparam.go
@@ -14,14 +14,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "unparam"
+const linterName = "unparam"
 
 func New(settings *config.UnparamSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name:     name,
+		Name:     linterName,
 		Doc:      goanalysis.TheOnlyanalyzerDoc,
 		Requires: []*analysis.Analyzer{buildssa.Analyzer},
 		Run: func(pass *analysis.Pass) (any, error) {
@@ -43,7 +43,7 @@ func New(settings *config.UnparamSettings) *goanalysis.Linter {
 	}
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Reports unused function parameters",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -82,7 +82,7 @@ func runUnparam(pass *analysis.Pass, settings *config.UnparamSettings) ([]goanal
 		issues = append(issues, goanalysis.NewIssue(&result.Issue{
 			Pos:        pass.Fset.Position(i.Pos()),
 			Text:       i.Message(),
-			FromLinter: name,
+			FromLinter: linterName,
 		}, pass))
 	}
 

--- a/pkg/golinters/unused/unused.go
+++ b/pkg/golinters/unused/unused.go
@@ -17,14 +17,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "unused"
+const linterName = "unused"
 
 func New(settings *config.UnusedSettings, scSettings *config.StaticCheckSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
 	analyzer := &analysis.Analyzer{
-		Name:     name,
+		Name:     linterName,
 		Doc:      unused.Analyzer.Analyzer.Doc,
 		Requires: unused.Analyzer.Analyzer.Requires,
 		Run: func(pass *analysis.Pass) (any, error) {
@@ -44,7 +44,7 @@ func New(settings *config.UnusedSettings, scSettings *config.StaticCheckSettings
 	internal.SetAnalyzerGoVersion(analyzer, internal.GetGoVersion(scSettings))
 
 	return goanalysis.NewLinter(
-		name,
+		linterName,
 		"Checks Go code for unused constants, variables, functions and types",
 		[]*analysis.Analyzer{analyzer},
 		nil,
@@ -75,7 +75,7 @@ func runUnused(pass *analysis.Pass, cfg *config.UnusedSettings) []goanalysis.Iss
 		}
 
 		issue := goanalysis.NewIssue(&result.Issue{
-			FromLinter: name,
+			FromLinter: linterName,
 			Text:       fmt.Sprintf("%s %s is unused", object.Kind, object.Name),
 			Pos:        object.Position,
 		}, pass)

--- a/pkg/golinters/whitespace/whitespace.go
+++ b/pkg/golinters/whitespace/whitespace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const name = "whitespace"
+const linterName = "whitespace"
 
 func New(settings *config.WhitespaceSettings) *goanalysis.Linter {
 	var mu sync.Mutex
@@ -63,7 +63,7 @@ func runWhitespace(pass *analysis.Pass, wsSettings whitespace.Settings) ([]goana
 	issues := make([]goanalysis.Issue, len(lintIssues))
 	for i, issue := range lintIssues {
 		report := &result.Issue{
-			FromLinter: name,
+			FromLinter: linterName,
 			Pos:        pass.Fset.PositionFor(issue.Diagnostic, false),
 			Text:       issue.Message,
 		}

--- a/pkg/result/processors/nolint.go
+++ b/pkg/result/processors/nolint.go
@@ -35,7 +35,7 @@ func (i *ignoredRange) doesMatch(issue *result.Issue) bool {
 	}
 
 	// only allow selective nolinting of nolintlint
-	nolintFoundForLinter := len(i.linters) == 0 && issue.FromLinter != nolintlint.Name
+	nolintFoundForLinter := len(i.linters) == 0 && issue.FromLinter != nolintlint.LinterName
 
 	for _, linterName := range i.linters {
 		if linterName == issue.FromLinter {
@@ -50,7 +50,7 @@ func (i *ignoredRange) doesMatch(issue *result.Issue) bool {
 
 	// handle possible unused nolint directives
 	// nolintlint generates potential issues for every nolint directive, and they are filtered out here
-	if issue.FromLinter == nolintlint.Name && issue.ExpectNoLint {
+	if issue.FromLinter == nolintlint.LinterName && issue.ExpectNoLint {
 		if issue.ExpectedNoLintLinter != "" {
 			return i.matchedIssueFromLinter[issue.ExpectedNoLintLinter]
 		}
@@ -111,7 +111,7 @@ func (p *Nolint) shouldPassIssue(issue *result.Issue) (bool, error) {
 	nolintDebugf("got issue: %v", *issue)
 
 	// don't expect disabled linters to cover their nolint statements
-	if issue.FromLinter == nolintlint.Name && issue.ExpectNoLint && issue.ExpectedNoLintLinter != "" {
+	if issue.FromLinter == nolintlint.LinterName && issue.ExpectNoLint && issue.ExpectedNoLintLinter != "" {
 		nolintDebugf("enabled linters: %v", p.enabledLinters)
 
 		if p.enabledLinters[issue.ExpectedNoLintLinter] == nil {
@@ -307,7 +307,7 @@ func (issues sortWithNolintlintLast) Len() int {
 }
 
 func (issues sortWithNolintlintLast) Less(i, j int) bool {
-	return issues[i].FromLinter != nolintlint.Name && issues[j].FromLinter == nolintlint.Name
+	return issues[i].FromLinter != nolintlint.LinterName && issues[j].FromLinter == nolintlint.LinterName
 }
 
 func (issues sortWithNolintlintLast) Swap(i, j int) {

--- a/pkg/result/processors/nolint_test.go
+++ b/pkg/result/processors/nolint_test.go
@@ -301,7 +301,7 @@ func TestNolintUnused(t *testing.T) {
 			Filename: fileName,
 			Line:     3,
 		},
-		FromLinter:           nolintlint.Name,
+		FromLinter:           nolintlint.LinterName,
 		ExpectNoLint:         true,
 		ExpectedNoLintLinter: "varcheck",
 	}
@@ -312,7 +312,7 @@ func TestNolintUnused(t *testing.T) {
 			Filename: fileName,
 			Line:     5,
 		},
-		FromLinter:           nolintlint.Name,
+		FromLinter:           nolintlint.LinterName,
 		ExpectNoLint:         true,
 		ExpectedNoLintLinter: "varcheck",
 	}


### PR DESCRIPTION
A variable `name` was shadowed by a constant `name`.

I renamed the constants `name` to `linterName` to avoid confusion.

Fixes #4697