### PR TITLE
dev: deprecate errcheck.ignore option

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -167,6 +167,9 @@ issues:
     - path: pkg/golinters/errcheck/errcheck.go
       linters: [staticcheck]
       text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
+    - path: pkg/golinters/errcheck/errcheck.go
+      linters: [staticcheck]
+      text: "SA1019: errCfg.Ignore is deprecated: use ExcludeFunctions instead"
     - path: pkg/golinters/govet/govet.go
       linters: [staticcheck]
       text: "SA1019: cfg.CheckShadowing is deprecated: the linter should be enabled inside Enable."

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -371,11 +371,13 @@ type ErrcheckSettings struct {
 	DisableDefaultExclusions bool     `mapstructure:"disable-default-exclusions"`
 	CheckTypeAssertions      bool     `mapstructure:"check-type-assertions"`
 	CheckAssignToBlank       bool     `mapstructure:"check-blank"`
-	Ignore                   string   `mapstructure:"ignore"`
 	ExcludeFunctions         []string `mapstructure:"exclude-functions"`
 
 	// Deprecated: use ExcludeFunctions instead
 	Exclude string `mapstructure:"exclude"`
+
+	// Deprecated: use ExcludeFunctions instead
+	Ignore string `mapstructure:"ignore"`
 }
 
 type ErrChkJSONSettings struct {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -355,6 +355,7 @@ func (l *Loader) handleDeprecation() error {
 	return nil
 }
 
+//nolint:gocyclo // the complexity cannot be reduced.
 func (l *Loader) handleLinterOptionDeprecations() {
 	// Deprecated since v1.57.0,
 	// but it was unofficially deprecated since v1.19 (2019) (https://github.com/golangci/golangci-lint/pull/697).
@@ -371,6 +372,12 @@ func (l *Loader) handleLinterOptionDeprecations() {
 	// Deprecated since v1.42.0.
 	if l.cfg.LintersSettings.Errcheck.Exclude != "" {
 		l.log.Warnf("The configuration option `linters.errcheck.exclude` is deprecated, please use `linters.errcheck.exclude-functions`.")
+	}
+
+	// Deprecated since v1.59.0,
+	// but it was unofficially deprecated since v1.13 (2018) (https://github.com/golangci/golangci-lint/pull/332).
+	if l.cfg.LintersSettings.Errcheck.Ignore != "" {
+		l.log.Warnf("The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.")
 	}
 
 	// Deprecated since v1.44.0.


### PR DESCRIPTION
The PR marks `errcheck.ignore` lint option as deprecated. See #332 and https://github.com/kisielk/errcheck#the-deprecated-method.

Related to #4673