### PR TITLE
dev: set CGO_ENABLED=1 when running "test" task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ clean:
 
 # Test
 test: export GOLANGCI_LINT_INSTALLED = true
+test: CGO_ENABLED=1
 test: build
 	GL_TEST_RUN=1 ./$(BINARY) run -v
 	GL_TEST_RUN=1 go test -v -parallel 2 ./...


### PR DESCRIPTION
In environment where CGO_ENABLED=0, some tests that require CGO will fail, in example

```
<REDACTED>
=== RUN   TestCgoOk
level=info msg="[test] ran [/tmp/TestCgoOk3811517097/001/golangci-lint
run --internal-cmd-test --allow-parallel-runners --no-config
--timeout=3m --enable-all -D nosnakecase --go=1.22 testdata/cgo] in
1.032596905s"
    run_test.go:111:
                Error Trace: /home/ms/go/src/git.sr.ht/~shulhan/golangci-lint/test/testshared/runner.go:282
                                                        /home/ms/go/src/git.sr.ht/~shulhan/golangci-lint/test/run_test.go:111
                Error:          Not equal:
                                expected: ""
                                actual  : "level=error msg=\"[linters_context] typechecking error: build constraints exclude all Go files in /home/ms/go/src/git.sr.ht/~shulhan/golangci-lint/test/testdata/cgo\"\n"
<REDACTED>
```