### PR TITLE
build(deps): bump github.com/Antonboom/testifylint from 1.2.0 to 1.3.0

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2159,9 +2159,10 @@ linters-settings:
       - error-is-as
       - error-nil
       - expected-actual
-      - go-require
       - float-compare
+      - go-require
       - len
+      - negative-positive
       - nil-compare
       - require-error
       - suite-dont-use-pkg
@@ -2175,7 +2176,7 @@ linters-settings:
     # Enable checkers by name
     # (in addition to default
     #   blank-import, bool-compare, compares, empty, error-is-as, error-nil, expected-actual, go-require, float-compare,
-    #   len, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, useless-assert
+    #   len, negative-positive, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, useless-assert
     # ).
     enable:
       - blank-import
@@ -2185,9 +2186,10 @@ linters-settings:
       - error-is-as
       - error-nil
       - expected-actual
-      - go-require
       - float-compare
+      - go-require
       - len
+      - negative-positive
       - nil-compare
       - require-error
       - suite-dont-use-pkg
@@ -2203,6 +2205,10 @@ linters-settings:
       # Regexp for expected variable name.
       # Default: (^(exp(ected)?|want(ed)?)([A-Z]\w*)?$)|(^(\w*[a-z])?(Exp(ected)?|Want(ed)?)$)
       pattern: ^expected
+    go-require:
+      # To ignore HTTP handlers (like http.HandlerFunc).
+      # Default: false
+      ignore-http-handlers: true
     require-error:
       # Regexp for assertions to analyze. If defined, then only matched error assertions will be reported.
       # Default: ""

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Abirdcfly/dupword v0.0.14
 	github.com/Antonboom/errname v0.1.13
 	github.com/Antonboom/nilnil v0.1.9
-	github.com/Antonboom/testifylint v1.2.0
+	github.com/Antonboom/testifylint v1.3.0
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Crocmagnon/fatcontext v0.2.2
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/Antonboom/errname v0.1.13 h1:JHICqsewj/fNckzrfVSe+T33svwQxmjC+1ntDsHO
 github.com/Antonboom/errname v0.1.13/go.mod h1:uWyefRYRN54lBg6HseYCFhs6Qjcy41Y3Jl/dVhA87Ns=
 github.com/Antonboom/nilnil v0.1.9 h1:eKFMejSxPSA9eLSensFmjW2XTgTwJMjZ8hUHtV4s/SQ=
 github.com/Antonboom/nilnil v0.1.9/go.mod h1:iGe2rYwCq5/Me1khrysB4nwI7swQvjclR8/YRPl5ihQ=
-github.com/Antonboom/testifylint v1.2.0 h1:015bxD8zc5iY8QwTp4+RG9I4kIbqwvGX9TrBbb7jGdM=
-github.com/Antonboom/testifylint v1.2.0/go.mod h1:rkmEqjqVnHDRNsinyN6fPSLnoajzFwsCcguJgwADBkw=
+github.com/Antonboom/testifylint v1.3.0 h1:UiqrddKs1W3YK8R0TUuWwrVKlVAnS07DTUVWWs9c+y4=
+github.com/Antonboom/testifylint v1.3.0/go.mod h1:NV0hTlteCkViPW9mSR4wEMfwp+Hs1T3dY60bkvSfhpM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -2772,16 +2772,6 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "bool-compare": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "ignore-custom-types": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
-            },
             "enable-all": {
               "description": "Enable all checkers.",
               "type": "boolean",
@@ -2804,9 +2794,10 @@
                   "error-is-as",
                   "error-nil",
                   "expected-actual",
-                  "go-require",
                   "float-compare",
+                  "go-require",
                   "len",
+                  "negative-positive",
                   "nil-compare",
                   "require-error",
                   "suite-dont-use-pkg",
@@ -2814,10 +2805,28 @@
                   "suite-thelper",
                   "useless-assert"
                 ]
-              }
+              },
+              "default": [
+                "blank-import",
+                "bool-compare",
+                "compares",
+                "empty",
+                "error-is-as",
+                "error-nil",
+                "expected-actual",
+                "float-compare",
+                "go-require",
+                "len",
+                "negative-positive",
+                "nil-compare",
+                "require-error",
+                "suite-dont-use-pkg",
+                "suite-extra-assert-call",
+                "useless-assert"
+              ]
             },
             "disable": {
-              "description": "Enable specific checkers.",
+              "description": "Disable specific checkers.",
               "type": "array",
               "items": {
                 "enum": [
@@ -2828,16 +2837,31 @@
                   "error-is-as",
                   "error-nil",
                   "expected-actual",
-                  "go-require",
                   "float-compare",
+                  "go-require",
                   "len",
+                  "negative-positive",
                   "nil-compare",
                   "require-error",
                   "suite-dont-use-pkg",
                   "suite-extra-assert-call",
                   "suite-thelper",
                   "useless-assert"
+                ],
+                "default": [
+                  "suite-thelper"
                 ]
+              }
+            },
+            "bool-compare": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignore-custom-types": {
+                  "description": "To ignore user defined types (over builtin bool).",
+                  "type": "boolean",
+                  "default": false
+                }
               }
             },
             "expected-actual": {
@@ -2846,7 +2870,19 @@
               "properties": {
                 "pattern": {
                   "description": "Regexp for expected variable name.",
-                  "type": "string"
+                  "type": "string",
+                  "default": "(^(exp(ected)?|want(ed)?)([A-Z]\\w*)?$)|(^(\\w*[a-z])?(Exp(ected)?|Want(ed)?)$)"
+                }
+              }
+            },
+            "go-require": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "ignore-http-handlers": {
+                  "description": "To ignore HTTP handlers (like http.HandlerFunc).",
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },
@@ -2855,8 +2891,9 @@
               "additionalProperties": false,
               "properties": {
                 "fn-pattern": {
-                  "description": "Regexp for expected variable name.",
-                  "type": "string"
+                  "description": "Regexp for assertions to analyze. If defined, then only matched error assertions will be reported.",
+                  "type": "string",
+                  "default": ""
                 }
               }
             },
@@ -2867,7 +2904,8 @@
                 "mode": {
                   "description": "To require or remove extra Assert() call?",
                   "type": "string",
-                  "enum": ["remove", "require"]
+                  "enum": ["remove", "require"],
+                  "default": "remove"
                 }
               }
             }

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -879,6 +879,10 @@ type TestifylintSettings struct {
 		ExpVarPattern string `mapstructure:"pattern"`
 	} `mapstructure:"expected-actual"`
 
+	GoRequire struct {
+		IgnoreHTTPHandlers bool `mapstructure:"ignore-http-handlers"`
+	} `mapstructure:"go-require"`
+
 	RequireError struct {
 		FnPattern string `mapstructure:"fn-pattern"`
 	} `mapstructure:"require-error"`

--- a/pkg/goanalysis/linter.go
+++ b/pkg/goanalysis/linter.go
@@ -116,7 +116,7 @@ func (*Linter) configureAnalyzer(a *analysis.Analyzer, cfg map[string]any) error
 		}
 
 		if err := f.Value.Set(valueToString(v)); err != nil {
-			return fmt.Errorf("failed to set analyzer setting %q with value %v: %w", k, v, err)
+			return fmt.Errorf("failed to set analyzer setting %q with value %q: %w", k, v, err)
 		}
 	}
 

--- a/pkg/golinters/testifylint/testifylint.go
+++ b/pkg/golinters/testifylint/testifylint.go
@@ -18,6 +18,7 @@ func New(settings *config.TestifylintSettings) *goanalysis.Linter {
 			"disable-all": settings.DisableAll,
 
 			"bool-compare.ignore-custom-types": settings.BoolCompare.IgnoreCustomTypes,
+			"go-require.ignore-http-handlers":  settings.GoRequire.IgnoreHTTPHandlers,
 		}
 		if len(settings.EnabledCheckers) > 0 {
 			cfg[a.Name]["enable"] = settings.EnabledCheckers


### PR DESCRIPTION
- Less false positives
- New checker `negative-positive`
- New option `go-require.ignore-http-handlers`

https://github.com/Antonboom/testifylint/releases/tag/v1.3.0
