### PR TITLE
fix: remove errcheck defaults

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -25,9 +25,6 @@ var defaultLintersSettings = LintersSettings{
 	Dupl: DuplSettings{
 		Threshold: 150,
 	},
-	Errcheck: ErrcheckSettings{
-		Ignore: "fmt:.*",
-	},
 	ErrorLint: ErrorLintSettings{
 		Errorf:      true,
 		ErrorfMulti: true,


### PR DESCRIPTION
The default value for `ignore` can be removed because [`errcheck.DefaultExcludedSymbols`](https://github.com/kisielk/errcheck/blob/b65821b80eeffbab5e01f8bf1f2cf801e9a284cb/errcheck/excludes.go#L20-L32) already handles those cases.

Fixes #4733

Regression related to #4709
