### PR TITLE
chore: add html to the JSONSchema 

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -66,6 +66,7 @@ output:
   # - `json`
   # - `colored-tab`
   # - `tab`
+  # - `html`
   # - `checkstyle`
   # - `code-climate`
   # - `junit-xml`

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -66,6 +66,7 @@ output:
   # - `json`
   # - `colored-tab`
   # - `tab`
+  # - `html`
   # - `checkstyle`
   # - `code-climate`
   # - `junit-xml`

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -432,7 +432,8 @@
                   "code-climate",
                   "junit-xml",
                   "github-actions",
-                  "teamcity"
+                  "teamcity",
+                  "html"
                 ]
               }
             },

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -428,12 +428,12 @@
                   "json",
                   "colored-tab",
                   "tab",
+                  "html",
                   "checkstyle",
                   "code-climate",
                   "junit-xml",
                   "github-actions",
-                  "teamcity",
-                  "html"
+                  "teamcity"
                 ]
               }
             },

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -428,6 +428,7 @@
                   "json",
                   "colored-tab",
                   "tab",
+                  "html",
                   "checkstyle",
                   "code-climate",
                   "junit-xml",


### PR DESCRIPTION
Include `html` as a valid value for the output format into schema for the configuration file.