### PR TITLE
feat: add warning about disabled and deprecated linters (level 2)

### DIFF
--- a/docs/src/docs/product/roadmap.mdx
+++ b/docs/src/docs/product/roadmap.mdx
@@ -47,8 +47,11 @@ A linter can be deprecated for various reasons, e.g. the linter stops working wi
 
 The deprecation of a linter will follow 3 phases:
 
-1. **Display of a warning message**: The linter can still be used (unless it's completely non-functional), but it's recommended to remove it from your configuration.
-2. **Display of an error message**: At this point, you should remove the linter. The original implementation is replaced by a placeholder that does nothing.
+1. **Display of a warning message**: The linter can still be used (unless it's completely non-functional),
+  but it's recommended to remove it from your configuration.
+2. **Display of an error message**: At this point, you should remove the linter.
+  The original implementation is replaced by a placeholder that does nothing.
+  The linter is NOT enabled when using `enable-all` and should be removed from the `disable` option.
 3. **Removal of the linter** from golangci-lint.
 
 Each phase corresponds to a minor version:

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -100,8 +100,6 @@ func TestCgoOk(t *testing.T) {
 		WithNoConfig().
 		WithArgs("--timeout=3m",
 			"--enable-all",
-			"-D",
-			"nosnakecase",
 		).
 		WithArgs("--go=1.22"). // TODO(ldez) remove this line when we will run go1.23 on the CI. (related to intrange, copyloopvar)
 		WithTargetPath(testdataDir, "cgo").


### PR DESCRIPTION
Follows https://github.com/golangci/golangci-lint/pull/4681

The log should be closed to the `Manager` because we need the list of linter's names defined inside the `disable` configuration and the `LinterConfigs` to check the state of the linter.

The warning will only appear on the `DeprecationError` level of deprecation.