### PR TITLE
dev: fix double call to startTracing

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -171,7 +171,7 @@ func (c *runCommand) persistentPreRunE(cmd *cobra.Command, args []string) error 
 		runtime.GOMAXPROCS(c.cfg.Run.Concurrency)
 	}
 
-	return c.startTracing()
+	return nil
 }
 
 func (c *runCommand) persistentPostRunE(_ *cobra.Command, _ []string) error {


### PR DESCRIPTION
```console
$ golangci-lint run --cpu-profile-path gcil.pprof
Error: can't start CPU profiling: cpu profiling already in use
Failed executing command with error: can't start CPU profiling: cpu profiling already in use
```