### PR TITLE
fix: init empty result slice for SARIF printer

### DIFF
--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -70,6 +70,7 @@ func NewSarif(w io.Writer) *Sarif {
 func (p Sarif) Print(issues []result.Issue) error {
 	run := sarifRun{}
 	run.Tool.Driver.Name = "golangci-lint"
+	run.Results = make([]sarifResult, 0)
 
 	for i := range issues {
 		issue := issues[i]

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -65,3 +65,17 @@ func TestSarif_Print(t *testing.T) {
 
 	assert.Equal(t, expected, buf.String())
 }
+
+func TestSarif_EmptyPrint(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	printer := NewSarif(buf)
+
+	err := printer.Print(make([]result.Issue, 0))
+	require.NoError(t, err)
+
+	expected := `{"version":"2.1.0","$schema":"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json","runs":[{"tool":{"driver":{"name":"golangci-lint"}},"results":[]}]}
+`
+
+	assert.Equal(t, expected, buf.String())
+}

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -66,12 +66,12 @@ func TestSarif_Print(t *testing.T) {
 	assert.Equal(t, expected, buf.String())
 }
 
-func TestSarif_EmptyPrint(t *testing.T) {
+func TestSarif_Print_empty(t *testing.T) {
 	buf := new(bytes.Buffer)
 
 	printer := NewSarif(buf)
 
-	err := printer.Print(make([]result.Issue, 0))
+	err := printer.Print(nil)
 	require.NoError(t, err)
 
 	expected := `{"version":"2.1.0","$schema":"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json","runs":[{"tool":{"driver":{"name":"golangci-lint"}},"results":[]}]}


### PR DESCRIPTION
if no issue is found, the sarif printer will produce a `nil` as a result, and `encoding/json` makes it a `null`, which is required to be an array in sarif format.

see https://github.com/Zxilly/go-size-analyzer/actions/runs/9254489826/job/25456396105 for real-world errors.
