### PR TITLE
dev: add targets to benchmark a linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,20 @@ fast_check_generated:
 	git checkout -- go.mod go.sum # can differ between go1.16 and go1.17
 	git diff --exit-code # check no changes
 
+# Benchmark
+
+# Benchmark with a local version
+# LINTER=gosec VERSION=v1.59.0 make bench_local
+bench_local:
+	./scripts/bench/bench_local.sh $(LINTER) $(VERSION)
+.PHONY: bench_local
+
+# Benchmark between 2 existing versions
+# LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0 make bench_version
+bench_version:
+	./scripts/bench/bench_version.sh $(LINTER) $(VERSION_OLD) $(VERSION_NEW)
+.PHONY: bench_version
+
 # Non-PHONY targets (real files)
 
 $(BINARY): FORCE

--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,19 @@ fast_check_generated:
 
 # Benchmark with a local version
 # LINTER=gosec VERSION=v1.59.0 make bench_local
-bench_local:
+bench_local: hyperfine
 	@./scripts/bench/bench_local.sh $(LINTER) $(VERSION)
 .PHONY: bench_local
 
 # Benchmark between 2 existing versions
 # LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0 make bench_version
-bench_version:
+bench_version: hyperfine
 	@./scripts/bench/bench_version.sh $(LINTER) $(VERSION_OLD) $(VERSION_NEW)
 .PHONY: bench_version
+
+hyperfine:
+	@which hyperfines > /dev/null || (echo "Please install hyperfine https://github.com/sharkdp/hyperfine#installation" && exit 1)
+.PHONY: hyperfine
 
 # Non-PHONY targets (real files)
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ bench_version: hyperfine
 .PHONY: bench_version
 
 hyperfine:
-	@which hyperfines > /dev/null || (echo "Please install hyperfine https://github.com/sharkdp/hyperfine#installation" && exit 1)
+	@which hyperfine > /dev/null || (echo "Please install hyperfine https://github.com/sharkdp/hyperfine#installation" && exit 1)
 .PHONY: hyperfine
 
 # Non-PHONY targets (real files)

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,13 @@ fast_check_generated:
 # Benchmark with a local version
 # LINTER=gosec VERSION=v1.59.0 make bench_local
 bench_local:
-	./scripts/bench/bench_local.sh $(LINTER) $(VERSION)
+	@./scripts/bench/bench_local.sh $(LINTER) $(VERSION)
 .PHONY: bench_local
 
 # Benchmark between 2 existing versions
 # LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0 make bench_version
 bench_version:
-	./scripts/bench/bench_version.sh $(LINTER) $(VERSION_OLD) $(VERSION_NEW)
+	@./scripts/bench/bench_version.sh $(LINTER) $(VERSION_OLD) $(VERSION_NEW)
 .PHONY: bench_version
 
 # Non-PHONY targets (real files)

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,14 @@ fast_check_generated:
 # Benchmark with a local version
 # LINTER=gosec VERSION=v1.59.0 make bench_local
 bench_local: hyperfine
+	@:$(call check_defined, LINTER VERSION, 'missing parameter(s)')
 	@./scripts/bench/bench_local.sh $(LINTER) $(VERSION)
 .PHONY: bench_local
 
 # Benchmark between 2 existing versions
-# LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0 make bench_version
+# make bench_version LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0
 bench_version: hyperfine
+	@:$(call check_defined, LINTER VERSION_OLD VERSION_NEW, 'missing parameter(s)')
 	@./scripts/bench/bench_version.sh $(LINTER) $(VERSION_OLD) $(VERSION_NEW)
 .PHONY: bench_version
 
@@ -120,3 +122,19 @@ website_dump_info:
 update_contributors_list:
 	cd .github/contributors && npm run all
 
+# Functions
+
+# Check that given variables are set and all have non-empty values,
+# die with an error otherwise.
+#
+# Params:
+#   1. Variable name(s) to test.
+#   2. (optional) Error message to print.
+#
+# https://stackoverflow.com/a/10858332/8228109
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Undefined $1$(if $2, ($2))))

--- a/scripts/bench/bench_local.sh
+++ b/scripts/bench/bench_local.sh
@@ -33,8 +33,8 @@ make build
 ## Run
 
 hyperfine \
---prepare 'golangci-lint cache clean' "./golangci-lint run --print-issued-lines=false --enable-only ${LINTER}" \
---prepare './golangci-lint cache clean' "./golangci-lint-${VERSION} run --print-issued-lines=false --enable-only ${LINTER}"
+--prepare './golangci-lint cache clean' "./golangci-lint run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}" \
+--prepare "./golangci-lint-${VERSION} cache clean" "./golangci-lint-${VERSION} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}"
 
 ## Clean
 

--- a/scripts/bench/bench_local.sh
+++ b/scripts/bench/bench_local.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+# Benchmark with a local version
+# Usage: ./scripts/bench/bench_local.sh gosec v1.59.0
+
+# ex: gosec
+LINTER_NAME=$1
+
+# ex: v1.59.0
+GCIL_VERSION=$2
+
+## Download version
+
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${GCIL_VERSION}/ ${GCIL_VERSION}
+
+mv temp-${GCIL_VERSION}/golangci-lint ./golangci-lint-${GCIL_VERSION}
+rm -rf temp-${GCIL_VERSION}
+
+## Build local version
+
+make build
+
+## Run
+
+hyperfine \
+--prepare 'golangci-lint cache clean' "./golangci-lint run --print-issued-lines=false --enable-only ${LINTER_NAME}" \
+--prepare './golangci-lint cache clean' "./golangci-lint-${GCIL_VERSION} run --print-issued-lines=false --enable-only ${LINTER_NAME}"
+
+## Clean
+
+rm ./golangci-lint-${GCIL_VERSION}

--- a/scripts/bench/bench_local.sh
+++ b/scripts/bench/bench_local.sh
@@ -13,7 +13,7 @@ VERSION=$2
 
 function cleanBinaries() {
   echo "Clean binaries"
-  rm ./golangci-lint-${VERSION}
+  rm "./golangci-lint-${VERSION}"
   rm ./golangci-lint
 }
 
@@ -21,10 +21,10 @@ trap cleanBinaries EXIT
 
 ## Download version
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${VERSION}/ ${VERSION}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "./temp-${VERSION}" "${VERSION}"
 
-mv temp-${VERSION}/golangci-lint ./golangci-lint-${VERSION}
-rm -rf temp-${VERSION}
+mv "temp-${VERSION}/golangci-lint" "./golangci-lint-${VERSION}"
+rm -rf "temp-${VERSION}"
 
 ## Build local version
 
@@ -38,4 +38,4 @@ hyperfine \
 
 ## Clean
 
-rm ./golangci-lint-${VERSION}
+rm "./golangci-lint-${VERSION}"

--- a/scripts/bench/bench_local.sh
+++ b/scripts/bench/bench_local.sh
@@ -4,17 +4,27 @@
 # Usage: ./scripts/bench/bench_local.sh gosec v1.59.0
 
 # ex: gosec
-LINTER_NAME=$1
+LINTER=$1
 
 # ex: v1.59.0
-GCIL_VERSION=$2
+VERSION=$2
+
+## Clean
+
+function cleanBinaries() {
+  echo "Clean binaries"
+  rm ./golangci-lint-${VERSION}
+  rm ./golangci-lint
+}
+
+trap cleanBinaries EXIT
 
 ## Download version
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${GCIL_VERSION}/ ${GCIL_VERSION}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${VERSION}/ ${VERSION}
 
-mv temp-${GCIL_VERSION}/golangci-lint ./golangci-lint-${GCIL_VERSION}
-rm -rf temp-${GCIL_VERSION}
+mv temp-${VERSION}/golangci-lint ./golangci-lint-${VERSION}
+rm -rf temp-${VERSION}
 
 ## Build local version
 
@@ -23,9 +33,9 @@ make build
 ## Run
 
 hyperfine \
---prepare 'golangci-lint cache clean' "./golangci-lint run --print-issued-lines=false --enable-only ${LINTER_NAME}" \
---prepare './golangci-lint cache clean' "./golangci-lint-${GCIL_VERSION} run --print-issued-lines=false --enable-only ${LINTER_NAME}"
+--prepare 'golangci-lint cache clean' "./golangci-lint run --print-issued-lines=false --enable-only ${LINTER}" \
+--prepare './golangci-lint cache clean' "./golangci-lint-${VERSION} run --print-issued-lines=false --enable-only ${LINTER}"
 
 ## Clean
 
-rm ./golangci-lint-${GCIL_VERSION}
+rm ./golangci-lint-${VERSION}

--- a/scripts/bench/bench_local.sh
+++ b/scripts/bench/bench_local.sh
@@ -9,6 +9,20 @@ LINTER=$1
 # ex: v1.59.0
 VERSION=$2
 
+
+if [ -z "$LINTER" ] || [ -z "$VERSION" ]; then
+  cat <<-EOF
+Missing required arguments!
+
+Usage:   $0 <linter> <old version> <new version>
+Example: $0 gosec v1.58.1 v1.58.2
+EOF
+
+  exit 1
+fi
+
+EOF
+
 ## Clean
 
 function cleanBinaries() {

--- a/scripts/bench/bench_local.sh
+++ b/scripts/bench/bench_local.sh
@@ -36,6 +36,3 @@ hyperfine \
 --prepare './golangci-lint cache clean' "./golangci-lint run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}" \
 --prepare "./golangci-lint-${VERSION} cache clean" "./golangci-lint-${VERSION} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}"
 
-## Clean
-
-rm "./golangci-lint-${VERSION}"

--- a/scripts/bench/bench_version.sh
+++ b/scripts/bench/bench_version.sh
@@ -43,5 +43,5 @@ install "${VERSION_NEW}"
 ## Run
 
 hyperfine \
---prepare 'golangci-lint cache clean' "./golangci-lint-${VERSION_OLD} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}" \
---prepare './golangci-lint cache clean' "./golangci-lint-${VERSION_NEW} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}"
+--prepare "./golangci-lint-${VERSION_OLD} cache clean" "./golangci-lint-${VERSION_OLD} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}" \
+--prepare "./golangci-lint-${VERSION_NEW} cache clean" "./golangci-lint-${VERSION_NEW} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}"

--- a/scripts/bench/bench_version.sh
+++ b/scripts/bench/bench_version.sh
@@ -15,25 +15,30 @@ VERSION_NEW="$3"
 
 function cleanBinaries() {
   echo "Clean binaries"
-  rm ./golangci-lint-${VERSION_OLD}
-  rm ./golangci-lint-${VERSION_NEW}
+  rm "./golangci-lint-${VERSION_OLD}"
+  rm "./golangci-lint-${VERSION_NEW}"
 }
 
 trap cleanBinaries EXIT
 
+## Install
+
+function install() {
+  local VERSION=$1
+
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "./temp-${VERSION}" "${VERSION}"
+
+  mv "temp-${VERSION}/golangci-lint" "./golangci-lint-${VERSION}"
+  rm -rf "temp-${VERSION}"
+}
+
 ## VERSION_OLD
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${VERSION_OLD} ${VERSION_OLD}
-
-mv temp-${VERSION_OLD}/golangci-lint ./golangci-lint-${VERSION_OLD}
-rm -rf temp-${VERSION_OLD}
+install "${VERSION_OLD}"
 
 ## VERSION_NEW
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${VERSION_NEW} ${VERSION_NEW}
-
-mv temp-${VERSION_NEW}/golangci-lint ./golangci-lint-${VERSION_NEW}
-rm -rf temp-${VERSION_NEW}
+install "${VERSION_NEW}"
 
 ## Run
 

--- a/scripts/bench/bench_version.sh
+++ b/scripts/bench/bench_version.sh
@@ -4,34 +4,39 @@
 # Usage: ./scripts/bench/bench_version.sh gosec v1.58.1 v1.58.2
 
 # ex: gosec
-LINTER_NAME=$1
+LINTER="$1"
 
 # ex: v1.58.1
-GCIL_VERSION_ONE=$2
+VERSION_OLD="$2"
 # ex: v1.58.2
-GCIL_VERSION_TWO=$3
+VERSION_NEW="$3"
 
-## GCIL_VERSION_ONE
+## Clean
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${GCIL_VERSION_ONE} ${GCIL_VERSION_ONE}
+function cleanBinaries() {
+  echo "Clean binaries"
+  rm ./golangci-lint-${VERSION_OLD}
+  rm ./golangci-lint-${VERSION_NEW}
+}
 
-mv temp-${GCIL_VERSION_ONE}/golangci-lint ./golangci-lint-${GCIL_VERSION_ONE}
-rm -rf temp-${GCIL_VERSION_ONE}
+trap cleanBinaries EXIT
 
-## GCIL_VERSION_TWO
+## VERSION_OLD
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${GCIL_VERSION_TWO} ${GCIL_VERSION_TWO}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${VERSION_OLD} ${VERSION_OLD}
 
-mv temp-${GCIL_VERSION_TWO}/golangci-lint ./golangci-lint-${GCIL_VERSION_TWO}
-rm -rf temp-${GCIL_VERSION_TWO}
+mv temp-${VERSION_OLD}/golangci-lint ./golangci-lint-${VERSION_OLD}
+rm -rf temp-${VERSION_OLD}
+
+## VERSION_NEW
+
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${VERSION_NEW} ${VERSION_NEW}
+
+mv temp-${VERSION_NEW}/golangci-lint ./golangci-lint-${VERSION_NEW}
+rm -rf temp-${VERSION_NEW}
 
 ## Run
 
 hyperfine \
---prepare 'golangci-lint cache clean' "./golangci-lint-${GCIL_VERSION_ONE} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER_NAME}" \
---prepare './golangci-lint cache clean' "./golangci-lint-${GCIL_VERSION_TWO} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER_NAME}"
-
-## Clean
-
-rm ./golangci-lint-${GCIL_VERSION_ONE}
-rm ./golangci-lint-${GCIL_VERSION_TWO}
+--prepare 'golangci-lint cache clean' "./golangci-lint-${VERSION_OLD} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}" \
+--prepare './golangci-lint cache clean' "./golangci-lint-${VERSION_NEW} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER}"

--- a/scripts/bench/bench_version.sh
+++ b/scripts/bench/bench_version.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+# Benchmark between 2 existing versions
+# Usage: ./scripts/bench/bench_version.sh gosec v1.58.1 v1.58.2
+
+# ex: gosec
+LINTER_NAME=$1
+
+# ex: v1.58.1
+GCIL_VERSION_ONE=$2
+# ex: v1.58.2
+GCIL_VERSION_TWO=$3
+
+## GCIL_VERSION_ONE
+
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${GCIL_VERSION_ONE} ${GCIL_VERSION_ONE}
+
+mv temp-${GCIL_VERSION_ONE}/golangci-lint ./golangci-lint-${GCIL_VERSION_ONE}
+rm -rf temp-${GCIL_VERSION_ONE}
+
+## GCIL_VERSION_TWO
+
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./temp-${GCIL_VERSION_TWO} ${GCIL_VERSION_TWO}
+
+mv temp-${GCIL_VERSION_TWO}/golangci-lint ./golangci-lint-${GCIL_VERSION_TWO}
+rm -rf temp-${GCIL_VERSION_TWO}
+
+## Run
+
+hyperfine \
+--prepare 'golangci-lint cache clean' "./golangci-lint-${GCIL_VERSION_ONE} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER_NAME}" \
+--prepare './golangci-lint cache clean' "./golangci-lint-${GCIL_VERSION_TWO} run --issues-exit-code 0 --print-issued-lines=false --enable-only ${LINTER_NAME}"
+
+## Clean
+
+rm ./golangci-lint-${GCIL_VERSION_ONE}
+rm ./golangci-lint-${GCIL_VERSION_TWO}

--- a/scripts/bench/bench_version.sh
+++ b/scripts/bench/bench_version.sh
@@ -11,6 +11,19 @@ VERSION_OLD="$2"
 # ex: v1.58.2
 VERSION_NEW="$3"
 
+if [ -z "$LINTER" ] || [ -z "$VERSION_OLD" ] || [ -z "$VERSION_NEW" ]; then
+  cat <<-EOF
+Missing required arguments!
+
+Usage:   $0 <linter> <old version> <new version>
+Example: $0 gosec v1.58.1 v1.58.2
+EOF
+
+  exit 1
+fi
+
+EOF
+
 ## Clean
 
 function cleanBinaries() {

--- a/scripts/bench/readme.md
+++ b/scripts/bench/readme.md
@@ -1,0 +1,15 @@
+# Benchmarks
+
+The script use [Hyperfine](https://github.com/sharkdp/hyperfine) to benchmark the command line of golangci-lint.
+
+## Benchmark one linter: with a local version
+
+```bash
+LINTER=gosec VERSION=v1.59.0 make bench_local
+```
+
+## Benchmark one linter: between 2 existing versions
+
+```bash
+LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0 make bench_version
+```

--- a/scripts/bench/readme.md
+++ b/scripts/bench/readme.md
@@ -5,11 +5,11 @@ The script use [Hyperfine](https://github.com/sharkdp/hyperfine) to benchmark th
 ## Benchmark one linter: with a local version
 
 ```bash
-LINTER=gosec VERSION=v1.59.0 make bench_local
+make bench_local LINTER=gosec VERSION=v1.59.0
 ```
 
 ## Benchmark one linter: between 2 existing versions
 
 ```bash
-LINTER=gosec VERSION_OLD=v1.58.1 VERSION_NEW=v1.59.0 make bench_version
+make bench_version LINTER=gosec VERSION_OLD=v1.58.1 VERSION_NEW=v1.59.0 
 ```

--- a/scripts/bench/readme.md
+++ b/scripts/bench/readme.md
@@ -11,5 +11,5 @@ LINTER=gosec VERSION=v1.59.0 make bench_local
 ## Benchmark one linter: between 2 existing versions
 
 ```bash
-LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0 make bench_version
+LINTER=gosec VERSION_OLD=v1.58.1 VERSION_NEW=v1.59.0 make bench_version
 ```


### PR DESCRIPTION
Adds 2 targets to benchmark a linter.

```bash
LINTER=gosec VERSION=v1.59.0 make bench_local
```

```bash
LINTER=gosec VERSION_OLD=v1.58.2 VERSION_NEW=v1.59.0 make bench_version
```

It uses [Hyperfine](https://github.com/sharkdp/hyperfine).

It's not really possible to automate that because it will take too much time to run, but at least we will be able to benchmark manually a PR.

<details>
<summary>Demo</summary>

```console
$ LINTER=misspell VERSION_OLD=v1.57.2 VERSION_NEW=v1.59.0 make bench_version
golangci/golangci-lint info checking GitHub for tag 'v1.57.2'
golangci/golangci-lint info found version: 1.57.2 for v1.57.2/linux/amd64
golangci/golangci-lint info installed ./temp-v1.57.2/golangci-lint
golangci/golangci-lint info checking GitHub for tag 'v1.59.0'
golangci/golangci-lint info found version: 1.59.0 for v1.59.0/linux/amd64
golangci/golangci-lint info installed ./temp-v1.59.0/golangci-lint
Benchmark 1: ./golangci-lint-v1.57.2 run --issues-exit-code 0 --print-issued-lines=false --enable-only misspell
  Time (mean ± σ):     630.3 ms ±  26.9 ms    [User: 2246.2 ms, System: 1483.3 ms]
  Range (min … max):   591.8 ms … 668.5 ms    10 runs
 
Benchmark 2: ./golangci-lint-v1.59.0 run --issues-exit-code 0 --print-issued-lines=false --enable-only misspell
  Time (mean ± σ):     379.5 ms ±  24.7 ms    [User: 1055.4 ms, System: 479.7 ms]
  Range (min … max):   349.4 ms … 430.7 ms    10 runs
 
Summary
  ./golangci-lint-v1.59.0 run --issues-exit-code 0 --print-issued-lines=false --enable-only misspell ran
    1.66 ± 0.13 times faster than ./golangci-lint-v1.57.2 run --issues-exit-code 0 --print-issued-lines=false --enable-only misspell
Clean binaries
```

</details>

Related to #1152