### PR TITLE
chore: fix typo with errchkjson in linters info

### DIFF
--- a/assets/linters-info.json
+++ b/assets/linters-info.json
@@ -200,7 +200,7 @@
   },
   {
     "name": "errchkjson",
-    "desc": "Checks types passed to the json encoding functions. Reports unsupported types and reports occations, where the check for the returned error can be omitted.",
+    "desc": "Checks types passed to the json encoding functions. Reports unsupported types and reports occurrences where the check for the returned error can be omitted.",
     "loadMode": 575,
     "inPresets": [
       "bugs"


### PR DESCRIPTION
This typo was fixed ages ago on errchkjson repository

https://github.com/breml/errchkjson/commit/04c87589f1499fb1cf3380124f87deabeab77d76
