### PR TITLE
dev: display version in verbose mode

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -152,6 +152,8 @@ func (c *runCommand) persistentPreRunE(cmd *cobra.Command, args []string) error 
 		return err
 	}
 
+	c.log.Infof(c.buildInfo.String())
+
 	loader := config.NewLoader(c.log.Child(logutils.DebugKeyConfigReader), c.viper, cmd.Flags(), c.opts.LoaderOptions, c.cfg, args)
 
 	err := loader.Load(config.LoadOptions{CheckDeprecation: true, Validation: true})

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -19,6 +19,11 @@ type BuildInfo struct {
 	Date      string `json:"date"`
 }
 
+func (b BuildInfo) String() string {
+	return fmt.Sprintf("golangci-lint has version %s built with %s from %s on %s",
+		b.Version, b.GoVersion, b.Commit, b.Date)
+}
+
 type versionInfo struct {
 	Info      BuildInfo
 	BuildInfo *debug.BuildInfo
@@ -92,7 +97,6 @@ func (c *versionCommand) execute(_ *cobra.Command, _ []string) error {
 }
 
 func printVersion(w io.Writer, info BuildInfo) error {
-	_, err := fmt.Fprintf(w, "golangci-lint has version %s built with %s from %s on %s\n",
-		info.Version, info.GoVersion, info.Commit, info.Date)
+	_, err := fmt.Fprintln(w, info.String())
 	return err
 }


### PR DESCRIPTION
Displays the golangci-lint version in verbose mode.

This allows us to check the effective version inside issues.