### PR TITLE
fix: SARIF format require issue column >= 1

### DIFF
--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -89,8 +89,10 @@ func (p Sarif) Print(issues []result.Issue) error {
 					PhysicalLocation: sarifPhysicalLocation{
 						ArtifactLocation: sarifArtifactLocation{URI: issue.FilePath()},
 						Region: sarifRegion{
-							StartLine:   issue.Line(),
-							StartColumn: max(1, issue.Column()), // sarif column is required to be >= 1
+							StartLine: issue.Line(),
+							// If startColumn is absent, it SHALL default to 1.
+							// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790941
+							StartColumn: max(1, issue.Column()),
 						},
 					},
 				},

--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -90,7 +90,7 @@ func (p Sarif) Print(issues []result.Issue) error {
 						ArtifactLocation: sarifArtifactLocation{URI: issue.FilePath()},
 						Region: sarifRegion{
 							StartLine:   issue.Line(),
-							StartColumn: issue.Column(),
+							StartColumn: max(1, issue.Column()), // sarif column is required to be >= 1
 						},
 					},
 				},

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -51,6 +51,16 @@ func TestSarif_Print(t *testing.T) {
 				Column:   5,
 			},
 		},
+		{
+			FromLinter: "linter-c",
+			Severity:   "error",
+			Text:       "some issue without column",
+			Pos: token.Position{
+				Filename: "path/to/filed.go",
+				Offset:   3,
+				Line:     11,
+			},
+		},
 	}
 
 	buf := new(bytes.Buffer)
@@ -60,7 +70,7 @@ func TestSarif_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	expected := `{"version":"2.1.0","$schema":"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json","runs":[{"tool":{"driver":{"name":"golangci-lint"}},"results":[{"ruleId":"linter-a","level":"warning","message":{"text":"some issue"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"path/to/filea.go","index":0},"region":{"startLine":10,"startColumn":4}}}]},{"ruleId":"linter-b","level":"error","message":{"text":"another issue"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"path/to/fileb.go","index":0},"region":{"startLine":300,"startColumn":9}}}]},{"ruleId":"linter-a","level":"error","message":{"text":"some issue 2"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"path/to/filec.go","index":0},"region":{"startLine":11,"startColumn":5}}}]}]}]}
+	expected := `{"version":"2.1.0","$schema":"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.6.json","runs":[{"tool":{"driver":{"name":"golangci-lint"}},"results":[{"ruleId":"linter-a","level":"warning","message":{"text":"some issue"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"path/to/filea.go","index":0},"region":{"startLine":10,"startColumn":4}}}]},{"ruleId":"linter-b","level":"error","message":{"text":"another issue"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"path/to/fileb.go","index":0},"region":{"startLine":300,"startColumn":9}}}]},{"ruleId":"linter-a","level":"error","message":{"text":"some issue 2"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"path/to/filec.go","index":0},"region":{"startLine":11,"startColumn":5}}}]},{"ruleId":"linter-c","level":"error","message":{"text":"some issue without column"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"path/to/filed.go","index":0},"region":{"startLine":11,"startColumn":1}}}]}]}]}
 `
 
 	assert.Equal(t, expected, buf.String())


### PR DESCRIPTION
Some linters won't provider column value for issue, under this situation we should set it to 1.

![image](https://github.com/golangci/golangci-lint/assets/31370133/4c85ff25-e80a-4479-88cd-0bc8eeab3aab)

For real world error see https://github.com/Zxilly/go-size-analyzer/actions/runs/9300840788/job/25597744381