### PR TITLE
lll: Advertise max line length instead of just reporting failure

### DIFF
--- a/pkg/golinters/lll/lll.go
+++ b/pkg/golinters/lll/lll.go
@@ -121,7 +121,7 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 					Filename: filename,
 					Line:     lineNumber,
 				},
-				Text:       fmt.Sprintf("line is %d characters, max %d", lineLen, maxLineLen),
+				Text:       fmt.Sprintf("The line is %d characters long, which exceeds the maximum of %d characters.", lineLen, maxLineLen),
 				FromLinter: linterName,
 			})
 		}

--- a/pkg/golinters/lll/lll.go
+++ b/pkg/golinters/lll/lll.go
@@ -121,7 +121,7 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 					Filename: filename,
 					Line:     lineNumber,
 				},
-				Text:       fmt.Sprintf("line is %d characters", lineLen),
+				Text:       fmt.Sprintf("line is %d characters, max %d", lineLen, maxLineLen),
 				FromLinter: linterName,
 			})
 		}

--- a/pkg/golinters/lll/lll.go
+++ b/pkg/golinters/lll/lll.go
@@ -121,7 +121,7 @@ func getLLLIssuesForFile(filename string, maxLineLen int, tabSpaces string) ([]r
 					Filename: filename,
 					Line:     lineNumber,
 				},
-				Text:       fmt.Sprintf("The line is %d characters long, which exceeds the maximum of %d characters.", lineLen, maxLineLen),
+				Text:       fmt.Sprintf("the line is %d characters long, which exceeds the maximum of %d characters.", lineLen, maxLineLen),
 				FromLinter: linterName,
 			})
 		}

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -218,7 +218,7 @@ func TestLineDirective(t *testing.T) {
 			},
 			configPath: "testdata/linedirective/lll.yml",
 			targetPath: "linedirective",
-			expected:   "line is 57 characters, max 50 (lll)",
+			expected:   "The line is 57 characters long, which exceeds the maximum of 50 characters. (lll)",
 		},
 		{
 			desc: "misspell",

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -218,7 +218,7 @@ func TestLineDirective(t *testing.T) {
 			},
 			configPath: "testdata/linedirective/lll.yml",
 			targetPath: "linedirective",
-			expected:   "The line is 57 characters long, which exceeds the maximum of 50 characters. (lll)",
+			expected:   "the line is 57 characters long, which exceeds the maximum of 50 characters. (lll)",
 		},
 		{
 			desc: "misspell",

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -218,7 +218,7 @@ func TestLineDirective(t *testing.T) {
 			},
 			configPath: "testdata/linedirective/lll.yml",
 			targetPath: "linedirective",
-			expected:   "line is 57 characters (lll)",
+			expected:   "line is 57 characters, max 50 (lll)",
 		},
 		{
 			desc: "misspell",


### PR DESCRIPTION
Pardon if this has been discussed before, I couldn't find it in the issue/PR list.

As a user, I find it disorienting when tools inform me that I have made a mistake but do not offer any insights into how to resolve the issue.

In this case in particular, we have all the information, but then require the user to know the defaults and to traverse the config overrides.

It'd be nice to just provide this information. Impact to existing users should be minimal, including data transfer or storage of logs in CI, since teams who are already in compliance would not get the new log component, and teams who are not in compliance yet would get the message once and then be done.

Happy to circle back if there's prior art for how this information should be displayed.

Thanks!