### PR TITLE
docs: move whole-files near of new-from-xxx

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2958,13 +2958,14 @@ issues:
   # Default: ""
   new-from-patch: path/to/patch/file
 
+  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
+  # Default: false
+  whole-files: true
+
   # Fix found issues (if it's supported by the linter).
   # Default: false
   fix: true
 
-  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
-  # Default: false
-  whole-files: true
 
 severity:
   # Set the default severity for issues.

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2944,13 +2944,14 @@ issues:
   # Default: ""
   new-from-patch: path/to/patch/file
 
+  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
+  # Default: false
+  whole-files: true
+
   # Fix found issues (if it's supported by the linter).
   # Default: false
   fix: true
 
-  # Show issues in any part of update files (requires new-from-rev or new-from-patch).
-  # Default: false
-  whole-files: true
 
 severity:
   # Set the default severity for issues.


### PR DESCRIPTION
`whole-files` is related to new-from-rev and new-from-patch, it's better to have it near of those options.