### PR TITLE
fix: sanitize level property for SARIF

### DIFF
--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -76,8 +76,15 @@ func (p Sarif) Print(issues []result.Issue) error {
 		issue := issues[i]
 
 		severity := issue.Severity
-		if severity == "" {
-			severity = "error"
+
+		// can be only none, note, warning, error
+		// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790898
+		if severity == "" ||
+			severity != "none" &&
+				severity != "note" &&
+				severity != "warning" &&
+				severity != "error" {
+			severity = "note"
 		}
 
 		sr := sarifResult{

--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -79,12 +79,11 @@ func (p Sarif) Print(issues []result.Issue) error {
 
 		// can be only none, note, warning, error
 		// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790898
-		if severity == "" ||
-			severity != "none" &&
-				severity != "note" &&
-				severity != "warning" &&
-				severity != "error" {
-			severity = "note"
+		switch severity {
+		case "none", "note", "warning", "error":
+			// valid
+		default:
+			severity = "error"
 		}
 
 		sr := sarifResult{

--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -77,11 +77,10 @@ func (p Sarif) Print(issues []result.Issue) error {
 
 		severity := issue.Severity
 
-		// can be only none, note, warning, error
-		// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790898
 		switch severity {
+		// https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790898
 		case "none", "note", "warning", "error":
-			// valid
+			// Valid levels.
 		default:
 			severity = "error"
 		}

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -42,7 +42,7 @@ func TestSarif_Print(t *testing.T) {
 		},
 		{
 			FromLinter: "linter-a",
-			Severity:   "error",
+			Severity:   "low",
 			Text:       "some issue 2",
 			Pos: token.Position{
 				Filename: "path/to/filec.go",


### PR DESCRIPTION
https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790898

level can only be `none, note, warning, error`, some linter like `gosec` may report something like `high`

For real-world error, see https://github.com/Zxilly/go-size-analyzer/actions/runs/9586342361/job/26434117667