### PR TITLE
misspell: support multiple correction words

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1321,7 +1321,8 @@ linters-settings:
     ignore-words:
       - someword
     # Extra word corrections.
-    # `typo` and `correction` should only contain letters.
+    # `typo` should only contain letters.
+    # `correction` can contains one or more words separated by commas without spaces.
     # The words are case-insensitive.
     # Default: []
     extra-words:
@@ -1329,6 +1330,8 @@ linters-settings:
         correction: "if"
       - typo: "cancelation"
         correction: "cancellation"
+      - typo: "successed"
+        correction: "successful,success,succeeded"
     # Mode of the analysis:
     # - default: checks all the file content.
     # - restricted: checks only comments.

--- a/pkg/golinters/misspell/misspell_test.go
+++ b/pkg/golinters/misspell/misspell_test.go
@@ -20,6 +20,10 @@ func Test_appendExtraWords(t *testing.T) {
 			Typo:       "canCELation",
 			Correction: "canceLLaTION",
 		},
+		{
+			Typo:       "successed",
+			Correction: "successful,success,succeeded",
+		},
 	}
 
 	replacer := &misspell.Replacer{}
@@ -27,7 +31,7 @@ func Test_appendExtraWords(t *testing.T) {
 	err := appendExtraWords(replacer, extraWords)
 	require.NoError(t, err)
 
-	expected := []string{"iff", "if", "cancelation", "cancellation"}
+	expected := []string{"iff", "if", "cancelation", "cancellation", "successed", "successful,success,succeeded"}
 
 	assert.Equal(t, expected, replacer.Replacements)
 }

--- a/pkg/golinters/misspell/testdata/fix/in/misspell.go
+++ b/pkg/golinters/misspell/testdata/fix/in/misspell.go
@@ -1,4 +1,5 @@
 //golangcitest:args -Emisspell
+//golangcitest:config_path testdata/misspell_fix.yml
 //golangcitest:expected_exitcode 0
 package p
 
@@ -8,6 +9,7 @@ import "log"
 // lala langauge
 // langauge
 // langauge langauge
+// successed
 
 // check Langauge
 // and check langAuge

--- a/pkg/golinters/misspell/testdata/fix/out/misspell.go
+++ b/pkg/golinters/misspell/testdata/fix/out/misspell.go
@@ -1,4 +1,5 @@
 //golangcitest:args -Emisspell
+//golangcitest:config_path testdata/misspell_fix.yml
 //golangcitest:expected_exitcode 0
 package p
 
@@ -8,6 +9,7 @@ import "log"
 // lala language
 // language
 // language language
+// successful
 
 // check Language
 // and check langAuge

--- a/pkg/golinters/misspell/testdata/misspell_custom.go
+++ b/pkg/golinters/misspell/testdata/misspell_custom.go
@@ -8,3 +8,4 @@ func Misspell() {
 
 // the word iff should be reported here // want "\\`iff\\` is a misspelling of \\`if\\`"
 // the word cancelation should be reported here // want "\\`cancelation\\` is a misspelling of \\`cancellation\\`"
+// the word successed should be reported here // want "\\`successed\\` is a misspelling of \\`successful,success,succeeded\\`"

--- a/pkg/golinters/misspell/testdata/misspell_fix.yml
+++ b/pkg/golinters/misspell/testdata/misspell_fix.yml
@@ -1,9 +1,5 @@
 linters-settings:
   misspell:
     extra-words:
-      - typo: "iff"
-        correction: "if"
-      - typo: "cancelation"
-        correction: "cancellation"
       - typo: "successed"
         correction: "successful,success,succeeded"


### PR DESCRIPTION
Allows to have multiple corrections.

`extra-words.correction` can accept either a single word or a list of words separated by commas:

```yml
linters-settings:
  misspell:
    extra-words:
      - typo: "iff"
        correction: "if"
      - typo: "successed"
        correction: "successful,success,succeeded"
```

When a `misspell`ing is detected, the following lint message is displayed:
```
`successed` is a misspelling of `successful,success,succeeded`
```

However, during the `fix` process, only the first word in the list of corrections is used: "successed" is replaced with "successful".

The feature was requested in [Slack discussion](https://gophers.slack.com/archives/CS0TBRKPC/p1718957723050869).