### PR TITLE
go1.23 support

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.22'
+      GO_VERSION: '1.23.0-rc.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,36 +11,18 @@ jobs:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     env:
+      # https://github.com/actions/setup-go#supported-version-syntax
+      # ex:
+      # - 1.18beta1 -> 1.18.0-beta.1
+      # - 1.18rc1 -> 1.18.0-rc.1
       GO_VERSION: '1.23.0-rc.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
-
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: docs-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            docs-${{ runner.os }}-go-
-
-      - run: go mod download
-
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
@@ -48,12 +30,14 @@ jobs:
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
+      - run: go mod download
+
       - run:  npm install --legacy-peer-deps
         working-directory: ./docs
 
       - name: Build Documentation
-        run: npm run build
         working-directory: ./docs
+        run: npm run build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23.0-rc.1'
+      GO_VERSION: '1.23.0-rc.2'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23.0-rc.2'
+      GO_VERSION: '1.23'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+      # https://github.com/actions/setup-go#supported-version-syntax
+      # ex:
+      # - 1.18beta1 -> 1.18.0-beta.1
+      # - 1.18rc1 -> 1.18.0-rc.1
+      GO_VERSION: '1.23.0-rc.1'
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.23.0-rc.1'
+          go-version: ${{ env.GO_VERSION }}
       - uses: actions/setup-node@v4
         with:
           node-version: "15"
@@ -49,14 +49,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.23.0-rc.1'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Update GitHub Action config
         run: make assets/github-action-config.json
@@ -77,14 +72,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.23.0-rc.1'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Update reference files
         run: cp .golangci.next.reference.yml .golangci.reference.yml
@@ -110,6 +100,5 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-
     steps:
       - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "./install-golangci-lint"

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,7 +15,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23.0-rc.1'
+      GO_VERSION: '1.23.0-rc.2'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -20,7 +20,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.22'
+          go-version: '1.23.0-rc.1'
       - uses: actions/setup-node@v4
         with:
           node-version: "15"
@@ -56,7 +56,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.22'
+          go-version: '1.23.0-rc.1'
 
       - name: Update GitHub Action config
         run: make assets/github-action-config.json
@@ -84,7 +84,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.22'
+          go-version: '1.23.0-rc.1'
 
       - name: Update reference files
         run: cp .golangci.next.reference.yml .golangci.reference.yml

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,7 +15,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23.0-rc.2'
+      GO_VERSION: '1.23'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -13,7 +13,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23.0-rc.1'
+      GO_VERSION: '1.23.0-rc.2'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -9,42 +9,27 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     env:
+      # https://github.com/actions/setup-go#supported-version-syntax
+      # ex:
+      # - 1.18beta1 -> 1.18.0-beta.1
+      # - 1.18rc1 -> 1.18.0-rc.1
       GO_VERSION: '1.23.0-rc.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: docs-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            docs-${{ runner.os }}-go-
-
-      - run: go mod download
-
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: docs/package-lock.json
+
+      - run: go mod download
 
       - run:  npm install --legacy-peer-deps
         working-directory: ./docs

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: '1.22'
+      GO_VERSION: '1.23.0-rc.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -13,7 +13,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23.0-rc.2'
+      GO_VERSION: '1.23'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.23.0-rc.1'
+          go-version: '1.23.0-rc.2'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.22'
+          go-version: '1.23.0-rc.1'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr-extra.yml
+++ b/.github/workflows/pr-extra.yml
@@ -17,7 +17,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: '1.23.0-rc.2'
+          go-version: '1.23'
       - name: Run go list
         run: go list -json -m all > go.list
       - name: Nancy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
 
 env:
+  # https://github.com/actions/setup-go#supported-version-syntax
+  # ex:
+  # - 1.18beta1 -> 1.18.0-beta.1
+  # - 1.18rc1 -> 1.18.0-rc.1
   GO_VERSION: '1.23.0-rc.1'
 
 jobs:
@@ -13,16 +17,10 @@ jobs:
   go-mod:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }}
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Check go mod
         run: |
           go mod tidy
@@ -35,8 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           # https://github.com/actions/setup-go#supported-version-syntax
           # ex:
@@ -53,13 +50,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
       - name: Run tests
         run: make.exe test
@@ -69,13 +61,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
       - name: Run tests
         run: make test
@@ -90,39 +77,23 @@ jobs:
           - '1.23.0-rc.1'
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ matrix.golang }}
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ matrix.golang }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.golang }}-
       - name: Run tests
         run: make test
 
+  # Checks: GitHub action assets
   check_generated:
-    needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-      - name: Install Go
-        uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Check generated files are up to date
+      - name: Check generated files are up-to-date
         run: make fast_check_generated
         env:
           # needed for github-action-config.json generation
@@ -145,13 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          # https://github.com/actions/setup-go#supported-version-syntax
-          # ex:
-          # - 1.18beta1 -> 1.18.0-beta.1
-          # - 1.18rc1 -> 1.18.0-rc.1
           go-version: ${{ env.GO_VERSION }}
       - name: Build golangci-lint
         run: make build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.23.0-rc.1'
+  GO_VERSION: '1.23.0-rc.2'
 
 jobs:
   # Check if there is any dirty change for go mod tidy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.23.0-rc.2'
+  GO_VERSION: '1.23'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -39,6 +39,8 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
+          # TODO(ldez) must be changed after the first release of golangci-lint with go1.23
+          # go-version: ${{ env.GO_VERSION }}
           go-version: '1.22'
       - name: lint
         uses: golangci/golangci-lint-action@v6.1.0
@@ -74,7 +76,7 @@ jobs:
       matrix:
         golang:
           - '1.22'
-          - '1.23.0-rc.1'
+          - '1.23'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.22'
+  GO_VERSION: '1.23.0-rc.1'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -42,7 +42,7 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: ${{ env.GO_VERSION }}
+          go-version: '1.22'
       - name: lint
         uses: golangci/golangci-lint-action@v6.1.0
         with:
@@ -86,8 +86,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.21'
           - '1.22'
+          - '1.23.0-rc.1'
     steps:
       - uses: actions/checkout@v4
       - name: Install Go

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,12 +16,11 @@ jobs:
       CHOCOLATEY_VERSION: 2.2.0
     steps:
       - uses: actions/checkout@v4
-      - name: Install Go
-        uses: actions/setup-go@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Unshallow
-        run: git fetch --prune --unshallow
 
       - name: Install chocolatey
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.22'
+      GO_VERSION: '1.23.0-rc.1'
       CHOCOLATEY_VERSION: 2.2.0
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23.0-rc.1'
+      GO_VERSION: '1.23'
       CHOCOLATEY_VERSION: 2.2.0
     steps:
       - uses: actions/checkout@v4

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
----
+version: 2
+
 project_name: golangci-lint
 
 builds:

--- a/build/buildx-alpine.Dockerfile
+++ b/build/buildx-alpine.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.22-alpine
+FROM golang:1.23-alpine
 
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go

--- a/build/buildx.Dockerfile
+++ b/build/buildx.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM golang:1.22
+FROM golang:1.23
 
 # related to https://github.com/golangci/golangci-lint/issues/3107
 ENV GOROOT /usr/local/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.21.0
+go 1.22.0
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Antonboom/errname v0.1.13
 	github.com/Antonboom/nilnil v0.1.9
 	github.com/Antonboom/testifylint v1.4.3
-	github.com/BurntSushi/toml v1.4.0
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	github.com/Crocmagnon/fatcontext v0.4.0
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0
@@ -127,7 +127,7 @@ require (
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/tools v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
-	honnef.co/go/tools v0.4.7
+	honnef.co/go/tools v0.5.0-0.dev.0.20240621230735-3fe6ed0ecdfe
 	mvdan.cc/gofumpt v0.6.0
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.22.0
+go 1.22.1
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
@@ -127,7 +127,7 @@ require (
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/tools v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
-	honnef.co/go/tools v0.5.0-0.dev.0.20240621230735-3fe6ed0ecdfe
+	honnef.co/go/tools v0.5.0-rc.1
 	mvdan.cc/gofumpt v0.6.0
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f
 )

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	golang.org/x/tools v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
-	honnef.co/go/tools v0.5.0-rc.1
+	honnef.co/go/tools v0.5.0
 	mvdan.cc/gofumpt v0.6.0
 	mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f
 )

--- a/go.sum
+++ b/go.sum
@@ -965,8 +965,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.5.0-0.dev.0.20240621230735-3fe6ed0ecdfe h1:Y+6SWfXcOBRQiMlUF0XrKl5tCGnT8G1UPp5BkxSAmlk=
-honnef.co/go/tools v0.5.0-0.dev.0.20240621230735-3fe6ed0ecdfe/go.mod h1:pc9+SHkW5FWMyo6OLXIoDUr8l3TsBak6LpWpy6j8ezU=
+honnef.co/go/tools v0.5.0-rc.1 h1:V78/p4Nw2Gj1gLcq5vhQqZLkpvA+oS8vRRMBZRtBur4=
+honnef.co/go/tools v0.5.0-rc.1/go.mod h1:e9irvo83WDG9/irijV44wr3tbhcFeRnfpVlRqVwpzMs=
 mvdan.cc/gofumpt v0.6.0 h1:G3QvahNDmpD+Aek/bNOLrFR2XC6ZAdo62dZu65gmwGo=
 mvdan.cc/gofumpt v0.6.0/go.mod h1:4L0wf+kgIPZtcCWXynNS2e6bhmj73umwnuXSZarixzA=
 mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f h1:lMpcwN6GxNbWtbpI1+xzFLSW8XzX0u72NttUGVFjO3U=

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/Antonboom/nilnil v0.1.9/go.mod h1:iGe2rYwCq5/Me1khrysB4nwI7swQvjclR8/
 github.com/Antonboom/testifylint v1.4.3 h1:ohMt6AHuHgttaQ1xb6SSnxCeK4/rnK7KKzbvs7DmEck=
 github.com/Antonboom/testifylint v1.4.3/go.mod h1:+8Q9+AOLsz5ZiQiiYujJKs9mNz398+M6UgslP4qgJLA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Crocmagnon/fatcontext v0.4.0 h1:4ykozu23YHA0JB6+thiuEv7iT6xq995qS1vcuWZq0tg=
 github.com/Crocmagnon/fatcontext v0.4.0/go.mod h1:ZtWrXkgyfsYPzS6K3O88va6t2GEglG93vnII/F94WC0=
@@ -965,8 +965,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.4.7 h1:9MDAWxMoSnB6QoSqiVr7P5mtkT9pOc1kSxchzPCnqJs=
-honnef.co/go/tools v0.4.7/go.mod h1:+rnGS1THNh8zMwnd2oVOTL9QF6vmfyG6ZXBULae2uc0=
+honnef.co/go/tools v0.5.0-0.dev.0.20240621230735-3fe6ed0ecdfe h1:Y+6SWfXcOBRQiMlUF0XrKl5tCGnT8G1UPp5BkxSAmlk=
+honnef.co/go/tools v0.5.0-0.dev.0.20240621230735-3fe6ed0ecdfe/go.mod h1:pc9+SHkW5FWMyo6OLXIoDUr8l3TsBak6LpWpy6j8ezU=
 mvdan.cc/gofumpt v0.6.0 h1:G3QvahNDmpD+Aek/bNOLrFR2XC6ZAdo62dZu65gmwGo=
 mvdan.cc/gofumpt v0.6.0/go.mod h1:4L0wf+kgIPZtcCWXynNS2e6bhmj73umwnuXSZarixzA=
 mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f h1:lMpcwN6GxNbWtbpI1+xzFLSW8XzX0u72NttUGVFjO3U=

--- a/go.sum
+++ b/go.sum
@@ -965,8 +965,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.5.0-rc.1 h1:V78/p4Nw2Gj1gLcq5vhQqZLkpvA+oS8vRRMBZRtBur4=
-honnef.co/go/tools v0.5.0-rc.1/go.mod h1:e9irvo83WDG9/irijV44wr3tbhcFeRnfpVlRqVwpzMs=
+honnef.co/go/tools v0.5.0 h1:29uoiIormS3Z6R+t56STz/oI4v+mB51TSmEOdJPgRnE=
+honnef.co/go/tools v0.5.0/go.mod h1:e9irvo83WDG9/irijV44wr3tbhcFeRnfpVlRqVwpzMs=
 mvdan.cc/gofumpt v0.6.0 h1:G3QvahNDmpD+Aek/bNOLrFR2XC6ZAdo62dZu65gmwGo=
 mvdan.cc/gofumpt v0.6.0/go.mod h1:4L0wf+kgIPZtcCWXynNS2e6bhmj73umwnuXSZarixzA=
 mvdan.cc/unparam v0.0.0-20240528143540-8a5130ca722f h1:lMpcwN6GxNbWtbpI1+xzFLSW8XzX0u72NttUGVFjO3U=

--- a/pkg/golinters/govet/govet.go
+++ b/pkg/golinters/govet/govet.go
@@ -179,7 +179,7 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 }
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
-	// TODO(ldez) remove loopclosure when go1.23
+	// TODO(ldez) remove loopclosure when go1.24
 	if name == loopclosure.Analyzer.Name && config.IsGoGreaterThanOrEqual(cfg.Go, "1.22") {
 		return false
 	}

--- a/pkg/golinters/govet/govet_test.go
+++ b/pkg/golinters/govet/govet_test.go
@@ -84,7 +84,6 @@ func TestGovetAnalyzerIsEnabled(t *testing.T) {
 		{Name: "unsafeptr", Enabled: true, Enable: []string{"unsafeptr"}},
 		{Name: "shift", Enabled: true, EnableAll: true},
 		{Name: "shadow", EnableAll: true, Disable: []string{"shadow"}, Enabled: false},
-		{Name: "loopclosure", EnableAll: true, Enabled: false, Go: "1.22"}, // TODO(ldez) remove loopclosure when go1.23
 	} {
 		cfg := &config.GovetSettings{
 			Enable:     tc.Enable,

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -101,7 +101,6 @@ func TestCgoOk(t *testing.T) {
 		WithArgs("--timeout=3m",
 			"--enable-all",
 		).
-		WithArgs("--go=1.22"). // TODO(ldez) remove this line when we will run go1.23 on the CI. (related to intrange, copyloopvar)
 		WithTargetPath(testdataDir, "cgo").
 		Runner().
 		Install().
@@ -323,7 +322,6 @@ func TestUnsafeOk(t *testing.T) {
 	testshared.NewRunnerBuilder(t).
 		WithNoConfig().
 		WithArgs("--enable-all").
-		WithArgs("--go=1.22"). // TODO(ldez) remove this line when we will run go1.23 on the CI. (related to intrange, copyloopvar)
 		WithTargetPath(testdataDir, "unsafe").
 		Runner().
 		Install().
@@ -484,7 +482,6 @@ func TestEnableAllFastAndEnableCanCoexist(t *testing.T) {
 			testshared.NewRunnerBuilder(t).
 				WithNoConfig().
 				WithArgs(test.args...).
-				WithArgs("--go=1.22"). // TODO(ldez) remove this line when we will run go1.23 on the CI. (related to intrange, copyloopvar)
 				WithTargetPath(testdataDir, minimalPkg).
 				WithBinPath(binPath).
 				Runner().

--- a/test/testshared/integration/run.go
+++ b/test/testshared/integration/run.go
@@ -63,7 +63,6 @@ func testOneSource(t *testing.T, log *logutils.StderrLog, binPath, sourcePath st
 	}
 
 	args := []string{
-		"--go=1.22", // TODO(ldez) remove this line when we will run go1.23 on the CI. (related to intrange, copyloopvar)
 		"--disable-all",
 		"--out-format=json",
 		"--max-same-issues=100",


### PR DESCRIPTION
This PR is to evaluate and prepare golangci-lint to [go1.23](https://tip.golang.org/doc/go1.23)

This PR will evolve during the beta and RC phases of [go1.23](https://tip.golang.org/doc/go1.23).


**Questions and problems related to go1.23 should be reported in the issue #4837.**


---

`golangci-lint` is a free and open-source project built by volunteers.

If you value it, consider supporting us, we appreciate it! :heart:

[![Open Collective backers and sponsors](https://img.shields.io/badge/OpenCollective-Donate-blue?logo=opencollective&style=for-the-badge)](https://opencollective.com/golangci-lint)

[![GitHub Sponsors](https://img.shields.io/badge/GitHub-Donate-blue?logo=github&style=for-the-badge)](https://github.com/sponsors/golangci)
