### PR TITLE
docs: add link on linter without configuration

### DIFF
--- a/docs/src/docs/contributing/workflow.mdx
+++ b/docs/src/docs/contributing/workflow.mdx
@@ -36,7 +36,7 @@ Which runs all the linters and tests.
 
 ## Create or update parameters for docs
 
-Add your new or updated parameters to `.golangci.reference.yml` so they will be shown in the docs
+Add your new or updated parameters to `.golangci.next.reference.yml` so they will be shown in the docs
 
 ## Submit a pull request
 

--- a/docs/src/docs/usage/linters.mdx
+++ b/docs/src/docs/usage/linters.mdx
@@ -2,7 +2,7 @@
 title: Linters
 ---
 
-import { FaGithub, FaGitlab } from "react-icons/fa";
+import { FaGithub, FaGitlab, FaArrowUp } from "react-icons/fa";
 
 To see a list of supported linters and which linters are enabled/disabled:
 

--- a/docs/src/docs/usage/linters.mdx
+++ b/docs/src/docs/usage/linters.mdx
@@ -2,7 +2,7 @@
 title: Linters
 ---
 
-import { FaGithub, FaGitlab, FaLink } from "react-icons/fa";
+import { FaGithub, FaGitlab } from "react-icons/fa";
 
 To see a list of supported linters and which linters are enabled/disabled:
 

--- a/docs/src/docs/usage/linters.mdx
+++ b/docs/src/docs/usage/linters.mdx
@@ -2,7 +2,7 @@
 title: Linters
 ---
 
-import { FaGithub, FaGitlab, FaArrowUp } from "react-icons/fa";
+import { FaGithub, FaGitlab, FaArrowUp, FaCog } from "react-icons/fa";
 
 To see a list of supported linters and which linters are enabled/disabled:
 

--- a/docs/src/docs/usage/linters.mdx
+++ b/docs/src/docs/usage/linters.mdx
@@ -2,7 +2,7 @@
 title: Linters
 ---
 
-import { FaGithub, FaGitlab } from "react-icons/fa";
+import { FaGithub, FaGitlab, FaLink } from "react-icons/fa";
 
 To see a list of supported linters and which linters are enabled/disabled:
 

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -104,10 +104,7 @@ func getName(lc *types.LinterWrapper) string {
 			icon = "<FaGitlab size={'0.8rem'} />"
 		}
 
-		name += fmt.Sprintf("&nbsp;[%s](%s)",
-			span(lc.Name+" repository", icon),
-			lc.OriginalURL,
-		)
+		name += fmt.Sprintf("&nbsp;[%s](%s)", span(lc.Name+" repository", icon), lc.OriginalURL)
 	}
 
 	if lc.Deprecation == nil {

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -104,7 +104,12 @@ func getName(lc *types.LinterWrapper) string {
 			icon = "<FaGitlab size={'0.8rem'} />"
 		}
 
-		name = fmt.Sprintf("%s&nbsp;[%s](%s)", name, spanWithID(listItemPrefix+lc.Name, lc.Name+" repository", icon), lc.OriginalURL)
+		name = fmt.Sprintf("%s%s&nbsp;[%s](%s)",
+			spanWithID(listItemPrefix+lc.Name, "", ""),
+			name,
+			span(lc.Name+" repository", icon),
+			lc.OriginalURL,
+		)
 	}
 
 	if lc.Deprecation == nil {

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -95,7 +95,7 @@ func getName(lc *types.LinterWrapper) string {
 	if hasSettings(lc.Name) {
 		name = fmt.Sprintf("[%[1]s](#%[2]s \"%[1]s configuration\")", name, lc.Name)
 	} else {
-		name = fmt.Sprintf("%s&nbsp;%s", lc.Name, "[<FaLink size={'0.8rem'} />](#"+listItemPrefix+lc.Name+")")
+		name = fmt.Sprintf("%s [%s](#%s)", spanWithID(lc.Name, "", ""), name, lc.Name)
 	}
 
 	if lc.OriginalURL != "" {

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -92,8 +92,8 @@ func getLintersListMarkdown(enabled bool) string {
 func getName(lc *types.LinterWrapper) string {
 	name := spanWithID(listItemPrefix+lc.Name, "", "")
 
-	if hasSettings(lc.Name) {
-		name += fmt.Sprintf("[%[1]s](#%[1]s \"%[1]s configuration\")", lc.Name)
+	if hasSettings(lc.Name) && lc.Deprecation == nil {
+		name += fmt.Sprintf("[%[1]s&nbsp;%[2]s](#%[1]s \"%[1]s configuration\")", lc.Name, "<FaCog size={'0.8rem'} />")
 	} else {
 		name += fmt.Sprintf("%[1]s[%[2]s](#%[2]s \"%[2]s has no configuration\")", spanWithID(lc.Name, "", ""), lc.Name)
 	}

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -95,7 +95,7 @@ func getName(lc *types.LinterWrapper) string {
 	if hasSettings(lc.Name) {
 		name += fmt.Sprintf("[%[1]s](#%[1]s \"%[1]s configuration\")", lc.Name)
 	} else {
-		name += fmt.Sprintf("%[1]s[%[2]s](#%[2]s)", spanWithID(lc.Name, "", ""), lc.Name)
+		name += fmt.Sprintf("%[1]s[%[2]s](#%[2]s \"%[2]s has no configuration\")", spanWithID(lc.Name, "", ""), lc.Name)
 	}
 
 	if lc.OriginalURL != "" {

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -90,12 +90,12 @@ func getLintersListMarkdown(enabled bool) string {
 }
 
 func getName(lc *types.LinterWrapper) string {
-	name := lc.Name
+	name := spanWithID(listItemPrefix+lc.Name, "", "")
 
 	if hasSettings(lc.Name) {
-		name = fmt.Sprintf("[%[1]s](#%[2]s \"%[1]s configuration\")", name, lc.Name)
+		name += fmt.Sprintf("[%[1]s](#%[1]s \"%[1]s configuration\")", lc.Name)
 	} else {
-		name = fmt.Sprintf("%s [%s](#%s)", spanWithID(lc.Name, "", ""), name, lc.Name)
+		name += fmt.Sprintf("%[1]s[%[2]s](#%[2]s)", spanWithID(lc.Name, "", ""), lc.Name)
 	}
 
 	if lc.OriginalURL != "" {
@@ -104,9 +104,7 @@ func getName(lc *types.LinterWrapper) string {
 			icon = "<FaGitlab size={'0.8rem'} />"
 		}
 
-		name = fmt.Sprintf("%s%s&nbsp;[%s](%s)",
-			spanWithID(listItemPrefix+lc.Name, "", ""),
-			name,
+		name += fmt.Sprintf("&nbsp;[%s](%s)",
 			span(lc.Name+" repository", icon),
 			lc.OriginalURL,
 		)

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -324,7 +324,7 @@ func getLintersSettingSections(node, nextNode *yaml.Node) (string, error) {
 
 		_, _ = fmt.Fprintln(builder, "```")
 		_, _ = fmt.Fprintln(builder)
-		_, _ = fmt.Fprintf(builder, "[%s](#%s)\n\n", span("Back to the top", "🔼"), listItemPrefix+nextNode.Content[i].Value)
+		_, _ = fmt.Fprintf(builder, "[%s](#%s)\n\n", span("Back to the top", "<FaArrowUp />"), listItemPrefix+nextNode.Content[i].Value)
 		_, _ = fmt.Fprintln(builder)
 	}
 

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -94,6 +94,8 @@ func getName(lc *types.LinterWrapper) string {
 
 	if hasSettings(lc.Name) {
 		name = fmt.Sprintf("[%[1]s](#%[2]s \"%[1]s configuration\")", name, lc.Name)
+	} else {
+		name = fmt.Sprintf("%s&nbsp;%s", lc.Name, "[<FaLink size={'0.8rem'} />](#"+listItemPrefix+lc.Name+")")
 	}
 
 	if lc.OriginalURL != "" {


### PR DESCRIPTION
This PR creates an invisible span with ID to generate an anchor for all linter names.

Result:

![Screenshot 2024-06-26 at 09-04-04 Linters golangci-lint](https://github.com/golangci/golangci-lint/assets/5674651/a352b4a0-0cee-45cd-adf0-8b9e496ce6d4)


link example: `http://localhost:8000/usage/linters/#bodyclose`

This also fixes:
- "back to the top" link for linter without repo (ex: [lll](https://golangci-lint.run/usage/linters/#lll))
- the behavior of "back to the top" link when the repo icon is not on the same line as the linter name (ex: [staticcheck](https://golangci-lint.run/usage/linters/#staticcheck)) 

Fixes #4841