### PR TITLE
Add fparams linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -427,6 +427,15 @@ linters-settings:
     # Default: false
     analyze-types: true
 
+  fparams:
+    # Disable check function params
+    # Default: false
+    disableCheckFuncParams: false
+
+    # Disable check function return values
+    # Default false
+    disableCheckFuncReturns: false
+
   funlen:
     # Checks the number of lines in a function.
     # If lower than 0, disable the check.
@@ -2593,6 +2602,7 @@ linters:
     - fatcontext
     - forbidigo
     - forcetypeassert
+    - fparams
     - funlen
     - gci
     - ginkgolinter
@@ -2708,6 +2718,7 @@ linters:
     - fatcontext
     - forbidigo
     - forcetypeassert
+    - fparams
     - funlen
     - gci
     - ginkgolinter

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/golangci/golangci-lint
 
-go 1.21.0
+go 1.22
+
+toolchain go1.22.4
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
@@ -19,6 +21,7 @@ require (
 	github.com/alexkohler/nakedret/v2 v2.0.4
 	github.com/alexkohler/prealloc v1.0.0
 	github.com/alingse/asasalint v0.0.11
+	github.com/artemk1337/fparams v1.0.0
 	github.com/ashanbrown/forbidigo v1.6.0
 	github.com/ashanbrown/makezero v1.1.1
 	github.com/bkielbasa/cyclop v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,9 @@ github.com/alingse/asasalint v0.0.11 h1:SFwnQXJ49Kx/1GghOFz1XGqHYKp21Kq1nHad/0WQ
 github.com/alingse/asasalint v0.0.11/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/artemk1337/fparams v0.0.2 h1:qqRyv+DyNP96l/gjDiTAlZUqkvd/VfyYnRNKNnji3oE=
+github.com/artemk1337/fparams v0.0.2/go.mod h1:RAmfVQOF2V1jxm6gwkvRmTHjIfHO718H7z9DKq9QIns=
+github.com/artemk1337/fparams v1.0.0/go.mod h1:RAmfVQOF2V1jxm6gwkvRmTHjIfHO718H7z9DKq9QIns=
 github.com/ashanbrown/forbidigo v1.6.0 h1:D3aewfM37Yb3pxHujIPSpTf6oQk9sc9WZi8gerOIVIY=
 github.com/ashanbrown/forbidigo v1.6.0/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5FcB28s=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -212,6 +212,7 @@ type LintersSettings struct {
 	Exhaustive      ExhaustiveSettings
 	Exhaustruct     ExhaustructSettings
 	Forbidigo       ForbidigoSettings
+	Fparams         Fparams
 	Funlen          FunlenSettings
 	Gci             GciSettings
 	GinkgoLinter    GinkgoLinterSettings
@@ -453,6 +454,11 @@ func (p *ForbidigoPattern) MarshalString() ([]byte, error) {
 	}
 
 	return yaml.Marshal(p)
+}
+
+type Fparams struct {
+	DisableCheckFuncParams  bool `mapstructure:"disable-check-params"`
+	DisableCheckFuncReturns bool `mapstructure:"disable-check-returns"`
 }
 
 type FunlenSettings struct {

--- a/pkg/golinters/fparams/fparams.go
+++ b/pkg/golinters/fparams/fparams.go
@@ -1,0 +1,28 @@
+package fparams
+
+import (
+	"github.com/artemk1337/fparams/pkg/analyzer"
+	"github.com/golangci/golangci-lint/pkg/config"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New(settings *config.Fparams) *goanalysis.Linter {
+	a := analyzer.NewAnalyzer()
+
+	cfg := map[string]map[string]any{}
+	if settings != nil {
+		cfg[a.Name] = map[string]any{
+			"disableCheckFuncParams":  settings.DisableCheckFuncParams,
+			"disableCheckFuncReturns": settings.DisableCheckFuncReturns,
+		}
+	}
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/fparams/fparams_integration_test.go
+++ b/pkg/golinters/fparams/fparams_integration_test.go
@@ -1,0 +1,11 @@
+package fparams
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/fparams/testdata/fix/in/fparams.go
+++ b/pkg/golinters/fparams/testdata/fix/in/fparams.go
@@ -1,0 +1,74 @@
+//golangcitest:args -Efparams
+//golangcitest:expected_exitcode 0
+package fparams
+
+func invalidArgsFuncA(a int,
+	b string) {
+	return
+}
+
+func invalidArgsFuncB(a, b int,
+	c string) {
+	return
+}
+
+func invalidArgsFuncC(a,
+	b int,
+	c string,
+) {
+	return
+}
+
+func invalidArgsFuncD(
+	a, b int,
+	c string,
+) {
+	return
+}
+
+func invalidArgsAndResultsFuncA(a int,
+	b string) (c bool,
+	d error) {
+	return false, nil
+}
+
+func invalidArgsAndResultsFuncB(a int, b int,
+	c string) (
+	d bool,
+	e error) {
+	return false, nil
+}
+
+func invalidResultsFuncA() (a bool,
+	b error) {
+	return false, nil
+}
+
+func invalidResultsFuncB() (
+	a bool,
+	b error) {
+	return false, nil
+}
+
+func invalidResultsFuncC() (
+	a bool, b error) {
+	return false, nil
+}
+
+func invalidResultsFuncD() (
+	a, b bool,
+	c error) {
+	return false, false, nil
+}
+
+func invalidResultsFuncE() (bool, bool,
+	error) {
+	return false, false, nil
+}
+
+func invalidResultsFuncF() (
+	bool,
+	bool,
+	error) {
+	return false, false, nil
+}

--- a/pkg/golinters/fparams/testdata/fix/out/fparams.go
+++ b/pkg/golinters/fparams/testdata/fix/out/fparams.go
@@ -1,0 +1,100 @@
+//golangcitest:args -Efparams
+//golangcitest:expected_exitcode 0
+package fparams
+
+func invalidArgsFuncA(
+	a int,
+	b string,
+) {
+	return
+}
+
+func invalidArgsFuncB(
+	a int,
+	b int,
+	c string,
+) {
+	return
+}
+
+func invalidArgsFuncC(
+	a int,
+	b int,
+	c string,
+) {
+	return
+}
+
+func invalidArgsFuncD(
+	a int,
+	b int,
+	c string,
+) {
+	return
+}
+
+func invalidArgsAndResultsFuncA(
+	a int,
+	b string,
+) (
+	c bool,
+	d error,
+) {
+	return false, nil
+}
+
+func invalidArgsAndResultsFuncB(
+	a int,
+	b int,
+	c string,
+) (
+	d bool,
+	e error,
+) {
+	return false, nil
+}
+
+func invalidResultsFuncA() (
+	a bool,
+	b error,
+) {
+	return false, nil
+}
+
+func invalidResultsFuncB() (
+	a bool,
+	b error,
+) {
+	return false, nil
+}
+
+func invalidResultsFuncC() (
+	a bool,
+	b error,
+) {
+	return false, nil
+}
+
+func invalidResultsFuncD() (
+	a bool,
+	b bool,
+	c error,
+) {
+	return false, false, nil
+}
+
+func invalidResultsFuncE() (
+	bool,
+	bool,
+	error,
+) {
+	return false, false, nil
+}
+
+func invalidResultsFuncF() (
+	bool,
+	bool,
+	error,
+) {
+	return false, false, nil
+}

--- a/pkg/golinters/fparams/testdata/fparams.go
+++ b/pkg/golinters/fparams/testdata/fparams.go
@@ -1,0 +1,117 @@
+//golangcitest:args -Efparams
+package testdata
+
+func multiLineFuncA(
+	a int,
+	b string,
+) (
+	c bool,
+	d error,
+) {
+	return false, nil
+}
+
+func multiLineFuncB(
+	a int,
+	b string,
+) {
+	return
+}
+
+func multiLineFuncC() (
+	a bool,
+	b error,
+) {
+	return false, nil
+}
+
+func singleLineFuncA(a int, b string) (c bool, d error) {
+	return false, nil
+}
+
+func singleLineFuncB(a int) (b bool, c error) {
+	return false, nil
+}
+
+func singleLineFuncC(a int, b string) (c error) {
+	return nil
+}
+
+func singleLineFuncD(int, string) error {
+	return nil
+}
+
+func singleLineFuncE(_ int, _ string) error {
+	return nil
+}
+
+func invalidArgsFuncA(a int, // want "the parameters of the function \"invalidArgsFuncA\" should be on separate lines"
+	b string) {
+	return
+}
+
+func invalidArgsFuncB(a, b int, // want "the parameters of the function \"invalidArgsFuncB\" should be on separate lines"
+	c string) {
+	return
+}
+
+func invalidArgsFuncC(a, // want "the parameters of the function \"invalidArgsFuncC\" should be on separate lines"
+	b int,
+	c string,
+) {
+	return
+}
+
+func invalidArgsFuncD( // want "the parameters of the function \"invalidArgsFuncD\" should be on separate lines"
+	a, b int,
+	c string,
+) {
+	return
+}
+
+func invalidArgsAndResultsFuncA(a int, // want "the parameters and return values of the function \"invalidArgsAndResultsFuncA\" should be on separate lines"
+	b string) (c bool,
+	d error) {
+	return false, nil
+}
+
+func invalidArgsAndResultsFuncB(a int, b int, // want "the parameters and return values of the function \"invalidArgsAndResultsFuncB\" should be on separate lines"
+	c string) (
+	d bool,
+	e error) {
+	return false, nil
+}
+
+func invalidResultsFuncA() (a bool, // want "the return values of the function \"invalidResultsFuncA\" should be on separate lines"
+	b error) {
+	return false, nil
+}
+
+func invalidResultsFuncB() ( // want "the return values of the function \"invalidResultsFuncB\" should be on separate lines"
+	a bool,
+	b error) {
+	return false, nil
+}
+
+func invalidResultsFuncC() ( // want "the return values of the function \"invalidResultsFuncC\" should be on separate lines"
+	a bool, b error) {
+	return false, nil
+}
+
+func invalidResultsFuncD() ( // want "the return values of the function \"invalidResultsFuncD\" should be on separate lines"
+	a, b bool,
+	c error) {
+	return false, false, nil
+}
+
+func invalidResultsFuncE() (bool, bool, // want "the return values of the function \"invalidResultsFuncE\" should be on separate lines"
+	error) {
+	return false, false, nil
+}
+
+func invalidResultsFuncF() ( // want "the return values of the function \"invalidResultsFuncF\" should be on separate lines"
+	bool,
+	bool,
+	error) {
+	return false, false, nil
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/fatcontext"
 	"github.com/golangci/golangci-lint/pkg/golinters/forbidigo"
 	"github.com/golangci/golangci-lint/pkg/golinters/forcetypeassert"
+	"github.com/golangci/golangci-lint/pkg/golinters/fparams"
 	"github.com/golangci/golangci-lint/pkg/golinters/funlen"
 	"github.com/golangci/golangci-lint/pkg/golinters/gci"
 	"github.com/golangci/golangci-lint/pkg/golinters/ginkgolinter"
@@ -300,6 +301,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetPerformance).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/Crocmagnon/fatcontext"),
+
+		linter.NewConfig(fparams.New(&cfg.LintersSettings.Fparams)).
+			WithSince("1.60.0").
+			WithPresets(linter.PresetFormatting).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/artemk1337/fparamsx"),
 
 		linter.NewConfig(funlen.New(&cfg.LintersSettings.Funlen)).
 			WithSince("v1.18.0").


### PR DESCRIPTION
### Description

fparams is a linter tool for Go that checks the formatting of function parameters and return values. The linter ensures that function parameters and return values are either all on one line or each on a new line. This helps maintain consistent and readable code formatting in Go projects.

Link: https://github.com/artemk1337/fparams

### Example

Given a function declaration like this:
```go
func example(a int, b int, 
    c, d string) (int, error) {
    return 0, nil
}
```

fparams will suggest changing it to:
```go
func example(
    a int,
    b int,
    c string,
    d string,
) (
    int,
    error,
) {
    return 0, nil
}
```