### PR TITLE
Add ctxcause linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2588,6 +2588,7 @@ linters:
     - containedctx
     - contextcheck
     - copyloopvar
+    - ctxcause
     - cyclop
     - decorder
     - depguard
@@ -2703,6 +2704,7 @@ linters:
     - containedctx
     - contextcheck
     - copyloopvar
+    - ctxcause
     - cyclop
     - decorder
     - depguard

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.21.0
+go 1.22
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
@@ -176,6 +176,7 @@ require (
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/sivchari/ctxcause v0.1.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/sivchari/containedctx v1.0.3
+	github.com/sivchari/ctxcause v0.1.0
 	github.com/sivchari/tenv v1.10.0
 	github.com/sonatard/noctx v0.0.2
 	github.com/sourcegraph/go-diff v0.7.0
@@ -176,7 +177,6 @@ require (
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	github.com/sivchari/ctxcause v0.1.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sivchari/containedctx v1.0.3 h1:x+etemjbsh2fB5ewm5FeLNi5bUjK0V8n0RB+Wwfd0XE=
 github.com/sivchari/containedctx v1.0.3/go.mod h1:c1RDvCbnJLtH4lLcYD/GqwiBSSf4F5Qk0xld2rBqzJ4=
+github.com/sivchari/ctxcause v0.1.0 h1:fXJgDWz6tXlZtwFlnwCuHdj936N86m4I9SmcMafQPtY=
+github.com/sivchari/ctxcause v0.1.0/go.mod h1:iFuk1Ylrt0BuNRnWNHWXcSptt8hcWi/ujTHeFge1vZA=
 github.com/sivchari/tenv v1.10.0 h1:g/hzMA+dBCKqGXgW8AV/1xIWhAvDrx0zFKNR48NFMg0=
 github.com/sivchari/tenv v1.10.0/go.mod h1:tdY24masnVoZFxYrHv/nD6Tc8FbkEtAQEEziXpyMgqY=
 github.com/sonatard/noctx v0.0.2 h1:L7Dz4De2zDQhW8S0t+KUjY0MAQJd6SgVwhzNIc4ok00=

--- a/pkg/golinters/ctxcause/ctxcause.go
+++ b/pkg/golinters/ctxcause/ctxcause.go
@@ -1,0 +1,19 @@
+package ctxcause
+
+import (
+	"github.com/sivchari/ctxcause"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	a := ctxcause.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/ctxcause/ctxcause_integration_test.go
+++ b/pkg/golinters/ctxcause/ctxcause_integration_test.go
@@ -1,0 +1,11 @@
+package ctxcause
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/ctxcause/testdata/ctxcause.go
+++ b/pkg/golinters/ctxcause/testdata/ctxcause.go
@@ -1,0 +1,14 @@
+//golangitest:args -Ectxcause
+package testdata
+
+import (
+	"context"
+	"time"
+)
+
+func ctxcause() {
+	ctx, cancel := context.WithCancel(context.Background())                                 // want "context.WithCancel should be replaced with context.WithCancelCause"
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)                  // want "context.WithTimeout should be replaced with context.WithTimeoutCause"
+	ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(1*time.Second)) // want "context.WithDeadline should be replaced with context.WithDeadlineCause"
+	_, _ = ctx, cancel
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/containedctx"
 	"github.com/golangci/golangci-lint/pkg/golinters/contextcheck"
 	"github.com/golangci/golangci-lint/pkg/golinters/copyloopvar"
+	"github.com/golangci/golangci-lint/pkg/golinters/ctxcause"
 	"github.com/golangci/golangci-lint/pkg/golinters/cyclop"
 	"github.com/golangci/golangci-lint/pkg/golinters/decorder"
 	"github.com/golangci/golangci-lint/pkg/golinters/depguard"
@@ -178,6 +179,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/karamaru-alpha/copyloopvar").
 			WithNoopFallback(cfg, linter.IsGoLowerThanGo122()),
+
+		linter.NewConfig(ctxcause.New()).
+			WithSince("v1.60.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/sivchari/ctxcause"),
 
 		linter.NewConfig(cyclop.New(&cfg.LintersSettings.Cyclop)).
 			WithSince("v1.37.0").


### PR DESCRIPTION
I added [ctxcause](https://github.com/sivchari/ctxcause) linter to golangci-lint.
This linter reports the use of context.WithCancel, context.WithTimeout, and context.WithDeadline instead of context.WithCancelCause, context.WithTimeoutCause, and context.WithDeadlineCause.