### PR TITLE
feat: improve processors filtering stats

### DIFF
--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -208,11 +208,11 @@ func (r *Runner) printPerProcessorStat(stat map[string]processorStat) {
 	parts := make([]string, 0, len(stat))
 	for name, ps := range stat {
 		if ps.inCount != 0 {
-			parts = append(parts, fmt.Sprintf("%s: %d/%d", name, ps.outCount, ps.inCount))
+			parts = append(parts, fmt.Sprintf("%s: %d/%d", name, ps.inCount, ps.outCount))
 		}
 	}
 	if len(parts) != 0 {
-		r.Log.Infof("Processors filtering stat (out/in): %s", strings.Join(parts, ", "))
+		r.Log.Infof("Processors filtering stat (in/out): %s", strings.Join(parts, ", "))
 	}
 }
 


### PR DESCRIPTION

The current log:

```
INFO [runner] Processors filtering stat (out/in): skip_files: 13145/13145, cgo: 19030/19030, exclude: 13145/13145, invalid_issue: 13145/19030, skip_dirs: 13145/13145, autogenerated_exclude: 13145/13145, nolint: 0/13145, filename_unadjuster: 19030/19030, path_prettifier: 13145/13145, identifier_marker: 13145/13145, exclude-rules: 13145/13145
```

The "out/in" is unexpected, I think it's better to change the order to `in/out`.