### PR TITLE
dev: remove unnecessary nil slice check

### DIFF
--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -234,10 +234,6 @@ func (r *Runner) processIssues(issues []result.Issue, sw *timeutils.Stopwatch, s
 			statPerProcessor[p.Name()] = stat
 			issues = newIssues
 		}
-
-		if issues == nil {
-			issues = []result.Issue{}
-		}
 	}
 
 	return issues


### PR DESCRIPTION
`len(issues) == 0` is true for `[]result.Issue{}` or `[]result.Issue(nil)`.

And `nil` slice is preferable to the empty slice according to the [Go Wiki](https://go.dev/wiki/CodeReviewComments#declaring-empty-slices).