### PR TITLE
exportloopref: disable linter for Go versions >= Go 1.22

### DIFF
--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -163,6 +163,16 @@ func (lc *Config) WithNoopFallback(cfg *config.Config, cond func(cfg *config.Con
 	return lc
 }
 
+func IsGoGreaterThanOrEqualGo122() func(cfg *config.Config) error {
+	return func(cfg *config.Config) error {
+		if cfg == nil || !config.IsGoGreaterThanOrEqual(cfg.Run.Go, "1.22") {
+			return nil
+		}
+
+		return fmt.Errorf("this linter is disabled because the Go version (%s) of your project is greater than or equal Go 1.22", cfg.Run.Go)
+	}
+}
+
 func IsGoLowerThanGo122() func(cfg *config.Config) error {
 	return func(cfg *config.Config) error {
 		if cfg == nil || config.IsGoGreaterThanOrEqual(cfg.Run.Go, "1.22") {

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -278,7 +278,8 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.28.0").
 			WithPresets(linter.PresetBugs).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/kyoh86/exportloopref"),
+			WithURL("https://github.com/kyoh86/exportloopref").
+			WithNoopFallback(cfg, linter.IsGoGreaterThanOrEqualGo122()),
 
 		linter.NewConfig(forbidigo.New(&cfg.LintersSettings.Forbidigo)).
 			WithSince("v1.34.0").


### PR DESCRIPTION
The problem reported by the linter has been fixed with Go 1.22.
See https://go.dev/blog/loopvar-preview.