### PR TITLE
feat(linters): add new linter gobreakselectinfor

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2620,6 +2620,7 @@ linters:
     - funlen
     - gci
     - ginkgolinter
+    - gobreakselectinfor
     - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits
@@ -2735,6 +2736,7 @@ linters:
     - funlen
     - gci
     - ginkgolinter
+    - gobreakselectinfor
     - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -324,6 +324,7 @@
             "funlen",
             "gci",
             "ginkgolinter",
+            "gobreakselectinfor",
             "gocheckcompilerdirectives",
             "gochecknoglobals",
             "gochecknoinits",

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/funlen"
 	"github.com/golangci/golangci-lint/pkg/golinters/gci"
 	"github.com/golangci/golangci-lint/pkg/golinters/ginkgolinter"
+	"github.com/golangci/golangci-lint/pkg/golinters/gobreakselectinfor"
 	"github.com/golangci/golangci-lint/pkg/golinters/gocheckcompilerdirectives"
 	"github.com/golangci/golangci-lint/pkg/golinters/gochecknoglobals"
 	"github.com/golangci/golangci-lint/pkg/golinters/gochecknoinits"
@@ -317,6 +318,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/nunnatsa/ginkgolinter"),
+
+		linter.NewConfig(gobreakselectinfor.New()).
+			WithSince("1.61.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/rnben/go-break-select-in-for"),
 
 		linter.NewConfig(gocheckcompilerdirectives.New()).
 			WithSince("v1.51.0").


### PR DESCRIPTION
The Go linter go-break-select-in-for checks that break statement inside select statement inside for loop.

For example, in myFunc the break may want to exit the outer for loop, but it doesn't work as expected.

```go
func myFunc() {
    for {
        select {
        case <-ch:
            break // should be careful
        }
    }
}
```