### PR TITLE
feat(linters): add new linter gobreakselectinfor

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2620,6 +2620,7 @@ linters:
     - funlen
     - gci
     - ginkgolinter
+    - gobreakselectinfor
     - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits
@@ -2735,6 +2736,7 @@ linters:
     - funlen
     - gci
     - ginkgolinter
+    - gobreakselectinfor
     - gocheckcompilerdirectives
     - gochecknoglobals
     - gochecknoinits

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/polyfloyd/go-errorlint v1.6.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
+	github.com/rnben/go-break-select-in-for v0.0.1
 	github.com/ryancurrah/gomodguard v1.3.3
 	github.com/ryanrolds/sqlclosecheck v0.5.1
 	github.com/sanposhiho/wastedassign/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -456,6 +456,8 @@ github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 h1:TCg2WBOl
 github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4lu7Gd+PU1fV2/qnDNfzT635KRSObncs=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
+github.com/rnben/go-break-select-in-for v0.0.1 h1:nsl0IXc94wigYVwbecdeBYrCLookdYvYTgwn/LWyHmg=
+github.com/rnben/go-break-select-in-for v0.0.1/go.mod h1:7JoY3ApLuYoE4iHy1U9X/v5ix10c/9Z54hpFoYhwmow=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -324,6 +324,7 @@
             "funlen",
             "gci",
             "ginkgolinter",
+            "gobreakselectinfor",
             "gocheckcompilerdirectives",
             "gochecknoglobals",
             "gochecknoinits",

--- a/pkg/golinters/gobreakselectinfor/gobreakselectinfor.go
+++ b/pkg/golinters/gobreakselectinfor/gobreakselectinfor.go
@@ -1,0 +1,92 @@
+package gobreakselectinfor
+
+import (
+	"go/ast"
+	"go/token"
+	"sync"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/lint/linter"
+	"github.com/golangci/golangci-lint/pkg/result"
+)
+
+const linterName = "gobreakselectinfor"
+
+func New() *goanalysis.Linter {
+	var mu sync.Mutex
+	var resIssues []goanalysis.Issue
+
+	analyzer := &analysis.Analyzer{
+		Name: linterName,
+		Doc:  goanalysis.TheOnlyanalyzerDoc,
+		Run: func(pass *analysis.Pass) (any, error) {
+			fileIssues := run(pass)
+			res := make([]goanalysis.Issue, 0, len(fileIssues))
+			for i := range fileIssues {
+				res = append(res, goanalysis.NewIssue(&fileIssues[i], pass))
+			}
+			if len(res) == 0 {
+				return nil, nil
+			}
+
+			mu.Lock()
+			resIssues = append(resIssues, res...)
+			mu.Unlock()
+
+			return nil, nil
+		},
+	}
+
+	return goanalysis.NewLinter(
+		linterName,
+		"Checks that break statement inside select statement inside for loop",
+		[]*analysis.Analyzer{analyzer},
+		nil,
+	).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
+		return resIssues
+	}).WithLoadMode(goanalysis.LoadModeSyntax)
+}
+
+func run(pass *analysis.Pass) []result.Issue {
+	var res []result.Issue
+
+	inspect := func(node ast.Node) bool {
+		funcDecl, ok := node.(*ast.FuncDecl)
+		if !ok {
+			return true
+		}
+
+		ast.Inspect(funcDecl.Body, func(stmt ast.Node) bool {
+			if forStmt, ok := stmt.(*ast.ForStmt); ok {
+				ast.Inspect(forStmt.Body, func(stmt ast.Node) bool {
+					if selStmt, ok := stmt.(*ast.SelectStmt); ok {
+						ast.Inspect(selStmt.Body, func(stmt ast.Node) bool {
+							if brkStmt, ok := stmt.(*ast.BranchStmt); ok && brkStmt.Tok == token.BREAK {
+								pass.Reportf(stmt.Pos(), "break statement inside select statement inside for loop")
+								res = append(res, result.Issue{
+									Pos:        pass.Fset.Position(stmt.Pos()),
+									Text:       "break statement inside select statement inside for loop",
+									FromLinter: linterName,
+								})
+								return true
+							}
+							return true
+						})
+					}
+					return true
+				})
+			}
+			return true
+		})
+
+		return true
+	}
+
+	for _, f := range pass.Files {
+		ast.Inspect(f, inspect)
+	}
+
+	return res
+}

--- a/pkg/golinters/gobreakselectinfor/gobreakselectinfor.go
+++ b/pkg/golinters/gobreakselectinfor/gobreakselectinfor.go
@@ -1,92 +1,19 @@
 package gobreakselectinfor
 
 import (
-	"go/ast"
-	"go/token"
-	"sync"
-
+	"github.com/rnben/go-break-select-in-for/pkg/analyzer"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/pkg/lint/linter"
-	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const linterName = "gobreakselectinfor"
-
 func New() *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []goanalysis.Issue
-
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			fileIssues := run(pass)
-			res := make([]goanalysis.Issue, 0, len(fileIssues))
-			for i := range fileIssues {
-				res = append(res, goanalysis.NewIssue(&fileIssues[i], pass))
-			}
-			if len(res) == 0 {
-				return nil, nil
-			}
-
-			mu.Lock()
-			resIssues = append(resIssues, res...)
-			mu.Unlock()
-
-			return nil, nil
-		},
-	}
+	a := analyzer.Analyzer
 
 	return goanalysis.NewLinter(
-		linterName,
-		"Checks that break statement inside select statement inside for loop",
-		[]*analysis.Analyzer{analyzer},
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
 		nil,
-	).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
-		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeSyntax)
-}
-
-func run(pass *analysis.Pass) []result.Issue {
-	var res []result.Issue
-
-	inspect := func(node ast.Node) bool {
-		funcDecl, ok := node.(*ast.FuncDecl)
-		if !ok {
-			return true
-		}
-
-		ast.Inspect(funcDecl.Body, func(stmt ast.Node) bool {
-			if forStmt, ok := stmt.(*ast.ForStmt); ok {
-				ast.Inspect(forStmt.Body, func(stmt ast.Node) bool {
-					if selStmt, ok := stmt.(*ast.SelectStmt); ok {
-						ast.Inspect(selStmt.Body, func(stmt ast.Node) bool {
-							if brkStmt, ok := stmt.(*ast.BranchStmt); ok && brkStmt.Tok == token.BREAK {
-								pass.Reportf(stmt.Pos(), "break statement inside select statement inside for loop")
-								res = append(res, result.Issue{
-									Pos:        pass.Fset.Position(stmt.Pos()),
-									Text:       "break statement inside select statement inside for loop",
-									FromLinter: linterName,
-								})
-								return true
-							}
-							return true
-						})
-					}
-					return true
-				})
-			}
-			return true
-		})
-
-		return true
-	}
-
-	for _, f := range pass.Files {
-		ast.Inspect(f, inspect)
-	}
-
-	return res
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/gobreakselectinfor/gobreakselectinfor_test.go
+++ b/pkg/golinters/gobreakselectinfor/gobreakselectinfor_test.go
@@ -1,0 +1,11 @@
+package gobreakselectinfor
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/gobreakselectinfor/testdata/gobreakselectinfor.go
+++ b/pkg/golinters/gobreakselectinfor/testdata/gobreakselectinfor.go
@@ -1,0 +1,12 @@
+//golangcitest:args -Egobreakselectinfor
+package testdata
+
+func bad() {
+	var ch chan string
+	for {
+		select {
+		case <-ch:
+			break // want "break statement inside select statement inside for loop"
+		}
+	}
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/funlen"
 	"github.com/golangci/golangci-lint/pkg/golinters/gci"
 	"github.com/golangci/golangci-lint/pkg/golinters/ginkgolinter"
+	"github.com/golangci/golangci-lint/pkg/golinters/gobreakselectinfor"
 	"github.com/golangci/golangci-lint/pkg/golinters/gocheckcompilerdirectives"
 	"github.com/golangci/golangci-lint/pkg/golinters/gochecknoglobals"
 	"github.com/golangci/golangci-lint/pkg/golinters/gochecknoinits"
@@ -317,6 +318,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/nunnatsa/ginkgolinter"),
+
+		linter.NewConfig(gobreakselectinfor.New()).
+			WithSince("1.61.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/rnben/go-break-select-in-for"),
 
 		linter.NewConfig(gocheckcompilerdirectives.New()).
 			WithSince("v1.51.0").


### PR DESCRIPTION
The Go linter go-break-select-in-for checks that break statement inside select statement inside for loop.

For example, in myFunc the break may want to exit the outer for loop, but it doesn't work as expected.

```go
func myFunc() {
    for {
        select {
        case <-ch:
            break // should be careful
        }
    }
}
```