### PR TITLE
dev: fix GO_VERSION in post release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -4,6 +4,13 @@ on:
     types:
       - published
 
+env:
+  # https://github.com/actions/setup-go#supported-version-syntax
+  # ex:
+  # - 1.18beta1 -> 1.18.0-beta.1
+  # - 1.18rc1 -> 1.18.0-rc.1
+  GO_VERSION: '1.23'
+
 jobs:
   update-docs:
     name: "Update readme"
@@ -11,11 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
-      # https://github.com/actions/setup-go#supported-version-syntax
-      # ex:
-      # - 1.18beta1 -> 1.18.0-beta.1
-      # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
There are multiple jobs in the GitHub post-release workflow that reference the `GO_VERSION` environment variable, but it is only defined for the `update-docs` (aka `Update readme`) job.

This means that the static assets for version `1.60.1` are built with Go `1.22` instead of `1.23`.

You can confirm this by comparing the version of Go used in the `actions/setup-go@5` step of the [Update readme](https://github.com/golangci/golangci-lint/actions/runs/10379882256/job/28738784965) job to the one in [Update GitHub Action assets](https://github.com/golangci/golangci-lint/actions/runs/10379882256/job/28738785585).
