### PR TITLE
feat: check that Go version use to build is greater or equals to the Go version of the project

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"fmt"
+	"go/version"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 
 	hcversion "github.com/hashicorp/go-version"
@@ -107,4 +110,38 @@ func trimGoVersion(v string) string {
 	}
 
 	return v
+}
+
+func getRuntimeGoVersion() string {
+	goVersion := runtime.Version()
+
+	parts := strings.Fields(goVersion)
+
+	if len(parts) == 0 {
+		return goVersion
+	}
+
+	// When using GOEXPERIMENT, the version returned might look something like "go1.23.0 X:boringcrypto".
+	return parts[0]
+}
+
+func checkGoVersion(goVersion string) error {
+	langVersion := version.Lang(getRuntimeGoVersion())
+
+	runtimeVersion, err := hcversion.NewVersion(strings.TrimPrefix(langVersion, "go"))
+	if err != nil {
+		return err
+	}
+
+	targetedVersion, err := hcversion.NewVersion(trimGoVersion(goVersion))
+	if err != nil {
+		return err
+	}
+
+	if runtimeVersion.LessThan(targetedVersion) {
+		return fmt.Errorf("the Go language version (%s) used to build golangci-lint is lower than the targeted Go version (%s)",
+			langVersion, goVersion)
+	}
+
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsGoGreaterThanOrEqual(t *testing.T) {
@@ -128,6 +129,59 @@ func Test_trimGoVersion(t *testing.T) {
 
 			version := trimGoVersion(test.version)
 			assert.Equal(t, test.expected, version)
+		})
+	}
+}
+
+func Test_checkGoVersion(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		version string
+		require require.ErrorAssertionFunc
+	}{
+		{
+			desc:    "version greater than runtime version (patch)",
+			version: "1.30.1",
+			require: require.Error,
+		},
+		{
+			desc:    "version greater than runtime version (family)",
+			version: "1.30",
+			require: require.Error,
+		},
+		{
+			desc:    "version greater than runtime version (RC)",
+			version: "1.30.0-rc1",
+			require: require.Error,
+		},
+		{
+			desc:    "version equals to runtime version",
+			version: getRuntimeGoVersion(),
+			require: require.NoError,
+		},
+		{
+			desc:    "version lower than runtime version (patch)",
+			version: "1.19.1",
+			require: require.NoError,
+		},
+		{
+			desc:    "version lower than runtime version (family)",
+			version: "1.19",
+			require: require.NoError,
+		},
+		{
+			desc:    "version lower than runtime version (RC)",
+			version: "1.19.0-rc1",
+			require: require.NoError,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkGoVersion(test.version)
+			test.require(t, err)
 		})
 	}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -74,6 +74,11 @@ func (l *Loader) Load(opts LoadOptions) error {
 
 	l.handleGoVersion()
 
+	err = checkGoVersion(l.cfg.Run.Go)
+	if err != nil {
+		return err
+	}
+
 	err = l.handleEnableOnlyOption()
 	if err != nil {
 		return err


### PR DESCRIPTION
To avoid issues related to the new version of Go, I would add a check to ensure that the Go version used to build is compatible with the Go version used by a project. 

Related to all the issues after each new release of Go.
A small extract of the related issues: #4909, #4908, #4932, #4933, etc.


Output example:
```console
$ ./golangci-lint run
Error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23)
Failed executing command with error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23)
```
