### PR TITLE
gosec: add G115 to default exclusions

### DIFF
--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -101,6 +101,12 @@ var DefaultExcludePatterns = []ExcludePattern{
 		Linter:  "revive",
 		Why:     "Annoying issue about not having a comment. The rare codebase has such comments.",
 	},
+	{
+		ID:      "EXC0016",
+		Pattern: `G115: integer overflow conversion`, // rule: package-comments
+		Linter:  "gosec",
+		Why:     "Too many false positives.",
+	},
 }
 
 type Issues struct {


### PR DESCRIPTION
Fixes #4935, #4939

Related to #4927