### PR TITLE
Add interfaceguard linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1249,6 +1249,14 @@ linters-settings:
     # Default: 10
     max: 5
 
+  interfaceguard:
+    # Disable check for direct interface-to-interface comparisons.
+    # Default: false
+    disable-interface-to-interface: true
+    # Disable check for direct interface-to-nil comparisons.
+    # Default: false
+    disable-interface-to-nil: true
+
   ireturn:
     # List of interfaces to allow.
     # Lists of the keywords and regular expressions matched to interface or package names can be used.
@@ -2658,6 +2666,7 @@ linters:
     - inamedparam
     - ineffassign
     - interfacebloat
+    - interfaceguard
     - intrange
     - ireturn
     - lll
@@ -2773,6 +2782,7 @@ linters:
     - inamedparam
     - ineffassign
     - interfacebloat
+    - interfaceguard
     - intrange
     - ireturn
     - lll

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af
 	github.com/jjti/go-spancheck v0.6.2
+	github.com/jkeys089/interfaceguard v1.0.1
 	github.com/julz/importas v0.1.0
 	github.com/karamaru-alpha/copyloopvar v1.1.0
 	github.com/kisielk/errcheck v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af h1:KA9B
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jjti/go-spancheck v0.6.2 h1:iYtoxqPMzHUPp7St+5yA8+cONdyXD3ug6KK15n7Pklk=
 github.com/jjti/go-spancheck v0.6.2/go.mod h1:+X7lvIrR5ZdUTkxFYqzJ0abr8Sb5LOo80uOhWNqIrYA=
+github.com/jkeys089/interfaceguard v1.0.1 h1:WUJTenaN3QO/OUPOWGDmjhBCiO9sc4/muQw7bhZOfI4=
+github.com/jkeys089/interfaceguard v1.0.1/go.mod h1:wDUCIHY0LsuP0qzwlSOwvz01sPpJ7z1JYJtjeASDhcw=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -359,6 +359,7 @@
             "inamedparam",
             "ineffassign",
             "interfacebloat",
+            "interfaceguard",
             "interfacer",
             "intrange",
             "ireturn",
@@ -1519,6 +1520,22 @@
             "max": {
               "description": "The maximum number of methods allowed for an interface.",
               "type": "integer"
+            }
+          }
+        },
+        "interfaceguard": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "disable-interface-to-interface": {
+              "description": "Disable check for direct interface-to-interface comparisons.",
+              "type": "boolean",
+              "default": false
+            },
+            "disable-interface-to-nil": {
+              "description": "Disable check for direct interface-to-nil comparisons.",
+              "type": "boolean",
+              "default": false
             }
           }
         },

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -94,6 +94,10 @@ var defaultLintersSettings = LintersSettings{
 	InterfaceBloat: InterfaceBloatSettings{
 		Max: 10,
 	},
+	Interfaceguard: InterfaceguardSettings{
+		DisableInterfaceComparison: false,
+		DisableNilComparison:       false,
+	},
 	Lll: LllSettings{
 		LineLength: 120,
 		TabWidth:   1,
@@ -236,6 +240,7 @@ type LintersSettings struct {
 	ImportAs        ImportAsSettings
 	Inamedparam     INamedParamSettings
 	InterfaceBloat  InterfaceBloatSettings
+	Interfaceguard  InterfaceguardSettings
 	Ireturn         IreturnSettings
 	Lll             LllSettings
 	LoggerCheck     LoggerCheckSettings
@@ -664,6 +669,11 @@ type INamedParamSettings struct {
 
 type InterfaceBloatSettings struct {
 	Max int `mapstructure:"max"`
+}
+
+type InterfaceguardSettings struct {
+	DisableInterfaceComparison bool `mapstructure:"disable-interface-to-interface"`
+	DisableNilComparison       bool `mapstructure:"disable-interface-to-nil"`
 }
 
 type IreturnSettings struct {

--- a/pkg/golinters/interfaceguard/interfaceguard.go
+++ b/pkg/golinters/interfaceguard/interfaceguard.go
@@ -1,0 +1,28 @@
+package interfaceguard
+
+import (
+	"github.com/jkeys089/interfaceguard"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New(settings *config.InterfaceguardSettings) *goanalysis.Linter {
+	var cfg map[string]any
+	if settings != nil {
+		cfg = map[string]any{
+			"i": settings.DisableInterfaceComparison,
+			"n": settings.DisableNilComparison,
+		}
+	}
+
+	a := interfaceguard.NewAnalyzer(false, false)
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		map[string]map[string]any{a.Name: cfg},
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/interfaceguard/interfaceguard_test.go
+++ b/pkg/golinters/interfaceguard/interfaceguard_test.go
@@ -1,0 +1,11 @@
+package interfaceguard
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/interfaceguard/testdata/interfaceguard.go
+++ b/pkg/golinters/interfaceguard/testdata/interfaceguard.go
@@ -1,0 +1,39 @@
+//golangcitest:args -Einterfaceguard
+package testdata
+
+import "fmt"
+
+type Greeter interface {
+	SayHi() string
+}
+
+type BasicGreeter struct{}
+
+func (b *BasicGreeter) SayHi() string {
+	return "Welcome!"
+}
+
+var (
+	greeter      Greeter
+	otherGreeter Greeter
+)
+
+func nilBasicComparison() {
+	if greeter == nil { // want "comparing interface to nil"
+		fmt.Println("greeter is nil")
+	}
+
+	if greeter != nil { // want "comparing interface to nil"
+		fmt.Println("greeter is not nil")
+	}
+}
+
+func interfaceBasicComparison() {
+	if greeter == otherGreeter { // want "comparing two interfaces"
+		fmt.Println("greeter == otherGreeter")
+	}
+
+	if greeter != otherGreeter { // want "comparing two interfaces"
+		fmt.Println("greeter != otherGreeter")
+	}
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -59,6 +59,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/inamedparam"
 	"github.com/golangci/golangci-lint/pkg/golinters/ineffassign"
 	"github.com/golangci/golangci-lint/pkg/golinters/interfacebloat"
+	"github.com/golangci/golangci-lint/pkg/golinters/interfaceguard"
 	"github.com/golangci/golangci-lint/pkg/golinters/intrange"
 	"github.com/golangci/golangci-lint/pkg/golinters/ireturn"
 	"github.com/golangci/golangci-lint/pkg/golinters/lll"
@@ -498,6 +499,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.49.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/sashamelentyev/interfacebloat"),
+
+		linter.NewConfig(interfaceguard.New(&cfg.LintersSettings.Interfaceguard)).
+			WithSince("v1.61.0").
+			WithPresets(linter.PresetBugs).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/jkeys089/interfaceguard"),
 
 		linter.NewConfig(linter.NewNoopDeprecated("interfacer", cfg, linter.DeprecationError)).
 			WithSince("v1.0.0").


### PR DESCRIPTION
[interfaceguard](https://github.com/jkeys089/interfaceguard) finds subtle interface-related issues, including improper comparisons and type mismatches.

Example:

<details>

```go
package main

import "fmt"

type Greeter interface {
	SayHi() string
}

type CostcoGreeter struct {}

func (c *CostcoGreeter) SayHi() string {
	return "Welcome to Costco, I love you."
}

func main() {
	var greeter Greeter = getCachedCostcoGreeter()
	
	if greeter == nil {
		panic("greeter is nil") // we might expect this to panic, but it doesn't!
	}
	
	fmt.Println("ok")
}

func getCachedCostcoGreeter() *CostcoGreeter {
	return nil
}
```

</details>

This is a safer way to check if an interface is nil:

<details>

```go
package main

import (
	"fmt"
	"reflect"
)

type Greeter interface {
	SayHi() string
}

type CostcoGreeter struct {}

func (c *CostcoGreeter) SayHi() string {
	return "Welcome to Costco, I love you."
}

func main() {
	var greeter Greeter = getCachedCostcoGreeter()

	if isNil(greeter) {
		panic("greeter is nil") // now we catch the nil greeter and panic as expected
	}

	fmt.Println("ok")
}

func getCachedCostcoGreeter() *CostcoGreeter {
	return nil
}

func isNil(val any) bool {
	//nolint:interfaceguard
	if val == nil {
		return true
	}

	v := reflect.ValueOf(val)

	//nolint:exhaustive
	switch v.Kind() {
	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer,
		reflect.UnsafePointer, reflect.Interface, reflect.Slice:
		return v.IsNil()
	default:
		return false
	}
}
```

</details>

What about comparing two interface values to each other:

<details>

```go
package main

import "fmt"

type Greeter interface {
	SayHi() string
}

type WallyWorldGreeter struct {}

func (w *WallyWorldGreeter) SayHi() string {
	return "Sorry, folks! We're closed for two weeks to clean and repair America's favorite family fun park. Sorry, uh-huh, uh-huh, uh-huh!"
}

func main() {
	var greeterA Greeter
	var greeterB Greeter = getCachedWallyWorldGreeter()
	
	if greeterA == greeterB {
		panic("greeterA == greeterB") // we might expect this to panic since both are nil, but it doesn't!
	}
	
	fmt.Println("ok")
}

func getCachedWallyWorldGreeter() *WallyWorldGreeter {
	return nil
}
```

Interface equality checks can be tricky! Here is a safer approach:
```go
package main

import (
	"fmt"
	"reflect"
)

type Greeter interface {
	SayHi() string
}

type WallyWorldGreeter struct {}

func (w *WallyWorldGreeter) SayHi() string {
	return "Sorry, folks! We're closed for two weeks to clean and repair America's favorite family fun park. Sorry, uh-huh, uh-huh, uh-huh!"
}

func main() {
	var greeterA Greeter
	var greeterB Greeter = getCachedWallyWorldGreeter()

	if isEqual(greeterA, greeterB) {
		panic("greeterA == greeterB") // now we see them as equal and panic as expected
	}
	
	fmt.Println("ok")
}

func getCachedWallyWorldGreeter() *WallyWorldGreeter {
	return nil
}

func isEqual(greeterA, greeterB Greeter) bool {
	if isNil(greeterA) && isNil(greeterB) {
		return true
	}
	
	return reflect.DeepEqual(greeterA, greeterB)
}

func isNil(val any) bool {
	//nolint:interfaceguard
	if val == nil {
		return true
	}

	v := reflect.ValueOf(val)

	//nolint:exhaustive
	switch v.Kind() {
	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer,
		reflect.UnsafePointer, reflect.Interface, reflect.Slice:
		return v.IsNil()
	default:
		return false
	}
}
```

</details>