### PR TITLE
update description for fatcontext

### DIFF
--- a/assets/linters-info.json
+++ b/assets/linters-info.json
@@ -319,7 +319,7 @@
   },
   {
     "name": "fatcontext",
-    "desc": "detects nested contexts in loops",
+    "desc": "detects nested contexts in loops or function literals",
     "loadMode": 575,
     "inPresets": [
       "performance"


### PR DESCRIPTION
Since v0.5.0, fatcontext now detects nested contexts in function literals too.
I'm not updating the linter itself because dependabot will take care of it. Please tell me if I should.