### PR TITLE
Report packages loading failure with a specific  exit-code

### DIFF
--- a/pkg/exitcodes/exitcodes.go
+++ b/pkg/exitcodes/exitcodes.go
@@ -1,5 +1,9 @@
 package exitcodes
 
+import (
+	"fmt"
+)
+
 const (
 	Success = iota
 	IssuesFound
@@ -9,16 +13,23 @@ const (
 	NoGoFiles
 	NoConfigFileDetected
 	ErrorWasLogged
+	PackagesLoadingFailure
 )
 
 type ExitError struct {
+	Inner   error
 	Message string
 	Code    int
 }
 
 func (e ExitError) Error() string {
+	if e.Inner != nil {
+		return fmt.Sprintf("%s, %s", e.Message, e.Inner.Error())
+	}
 	return e.Message
 }
+
+func (e ExitError) Unwrap() error { return e.Inner }
 
 var (
 	ErrNoGoFiles = &ExitError{

--- a/pkg/lint/package.go
+++ b/pkg/lint/package.go
@@ -84,7 +84,11 @@ func (l *PackageLoader) loadPackages(ctx context.Context, loadMode packages.Load
 
 	pkgs, err := packages.Load(conf, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load with go/packages: %w", err)
+		return nil, &exitcodes.ExitError{
+			Inner:   err,
+			Message: "failed to load with go/packages:",
+			Code:    exitcodes.PackagesLoadingFailure,
+		}
 	}
 
 	if loadMode&packages.NeedSyntax == 0 {


### PR DESCRIPTION
The `packages.Load()` function can use an [external package provider `GOPACKAGESDRIVER`](https://pkg.go.dev/golang.org/x/tools/go/packages#hdr-The_driver_protocol) for third-party build-systems like Bazel or Buck2.

Having a specific exit code when external driver fails would increase observability and will help to distinguish `GOPACKAGESDRIVER`'s failures from other kinds of failures.