### PR TITLE
nolintlint: remove empty line in unused directive replacement

### DIFF
--- a/pkg/golinters/nolintlint/internal/nolintlint.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint.go
@@ -259,6 +259,11 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 							NewString: "",
 						},
 					}
+					// if the directive starts from a new line, remove the line
+					if removeNolintCompletely.Inline.StartCol == 0 {
+						removeNolintCompletely.NeedOnlyDelete = true
+						removeNolintCompletely.Inline = nil
+					}
 
 					if len(linters) == 0 {
 						issue := UnusedCandidate{BaseIssue: base}

--- a/pkg/golinters/nolintlint/internal/nolintlint.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint.go
@@ -252,17 +252,19 @@ func (l Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
 
 				// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
 				if (l.needs & NeedsUnused) != 0 {
-					removeNolintCompletely := &result.Replacement{
-						Inline: &result.InlineFix{
-							StartCol:  pos.Column - 1,
+					removeNolintCompletely := &result.Replacement{}
+
+					startCol := pos.Column - 1
+
+					if startCol == 0 {
+						// if the directive starts from a new line, remove the line
+						removeNolintCompletely.NeedOnlyDelete = true
+					} else {
+						removeNolintCompletely.Inline = &result.InlineFix{
+							StartCol:  startCol,
 							Length:    end.Column - pos.Column,
 							NewString: "",
-						},
-					}
-					// if the directive starts from a new line, remove the line
-					if removeNolintCompletely.Inline.StartCol == 0 {
-						removeNolintCompletely.NeedOnlyDelete = true
-						removeNolintCompletely.Inline = nil
+						}
 					}
 
 					if len(linters) == 0 {

--- a/pkg/golinters/nolintlint/internal/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint_test.go
@@ -189,6 +189,25 @@ func foo() {
 			},
 		},
 		{
+			desc:  "needs unused with one specific linter in a new line generates replacement",
+			needs: NeedsUnused,
+			contents: `
+package bar
+
+//nolint:somelinter
+func foo() {
+  bad()
+}`,
+			expected: []issueWithReplacement{
+				{
+					issue: "directive `//nolint:somelinter` is unused for linter \"somelinter\" at testing.go:4:1",
+					replacement: &result.Replacement{
+						NeedOnlyDelete: true,
+					},
+				},
+			},
+		},
+		{
 			desc:  "needs unused with multiple specific linters does not generate replacements",
 			needs: NeedsUnused,
 			contents: `


### PR DESCRIPTION
When using the `nolintlint` linter in autofix mode, it does not remove the empty line along with the unused linter directive if it starts from a new line. Expected behavior: should remove the empty line.