### PR TITLE
Add receivernamelen linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2689,6 +2689,7 @@ linters:
     - promlinter
     - protogetter
     - reassign
+    - receivernamelen
     - revive
     - rowserrcheck
     - sloglint
@@ -2804,6 +2805,7 @@ linters:
     - promlinter
     - protogetter
     - reassign
+    - receivernamelen
     - revive
     - rowserrcheck
     - sloglint

--- a/go.mod
+++ b/go.mod
@@ -120,6 +120,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0
 	github.com/yeya24/promlinter v0.3.0
 	github.com/ykadowak/zerologlint v0.1.5
+	github.com/ytnsym/receivernamelen v0.0.0-20240911094623-cb234a87d58c
 	gitlab.com/bosi/decorder v0.4.2
 	go-simpler.org/musttag v0.12.2
 	go-simpler.org/sloglint v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -571,6 +571,8 @@ github.com/yeya24/promlinter v0.3.0 h1:JVDbMp08lVCP7Y6NP3qHroGAO6z2yGKQtS5Jsjqto
 github.com/yeya24/promlinter v0.3.0/go.mod h1:cDfJQQYv9uYciW60QT0eeHlFodotkYZlL+YcPQN+mW4=
 github.com/ykadowak/zerologlint v0.1.5 h1:Gy/fMz1dFQN9JZTPjv1hxEk+sRWm05row04Yoolgdiw=
 github.com/ykadowak/zerologlint v0.1.5/go.mod h1:KaUskqF3e/v59oPmdq1U1DnKcuHokl2/K1U4pmIELKg=
+github.com/ytnsym/receivernamelen v0.0.0-20240911094623-cb234a87d58c h1:AsS70Kik4mibMbHB7lco94iizYuCEoPwsF4FMn76KVw=
+github.com/ytnsym/receivernamelen v0.0.0-20240911094623-cb234a87d58c/go.mod h1:cgnDTZbZYr2LfrEMX6Zm790TNvNVC6YgZQjS4LCKDXo=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -388,6 +388,7 @@
             "promlinter",
             "protogetter",
             "reassign",
+            "receivernamelen",
             "revive",
             "rowserrcheck",
             "scopelint",

--- a/pkg/golinters/receivernamelen/receivernamelen.go
+++ b/pkg/golinters/receivernamelen/receivernamelen.go
@@ -1,0 +1,19 @@
+package receivernamelen
+
+import (
+	"github.com/ytnsym/receivernamelen"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	a := receivernamelen.Analyzer
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/receivernamelen/receivernamelen_test.go
+++ b/pkg/golinters/receivernamelen/receivernamelen_test.go
@@ -1,0 +1,11 @@
+package receivernamelen
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/receivernamelen/testdata/receivernamelen.go
+++ b/pkg/golinters/receivernamelen/testdata/receivernamelen.go
@@ -1,0 +1,20 @@
+//golangcitest:args -Ereceivernamelen
+package testdata
+
+type Example1 struct{}
+
+func (e *Example1) F() {}
+
+type Example2 struct{}
+
+func (ex *Example2) F() {}
+
+type Example3 struct{}
+
+func (ex3 *Example3) F() {} // want `receiver variable names must be one or two letters in length`
+
+type Example4 struct{}
+
+func (example *Example4) F() {} // want `receiver variable names must be one or two letters in length`
+
+func F() {}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -85,6 +85,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/promlinter"
 	"github.com/golangci/golangci-lint/pkg/golinters/protogetter"
 	"github.com/golangci/golangci-lint/pkg/golinters/reassign"
+	"github.com/golangci/golangci-lint/pkg/golinters/receivernamelen"
 	"github.com/golangci/golangci-lint/pkg/golinters/revive"
 	"github.com/golangci/golangci-lint/pkg/golinters/rowserrcheck"
 	"github.com/golangci/golangci-lint/pkg/golinters/sloglint"
@@ -656,6 +657,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetBugs).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/curioswitch/go-reassign"),
+
+		linter.NewConfig(receivernamelen.New()).
+			WithSince("v1.62.0").
+			WithPresets(linter.PresetStyle).
+			WithURL("https://github.com/ytnsym/receivernamelen"),
 
 		linter.NewConfig(revive.New(&cfg.LintersSettings.Revive)).
 			WithSince("v1.37.0").


### PR DESCRIPTION
[receivernamelen](https://github.com/ytnsym/receivernamelen) is a linter that checks whether the length of a receiver variable name follows [Go style](https://google.github.io/styleguide/go/decisions.html#receiver-names)).