### PR TITLE
dev: use slices package from stdlib

### DIFF
--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -16,7 +17,6 @@ import (
 	gocriticlinter "github.com/go-critic/go-critic/linter"
 	_ "github.com/quasilyte/go-ruleguard/dsl"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"

--- a/pkg/golinters/gocritic/gocritic_test.go
+++ b/pkg/golinters/gocritic/gocritic_test.go
@@ -1,6 +1,7 @@
 package gocritic
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/logutils"


### PR DESCRIPTION
The PR replaces `"golang.org/x/exp/slices"` with `"slices"` because the minimum supported version is Go 1.22.