### PR TITLE
Add useq linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2417,6 +2417,23 @@ linters-settings:
     # Default: true
     generated-is-used: false
 
+  useq:
+    # The list of functions with message formatting arguments that should be validated.
+    functions:
+      # The function name needs to be the full qualified name (including potential pointers).
+      # Examples:
+      #- github.com/custom/package.MyPrintf              # exported package level function.
+      #- (github.com/custom/package.MyStruct).MyPrintf   # exported method of a struct.
+      #- (*github.com/custom/package.MyStruct).MyPrintf  # exported method of a struct with a pointer receiver.
+
+      # By default, the following functions are validated:
+      #- fmt.Printf
+      #- fmt.Sprintf
+      #- fmt.Errorf
+      #- fmt.Fprintf
+      #- github.com/pkg/errors.Errorf
+      #- github.com/pkg/errors.Wrapf
+
   varnamelen:
     # The longest distance, in source lines, that is being considered a "small scope".
     # Variables used in at most this many lines will be ignored.
@@ -2709,6 +2726,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - useq
     - usestdlibvars
     - varnamelen
     - wastedassign
@@ -2825,6 +2843,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - useq
     - usestdlibvars
     - varnamelen
     - wastedassign

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/curioswitch/go-reassign v0.2.0
 	github.com/daixiang0/gci v0.13.5
 	github.com/denis-tingaikin/go-header v0.5.0
+	github.com/dhaus67/useq v1.3.0
 	github.com/fatih/color v1.17.0
 	github.com/firefart/nonamedreturns v1.0.5
 	github.com/fzipp/gocyclo v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42t4429eC9k8=
 github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okegmwQ3UgWl4V1D8gjlY=
+github.com/dhaus67/useq v1.3.0 h1:UYNZprUyoP510eLFBYdduqhjztG0ZGk0l9yPknb9skc=
+github.com/dhaus67/useq v1.3.0/go.mod h1:9Qypm9H/ocvQjvNTeAqwBCbdp1eqmplM7Pw/jNzF1L0=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -409,6 +409,7 @@
             "unconvert",
             "unparam",
             "unused",
+            "useq",
             "usestdlibvars",
             "varcheck",
             "varnamelen",
@@ -3146,6 +3147,20 @@
                   "default": true,
                   "type": "boolean"
                 }
+              }
+            }
+          }
+        },
+        "useq": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "functions": {
+              "type": "array",
+              "description": "List of functions to check for use of %q formatting",
+              "items": {
+                "type": "string",
+                "description": "The function name with package name, e.g. fmt.Sprintf"
               }
             }
           }

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -273,6 +273,7 @@ type LintersSettings struct {
 	Unparam         UnparamSettings
 	Unused          UnusedSettings
 	UseStdlibVars   UseStdlibVarsSettings
+	Useq            UseqSettings
 	Varnamelen      VarnamelenSettings
 	Whitespace      WhitespaceSettings
 	Wrapcheck       WrapcheckSettings
@@ -954,6 +955,10 @@ type UnusedSettings struct {
 	ParametersAreUsed      bool `mapstructure:"parameters-are-used"`
 	LocalVariablesAreUsed  bool `mapstructure:"local-variables-are-used"`
 	GeneratedIsUsed        bool `mapstructure:"generated-is-used"`
+}
+
+type UseqSettings struct {
+	Functions []string `mapstructure:"functions"`
 }
 
 type VarnamelenSettings struct {

--- a/pkg/golinters/useq/testdata/useq.go
+++ b/pkg/golinters/useq/testdata/useq.go
@@ -1,0 +1,31 @@
+//golangcitest:args -Euseq
+package testdata
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	name := "John"
+
+	fmt.Printf("This is my name: \"%s\"\n", name) // want `use %q instead of \"%s\" for formatting strings with quotations`
+	fmt.Printf("This is my name: %s", name)
+	fmt.Printf("This is my name: %q", name)
+	fmt.Printf("This is my age: %d", 42)
+
+	fmt.Sprintf("This is my name: \"%s\"\n", name) // want `use %q instead of \"%s\" for formatting strings with quotations`
+	fmt.Sprintf("This is my name: %s", name)
+	fmt.Sprintf("This is my name: %q", name)
+	fmt.Sprintf("This is my age: %d", 42)
+
+	fmt.Fprintf(os.Stdout, "This is my name: \"%s\"\n", name) // want `use %q instead of \"%s\" for formatting strings with quotations`
+	fmt.Fprintf(os.Stdout, "This is my name: %s", name)
+	fmt.Fprintf(os.Stdout, "This is my name: %q", name)
+	fmt.Fprintf(os.Stdout, "This is my age: %d", 42)
+
+	fmt.Errorf("This is my name: \"%s\"\n", name) // want `use %q instead of \"%s\" for formatting strings with quotations`
+	fmt.Errorf("This is my name: %s", name)
+	fmt.Errorf("This is my name: %q", name)
+	fmt.Errorf("This is my age: %d", 42)
+}

--- a/pkg/golinters/useq/testdata/useq_custom_funcs.go
+++ b/pkg/golinters/useq/testdata/useq_custom_funcs.go
@@ -1,0 +1,20 @@
+//golangcitest:args -Euseq
+//golangcitest:config_path testdata/useq_custom_funcs.yml
+package testdata
+
+import (
+	"fmt"
+)
+
+func customPrint(msg string, args ...any) {
+	fmt.Println(msg, args)
+}
+
+func main() {
+	name := "John"
+
+	customPrint("This is my name: \"%s\"\n", name) // want `use %q instead of \"%s\" for formatting strings with quotations`
+	customPrint("This is my name: %s", name)
+	customPrint("This is my name: %q", name)
+	customPrint("This is my age: %d", 42)
+}

--- a/pkg/golinters/useq/testdata/useq_custom_funcs.yml
+++ b/pkg/golinters/useq/testdata/useq_custom_funcs.yml
@@ -1,0 +1,4 @@
+linters-settings:
+  useq:
+    functions:
+      - command-line-arguments.customPrint

--- a/pkg/golinters/useq/useq.go
+++ b/pkg/golinters/useq/useq.go
@@ -1,0 +1,24 @@
+package useq
+
+import (
+	"github.com/dhaus67/useq"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/golinters/internal"
+)
+
+func New(settings *config.UseqSettings) *goanalysis.Linter {
+	a, err := useq.NewAnalyzer(useq.Settings{Functions: settings.Functions})
+	if err != nil {
+		internal.LinterLogger.Fatalf("useq: create analyzer: %v", err)
+	}
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/useq/useq_integration_test.go
+++ b/pkg/golinters/useq/useq_integration_test.go
@@ -1,0 +1,11 @@
+package useq
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestData(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -104,6 +104,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/unconvert"
 	"github.com/golangci/golangci-lint/pkg/golinters/unparam"
 	"github.com/golangci/golangci-lint/pkg/golinters/unused"
+	"github.com/golangci/golangci-lint/pkg/golinters/useq"
 	"github.com/golangci/golangci-lint/pkg/golinters/usestdlibvars"
 	"github.com/golangci/golangci-lint/pkg/golinters/varnamelen"
 	"github.com/golangci/golangci-lint/pkg/golinters/wastedassign"
@@ -792,6 +793,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			ConsiderSlow().
 			WithChangeTypes().
 			WithURL("https://github.com/dominikh/go-tools/tree/master/unused"),
+
+		linter.NewConfig(useq.New(&cfg.LintersSettings.Useq)).
+			WithSince("v1.62.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/dhaus67/useq"),
 
 		linter.NewConfig(usestdlibvars.New(&cfg.LintersSettings.UseStdlibVars)).
 			WithSince("v1.48.0").


### PR DESCRIPTION
Adding a new linter called [useq](https://github.com/dhaus67/useq).

The linter is checking formatting arguments and replacing manually crafted escapes (such as `fmt.Printf("Hello my name is \"%s\"", name)` with the `%q` formatting directive (resulting in `fmt.Printf("Hello my name is %q", name)`.


Some unrelated changes have been made to the `go.mod` since this seems to be the first module that introduces `go1.23`. If we want to make this change separately and keep `go 1.22.1` for the time being, I'm happy to downgrade the go version used in [the useq](https://github.com/dhaus67/useq) package for the time being.