### PR TITLE
fix: type sizing when cross-compiling (32-bit)

### DIFF
--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -165,7 +165,7 @@ func (lp *loadingPackage) loadFromSource(loadMode LoadMode) error {
 			pkg.Errors = append(pkg.Errors, lp.convertError(err)...)
 		},
 		GoVersion: rv, // TODO(ldez) temporary workaround
-		Sizes: types.SizesFor("gc", build.Default.GOARCH),
+		Sizes:     types.SizesFor(build.Default.Compiler, build.Default.GOARCH),
 	}
 
 	_ = types.NewChecker(tc, pkg.Fset, pkg.Types, pkg.TypesInfo).Files(pkg.Syntax)

--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"go/build"
 	"go/parser"
 	"go/scanner"
 	"go/types"
@@ -164,6 +165,7 @@ func (lp *loadingPackage) loadFromSource(loadMode LoadMode) error {
 			pkg.Errors = append(pkg.Errors, lp.convertError(err)...)
 		},
 		GoVersion: rv, // TODO(ldez) temporary workaround
+		Sizes: types.SizesFor("gc", build.Default.GOARCH),
 	}
 
 	_ = types.NewChecker(tc, pkg.Fset, pkg.Types, pkg.TypesInfo).Files(pkg.Syntax)


### PR DESCRIPTION
`golangci-lint` should respect `GOARCH` when performing typechecking.

For example, the code below fails to build with `GOARCH=arm`, but succeeds with `GOARCH=amd64`:

```
// -uintptr(x-y) creates a static assertion of x==y
const _ = -uintptr(unsafe.Sizeof((*byte)(nil)) - 8)
```

`golangci-lint` currently does not respect `GOARCH` for typechecking because it does not set `types.Config.Sizes`, which tells the typecheck package how to determine the size of machine-specific types (like pointers and `uintptr`). By default, [if `types.Config.Sizes` is `nil`](https://pkg.go.dev/go/types#Config), `SizesFor("gc", "amd64")` is used by default. This will notably break typechecking for 32-bit platforms.

This PR sets `types.Config.Sizes` from `build.Default`, which is set by the `GOARCH` environment variable.