### PR TITLE
Add paniccheck linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -201,6 +201,7 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
+    - paniccheck
     - paralleltest
     - perfsprint
     - prealloc

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -201,7 +201,6 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
-    - paniccheck
     - paralleltest
     - perfsprint
     - prealloc

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -201,6 +201,7 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
+    - paniccheck
     - paralleltest
     - perfsprint
     - prealloc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.22.1
+go 1.22.8
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
@@ -66,6 +66,7 @@ require (
 	github.com/kunwardeep/paralleltest v1.0.10
 	github.com/kyoh86/exportloopref v0.1.11
 	github.com/lasiar/canonicalheader v1.1.1
+	github.com/ldemailly/panic-linter v0.2.1
 	github.com/ldez/gomoddirectives v0.2.4
 	github.com/ldez/tagliatelle v0.5.0
 	github.com/leonklingele/grouper v1.1.2
@@ -134,6 +135,7 @@ require (
 )
 
 require (
+	fortio.org/sets v1.2.0 // indirect
 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+fortio.org/assert v1.2.1 h1:48I39urpeDj65RP1KguF7akCjILNeu6vICiYMEysR7Q=
+fortio.org/assert v1.2.1/go.mod h1:039mG+/iYDPO8Ibx8TrNuJCm2T2SuhwRI3uL9nHTTls=
+fortio.org/sets v1.2.0 h1:FBfC7R2xrOJtkcioUbY6WqEzdujuBoZRbSdp1fYF4Kk=
+fortio.org/sets v1.2.0/go.mod h1:J2BwIxNOLWsSU7IMZUg541kh3Au4JEKHrghVwXs68tE=
 github.com/4meepo/tagalign v1.3.4 h1:P51VcvBnf04YkHzjfclN6BbsopfJR5rxs1n+5zHt+w8=
 github.com/4meepo/tagalign v1.3.4/go.mod h1:M+pnkHH2vG8+qhE5bVc/zeP7HS/j910Fwa9TUSyZVI0=
 github.com/Abirdcfly/dupword v0.1.3 h1:9Pa1NuAsZvpFPi9Pqkd93I7LIYRURj+A//dFd5tgBeE=
@@ -341,6 +345,8 @@ github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
 github.com/lasiar/canonicalheader v1.1.1 h1:wC+dY9ZfiqiPwAexUApFush/csSPXeIi4QqyxXmng8I=
 github.com/lasiar/canonicalheader v1.1.1/go.mod h1:cXkb3Dlk6XXy+8MVQnF23CYKWlyA7kfQhSw2CcZtZb0=
+github.com/ldemailly/panic-linter v0.2.1 h1:Llh2KfvOoSuY+1GEZzRQkZLCjpEIsJlfyIv9nHkv4mc=
+github.com/ldemailly/panic-linter v0.2.1/go.mod h1:gz+Uj5blylcIwQROn9+xm5cUa6kLNVW5sWCbx5FqeHA=
 github.com/ldez/gomoddirectives v0.2.4 h1:j3YjBIjEBbqZ0NKtBNzr8rtMHTOrLPeiwTkfUJZ3alg=
 github.com/ldez/gomoddirectives v0.2.4/go.mod h1:oWu9i62VcQDYp9EQ0ONTfqLNh+mDLWWDO+SO0qSQw5g=
 github.com/ldez/tagliatelle v0.5.0 h1:epgfuYt9v0CG3fms0pEgIMNPuFf/LpPIfjk4kyqSioo=

--- a/pkg/golinters/paniccheck/paniccheck.go
+++ b/pkg/golinters/paniccheck/paniccheck.go
@@ -1,0 +1,19 @@
+package paniccheck
+
+import (
+	"github.com/ldemailly/panic-linter/analyser"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	a := analyser.Analyser
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/paniccheck/paniccheck_integration_test.go
+++ b/pkg/golinters/paniccheck/paniccheck_integration_test.go
@@ -1,0 +1,11 @@
+package paniccheck
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/paniccheck/testdata/panic.go
+++ b/pkg/golinters/paniccheck/testdata/panic.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	if false {
+		fmt.Println("Nested Hello, world") // Comment inside if.
+		panic("this is bad")               /* want "panic call without same line comment justifying it" */
+	} else {
+		panic("this is ok") // A comment on the same line makes panic() ok.
+	}
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -78,6 +78,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/nolintlint"
 	"github.com/golangci/golangci-lint/pkg/golinters/nonamedreturns"
 	"github.com/golangci/golangci-lint/pkg/golinters/nosprintfhostport"
+	"github.com/golangci/golangci-lint/pkg/golinters/paniccheck"
 	"github.com/golangci/golangci-lint/pkg/golinters/paralleltest"
 	"github.com/golangci/golangci-lint/pkg/golinters/perfsprint"
 	"github.com/golangci/golangci-lint/pkg/golinters/prealloc"
@@ -617,6 +618,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.46.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/stbenjam/no-sprintf-host-port"),
+
+		linter.NewConfig(paniccheck.New()).
+			WithSince("v1.62.0").
+			WithLoadForGoAnalysis().
+			WithPresets(linter.PresetError).
+			WithURL("https://github.com/ldemailly/panic-linter"),
 
 		linter.NewConfig(paralleltest.New(&cfg.LintersSettings.ParallelTest)).
 			WithSince("v1.33.0").


### PR DESCRIPTION
Adding paniccheck (off by default): requires an explanatory (not a //nolint) comment for all panic() calls

I think I followed all the steps in https://golangci-lint.run/contributing/new-linters/ but possibly missing something, lmk

Linter repo: https://github.com/ldemailly/panic-linter

Thanks
