### PR TITLE
dev: remove unused function SetAnalyzerGoVersion

### DIFF
--- a/pkg/golinters/internal/staticcheck_common.go
+++ b/pkg/golinters/internal/staticcheck_common.go
@@ -9,10 +9,7 @@ import (
 	scconfig "honnef.co/go/tools/config"
 
 	"github.com/golangci/golangci-lint/pkg/config"
-	"github.com/golangci/golangci-lint/pkg/logutils"
 )
-
-var debugf = logutils.Debug(logutils.DebugKeyMegacheck)
 
 func SetupStaticCheckAnalyzers(src []*lint.Analyzer, checks []string) []*analysis.Analyzer {
 	var names []string

--- a/pkg/golinters/internal/staticcheck_common.go
+++ b/pkg/golinters/internal/staticcheck_common.go
@@ -32,14 +32,6 @@ func SetupStaticCheckAnalyzers(src []*lint.Analyzer, checks []string) []*analysi
 	return ret
 }
 
-func SetAnalyzerGoVersion(a *analysis.Analyzer, goVersion string) {
-	if v := a.Flags.Lookup("go"); v != nil {
-		if err := v.Value.Set(goVersion); err != nil {
-			debugf("Failed to set go version: %s", err)
-		}
-	}
-}
-
 func StaticCheckConfig(settings *config.StaticCheckSettings) *scconfig.Config {
 	var cfg *scconfig.Config
 

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -60,11 +60,10 @@ const (
 )
 
 const (
-	DebugKeyGoCritic  = "gocritic"  // Debugs `go-critic` linter.
-	DebugKeyGovet     = "govet"     // Debugs `govet` linter.
-	DebugKeyMegacheck = "megacheck" // Debugs `staticcheck` related linters.
-	DebugKeyNolint    = "nolint"    // Debugs a filter excluding issues by `//nolint` comments.
-	DebugKeyRevive    = "revive"    // Debugs `revive` linter.
+	DebugKeyGoCritic = "gocritic" // Debugs `go-critic` linter.
+	DebugKeyGovet    = "govet"    // Debugs `govet` linter.
+	DebugKeyNolint   = "nolint"   // Debugs a filter excluding issues by `//nolint` comments.
+	DebugKeyRevive   = "revive"   // Debugs `revive` linter.
 )
 
 func getEnabledDebugs() map[string]bool {


### PR DESCRIPTION
The usage of `internal.SetAnalyzerGoVersion` was removed in #4907.