### PR TITLE
code-climate: add check_name field

### DIFF
--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -7,14 +7,18 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const defaultCodeClimateSeverity = "critical"
+const (
+	defaultCheckName           = "golangci-lint"
+	defaultCodeClimateSeverity = "critical"
+)
 
 // CodeClimateIssue is a subset of the Code Climate spec.
 // https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
 // It is just enough to support GitLab CI Code Quality.
-// https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html
+// https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool
 type CodeClimateIssue struct {
 	Description string `json:"description"`
+	CheckName   string `json:"check_name"`
 	Severity    string `json:"severity,omitempty"`
 	Fingerprint string `json:"fingerprint"`
 	Location    struct {
@@ -38,11 +42,16 @@ func (p CodeClimate) Print(issues []result.Issue) error {
 	for i := range issues {
 		issue := &issues[i]
 		codeClimateIssue := CodeClimateIssue{}
-		codeClimateIssue.Description = issue.Description()
+		codeClimateIssue.Description = issue.Text
+		codeClimateIssue.CheckName = defaultCheckName
 		codeClimateIssue.Location.Path = issue.Pos.Filename
 		codeClimateIssue.Location.Lines.Begin = issue.Pos.Line
 		codeClimateIssue.Fingerprint = issue.Fingerprint()
 		codeClimateIssue.Severity = defaultCodeClimateSeverity
+
+		if issue.FromLinter != "" {
+			codeClimateIssue.CheckName = issue.FromLinter
+		}
 
 		if issue.Severity != "" {
 			codeClimateIssue.Severity = issue.Severity

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -7,10 +7,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
-const (
-	defaultCheckName           = "golangci-lint"
-	defaultCodeClimateSeverity = "critical"
-)
+const defaultCodeClimateSeverity = "critical"
 
 // CodeClimateIssue is a subset of the Code Climate spec.
 // https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
@@ -39,19 +36,17 @@ func NewCodeClimate(w io.Writer) *CodeClimate {
 
 func (p CodeClimate) Print(issues []result.Issue) error {
 	codeClimateIssues := make([]CodeClimateIssue, 0, len(issues))
+
 	for i := range issues {
 		issue := &issues[i]
+
 		codeClimateIssue := CodeClimateIssue{}
-		codeClimateIssue.Description = issue.Text
-		codeClimateIssue.CheckName = defaultCheckName
+		codeClimateIssue.Description = issue.Description()
+		codeClimateIssue.CheckName = issue.FromLinter
 		codeClimateIssue.Location.Path = issue.Pos.Filename
 		codeClimateIssue.Location.Lines.Begin = issue.Pos.Line
 		codeClimateIssue.Fingerprint = issue.Fingerprint()
 		codeClimateIssue.Severity = defaultCodeClimateSeverity
-
-		if issue.FromLinter != "" {
-			codeClimateIssue.CheckName = issue.FromLinter
-		}
 
 		if issue.Severity != "" {
 			codeClimateIssue.Severity = issue.Severity
@@ -60,9 +55,5 @@ func (p CodeClimate) Print(issues []result.Issue) error {
 		codeClimateIssues = append(codeClimateIssues, codeClimateIssue)
 	}
 
-	err := json.NewEncoder(p.w).Encode(codeClimateIssues)
-	if err != nil {
-		return err
-	}
-	return nil
+	return json.NewEncoder(p.w).Encode(codeClimateIssues)
 }

--- a/pkg/printers/codeclimate_test.go
+++ b/pkg/printers/codeclimate_test.go
@@ -41,8 +41,7 @@ func TestCodeClimate_Print(t *testing.T) {
 			},
 		},
 		{
-			FromLinter: "linter-c",
-			Text:       "issue c",
+			Text: "issue c",
 			SourceLines: []string{
 				"func foo() {",
 				"\tfmt.Println(\"ccc\")",
@@ -63,7 +62,7 @@ func TestCodeClimate_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	expected := `[{"description":"linter-a: some issue","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"linter-b: another issue","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"linter-c: issue c","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]
+	expected := `[{"description":"some issue","check_name":"linter-a","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"another issue","check_name":"linter-b","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"issue c","check_name":"golangci-lint","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]
 `
 
 	assert.Equal(t, expected, buf.String())

--- a/pkg/printers/codeclimate_test.go
+++ b/pkg/printers/codeclimate_test.go
@@ -41,7 +41,8 @@ func TestCodeClimate_Print(t *testing.T) {
 			},
 		},
 		{
-			Text: "issue c",
+			FromLinter: "linter-c",
+			Text:       "issue c",
 			SourceLines: []string{
 				"func foo() {",
 				"\tfmt.Println(\"ccc\")",
@@ -62,7 +63,7 @@ func TestCodeClimate_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	expected := `[{"description":"some issue","check_name":"linter-a","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"another issue","check_name":"linter-b","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"issue c","check_name":"golangci-lint","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]
+	expected := `[{"description":"linter-a: some issue","check_name":"linter-a","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"linter-b: another issue","check_name":"linter-b","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"linter-c: issue c","check_name":"linter-c","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]
 `
 
 	assert.Equal(t, expected, buf.String())

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -81,10 +81,6 @@ func (i *Issue) GetLineRange() Range {
 	return *i.LineRange
 }
 
-func (i *Issue) Description() string {
-	return fmt.Sprintf("%s: %s", i.FromLinter, i.Text)
-}
-
 func (i *Issue) Fingerprint() string {
 	firstLine := ""
 	if len(i.SourceLines) > 0 {

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -81,6 +81,10 @@ func (i *Issue) GetLineRange() Range {
 	return *i.LineRange
 }
 
+func (i *Issue) Description() string {
+	return fmt.Sprintf("%s: %s", i.FromLinter, i.Text)
+}
+
 func (i *Issue) Fingerprint() string {
 	firstLine := ""
 	if len(i.SourceLines) > 0 {


### PR DESCRIPTION
CodeClimateIssue declares to contain just enough fields to support Gitlab CI Code Quality. But there's a field called `check_name`, which is not generated by golangci-lint, but is stated as required in both [Code Climate spec](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types) and [Gitlab CI Code Quality reference](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool). I moved linter's name from the `description` field to the `check_name` field. I'm not sure if there can be any issue made by an unknown linter, but I made a default value for this field as well, just to be sure.

I also updated the corresponding test and the link to the Gitlab page (the previous one reported 404).