### PR TITLE
Improve readability and maintenance of `internal/cache`

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -25,8 +25,11 @@ const (
 	HashModeNeedAllDeps
 )
 
-// Cache is a per-package data cache. A cached data is invalidated when
-// package, or it's dependencies change.
+var ErrMissing = errors.New("missing data")
+
+// Cache is a per-package data cache.
+// A cached data is invalidated when package,
+// or it's dependencies change.
 type Cache struct {
 	lowLevelCache cache.Cache
 	pkgHashes     sync.Map
@@ -90,8 +93,6 @@ func (c *Cache) Put(pkg *packages.Package, mode HashMode, key string, data any) 
 	return nil
 }
 
-var ErrMissing = errors.New("missing data")
-
 func (c *Cache) Get(pkg *packages.Package, mode HashMode, key string, data any) error {
 	var aID cache.ActionID
 	var err error
@@ -148,9 +149,9 @@ func (c *Cache) pkgActionID(pkg *packages.Package, mode HashMode) (cache.ActionI
 	return key.Sum(), nil
 }
 
-// packageHash computes a package's hash. The hash is based on all Go
-// files that make up the package, as well as the hashes of imported
-// packages.
+// packageHash computes a package's hash.
+// The hash is based on all Go files that make up the package,
+// as well as the hashes of imported packages.
 func (c *Cache) packageHash(pkg *packages.Package, mode HashMode) (string, error) {
 	type hashResults map[HashMode]string
 	hashResI, ok := c.pkgHashes.Load(pkg)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -95,7 +95,7 @@ func (c *Cache) Get(pkg *packages.Package, mode HashMode, key string, data any) 
 }
 
 func (c *Cache) buildKey(pkg *packages.Package, mode HashMode, key string) (cache.ActionID, error) {
-	return timeutils.TrackStage[cache.ActionID](c.sw, "key build", func() (cache.ActionID, error) {
+	return timeutils.TrackStage(c.sw, "key build", func() (cache.ActionID, error) {
 		actionID, err := c.pkgActionID(pkg, mode)
 		if err != nil {
 			return actionID, err
@@ -237,7 +237,7 @@ func (c *Cache) putBytes(actionID cache.ActionID, buf *bytes.Buffer) error {
 func (c *Cache) getBytes(actionID cache.ActionID) ([]byte, error) {
 	c.ioSem <- struct{}{}
 
-	cachedData, err := timeutils.TrackStage[[]byte](c.sw, "cache io", func() ([]byte, error) {
+	cachedData, err := timeutils.TrackStage(c.sw, "cache io", func() ([]byte, error) {
 		b, _, errGB := cache.GetBytes(c.lowLevelCache, actionID)
 		return b, errGB
 	})

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -29,6 +29,8 @@ const (
 
 var ErrMissing = errors.New("missing data")
 
+type hashResults map[HashMode]string
+
 // Cache is a per-package data cache.
 // A cached data is invalidated when package,
 // or it's dependencies change.
@@ -130,7 +132,6 @@ func (c *Cache) pkgActionID(pkg *packages.Package, mode HashMode) (cache.ActionI
 // The hash is based on all Go files that make up the package,
 // as well as the hashes of imported packages.
 func (c *Cache) packageHash(pkg *packages.Package, mode HashMode) (string, error) {
-	type hashResults map[HashMode]string
 	hashResI, ok := c.pkgHashes.Load(pkg)
 	if ok {
 		hashRes := hashResI.(hashResults)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -122,6 +122,7 @@ func (c *Cache) pkgActionID(pkg *packages.Package, mode HashMode) (cache.ActionI
 	if err != nil {
 		return cache.ActionID{}, fmt.Errorf("failed to make a hash: %w", err)
 	}
+
 	fmt.Fprintf(key, "pkgpath %s\n", pkg.PkgPath)
 	fmt.Fprintf(key, "pkghash %s\n", hash)
 
@@ -138,24 +139,28 @@ func (c *Cache) packageHash(pkg *packages.Package, mode HashMode) (string, error
 		if _, ok := hashRes[mode]; !ok {
 			return "", fmt.Errorf("no mode %d in hash result", mode)
 		}
+
 		return hashRes[mode], nil
 	}
-
-	hashRes := hashResults{}
 
 	key, err := cache.NewHash("package hash")
 	if err != nil {
 		return "", fmt.Errorf("failed to make a hash: %w", err)
 	}
 
+	hashRes := hashResults{}
+
 	fmt.Fprintf(key, "pkgpath %s\n", pkg.PkgPath)
+
 	for _, f := range pkg.CompiledGoFiles {
 		h, fErr := c.fileHash(f)
 		if fErr != nil {
 			return "", fmt.Errorf("failed to calculate file %s hash: %w", f, fErr)
 		}
+
 		fmt.Fprintf(key, "file %s %x\n", f, h)
 	}
+
 	curSum := key.Sum()
 	hashRes[HashModeNeedOnlySelf] = hex.EncodeToString(curSum[:])
 
@@ -175,6 +180,7 @@ func (c *Cache) packageHash(pkg *packages.Package, mode HashMode) (string, error
 	if err := c.computeDepsHash(HashModeNeedAllDeps, imps, key); err != nil {
 		return "", err
 	}
+
 	curSum = key.Sum()
 	hashRes[HashModeNeedAllDeps] = hex.EncodeToString(curSum[:])
 
@@ -183,6 +189,7 @@ func (c *Cache) packageHash(pkg *packages.Package, mode HashMode) (string, error
 	}
 
 	c.pkgHashes.Store(pkg, hashRes)
+
 	return hashRes[mode], nil
 }
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -52,12 +52,10 @@ func NewCache(sw *timeutils.Stopwatch, log logutils.Log) (*Cache, error) {
 }
 
 func (c *Cache) Close() {
-	c.sw.TrackStage("close", func() {
-		err := c.lowLevelCache.Close()
-		if err != nil {
-			c.log.Errorf("cache close: %v", err)
-		}
-	})
+	err := c.sw.TrackStageErr("close", c.lowLevelCache.Close)
+	if err != nil {
+		c.log.Errorf("cache close: %v", err)
+	}
 }
 
 func (c *Cache) Put(pkg *packages.Package, mode HashMode, key string, data any) error {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/golangci/golangci-lint/pkg/logutils"
+	"github.com/golangci/golangci-lint/pkg/timeutils"
+)
+
+func setupCache(t *testing.T) *Cache {
+	t.Helper()
+
+	log := logutils.NewStderrLog("skip")
+	sw := timeutils.NewStopwatch("pkgcache", log)
+
+	pkgCache, err := NewCache(sw, log)
+	require.NoError(t, err)
+
+	return pkgCache
+}
+
+func fakePackage() *packages.Package {
+	return &packages.Package{
+		PkgPath: "github.com/golangci/example",
+		CompiledGoFiles: []string{
+			"./testdata/hello.go",
+		},
+		Imports: map[string]*packages.Package{
+			"a": {
+				PkgPath: "github.com/golangci/example/a",
+			},
+			"b": {
+				PkgPath: "github.com/golangci/example/b",
+			},
+			"unsafe": {
+				PkgPath: "unsafe",
+			},
+		},
+	}
+}
+
+func Test_buildKey(t *testing.T) {
+	pkgCache := setupCache(t)
+
+	pkg := fakePackage()
+
+	actionID, err := pkgCache.buildKey(pkg, HashModeNeedAllDeps, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "f32bf1bf010aa9b570e081c64ec9e22e17aafa1e822990ba952905ec5fdf8d9d", fmt.Sprintf("%x", actionID))
+}
+
+func Test_pkgActionID(t *testing.T) {
+	pkgCache := setupCache(t)
+
+	pkg := fakePackage()
+
+	actionID, err := pkgCache.pkgActionID(pkg, HashModeNeedAllDeps)
+	require.NoError(t, err)
+
+	assert.Equal(t, "f690f05acd1024386ae912d9ad9c04080523b9a899f6afe56ab3108d88215c1d", fmt.Sprintf("%x", actionID))
+}
+
+func Test_packageHash_load(t *testing.T) {
+	pkgCache := setupCache(t)
+
+	pkg := fakePackage()
+
+	pkgCache.pkgHashes.Store(pkg, hashResults{HashModeNeedAllDeps: "fake"})
+
+	hash, err := pkgCache.packageHash(pkg, HashModeNeedAllDeps)
+	require.NoError(t, err)
+
+	assert.Equal(t, "fake", hash)
+}
+
+func Test_packageHash_store(t *testing.T) {
+	pkgCache := setupCache(t)
+
+	pkg := fakePackage()
+
+	hash, err := pkgCache.packageHash(pkg, HashModeNeedAllDeps)
+	require.NoError(t, err)
+
+	assert.Equal(t, "9c602ef861197b6807e82c99caa7c4042eb03c1a92886303fb02893744355131", hash)
+
+	results, ok := pkgCache.pkgHashes.Load(pkg)
+	require.True(t, ok)
+
+	hashRes := results.(hashResults)
+
+	require.Len(t, hashRes, 3)
+
+	assert.Equal(t, "8978e3d76c6f99e9663558d7147a7790f229a676804d1fde706a611898547b74", hashRes[HashModeNeedOnlySelf])
+	assert.Equal(t, "b1aef902a0619b5cbfc2d6e2e91a73dd58dd448e58274b2d7a5ff8efd97aefa4", hashRes[HashModeNeedDirectDeps])
+	assert.Equal(t, "9c602ef861197b6807e82c99caa7c4042eb03c1a92886303fb02893744355131", hashRes[HashModeNeedAllDeps])
+}
+
+func Test_computeHash(t *testing.T) {
+	pkgCache := setupCache(t)
+
+	pkg := fakePackage()
+
+	results, err := pkgCache.computePkgHash(pkg)
+	require.NoError(t, err)
+
+	require.Len(t, results, 3)
+
+	assert.Equal(t, "8978e3d76c6f99e9663558d7147a7790f229a676804d1fde706a611898547b74", results[HashModeNeedOnlySelf])
+	assert.Equal(t, "b1aef902a0619b5cbfc2d6e2e91a73dd58dd448e58274b2d7a5ff8efd97aefa4", results[HashModeNeedDirectDeps])
+	assert.Equal(t, "9c602ef861197b6807e82c99caa7c4042eb03c1a92886303fb02893744355131", results[HashModeNeedAllDeps])
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -44,7 +44,7 @@ func fakePackage() *packages.Package {
 	}
 }
 
-func Test_buildKey(t *testing.T) {
+func TestCache_buildKey(t *testing.T) {
 	pkgCache := setupCache(t)
 
 	pkg := fakePackage()
@@ -55,7 +55,7 @@ func Test_buildKey(t *testing.T) {
 	assert.Equal(t, "f32bf1bf010aa9b570e081c64ec9e22e17aafa1e822990ba952905ec5fdf8d9d", fmt.Sprintf("%x", actionID))
 }
 
-func Test_pkgActionID(t *testing.T) {
+func TestCache_pkgActionID(t *testing.T) {
 	pkgCache := setupCache(t)
 
 	pkg := fakePackage()
@@ -66,7 +66,7 @@ func Test_pkgActionID(t *testing.T) {
 	assert.Equal(t, "f690f05acd1024386ae912d9ad9c04080523b9a899f6afe56ab3108d88215c1d", fmt.Sprintf("%x", actionID))
 }
 
-func Test_packageHash_load(t *testing.T) {
+func TestCache_packageHash_load(t *testing.T) {
 	pkgCache := setupCache(t)
 
 	pkg := fakePackage()
@@ -79,7 +79,7 @@ func Test_packageHash_load(t *testing.T) {
 	assert.Equal(t, "fake", hash)
 }
 
-func Test_packageHash_store(t *testing.T) {
+func TestCache_packageHash_store(t *testing.T) {
 	pkgCache := setupCache(t)
 
 	pkg := fakePackage()
@@ -101,7 +101,7 @@ func Test_packageHash_store(t *testing.T) {
 	assert.Equal(t, "9c602ef861197b6807e82c99caa7c4042eb03c1a92886303fb02893744355131", hashRes[HashModeNeedAllDeps])
 }
 
-func Test_computeHash(t *testing.T) {
+func TestCache_computeHash(t *testing.T) {
 	pkgCache := setupCache(t)
 
 	pkg := fakePackage()

--- a/internal/cache/testdata/hello.go
+++ b/internal/cache/testdata/hello.go
@@ -1,0 +1,7 @@
+package testdata
+
+import "fmt"
+
+func Hello() {
+	fmt.Println("hello world")
+}

--- a/pkg/timeutils/stopwatch.go
+++ b/pkg/timeutils/stopwatch.go
@@ -114,3 +114,25 @@ func (s *Stopwatch) TrackStage(name string, f func()) {
 	s.stages[name] += time.Since(startedAt)
 	s.mu.Unlock()
 }
+
+func (s *Stopwatch) TrackStageErr(name string, f func() error) error {
+	startedAt := time.Now()
+	err := f()
+
+	s.mu.Lock()
+	s.stages[name] += time.Since(startedAt)
+	s.mu.Unlock()
+
+	return err
+}
+
+func TrackStage[T any](s *Stopwatch, name string, f func() (T, error)) (T, error) {
+	var result T
+	var err error
+
+	s.TrackStage(name, func() {
+		result, err = f()
+	})
+
+	return result, err
+}


### PR DESCRIPTION
Before reviewing the content of this PR, and if you want, I propose a quick "game" to illustrate the goal of this PR:
- Open the current version of  `internal/cache/cache.go` locally
- You have 10 seconds to read and explain what the method `Get` is doing
- Now open my version of the method `Get` and do the same thing
- Do you see the difference? :smile_cat:

Extends `stopwatch` to simplify the usage.

Isolates usage of `iosem`.

Factorizes methods to increase the readability.

Follows #5100