### PR TITLE
docs: fix iface linter name

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -179,7 +179,7 @@ linters:
     - gosmopolitan
     - govet
     - grouper
-    - ifcae
+    - iface
     - importas
     - inamedparam
     - ineffassign


### PR DESCRIPTION
The PR corrects a typo in linter name in `.golangci.next.reference.yml`.