### PR TITLE
fix: improve Go detection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,10 +75,9 @@ func IsGoGreaterThanOrEqual(current, limit string) bool {
 }
 
 func detectGoVersion() string {
-	file, _ := gomoddirectives.GetModuleFile()
-
-	if file != nil && file.Go != nil && file.Go.Version != "" {
-		return file.Go.Version
+	goVersion := detectGoVersionFromGoMod()
+	if goVersion != "" {
+		return goVersion
 	}
 
 	v := os.Getenv("GOVERSION")
@@ -87,4 +86,27 @@ func detectGoVersion() string {
 	}
 
 	return "1.17"
+}
+
+// detectGoVersionFromGoMod tries to get Go version from go.mod.
+// It returns toolchain version if present,
+// else it returns go version if present,
+// else it returns empty.
+func detectGoVersionFromGoMod() string {
+	file, _ := gomoddirectives.GetModuleFile()
+	if file == nil {
+		return ""
+	}
+
+	// The toolchain exist only if 'toolchain' version > 'go' version.
+	// If 'toolchain' version <= 'go' version, `go mod tidy` will remove 'toolchain' version from go.mod.
+	if file.Toolchain != nil && file.Toolchain.Name != "" {
+		return strings.TrimPrefix(file.Toolchain.Name, "go")
+	}
+
+	if file.Go != nil && file.Go.Version != "" {
+		return file.Go.Version
+	}
+
+	return ""
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,8 +89,8 @@ func detectGoVersion() string {
 }
 
 // detectGoVersionFromGoMod tries to get Go version from go.mod.
-// It returns toolchain version if present,
-// else it returns go version if present,
+// It returns `toolchain` version if present,
+// else it returns `go` version if present,
 // else it returns empty.
 func detectGoVersionFromGoMod() string {
 	file, _ := gomoddirectives.GetModuleFile()
@@ -98,7 +98,7 @@ func detectGoVersionFromGoMod() string {
 		return ""
 	}
 
-	// The toolchain exist only if 'toolchain' version > 'go' version.
+	// The toolchain exists only if 'toolchain' version > 'go' version.
 	// If 'toolchain' version <= 'go' version, `go mod tidy` will remove 'toolchain' version from go.mod.
 	if file.Toolchain != nil && file.Toolchain.Name != "" {
 		return strings.TrimPrefix(file.Toolchain.Name, "go")


### PR DESCRIPTION
To reproduce:
- clone this repo: https://github.com/ldez/cuddly-funicular
- use a version of golangci-lint compiled with go1.22

<details><summary>before</summary>

```console
$ docker run --rm -v $(pwd):/app -w /app -it golang:1.23.2-alpine sh  
/app # GOTOOLCHAIN=go1.22.1 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
...
/app # golangci-lint version
golangci-lint has version v1.61.0 built with go1.22.1 from (unknown, modified: ?, mod sum: "h1:VvbOLaRVWmyxCnUIMTbf1kDsaJbTzH20FAMXTAlQGu8=") on (unknown)

/app # rm -rf /go/pkg/mod/golang.org/toolchain@*

/app # go version
go version go1.23.2 linux/amd64

/app # golangci-lint run
###### High memory and CPU consumption and kill
```

</details>

<details><summary>after</summary>

```console
$ docker run --rm -v $(pwd):/app -w /app -it golang:1.23.2-alpine sh  
/app # ./golangci-lint version
golangci-lint has version (devel) built with go1.22.9 from (ac4d2c5c57fb41b42287cc0bad8b908eede8d01a, modified: false, mod sum: "") on 2024-11-07T14:40:46Z
/app # ./golangci-lint run
Error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.1)
Failed executing command with error: can't load config: the Go language version (go1.22) used to build golangci-lint is lower than the targeted Go version (1.23.1)
/app # 
```

</details>

There is still an unmanaged case:
- golangci-lint built with go1.22
- local Go version go1.23
- `go 1.22` with no toolchain inside the `go.mod`

But this case cannot be caught without calling the Go binary, and I think this is a bad idea.

Also technically, the `go` version inside the `go.mod` is enough to analyze but the problem happens when Go handles the `toolchain` version before running golangci-lint.
In this case, Go will install a newer version of Go (go1.23), and the problem will happen.

`toolchain` defines the minimum **Go compiler version** used to build.
`go` defines the minimum **Go language version** used to write the code.

The difference is really important: if your module is a lib, then the user of this lib will rely on `go` and not on `toolchain`. This is the same thing for the tool pattern, only `go` will be used and not on `toolchain`.

---

Related to #4909
Related to #4938