### PR TITLE
docs: improve forbidigo pattern examples for built-in functions

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -538,8 +538,8 @@ linters-settings:
     # Forbid the following identifiers (list of regexp).
     # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
     forbid:
-      # Builtin function:
-      - ^print.*$
+      # Built-in bootstrapping functions.
+      - ^print(ln)?$
       # Optional message that gets included in error reports.
       - p: ^fmt\.Print.*$
         msg: Do not commit print statements.

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -535,8 +535,8 @@ linters-settings:
     # Forbid the following identifiers (list of regexp).
     # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
     forbid:
-      # Builtin function:
-      - ^print.*$
+      # Built-in bootstrapping functions.
+      - ^print(ln)?$
       # Optional message that gets included in error reports.
       - p: ^fmt\.Print.*$
         msg: Do not commit print statements.

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -1018,7 +1018,7 @@
             "forbid": {
               "description": "List of identifiers to forbid (written using `regexp`)",
               "type": "array",
-              "examples": ["^print.*$"],
+              "examples": ["^print(ln)?$"],
               "items": {
                 "anyOf": [
                   {

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1020,7 +1020,7 @@
             "forbid": {
               "description": "List of identifiers to forbid (written using `regexp`)",
               "type": "array",
-              "examples": ["^print.*$"],
+              "examples": ["^print(ln)?$"],
               "items": {
                 "anyOf": [
                   {


### PR DESCRIPTION
The pattern `^print.*$` also matches `printer`, but it's expected to match only [`print` or `println`](https://go.dev/ref/spec#Bootstrapping) built-in functions.