### PR TITLE
fix: ignore cache error when file not found

### DIFF
--- a/internal/go/cache/cache.go
+++ b/internal/go/cache/cache.go
@@ -293,7 +293,7 @@ func GetBytes(c Cache, id ActionID) ([]byte, Entry, error) {
 	}
 	data, err := robustio.ReadFile(c.OutputFile(entry.OutputID))
 	if err != nil {
-		return nil, entry, err
+		return nil, entry, &entryNotFoundError{Err: err}
 	}
 	if sha256.Sum256(data) != entry.OutputID {
 		return nil, entry, &entryNotFoundError{Err: errors.New("bad checksum")}


### PR DESCRIPTION
Inside Go this error is ignored.

https://github.com/golang/go/blob/239dbd7dbac883d6f9b6522774a0dfd519f77fa8/src/cmd/go/internal/cache/cache.go#L288

As I explained inside #5098:

> The main modifications are about error handling: the official Go cache implementation ignores many errors, and the implementation inside Golangci-lint reports those "hidden" errors.

We should convert this error to an `entryNotFoundError` error, then the error will be "ignored".

Before this PR, something like that can happen:

<details>

```
WARN [linters_context/goanalysis] Failed to get persisted facts: failed to get data from low-level cache by key nilness/facts for package sync: open /home/ldez/.cache/golangci-lint/9a/9abfb2d9d6ddfa499fad612dd9d0a49dd6bc977b77567ba7a1bb3f93c4df2416-d: no such file or directory
WARN [linters_context/goanalysis] Failed to get persisted facts: failed to get data from low-level cache by key ctrlflow/facts for package parse: open /home/ldez/.cache/golangci-lint/f1/f1448da7201905db0144395265f008fe79b951a563a3bb06394caca82beb5b26-d: no such file or directory
WARN [linters_context/goanalysis] Failed to get persisted facts: failed to get data from low-level cache by key buildir/facts for package net: open /home/ldez/.cache/golangci-lint/6f/6f9b1fa1e2c68b39d24bfbc2a861709b922a5f07ed40e1b37b5790b4b6cc0a7d-d: no such file or directory
WARN [linters_context/goanalysis] Failed to get persisted facts: failed to get data from low-level cache by key nilness/facts for package norm: open /home/ldez/.cache/golangci-lint/e8/e8a1f2e3652e571676f929da6012ba01087ac65acbbdae9b35475dc69ca7feec-d: no such file or directory
```

</details>

It just a warning and it doesn't impact the behavior of golangci-lint but those logs are useless.
