### PR TITLE
dev: publish snap

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -69,4 +69,5 @@ jobs:
         env:
           AUR_KEY: ${{ secrets.AUR_KEY }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
           GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -127,7 +127,7 @@ chocolateys:
     summary: Fast linters Runner for Go
     description: |
       {{ .ProjectName }} installer package.
-      Fast linters Runner for Go .
+      Fast linters Runner for Go.
     release_notes: "https://github.com/golangci/golangci-lint/releases/tag/v{{ .Version }}"
     api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
     source_repo: "https://push.chocolatey.org/"
@@ -162,6 +162,18 @@ aurs:
       ./golangci-lint completion bash | install -Dm644 /dev/stdin "${pkgdir}/usr/share/bash-completion/completions/golangci-lint"
       ./golangci-lint completion zsh | install -Dm644 /dev/stdin "${pkgdir}/usr/share/zsh/site-functions/_golangci-lint"
       ./golangci-lint completion fish | install -Dm644 /dev/stdin "${pkgdir}/usr/share/fish/vendor_completions.d/golangci-lint.fish"
+
+snapcrafts:
+  - name_template: "{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    grade: stable
+    confinement: classic
+    license: GPL-3.0
+    base: core22
+    summary: Fast linters runner for Go.
+    description: |
+      It runs linters in parallel, uses caching, supports YAML configuration, integrates with all major IDEs, and includes over a hundred linters.
+    disable: false
+    publish: true
 
 nfpms:
   -


### PR DESCRIPTION
Goreleaser allows us to publish Snap, so we can integrate that inside our release system.

Currently, there is a snap https://snapcraft.io/golangci-lint
So I will contact the owner of this package.

https://github.com/alexmurray/golangci-lint-snap/issues/6