### PR TITLE
docs: improve testifylint description of require-f-funcs flag

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -3383,10 +3383,10 @@ linters-settings:
       # To enable go vet's printf checks.
       # Default: true
       check-format-string: false
-      # To require f-assertions (e.g. assert.Equalf) if format string is used, even if there are no variable-length
-      # variables, i.e. it requires require.NoErrorf for both these cases:
-      #   require.NoErrorf(t, err, "unexpected error")
-      #   require.NoErrorf(t, err, "unexpected error for sid: %v", sid)
+      # To require f-assertions (e.g. `assert.Equalf`) if format string is used, even if there are no variable-length
+      # variables, i.e. it requires `require.NoErrorf` for both these cases:
+      # - require.NoErrorf(t, err, "unexpected error")
+      # - require.NoErrorf(t, err, "unexpected error for sid: %v", sid)
       # To understand this behavior, please read the
       # https://github.com/Antonboom/testifylint?tab=readme-ov-file#historical-reference-of-formatter.
       # Default: false

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -3383,7 +3383,12 @@ linters-settings:
       # To enable go vet's printf checks.
       # Default: true
       check-format-string: false
-      # To require f-assertions if format string is used.
+      # To require f-assertions (e.g. assert.Equalf) if format string is used, even if there are no variable-length
+      # variables, i.e. it requires require.NoErrorf for both these cases:
+      #   require.NoErrorf(t, err, "unexpected error")
+      #   require.NoErrorf(t, err, "unexpected error for sid: %v", sid)
+      # To understand this behavior, please read the
+      # https://github.com/Antonboom/testifylint?tab=readme-ov-file#historical-reference-of-formatter.
       # Default: false
       require-f-funcs: true
     go-require:

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -3383,7 +3383,12 @@ linters-settings:
       # To enable go vet's printf checks.
       # Default: true
       check-format-string: false
-      # To require f-assertions if format string is used.
+      # To require f-assertions (e.g. `assert.Equalf`) if format string is used, even if there are no variable-length
+      # variables, i.e. it requires `require.NoErrorf` for both these cases:
+      # - require.NoErrorf(t, err, "unexpected error")
+      # - require.NoErrorf(t, err, "unexpected error for sid: %v", sid)
+      # To understand this behavior, please read the
+      # https://github.com/Antonboom/testifylint?tab=readme-ov-file#historical-reference-of-formatter.
       # Default: false
       require-f-funcs: true
     go-require:

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -3059,7 +3059,7 @@
                   "default": true
                 },
                 "require-f-funcs": {
-                  "description": "To require f-assertions if format string is used.",
+                  "description": "To require f-assertions (e.g. assert.Equalf) if format string is used, even if there are no variable-length variables.",
                   "type": "boolean",
                   "default": false
                 }

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -3059,7 +3059,7 @@
                   "default": true
                 },
                 "require-f-funcs": {
-                  "description": "To require f-assertions if format string is used.",
+                  "description": "To require f-assertions (e.g. assert.Equalf) if format string is used, even if there are no variable-length variables.",
                   "type": "boolean",
                   "default": false
                 }


### PR DESCRIPTION
To decrease common confusing. People often expect that they can continue use not-f assertions if only format string is used (without args).