### PR TITLE
Add docenv linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -22,6 +22,7 @@ linters:
     - cyclop
     - decorder
     - depguard
+    - docenv
     - dogsled
     - dupl
     - dupword
@@ -138,6 +139,7 @@ linters:
     - cyclop
     - decorder
     - depguard
+    - docenv
     - dogsled
     - dupl
     - dupword
@@ -393,6 +395,11 @@ linters-settings:
             desc: not allowed
           - pkg: "github.com/pkg/errors"
             desc: Should be replaced by standard lib errors package
+
+  docenv:
+    # Set custom env tag name.
+    # Default: env
+    tag-name: env
 
   dogsled:
     # Checks assignments with too many blank identifiers.

--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,7 @@ require (
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/g4s8/envdoc v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-toolsmith/astcast v1.1.0 // indirect
 	github.com/go-toolsmith/astcopy v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,12 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
+github.com/g4s8/envdoc v1.2.0 h1:PDQIO7beaaAZdR8GM/5zy537wSwJZXPJ+pMELFs6A08=
+github.com/g4s8/envdoc v1.2.0/go.mod h1:SKfUkznezzkE98q07wGhJ/3oGthPMEBevQUdVW0xcgI=
+github.com/g4s8/envdoc v1.2.1 h1:QMpR/h0PR1WkdHzw/h7wG6FIbpDPvkfysKaOktb1u7Y=
+github.com/g4s8/envdoc v1.2.1/go.mod h1:SKfUkznezzkE98q07wGhJ/3oGthPMEBevQUdVW0xcgI=
+github.com/g4s8/envdoc v1.2.2 h1:bY0YOJJMZtdqDlhWTX1riQ7OXx94kYIce4p1JgQf6mU=
+github.com/g4s8/envdoc v1.2.2/go.mod h1:SKfUkznezzkE98q07wGhJ/3oGthPMEBevQUdVW0xcgI=
 github.com/ghostiam/protogetter v0.3.8 h1:LYcXbYvybUyTIxN2Mj9h6rHrDZBDwZloPoKctWrFyJY=
 github.com/ghostiam/protogetter v0.3.8/go.mod h1:WZ0nw9pfzsgxuRsPOFQomgDVSWtDLJRfQJEhsGbmQMA=
 github.com/go-critic/go-critic v0.11.5 h1:TkDTOn5v7EEngMxu8KbuFqFR43USaaH8XRJLz1jhVYA=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -19,6 +19,9 @@ var defaultLintersSettings = LintersSettings{
 		DisableDecOrderCheck:      true,
 		DisableInitFuncFirstCheck: true,
 	},
+	Docenv: DocenvSettings{
+		TagName: "env",
+	},
 	Dogsled: DogsledSettings{
 		MaxBlankIdentifiers: 2,
 	},
@@ -206,6 +209,7 @@ type LintersSettings struct {
 	Cyclop          Cyclop
 	Decorder        DecorderSettings
 	Depguard        DepGuardSettings
+	Docenv          DocenvSettings
 	Dogsled         DogsledSettings
 	Dupl            DuplSettings
 	DupWord         DupWordSettings
@@ -353,6 +357,10 @@ type DecorderSettings struct {
 	DisableVarDecNumCheck     bool     `mapstructure:"disable-var-dec-num-check"`
 	DisableDecOrderCheck      bool     `mapstructure:"disable-dec-order-check"`
 	DisableInitFuncFirstCheck bool     `mapstructure:"disable-init-func-first-check"`
+}
+
+type DocenvSettings struct {
+	TagName string `mapstructure:"tag-name"`
 }
 
 type DogsledSettings struct {

--- a/pkg/golinters/docenv/docenv.go
+++ b/pkg/golinters/docenv/docenv.go
@@ -1,0 +1,25 @@
+package docenv
+
+import (
+	"github.com/g4s8/envdoc/linter"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New(cfg *config.DocenvSettings) *goanalysis.Linter {
+	opts := []linter.Option{linter.WithNoComments()}
+	if cfg != nil {
+		opts = append(opts, linter.WithEnvName(cfg.TagName))
+	}
+
+	a := linter.NewAnlyzer(false, opts...)
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/docenv/docenv_integration_test.go
+++ b/pkg/golinters/docenv/docenv_integration_test.go
@@ -1,0 +1,11 @@
+package docenv
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/docenv/testdata/docenv.go
+++ b/pkg/golinters/docenv/testdata/docenv.go
@@ -1,0 +1,14 @@
+//golangcitest:args -Edocenv
+package testdata
+
+type Config struct {
+	// Host name.
+	Host string `env:"HOST"`
+
+	// Port number.
+	Port int `env:"PORT"`
+
+	Undocumented string `env:"UNDOCUMENTED"` // want "field `Undocumented` with `env` tag should have a documentation comment"
+
+	NotEnv string
+}

--- a/pkg/golinters/docenv/testdata/docenv_custom.go
+++ b/pkg/golinters/docenv/testdata/docenv_custom.go
@@ -1,0 +1,15 @@
+//golangcitest:args -Edocenv
+//golangcitest:config_path testdata/docenv_custom.yml
+package testdata
+
+type Config struct {
+	// Host name.
+	Host string `foo:"HOST"`
+
+	// Port number.
+	Port int `foo:"PORT"`
+
+	Undocumented string `foo:"UNDOCUMENTED"` // want "field `Undocumented` with `foo` tag should have a documentation comment"
+
+	NotEnv string
+}

--- a/pkg/golinters/docenv/testdata/docenv_custom.yml
+++ b/pkg/golinters/docenv/testdata/docenv_custom.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  docenv:
+    tag-name: foo

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/cyclop"
 	"github.com/golangci/golangci-lint/pkg/golinters/decorder"
 	"github.com/golangci/golangci-lint/pkg/golinters/depguard"
+	"github.com/golangci/golangci-lint/pkg/golinters/docenv"
 	"github.com/golangci/golangci-lint/pkg/golinters/dogsled"
 	"github.com/golangci/golangci-lint/pkg/golinters/dupl"
 	"github.com/golangci/golangci-lint/pkg/golinters/dupword"
@@ -202,6 +203,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.4.0").
 			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
 			WithURL("https://github.com/OpenPeeDeeP/depguard"),
+
+		linter.NewConfig(docenv.New(&cfg.LintersSettings.Docenv)).
+			WithSince("v1.63.0").
+			WithPresets(linter.PresetComment).
+			WithURL("https://github.com/g4s8/envdoc/tree/master/docenv"),
 
 		linter.NewConfig(dogsled.New(&cfg.LintersSettings.Dogsled)).
 			WithSince("v1.19.0").


### PR DESCRIPTION
Add new docenv linter to validate that struct fields with env tags are documented: https://github.com/g4s8/envdoc/blob/master/docenv/README.md

Linter source code: https://github.com/g4s8/envdoc/tree/master/linter