### PR TITLE
dev: publish AUR -bin automatically

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -134,6 +134,35 @@ chocolateys:
     skip_publish: false
     goamd64: v1
 
+aurs:
+  - description: Fast linters runner for Go.
+    skip_upload: false
+    homepage: https://golangci.com
+    provides:
+      - "golangci-lint"
+    maintainers:
+      - "Fernandez Ludovic <lfernandez dot dev at gmail dot com>"
+    license: GPL-3.0
+    private_key: "{{ .Env.AUR_KEY }}"
+    git_url: "ssh://aur@aur.archlinux.org/golangci-lint-bin.git"
+    commit_author:
+      name: golangci-releaser
+      email: 65486276+golangci-releaser@users.noreply.github.com
+    package: |-
+      # bin
+      install -Dm755 "./golangci-lint" "${pkgdir}/usr/bin/golangci-lint"
+
+      # license
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/golangci-lint/LICENSE"
+
+      # completions
+      mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
+      mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
+      mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
+      ./golangci-lint completion bash | install -Dm644 /dev/stdin "${pkgdir}/usr/share/bash-completion/completions/golangci-lint"
+      ./golangci-lint completion zsh | install -Dm644 /dev/stdin "${pkgdir}/usr/share/zsh/site-functions/_golangci-lint"
+      ./golangci-lint completion fish | install -Dm644 /dev/stdin "${pkgdir}/usr/share/fish/vendor_completions.d/golangci-lint.fish"
+
 nfpms:
   -
     id: golangci-lint-nfpms


### PR DESCRIPTION
Goreleaser allows us to publish AUR (`-bin`), and we can integrate that into our release system.

Currently, I maintain this manually, this will remove a bit of work related to the release.