### PR TITLE
loggercheck: add missing slog option

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2032,6 +2032,9 @@ linters-settings:
     # Allow check for the github.com/go-logr/logr library.
     # Default: true
     logr: false
+    # Allow check for the log/slog library.
+    # Default: true
+    slog: false
     # Allow check for the "sugar logger" from go.uber.org/zap library.
     # Default: true
     zap: false

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2032,6 +2032,9 @@ linters-settings:
     # Allow check for the github.com/go-logr/logr library.
     # Default: true
     logr: false
+    # Allow check for the log/slog library.
+    # Default: true
+    slog: false
     # Allow check for the "sugar logger" from go.uber.org/zap library.
     # Default: true
     zap: false

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -2111,6 +2111,11 @@
               "type": "boolean",
               "default": true
             },
+            "slog": {
+              "description": "Allow check for the log/slog library.",
+              "type": "boolean",
+              "default": true
+            },
             "zap": {
               "description": "Allow check for the \"sugar logger\" from go.uber.org/zap library.",
               "type": "boolean",

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -2111,6 +2111,11 @@
               "type": "boolean",
               "default": true
             },
+            "slog": {
+              "description": "Allow check for the log/slog library.",
+              "type": "boolean",
+              "default": true
+            },
             "zap": {
               "description": "Allow check for the \"sugar logger\" from go.uber.org/zap library.",
               "type": "boolean",

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -105,6 +105,7 @@ var defaultLintersSettings = LintersSettings{
 		Kitlog:           true,
 		Klog:             true,
 		Logr:             true,
+		Slog:             true,
 		Zap:              true,
 		RequireStringKey: false,
 		NoPrintfLike:     false,
@@ -687,6 +688,7 @@ type LoggerCheckSettings struct {
 	Kitlog           bool     `mapstructure:"kitlog"`
 	Klog             bool     `mapstructure:"klog"`
 	Logr             bool     `mapstructure:"logr"`
+	Slog             bool     `mapstructure:"slog"`
 	Zap              bool     `mapstructure:"zap"`
 	RequireStringKey bool     `mapstructure:"require-string-key"`
 	NoPrintfLike     bool     `mapstructure:"no-printf-like"`

--- a/pkg/golinters/loggercheck/loggercheck.go
+++ b/pkg/golinters/loggercheck/loggercheck.go
@@ -22,6 +22,9 @@ func New(settings *config.LoggerCheckSettings) *goanalysis.Linter {
 		if !settings.Logr {
 			disable = append(disable, "logr")
 		}
+		if !settings.Slog {
+			disable = append(disable, "slog")
+		}
 		if !settings.Zap {
 			disable = append(disable, "zap")
 		}

--- a/pkg/golinters/loggercheck/testdata/loggercheck_default.go
+++ b/pkg/golinters/loggercheck/testdata/loggercheck_default.go
@@ -3,6 +3,7 @@ package loggercheck
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/go-logr/logr"
 	"go.uber.org/zap"
@@ -25,4 +26,11 @@ func ExampleZapSugarNotChecked() {
 	sugar := zap.NewExample().Sugar()
 	defer sugar.Sync()
 	sugar.Infow("message", "key1", "value1", "key2") // want `odd number of arguments passed as key-value pairs for logging`
+}
+
+func ExampleSlog() {
+	logger := slog.With("key1", "value1")
+
+	logger.Info("msg", "key1") // want `odd number of arguments passed as key-value pairs for logging`
+	slog.Info("msg", "key1")   // want `odd number of arguments passed as key-value pairs for logging`
 }

--- a/pkg/golinters/loggercheck/testdata/loggercheck_logronly.yml
+++ b/pkg/golinters/loggercheck/testdata/loggercheck_logronly.yml
@@ -2,4 +2,5 @@ linters-settings:
   loggercheck:
     logr: true
     klog: false
+    slog: false
     zap: false

--- a/pkg/golinters/loggercheck/testdata/loggercheck_slogonly.go
+++ b/pkg/golinters/loggercheck/testdata/loggercheck_slogonly.go
@@ -1,0 +1,12 @@
+//golangcitest:args -Eloggercheck
+//golangcitest:config_path testdata/loggercheck_slogonly.yml
+package loggercheck
+
+import "log/slog"
+
+func ExampleSlogOnly() {
+	logger := slog.With("key1", "value1")
+
+	logger.Info("msg", "key1") // want `odd number of arguments passed as key-value pairs for logging`
+	slog.Info("msg", "key1")   // want `odd number of arguments passed as key-value pairs for logging`
+}

--- a/pkg/golinters/loggercheck/testdata/loggercheck_slogonly.yml
+++ b/pkg/golinters/loggercheck/testdata/loggercheck_slogonly.yml
@@ -1,7 +1,6 @@
 linters-settings:
   loggercheck:
-    kitlog: true
-    klog: false
     logr: false
-    slog: false
+    klog: false
+    slog: true
     zap: false

--- a/pkg/golinters/loggercheck/testdata/loggercheck_zaponly.yml
+++ b/pkg/golinters/loggercheck/testdata/loggercheck_zaponly.yml
@@ -2,4 +2,5 @@ linters-settings:
   loggercheck:
     logr: false
     klog: false
+    slog: false
     zap: true


### PR DESCRIPTION
Support for `log/slog` was added in timonwong/loggercheck#72. And integrated to golangci-lint in #5094