### PR TITLE
dev: fix AUR prepare step

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -155,6 +155,9 @@ aurs:
       name: golangci-releaser
       email: 65486276+golangci-releaser@users.noreply.github.com
     package: |-
+      local x86_64=amd64 i686=386 aarch64=arm64 armv6h=armv6 armv7h=armv7
+      cd "golangci-lint-${pkgver}-linux-${!CARCH}"
+      
       # bin
       install -Dm755 "./golangci-lint" "${pkgdir}/usr/bin/golangci-lint"
 


### PR DESCRIPTION
Related to https://aur.archlinux.org/packages/golangci-lint-bin#comment-999855

I fixed the PKGBUILD manually, so no need to create a new release. 

The problem happen because:
```yml
archives:
  - format: tar.gz
    wrap_in_directory: true # <-----
```

so we have to move the directory that wraps the files.