### PR TITLE
dev: use `encoding/xml` instead of `go-xmlfmt/xmlfmt`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/ghostiam/protogetter v0.3.8
 	github.com/go-critic/go-critic v0.11.5
 	github.com/go-viper/mapstructure/v2 v2.2.1
-	github.com/go-xmlfmt/xmlfmt v1.1.2
 	github.com/gofrs/flock v0.12.1
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
 	github.com/golangci/go-printf-func-name v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,6 @@ github.com/go-toolsmith/typep v1.1.0 h1:fIRYDyF+JywLfqzyhdiHzRop/GQDxxNhLGQ6gFUN
 github.com/go-toolsmith/typep v1.1.0/go.mod h1:fVIw+7zjdsMxDA3ITWnH1yOiw1rnTQKCsF/sk2H/qig=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
-github.com/go-xmlfmt/xmlfmt v1.1.2 h1:Nea7b4icn8s57fTx1M5AI4qQT5HEM3rVUO8MuE6g80U=
-github.com/go-xmlfmt/xmlfmt v1.1.2/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=

--- a/pkg/printers/checkstyle.go
+++ b/pkg/printers/checkstyle.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"sort"
 
-	"github.com/go-xmlfmt/xmlfmt"
 	"golang.org/x/exp/maps"
 
 	"github.com/golangci/golangci-lint/pkg/result"
@@ -81,12 +80,12 @@ func (p Checkstyle) Print(issues []result.Issue) error {
 		return out.Files[i].Name < out.Files[j].Name
 	})
 
-	data, err := xml.Marshal(&out)
+	data, err := xml.MarshalIndent(&out, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(p.w, "%s%s\n", xml.Header, xmlfmt.FormatXML(string(data), "", "  "))
+	_, err = fmt.Fprintf(p.w, "%s\n%s\n", xml.Header, data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The PR refactors the `Checkstyle.Print` implementation to use `xml.MarshalIndent` instead of `go-xmlfmt/xmlfmt.FormatXML`. This allows dropping the `github.com/go-xmlfmt/xmlfmt` dependency.