### PR TITLE
docs: fix GitLab doc link in CodeClimateIssue comment

### DIFF
--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -12,7 +12,7 @@ const defaultCodeClimateSeverity = "critical"
 // CodeClimateIssue is a subset of the Code Climate spec.
 // https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
 // It is just enough to support GitLab CI Code Quality.
-// https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool
+// https://docs.gitlab.com/17.6/ee/ci/testing/code_quality.html#implement-a-custom-tool
 type CodeClimateIssue struct {
 	Description string `json:"description"`
 	CheckName   string `json:"check_name"`

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -12,7 +12,7 @@ const defaultCodeClimateSeverity = "critical"
 // CodeClimateIssue is a subset of the Code Climate spec.
 // https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
 // It is just enough to support GitLab CI Code Quality.
-// https://docs.gitlab.com/17.6/ee/ci/testing/code_quality.html#implement-a-custom-tool
+// https://docs.gitlab.com/ee/ci/testing/code_quality.html#code-quality-report-format
 type CodeClimateIssue struct {
 	Description string `json:"description"`
 	CheckName   string `json:"check_name"`


### PR DESCRIPTION
The link https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool does not exist ~~and should be https://docs.gitlab.com/17.6/ee/ci/testing/code_quality.html#implement-a-custom-tool.~~