### PR TITLE
build(deps): bump santhosh-tekuri/jsonschema/v5 to v6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/ryancurrah/gomodguard v1.3.5
 	github.com/ryanrolds/sqlclosecheck v0.5.1
 	github.com/sanposhiho/wastedassign/v2 v2.0.7
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/sashamelentyev/interfacebloat v1.1.0
 	github.com/sashamelentyev/usestdlibvars v1.27.0
 	github.com/securego/gosec/v2 v2.21.4

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42t4429eC9k8=
 github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okegmwQ3UgWl4V1D8gjlY=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/ebitengine/purego v0.8.1 h1:sdRKd6plj7KYW33EH5As6YKfe8m9zbN9JMrOjNVF/BE=
 github.com/ebitengine/purego v0.8.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -474,8 +476,8 @@ github.com/ryanrolds/sqlclosecheck v0.5.1 h1:dibWW826u0P8jNLsLN+En7+RqWWTYrjCB9f
 github.com/ryanrolds/sqlclosecheck v0.5.1/go.mod h1:2g3dUjoS6AL4huFdv6wn55WpLIDjY7ZgUR4J8HOO/XQ=
 github.com/sanposhiho/wastedassign/v2 v2.0.7 h1:J+6nrY4VW+gC9xFzUc+XjPD3g3wF3je/NsJFwFK7Uxc=
 github.com/sanposhiho/wastedassign/v2 v2.0.7/go.mod h1:KyZ0MWTwxxBmfwn33zh3k1dmsbF2ud9pAAGfoLfjhtI=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sashamelentyev/interfacebloat v1.1.0 h1:xdRdJp0irL086OyW1H/RTZTr1h/tMEOsumirXcOJqAw=
 github.com/sashamelentyev/interfacebloat v1.1.0/go.mod h1:+Y9yU5YdTkrNvoX0xHc84dxiN1iBi9+G8zZIhPVoNjQ=
 github.com/sashamelentyev/usestdlibvars v1.27.0 h1:t/3jZpSXtRPRf2xr0m63i32ZrusyurIGT9E5wAvXQnI=

--- a/test/configuration_file_test.go
+++ b/test/configuration_file_test.go
@@ -73,7 +73,7 @@ func loadSchema(schemaPath string) (*jsonschema.Schema, error) {
 		return nil, fmt.Errorf("unmarshal schema resource: %w", err)
 	}
 
-	if err := compiler.AddResource(filepath.Base(schemaPath), doc); err != nil {
+	if err = compiler.AddResource(filepath.Base(schemaPath), doc); err != nil {
 		return nil, fmt.Errorf("add schema resource: %w", err)
 	}
 

--- a/test/configuration_file_test.go
+++ b/test/configuration_file_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test_validateTestConfigurationFiles(t *testing.T) {
-	err := validateTestConfigurationFiles("../../jsonschema/golangci.next.jsonschema.json", ".")
+	err := validateTestConfigurationFiles("../jsonschema/golangci.next.jsonschema.json", ".")
 	require.NoError(t, err)
 }
 

--- a/test/configuration_file_test.go
+++ b/test/configuration_file_test.go
@@ -68,12 +68,16 @@ func loadSchema(schemaPath string) (*jsonschema.Schema, error) {
 
 	defer func() { _ = schemaFile.Close() }()
 
-	err = compiler.AddResource(filepath.Base(schemaPath), schemaFile)
+	doc, err := jsonschema.UnmarshalJSON(schemaFile)
 	if err != nil {
+		return nil, fmt.Errorf("unmarshal schema resource: %w", err)
+	}
+
+	if err := compiler.AddResource(filepath.Base(schemaPath), doc); err != nil {
 		return nil, fmt.Errorf("add schema resource: %w", err)
 	}
 
-	schema, err := compiler.Compile(schemaPath)
+	schema, err := compiler.Compile(filepath.Base(schemaPath))
 	if err != nil {
 		return nil, fmt.Errorf("compile schema: %w", err)
 	}

--- a/test/configuration_file_test.go
+++ b/test/configuration_file_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/santhosh-tekuri/jsonschema/v5"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )

--- a/test/configuration_file_test.go
+++ b/test/configuration_file_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test_validateTestConfigurationFiles(t *testing.T) {
-	err := validateTestConfigurationFiles("../jsonschema/golangci.next.jsonschema.json", ".")
+	err := validateTestConfigurationFiles("../../jsonschema/golangci.next.jsonschema.json", ".")
 	require.NoError(t, err)
 }
 
@@ -59,7 +59,7 @@ func validateTestConfigurationFiles(schemaPath, targetDir string) error {
 
 func loadSchema(schemaPath string) (*jsonschema.Schema, error) {
 	compiler := jsonschema.NewCompiler()
-	compiler.Draft = jsonschema.Draft7
+	compiler.DefaultDraft(jsonschema.Draft7)
 
 	schemaFile, err := os.Open(schemaPath)
 	if err != nil {
@@ -73,7 +73,7 @@ func loadSchema(schemaPath string) (*jsonschema.Schema, error) {
 		return nil, fmt.Errorf("add schema resource: %w", err)
 	}
 
-	schema, err := compiler.Compile(filepath.Base(schemaPath))
+	schema, err := compiler.Compile(schemaPath)
 	if err != nil {
 		return nil, fmt.Errorf("compile schema: %w", err)
 	}


### PR DESCRIPTION
https://github.com/santhosh-tekuri/jsonschema/compare/v6.0.0-beta1...v6.0.1

It's impossible to compare v5 and v6 on GitHub because ["There isn’t anything to compare. v5.3.1 and v6.0.1 are entirely different commit histories"](https://github.com/santhosh-tekuri/jsonschema/compare/v5.3.1...v6.0.1).

Used the following commands for tests:

```sh
$ go run ./cmd/golangci-lint config verify

```

```sh
$ go run ./cmd/golangci-lint config verify --schema jsonschema/golangci.jsonschema.json
$ echo $?
0
```

```sh
$ go run ./cmd/golangci-lint config verify -c .golangci.next.reference.yml --schema ./jsonschema/golangci.next.jsonschema.json

jsonschema: "linters-settings.goheader" does not validate with "/properties/linters-settings/properties/goheader/oneOf": "oneOf failed, subschemas 0, 1 matched"
jsonschema: "linters-settings.custom.example" does not validate with "/properties/linters-settings/properties/custom/patternProperties/%5E.%2A$/oneOf": "oneOf failed, subschemas 0, 1 matched"
Failed executing command with error: the configuration contains invalid elements
exit status 3
```

```sh
$ go run ./cmd/golangci-lint config verify --schema https://raw.githubusercontent.com/golangci/golangci-lint/master/jsonschema/golangci.next.jsonschema.json
$ echo $?
0
```

```sh
$ go run ./cmd/golangci-lint config verify
Failed executing command with error: [.golangci.yml] validate: compile schema: failing loading "https://raw.githubusercontent.com/golangci/golangci-lint/unknown/jsonschema/golangci.next.jsonschema.json": https://raw.githubusercontent.com/golangci/golangci-lint/unknown/jsonschema/golangci.next.jsonschema.json returned status code 404
exit status 3
```

**This update is done by hand because dependabot is not able to handle major version.**