### PR TITLE
dev: refactor linter constructors for consistency

### DIFF
--- a/pkg/golinters/asasalint/asasalint.go
+++ b/pkg/golinters/asasalint/asasalint.go
@@ -9,12 +9,12 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/internal"
 )
 
-func New(setting *config.AsasalintSettings) *goanalysis.Linter {
+func New(settings *config.AsasalintSettings) *goanalysis.Linter {
 	cfg := asasalint.LinterSetting{}
-	if setting != nil {
-		cfg.Exclude = setting.Exclude
-		cfg.NoBuiltinExclusions = !setting.UseBuiltinExclusions
-		cfg.IgnoreTest = setting.IgnoreTest
+	if settings != nil {
+		cfg.Exclude = settings.Exclude
+		cfg.NoBuiltinExclusions = !settings.UseBuiltinExclusions
+		cfg.IgnoreTest = settings.IgnoreTest
 	}
 
 	a, err := asasalint.NewAnalyzer(cfg)

--- a/pkg/golinters/bidichk/bidichk.go
+++ b/pkg/golinters/bidichk/bidichk.go
@@ -10,42 +10,42 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(cfg *config.BiDiChkSettings) *goanalysis.Linter {
+func New(settings *config.BiDiChkSettings) *goanalysis.Linter {
 	a := bidichk.NewAnalyzer()
 
-	cfgMap := map[string]map[string]any{}
-	if cfg != nil {
+	cfg := map[string]map[string]any{}
+	if settings != nil {
 		var opts []string
 
-		if cfg.LeftToRightEmbedding {
+		if settings.LeftToRightEmbedding {
 			opts = append(opts, "LEFT-TO-RIGHT-EMBEDDING")
 		}
-		if cfg.RightToLeftEmbedding {
+		if settings.RightToLeftEmbedding {
 			opts = append(opts, "RIGHT-TO-LEFT-EMBEDDING")
 		}
-		if cfg.PopDirectionalFormatting {
+		if settings.PopDirectionalFormatting {
 			opts = append(opts, "POP-DIRECTIONAL-FORMATTING")
 		}
-		if cfg.LeftToRightOverride {
+		if settings.LeftToRightOverride {
 			opts = append(opts, "LEFT-TO-RIGHT-OVERRIDE")
 		}
-		if cfg.RightToLeftOverride {
+		if settings.RightToLeftOverride {
 			opts = append(opts, "RIGHT-TO-LEFT-OVERRIDE")
 		}
-		if cfg.LeftToRightIsolate {
+		if settings.LeftToRightIsolate {
 			opts = append(opts, "LEFT-TO-RIGHT-ISOLATE")
 		}
-		if cfg.RightToLeftIsolate {
+		if settings.RightToLeftIsolate {
 			opts = append(opts, "RIGHT-TO-LEFT-ISOLATE")
 		}
-		if cfg.FirstStrongIsolate {
+		if settings.FirstStrongIsolate {
 			opts = append(opts, "FIRST-STRONG-ISOLATE")
 		}
-		if cfg.PopDirectionalIsolate {
+		if settings.PopDirectionalIsolate {
 			opts = append(opts, "POP-DIRECTIONAL-ISOLATE")
 		}
 
-		cfgMap[a.Name] = map[string]any{
+		cfg[a.Name] = map[string]any{
 			"disallowed-runes": strings.Join(opts, ","),
 		}
 	}
@@ -54,6 +54,6 @@ func New(cfg *config.BiDiChkSettings) *goanalysis.Linter {
 		a.Name,
 		"Checks for dangerous unicode character sequences",
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/dupword/dupword.go
+++ b/pkg/golinters/dupword/dupword.go
@@ -10,14 +10,14 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(setting *config.DupWordSettings) *goanalysis.Linter {
+func New(settings *config.DupWordSettings) *goanalysis.Linter {
 	a := dupword.NewAnalyzer()
 
-	cfgMap := map[string]map[string]any{}
-	if setting != nil {
-		cfgMap[a.Name] = map[string]any{
-			"keyword": strings.Join(setting.Keywords, ","),
-			"ignore":  strings.Join(setting.Ignore, ","),
+	cfg := map[string]map[string]any{}
+	if settings != nil {
+		cfg[a.Name] = map[string]any{
+			"keyword": strings.Join(settings.Keywords, ","),
+			"ignore":  strings.Join(settings.Ignore, ","),
 		}
 	}
 
@@ -25,6 +25,6 @@ func New(setting *config.DupWordSettings) *goanalysis.Linter {
 		a.Name,
 		"checks for duplicate words in the source code",
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/errchkjson/errchkjson.go
+++ b/pkg/golinters/errchkjson/errchkjson.go
@@ -8,17 +8,17 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(cfg *config.ErrChkJSONSettings) *goanalysis.Linter {
+func New(settings *config.ErrChkJSONSettings) *goanalysis.Linter {
 	a := errchkjson.NewAnalyzer()
 
-	cfgMap := map[string]map[string]any{}
-	cfgMap[a.Name] = map[string]any{
+	cfg := map[string]map[string]any{}
+	cfg[a.Name] = map[string]any{
 		"omit-safe": true,
 	}
-	if cfg != nil {
-		cfgMap[a.Name] = map[string]any{
-			"omit-safe":          !cfg.CheckErrorFreeEncoding,
-			"report-no-exported": cfg.ReportNoExported,
+	if settings != nil {
+		cfg[a.Name] = map[string]any{
+			"omit-safe":          !settings.CheckErrorFreeEncoding,
+			"report-no-exported": settings.ReportNoExported,
 		}
 	}
 
@@ -26,6 +26,6 @@ func New(cfg *config.ErrChkJSONSettings) *goanalysis.Linter {
 		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/errorlint/errorlint.go
+++ b/pkg/golinters/errorlint/errorlint.go
@@ -8,16 +8,16 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(cfg *config.ErrorLintSettings) *goanalysis.Linter {
+func New(settings *config.ErrorLintSettings) *goanalysis.Linter {
 	var opts []errorlint.Option
 
-	if cfg != nil {
-		ae := toAllowPairs(cfg.AllowedErrors)
+	if settings != nil {
+		ae := toAllowPairs(settings.AllowedErrors)
 		if len(ae) > 0 {
 			opts = append(opts, errorlint.WithAllowedErrors(ae))
 		}
 
-		aew := toAllowPairs(cfg.AllowedErrorsWildcard)
+		aew := toAllowPairs(settings.AllowedErrorsWildcard)
 		if len(aew) > 0 {
 			opts = append(opts, errorlint.WithAllowedWildcard(aew))
 		}
@@ -25,14 +25,14 @@ func New(cfg *config.ErrorLintSettings) *goanalysis.Linter {
 
 	a := errorlint.NewAnalyzer(opts...)
 
-	cfgMap := map[string]map[string]any{}
+	cfg := map[string]map[string]any{}
 
-	if cfg != nil {
-		cfgMap[a.Name] = map[string]any{
-			"errorf":       cfg.Errorf,
-			"errorf-multi": cfg.ErrorfMulti,
-			"asserts":      cfg.Asserts,
-			"comparison":   cfg.Comparison,
+	if settings != nil {
+		cfg[a.Name] = map[string]any{
+			"errorf":       settings.Errorf,
+			"errorf-multi": settings.ErrorfMulti,
+			"asserts":      settings.Asserts,
+			"comparison":   settings.Comparison,
 		}
 	}
 
@@ -41,7 +41,7 @@ func New(cfg *config.ErrorLintSettings) *goanalysis.Linter {
 		"errorlint is a linter for that can be used to find code "+
 			"that will cause problems with the error wrapping scheme introduced in Go 1.13.",
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 

--- a/pkg/golinters/gosmopolitan/gosmopolitan.go
+++ b/pkg/golinters/gosmopolitan/gosmopolitan.go
@@ -10,16 +10,16 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(s *config.GosmopolitanSettings) *goanalysis.Linter {
+func New(settings *config.GosmopolitanSettings) *goanalysis.Linter {
 	a := gosmopolitan.NewAnalyzer()
 
-	cfgMap := map[string]map[string]any{}
-	if s != nil {
-		cfgMap[a.Name] = map[string]any{
-			"allowtimelocal":  s.AllowTimeLocal,
-			"escapehatches":   strings.Join(s.EscapeHatches, ","),
-			"lookattests":     !s.IgnoreTests,
-			"watchforscripts": strings.Join(s.WatchForScripts, ","),
+	cfg := map[string]map[string]any{}
+	if settings != nil {
+		cfg[a.Name] = map[string]any{
+			"allowtimelocal":  settings.AllowTimeLocal,
+			"escapehatches":   strings.Join(settings.EscapeHatches, ","),
+			"lookattests":     !settings.IgnoreTests,
+			"watchforscripts": strings.Join(settings.WatchForScripts, ","),
 		}
 	}
 
@@ -27,6 +27,6 @@ func New(s *config.GosmopolitanSettings) *goanalysis.Linter {
 		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/grouper/grouper.go
+++ b/pkg/golinters/grouper/grouper.go
@@ -11,9 +11,9 @@ import (
 func New(settings *config.GrouperSettings) *goanalysis.Linter {
 	a := grouper.New()
 
-	linterCfg := map[string]map[string]any{}
+	cfg := map[string]map[string]any{}
 	if settings != nil {
-		linterCfg[a.Name] = map[string]any{
+		cfg[a.Name] = map[string]any{
 			"const-require-single-const":   settings.ConstRequireSingleConst,
 			"const-require-grouping":       settings.ConstRequireGrouping,
 			"import-require-single-import": settings.ImportRequireSingleImport,
@@ -29,6 +29,6 @@ func New(settings *config.GrouperSettings) *goanalysis.Linter {
 		a.Name,
 		"Analyze expression groups.",
 		[]*analysis.Analyzer{a},
-		linterCfg,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/maintidx/maintidx.go
+++ b/pkg/golinters/maintidx/maintidx.go
@@ -8,16 +8,16 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(cfg *config.MaintIdxSettings) *goanalysis.Linter {
+func New(settings *config.MaintIdxSettings) *goanalysis.Linter {
 	analyzer := maintidx.Analyzer
 
-	cfgMap := map[string]map[string]any{
+	cfg := map[string]map[string]any{
 		analyzer.Name: {"under": 20},
 	}
 
-	if cfg != nil {
-		cfgMap[analyzer.Name] = map[string]any{
-			"under": cfg.Under,
+	if settings != nil {
+		cfg[analyzer.Name] = map[string]any{
+			"under": settings.Under,
 		}
 	}
 
@@ -25,6 +25,6 @@ func New(cfg *config.MaintIdxSettings) *goanalysis.Linter {
 		analyzer.Name,
 		analyzer.Doc,
 		[]*analysis.Analyzer{analyzer},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/musttag/musttag.go
+++ b/pkg/golinters/musttag/musttag.go
@@ -8,11 +8,11 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(setting *config.MustTagSettings) *goanalysis.Linter {
+func New(settings *config.MustTagSettings) *goanalysis.Linter {
 	var funcs []musttag.Func
 
-	if setting != nil {
-		for _, fn := range setting.Functions {
+	if settings != nil {
+		for _, fn := range settings.Functions {
 			funcs = append(funcs, musttag.Func{
 				Name:   fn.Name,
 				Tag:    fn.Tag,

--- a/pkg/golinters/nilnil/nilnil.go
+++ b/pkg/golinters/nilnil/nilnil.go
@@ -11,13 +11,13 @@ import (
 func New(settings *config.NilNilSettings) *goanalysis.Linter {
 	a := analyzer.New()
 
-	cfgMap := make(map[string]map[string]any)
+	cfg := make(map[string]map[string]any)
 	if settings != nil {
-		cfgMap[a.Name] = map[string]any{
+		cfg[a.Name] = map[string]any{
 			"detect-opposite": settings.DetectOpposite,
 		}
 		if len(settings.CheckedTypes) != 0 {
-			cfgMap[a.Name]["checked-types"] = settings.CheckedTypes
+			cfg[a.Name]["checked-types"] = settings.CheckedTypes
 		}
 	}
 
@@ -25,7 +25,7 @@ func New(settings *config.NilNilSettings) *goanalysis.Linter {
 		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/testpackage/testpackage.go
+++ b/pkg/golinters/testpackage/testpackage.go
@@ -10,19 +10,19 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(cfg *config.TestpackageSettings) *goanalysis.Linter {
+func New(settings *config.TestpackageSettings) *goanalysis.Linter {
 	a := testpackage.NewAnalyzer()
 
-	var settings map[string]map[string]any
-	if cfg != nil {
-		settings = map[string]map[string]any{
+	var cfg map[string]map[string]any
+	if settings != nil {
+		cfg = map[string]map[string]any{
 			a.Name: {
-				testpackage.SkipRegexpFlagName:    cfg.SkipRegexp,
-				testpackage.AllowPackagesFlagName: strings.Join(cfg.AllowPackages, ","),
+				testpackage.SkipRegexpFlagName:    settings.SkipRegexp,
+				testpackage.AllowPackagesFlagName: strings.Join(settings.AllowPackages, ","),
 			},
 		}
 	}
 
-	return goanalysis.NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, settings).
+	return goanalysis.NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, cfg).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/thelper/thelper.go
+++ b/pkg/golinters/thelper/thelper.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/internal"
 )
 
-func New(cfg *config.ThelperSettings) *goanalysis.Linter {
+func New(settings *config.ThelperSettings) *goanalysis.Linter {
 	a := analyzer.NewAnalyzer()
 
 	opts := map[string]struct{}{
@@ -33,11 +33,11 @@ func New(cfg *config.ThelperSettings) *goanalysis.Linter {
 		"tb_first": {},
 	}
 
-	if cfg != nil {
-		applyTHelperOptions(cfg.Test, "t_", opts)
-		applyTHelperOptions(cfg.Fuzz, "f_", opts)
-		applyTHelperOptions(cfg.Benchmark, "b_", opts)
-		applyTHelperOptions(cfg.TB, "tb_", opts)
+	if settings != nil {
+		applyTHelperOptions(settings.Test, "t_", opts)
+		applyTHelperOptions(settings.Fuzz, "f_", opts)
+		applyTHelperOptions(settings.Benchmark, "b_", opts)
+		applyTHelperOptions(settings.TB, "tb_", opts)
 	}
 
 	if len(opts) == 0 {
@@ -46,7 +46,7 @@ func New(cfg *config.ThelperSettings) *goanalysis.Linter {
 
 	args := maps.Keys(opts)
 
-	cfgMap := map[string]map[string]any{
+	cfg := map[string]map[string]any{
 		a.Name: {
 			"checks": strings.Join(args, ","),
 		},
@@ -56,7 +56,7 @@ func New(cfg *config.ThelperSettings) *goanalysis.Linter {
 		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 

--- a/pkg/golinters/usestdlibvars/usestdlibvars.go
+++ b/pkg/golinters/usestdlibvars/usestdlibvars.go
@@ -8,24 +8,24 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
 )
 
-func New(cfg *config.UseStdlibVarsSettings) *goanalysis.Linter {
+func New(settings *config.UseStdlibVarsSettings) *goanalysis.Linter {
 	a := analyzer.New()
 
-	cfgMap := make(map[string]map[string]any)
-	if cfg != nil {
-		cfgMap[a.Name] = map[string]any{
-			analyzer.ConstantKindFlag:       cfg.ConstantKind,
-			analyzer.CryptoHashFlag:         cfg.CryptoHash,
-			analyzer.HTTPMethodFlag:         cfg.HTTPMethod,
-			analyzer.HTTPStatusCodeFlag:     cfg.HTTPStatusCode,
-			analyzer.OSDevNullFlag:          cfg.OSDevNull,
-			analyzer.RPCDefaultPathFlag:     cfg.DefaultRPCPath,
-			analyzer.SQLIsolationLevelFlag:  cfg.SQLIsolationLevel,
-			analyzer.SyslogPriorityFlag:     cfg.SyslogPriority,
-			analyzer.TimeLayoutFlag:         cfg.TimeLayout,
-			analyzer.TimeMonthFlag:          cfg.TimeMonth,
-			analyzer.TimeWeekdayFlag:        cfg.TimeWeekday,
-			analyzer.TLSSignatureSchemeFlag: cfg.TLSSignatureScheme,
+	cfg := make(map[string]map[string]any)
+	if settings != nil {
+		cfg[a.Name] = map[string]any{
+			analyzer.ConstantKindFlag:       settings.ConstantKind,
+			analyzer.CryptoHashFlag:         settings.CryptoHash,
+			analyzer.HTTPMethodFlag:         settings.HTTPMethod,
+			analyzer.HTTPStatusCodeFlag:     settings.HTTPStatusCode,
+			analyzer.OSDevNullFlag:          settings.OSDevNull,
+			analyzer.RPCDefaultPathFlag:     settings.DefaultRPCPath,
+			analyzer.SQLIsolationLevelFlag:  settings.SQLIsolationLevel,
+			analyzer.SyslogPriorityFlag:     settings.SyslogPriority,
+			analyzer.TimeLayoutFlag:         settings.TimeLayout,
+			analyzer.TimeMonthFlag:          settings.TimeMonth,
+			analyzer.TimeWeekdayFlag:        settings.TimeWeekday,
+			analyzer.TLSSignatureSchemeFlag: settings.TLSSignatureScheme,
 		}
 	}
 
@@ -33,6 +33,6 @@ func New(cfg *config.UseStdlibVarsSettings) *goanalysis.Linter {
 		a.Name,
 		a.Doc,
 		[]*analysis.Analyzer{a},
-		cfgMap,
+		cfg,
 	).WithLoadMode(goanalysis.LoadModeSyntax)
 }


### PR DESCRIPTION
Refactor linters constructors:

- rename parameters `setting`, `s`, and `cfg` to `settings`
- rename variables `cfgMap`, `linterCfg` to `cfg`.