### PR TITLE
fix: improve Go version detection inside workspace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/kyoh86/exportloopref v0.1.11
 	github.com/lasiar/canonicalheader v1.1.2
 	github.com/ldez/gomoddirectives v0.4.2
+	github.com/ldez/grignotin v0.6.0
 	github.com/ldez/tagliatelle v0.6.0
 	github.com/ldez/usetesting v0.2.0
 	github.com/leonklingele/grouper v1.1.2
@@ -128,6 +129,7 @@ require (
 	go-simpler.org/sloglint v0.7.2
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
+	golang.org/x/mod v0.22.0
 	golang.org/x/sys v0.27.0
 	golang.org/x/tools v0.27.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -164,7 +166,6 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/ldez/grignotin v0.6.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -197,7 +198,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20241108190413-2d47ceb2692f // indirect
-	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.9.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/pkg/golinters/gomodguard/testdata/go.mod
+++ b/pkg/golinters/gomodguard/testdata/go.mod
@@ -1,0 +1,8 @@
+module gomodguard
+
+go 1.22.0
+
+require (
+	golang.org/x/mod v0.22.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/pkg/golinters/gomodguard/testdata/go.sum
+++ b/pkg/golinters/gomodguard/testdata/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/golinters/gomodguard/testdata/gomodguard.yml
+++ b/pkg/golinters/gomodguard/testdata/gomodguard.yml
@@ -1,8 +1,8 @@
 linters-settings:
   gomodguard:
     allowed:
-      modules:                                                    # List of allowed modules
-        - golang.org/x/mod/modfile
+      modules:                                                      # List of allowed modules
+        - golang.org/x/mod
     blocked:
       modules:                                                      # List of blocked modules
         - gopkg.in/yaml.v3:                                         # Blocked module


### PR DESCRIPTION
Fixes #4894

<details><summary>To reproduce</summary>

```bash
#!/bin/bash -e

rm -rf wpsample

mkdir wpsample
cd wpsample

go work init

mkdir a b
echo module a > a/go.mod
echo go 1.20 >> a/go.mod

echo module b > b/go.mod
echo go 1.22 >> b/go.mod

echo package main > b/main.go

go work use a
go work use b

cd b

golangci-lint run --enable=copyloopvar,intrange
```

</details>

Note:
By adding `golang.org/x/mod` as a dependency, a bug inside the integration test for `gomodguard` has been detected.
The test used the `go.mod` of golangci-lint instead of a dedicated `go.mod` so we never saw the problem.
The module defined inside the `allowed` section was not a module but a package (`golang.org/x/mod/modfile`) and as the `go.mod` of golangci-lint didn't contain `golang.org/x/mod` the problem was hidden.
So I fixed the test because without that, the CI was unhappy with this PR.


