### PR TITLE
docs: Ignore previously ignored contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ If you value it, consider supporting us, we appreciate it! :heart:
 
 This project exists thanks to all the people who contribute. [How to contribute](https://golangci-lint.run/contributing/quick-start/).
 
-<a href="https://github.com/golangci/golangci-lint/graphs/contributors"><img src="https://opencollective.com/golangci-lint/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/golangci/golangci-lint/graphs/contributors">
+  <img src="https://opencollective.com/golangci-lint/contributors.svg?width=890&button=false&skip=golangcidev&skip=CLAassistant&skip=renovate&skipfossabot&skip=golangcibot&skip=kortschak&skip=golangci-releaser&skip=dependabot%5Bbot%5D" />
+</a>
 
 ## Stargazers over time
 


### PR DESCRIPTION
Followup from #5148. It's now supported to filter out users since https://github.com/opencollective/contributors-svg/pull/68 got merged so this will restore the previously ignored users + add `dependabot[bot]`.