### PR TITLE
dev: format linter descriptions inside help command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,6 @@ require (
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/mod v0.22.0
 	golang.org/x/sys v0.28.0
-	golang.org/x/text v0.20.0
 	golang.org/x/tools v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.5.1
@@ -200,6 +199,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20241108190413-2d47ceb2692f // indirect
 	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/text v0.20.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -131,6 +131,7 @@ require (
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/mod v0.22.0
 	golang.org/x/sys v0.28.0
+	golang.org/x/text v0.20.0
 	golang.org/x/tools v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.5.1
@@ -199,7 +200,6 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20241108190413-2d47ceb2692f // indirect
 	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/text v0.20.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
@@ -129,6 +131,11 @@ func printLinters(lcs []*linter.Config) {
 		firstNewline := strings.IndexRune(linterDescription, '\n')
 		if firstNewline > 0 {
 			linterDescription = linterDescription[:firstNewline]
+		}
+
+		// Capitalize the first word of the linter description
+		if firstWord, remaining, ok := strings.Cut(linterDescription, " "); ok {
+			linterDescription = cases.Title(language.Und, cases.NoLower).String(firstWord) + " " + remaining
 		}
 
 		deprecatedMark := ""

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -5,11 +5,11 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
@@ -126,16 +126,21 @@ func printLinters(lcs []*linter.Config) {
 	})
 
 	for _, lc := range lcs {
+		desc := lc.Linter.Desc()
+
 		// If the linter description spans multiple lines, truncate everything following the first newline
-		linterDescription := lc.Linter.Desc()
-		firstNewline := strings.IndexRune(linterDescription, '\n')
-		if firstNewline > 0 {
-			linterDescription = linterDescription[:firstNewline]
+		endFirstLine := strings.IndexRune(desc, '\n')
+		if endFirstLine > 0 {
+			desc = desc[:endFirstLine]
 		}
 
-		// Capitalize the first word of the linter description
-		if firstWord, remaining, ok := strings.Cut(linterDescription, " "); ok {
-			linterDescription = cases.Title(language.Und, cases.NoLower).String(firstWord) + " " + remaining
+		rawDesc := []rune(desc)
+
+		r, _ := utf8.DecodeRuneInString(desc)
+		rawDesc[0] = unicode.ToUpper(r)
+
+		if rawDesc[len(rawDesc)-1] != '.' {
+			rawDesc = append(rawDesc, '.')
 		}
 
 		deprecatedMark := ""
@@ -144,6 +149,6 @@ func printLinters(lcs []*linter.Config) {
 		}
 
 		_, _ = fmt.Fprintf(logutils.StdOut, "%s%s: %s [fast: %t, auto-fix: %t]\n",
-			color.YellowString(lc.Name()), deprecatedMark, linterDescription, !lc.IsSlowLinter(), lc.CanAutoFix)
+			color.YellowString(lc.Name()), deprecatedMark, string(rawDesc), !lc.IsSlowLinter(), lc.CanAutoFix)
 	}
 }


### PR DESCRIPTION
This is for consistency with the documentation.

Before:
```console
$ go run ./cmd/golangci-lint/ help linters
Enabled by default linters:
errcheck: errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
gosimple: Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]
govet: Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes. [fast: false, auto-fix: false]
ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
staticcheck: It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
unused: Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]

Disabled by default linters:
asasalint: check for pass []any as any in variadic func(...any) [fast: false, auto-fix: false]
asciicheck: checks that all code identifiers does not have non-ASCII symbols in the name [fast: true, auto-fix: false]
bidichk: Checks for dangerous unicode character sequences [fast: true, auto-fix: false]
...
```

After:

```console
$ go run ./cmd/golangci-lint/ help linters
Enabled by default linters:
errcheck: Errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases. [fast: false, auto-fix: false]
gosimple: Linter for Go source code that specializes in simplifying code. [fast: false, auto-fix: false]
govet: Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes. [fast: false, auto-fix: false]
ineffassign: Detects when assignments to existing variables are not used. [fast: true, auto-fix: false]
staticcheck: It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
unused: Checks Go code for unused constants, variables, functions and types. [fast: false, auto-fix: false]

Disabled by default linters:
asasalint: Check for pass []any as any in variadic func(...any). [fast: false, auto-fix: false]
asciicheck: Checks that all code identifiers does not have non-ASCII symbols in the name. [fast: true, auto-fix: false]
bidichk: Checks for dangerous unicode character sequences. [fast: true, auto-fix: false]
...
```