### PR TITLE
dev: simplify cutVal implementation

### DIFF
--- a/pkg/printers/teamcity.go
+++ b/pkg/printers/teamcity.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -112,11 +111,9 @@ func (i InspectionInstance) Print(w io.Writer, replacer *strings.Replacer) (int,
 }
 
 func cutVal(s string, limit int) string {
-	var size, count int
-	for i := 0; i < limit && count < len(s); i++ {
-		_, size = utf8.DecodeRuneInString(s[count:])
-		count += size
+	runes := []rune(s)
+	if len(runes) > limit {
+		return string(runes[:limit])
 	}
-
-	return s[:count]
+	return s
 }


### PR DESCRIPTION
The PR refactors the implementation of an unexported function `cutVal` in the `printers` package.