### PR TITLE
dev: enhance help linters output on fast and auto-fix capabilities

### DIFF
--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -150,7 +150,7 @@ func printLinters(lcs []*linter.Config) {
 
 		var capabilities []string
 		if !lc.IsSlowLinter() {
-			capabilities = append(capabilities, color.GreenString("fast"))
+			capabilities = append(capabilities, color.BlueString("fast"))
 		}
 		if lc.CanAutoFix {
 			capabilities = append(capabilities, color.GreenString("auto-fix"))

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -148,7 +148,18 @@ func printLinters(lcs []*linter.Config) {
 			deprecatedMark = " [" + color.RedString("deprecated") + "]"
 		}
 
-		_, _ = fmt.Fprintf(logutils.StdOut, "%s%s: %s [fast: %t, auto-fix: %t]\n",
-			color.YellowString(lc.Name()), deprecatedMark, string(rawDesc), !lc.IsSlowLinter(), lc.CanAutoFix)
+		var capability string
+		switch isFast := !lc.IsSlowLinter(); {
+		case isFast && lc.CanAutoFix:
+			capability = " [" + color.GreenString("fast, auto-fix") + "]"
+		case isFast:
+			capability = " [" + color.GreenString("fast") + "]"
+		case lc.CanAutoFix:
+			capability = " [" + color.GreenString("auto-fix") + "]"
+		default:
+		}
+
+		_, _ = fmt.Fprintf(logutils.StdOut, "%s%s: %s%s\n",
+			color.YellowString(lc.Name()), deprecatedMark, string(rawDesc), capability)
 	}
 }

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -148,15 +148,17 @@ func printLinters(lcs []*linter.Config) {
 			deprecatedMark = " [" + color.RedString("deprecated") + "]"
 		}
 
+		var capabilities []string
+		if !lc.IsSlowLinter() {
+			capabilities = append(capabilities, color.GreenString("fast"))
+		}
+		if lc.CanAutoFix {
+			capabilities = append(capabilities, color.GreenString("auto-fix"))
+		}
+
 		var capability string
-		switch isFast := !lc.IsSlowLinter(); {
-		case isFast && lc.CanAutoFix:
-			capability = " [" + color.GreenString("fast, auto-fix") + "]"
-		case isFast:
-			capability = " [" + color.GreenString("fast") + "]"
-		case lc.CanAutoFix:
-			capability = " [" + color.GreenString("auto-fix") + "]"
-		default:
+		if capabilities != nil {
+			capability = " [" + strings.Join(capabilities, ", ") + "]"
 		}
 
 		_, _ = fmt.Fprintf(logutils.StdOut, "%s%s: %s%s\n",


### PR DESCRIPTION
The PR changes the output for the `golangci-lint linters help` command.
I think outputting `[fast: false, auto-fix: false]` is redundant, and `help` prints nothing if the linter is slow and does not have auto-fix. If a linter is fast, the command prints green `[fast]`. If a linter can auto fix, the command prints green `[auto-fix]`. If a linter is fast and has auto fix - `[fast, auto-fix]` in green.

<details>
<summary>Before</summary>


<img width="797" alt="image" src="https://github.com/user-attachments/assets/82461163-db4a-480a-a349-ef07e65ca5f4">

</details>

<details>
<summary>After</summary>

<img width="795" alt="image" src="https://github.com/user-attachments/assets/533a13e0-e728-4d83-8cc7-da1c1cdd6e15">


</details>

