### PR TITLE
feat: display linters help as JSON

### DIFF
--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -70,7 +70,7 @@ func newHelpCommand(logger logutils.Log) *helpCommand {
 	fs := lintersCmd.Flags()
 	fs.SortFlags = false // sort them as they are defined here
 
-	fs.BoolVar(&c.opts.JSON, "json", true, color.GreenString("Display as JSON"))
+	fs.BoolVar(&c.opts.JSON, "json", false, color.GreenString("Display as JSON"))
 
 	c.cmd = helpCmd
 

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -26,6 +26,8 @@ type linterHelp struct {
 	Presets          []string `json:"presets"`
 	EnabledByDefault bool     `json:"enabledByDefault"`
 	Deprecated       bool     `json:"deprecated"`
+	Since            string   `json:"since"`
+	OriginalURL      string   `json:"originalURL,omitempty"`
 }
 
 type helpOptions struct {
@@ -114,6 +116,8 @@ func (c *helpCommand) printJSON() error {
 			Presets:          lc.InPresets,
 			EnabledByDefault: lc.EnabledByDefault,
 			Deprecated:       lc.IsDeprecated(),
+			Since:            lc.Since,
+			OriginalURL:      lc.OriginalURL,
 		})
 	}
 

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -17,8 +18,24 @@ import (
 	"github.com/golangci/golangci-lint/pkg/logutils"
 )
 
+type linterHelp struct {
+	Name             string   `json:"name"`
+	Desc             string   `json:"description"`
+	Fast             bool     `json:"fast"`
+	AutoFix          bool     `json:"autoFix"`
+	Presets          []string `json:"presets"`
+	EnabledByDefault bool     `json:"enabledByDefault"`
+	Deprecated       bool     `json:"deprecated"`
+}
+
+type helpOptions struct {
+	JSON bool
+}
+
 type helpCommand struct {
 	cmd *cobra.Command
+
+	opts helpOptions
 
 	dbManager *lintersdb.Manager
 
@@ -37,16 +54,21 @@ func newHelpCommand(logger logutils.Log) *helpCommand {
 		},
 	}
 
-	helpCmd.AddCommand(
-		&cobra.Command{
-			Use:               "linters",
-			Short:             "Help about linters",
-			Args:              cobra.NoArgs,
-			ValidArgsFunction: cobra.NoFileCompletions,
-			Run:               c.execute,
-			PreRunE:           c.preRunE,
-		},
-	)
+	lintersCmd := &cobra.Command{
+		Use:               "linters",
+		Short:             "Help about linters",
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              c.execute,
+		PreRunE:           c.preRunE,
+	}
+
+	helpCmd.AddCommand(lintersCmd)
+
+	fs := lintersCmd.Flags()
+	fs.SortFlags = false // sort them as they are defined here
+
+	fs.BoolVar(&c.opts.JSON, "json", true, color.GreenString("Display as JSON"))
 
 	c.cmd = helpCmd
 
@@ -66,7 +88,39 @@ func (c *helpCommand) preRunE(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (c *helpCommand) execute(_ *cobra.Command, _ []string) {
+func (c *helpCommand) execute(_ *cobra.Command, _ []string) error {
+	if c.opts.JSON {
+		return c.printJSON()
+	}
+
+	c.print()
+
+	return nil
+}
+
+func (c *helpCommand) printJSON() error {
+	var linters []linterHelp
+
+	for _, lc := range c.dbManager.GetAllSupportedLinterConfigs() {
+		if lc.Internal {
+			continue
+		}
+
+		linters = append(linters, linterHelp{
+			Name:             lc.Name(),
+			Desc:             formatDescription(lc.Linter.Desc()),
+			Fast:             !lc.IsSlowLinter(),
+			AutoFix:          lc.CanAutoFix,
+			Presets:          lc.InPresets,
+			EnabledByDefault: lc.EnabledByDefault,
+			Deprecated:       lc.IsDeprecated(),
+		})
+	}
+
+	return json.NewEncoder(c.cmd.OutOrStdout()).Encode(linters)
+}
+
+func (c *helpCommand) print() {
 	var enabledLCs, disabledLCs []*linter.Config
 	for _, lc := range c.dbManager.GetAllSupportedLinterConfigs() {
 		if lc.Internal {
@@ -126,22 +180,7 @@ func printLinters(lcs []*linter.Config) {
 	})
 
 	for _, lc := range lcs {
-		desc := lc.Linter.Desc()
-
-		// If the linter description spans multiple lines, truncate everything following the first newline
-		endFirstLine := strings.IndexRune(desc, '\n')
-		if endFirstLine > 0 {
-			desc = desc[:endFirstLine]
-		}
-
-		rawDesc := []rune(desc)
-
-		r, _ := utf8.DecodeRuneInString(desc)
-		rawDesc[0] = unicode.ToUpper(r)
-
-		if rawDesc[len(rawDesc)-1] != '.' {
-			rawDesc = append(rawDesc, '.')
-		}
+		desc := formatDescription(lc.Linter.Desc())
 
 		deprecatedMark := ""
 		if lc.IsDeprecated() {
@@ -162,6 +201,25 @@ func printLinters(lcs []*linter.Config) {
 		}
 
 		_, _ = fmt.Fprintf(logutils.StdOut, "%s%s: %s%s\n",
-			color.YellowString(lc.Name()), deprecatedMark, string(rawDesc), capability)
+			color.YellowString(lc.Name()), deprecatedMark, desc, capability)
 	}
+}
+
+func formatDescription(desc string) string {
+	// If the linter description spans multiple lines, truncate everything following the first newline
+	endFirstLine := strings.IndexRune(desc, '\n')
+	if endFirstLine > 0 {
+		desc = desc[:endFirstLine]
+	}
+
+	rawDesc := []rune(desc)
+
+	r, _ := utf8.DecodeRuneInString(desc)
+	rawDesc[0] = unicode.ToUpper(r)
+
+	if rawDesc[len(rawDesc)-1] != '.' {
+		rawDesc = append(rawDesc, '.')
+	}
+
+	return string(rawDesc)
 }


### PR DESCRIPTION
Adds the option `--json` to the command `help linters`.

<details>
<summary>Some examples of the usage</summary>

#### Gets a linter by name:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.name=="nolintlint") ]'
```

#### Gets all the "fast" linters:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.fast) ]'
```

#### Gets all the "slow" linters:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.fast==false) ]'
```

#### Gets all linters with autofix:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.autoFix==true) ]'
```
#### Gets all the "slow" linters with autofix:

```bash
 go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.autoFix==true and .fast==false) ]'
```

#### Gets all linters with a specific preset:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(any(.presets[]; . == "style")) ]'
```

#### Gets all linters added in a specific version:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.since=="v1.62.0") ]'
```

#### Gets all linter names:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[].name ]'
```

#### Gets all the names of linters enabled by default:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.enabledByDefault==true) ] | map(.name)'
```

#### Gets all the names of "slow" linter with autofix:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(.autoFix==true and .fast==false) ] | map(.name)' 
```

#### Gets all the names of linter inside a specific preset:

```bash
go run ./cmd/golangci-lint/ help linters --json | jq '[ .[] | select(any(.presets[]; . == "bugs")) ] | map(.name)'
```

</details>



Related to #5207