### PR TITLE
docs: update contributors image

### DIFF
--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -58,7 +58,7 @@ If you value it, consider supporting us, we appreciate it! ❤️
 
 This project exists thanks to all the people who contribute. [How to contribute](/contributing/workflow/).
 
-[![golangci-lint contributors](https://contributors-img.web.app/image?repo=golangci/golangci-lint)](https://github.com/golangci/golangci-lint/graphs/contributors)
+[![golangci-lint contributors](https://opencollective.com/golangci-lint/contributors.svg?width=890&button=false&skip=golangcidev,CLAassistant,renovate,fossabot,golangcibot,kortschak,golangci-releaser,dependabot%5Bbot%5D)](https://github.com/golangci/golangci-lint/graphs/contributors)
 
 <!-- TODO: use `allcontributors` -->
 


### PR DESCRIPTION
The PR sets contributor's image on the website to be the same as in the [README](https://github.com/golangci/golangci-lint/blob/ba4b6df5eae5908e1f634b03bf257372aea9e5fe/README.md?plain=1#L53).

Follows #5200