### PR TITLE
go1.24 support 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23'
+      GO_VERSION: '1.24.0-rc.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,7 +9,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: "1.23"
+  GO_VERSION: '1.24.0-rc.1'
 
 jobs:
   update-gha-assets:

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -13,7 +13,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23'
+      GO_VERSION: '1.24.0-rc.1'
       NODE_VERSION: '20.x'
       CGO_ENABLED: 0
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ env:
   # ex:
   # - 1.18beta1 -> 1.18.0-beta.1
   # - 1.18rc1 -> 1.18.0-rc.1
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24.0-rc.1'
 
 jobs:
   # Check if there is any dirty change for go mod tidy
@@ -39,7 +39,9 @@ jobs:
           # ex:
           # - 1.18beta1 -> 1.18.0-beta.1
           # - 1.18rc1 -> 1.18.0-rc.1
-          go-version: ${{ env.GO_VERSION }}
+          # TODO(ldez) must be changed after the first release of golangci-lint with go1.24
+          # go-version: ${{ env.GO_VERSION }}
+          go-version: '1.23'
       - name: lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:
@@ -73,8 +75,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.22'
           - '1.23'
+          - '1.24.0-rc.1'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
       # ex:
       # - 1.18beta1 -> 1.18.0-beta.1
       # - 1.18rc1 -> 1.18.0-rc.1
-      GO_VERSION: '1.23'
+      GO_VERSION: '1.24.0-rc.1'
       CHOCOLATEY_VERSION: 2.2.0
     steps:
       # temporary workaround for an error in free disk space action

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,6 @@ require (
 	go-simpler.org/musttag v0.13.0
 	go-simpler.org/sloglint v0.7.2
 	go.uber.org/automaxprocs v1.6.0
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/mod v0.22.0
 	golang.org/x/sys v0.28.0
 	golang.org/x/tools v0.28.0
@@ -195,6 +194,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20241108190413-2d47ceb2692f // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.20.0 // indirect

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -6,12 +6,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"runtime"
 	"slices"
 	"strings"
 	"sync"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/tools/go/packages"
 
 	"github.com/golangci/golangci-lint/internal/go/cache"
@@ -178,9 +178,7 @@ func (c *Cache) computePkgHash(pkg *packages.Package) (hashResults, error) {
 	curSum := key.Sum()
 	hashRes[HashModeNeedOnlySelf] = hex.EncodeToString(curSum[:])
 
-	imps := maps.Values(pkg.Imports)
-
-	slices.SortFunc(imps, func(a, b *packages.Package) int {
+	imps := slices.SortedFunc(maps.Values(pkg.Imports), func(a, b *packages.Package) int {
 		return strings.Compare(a.PkgPath, b.PkgPath)
 	})
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
 	"runtime/pprof"
 	"runtime/trace"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -24,7 +25,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/automaxprocs/maxprocs"
-	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
 
 	"github.com/golangci/golangci-lint/internal/cache"
@@ -445,8 +445,7 @@ func (c *runCommand) printStats(issues []result.Issue) {
 
 	c.cmd.Printf("%d issues:\n", len(issues))
 
-	keys := maps.Keys(stats)
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(stats))
 
 	for _, key := range keys {
 		c.cmd.Printf("* %s: %d\n", key, stats[key])

--- a/pkg/goanalysis/runner.go
+++ b/pkg/goanalysis/runner.go
@@ -8,11 +8,11 @@ import (
 	"encoding/gob"
 	"fmt"
 	"go/token"
+	"maps"
 	"runtime"
-	"sort"
+	"slices"
 	"sync"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/packages"
 
@@ -158,8 +158,8 @@ func (r *runner) buildActionFactDeps(act *action, a *analysis.Analyzer, pkg *pac
 	act.objectFacts = make(map[objectFactKey]analysis.Fact)
 	act.packageFacts = make(map[packageFactKey]analysis.Fact)
 
-	paths := maps.Keys(pkg.Imports)
-	sort.Strings(paths) // for determinism
+	paths := slices.Sorted(maps.Keys(pkg.Imports)) // for determinism
+
 	for _, path := range paths {
 		dep := r.makeAction(a, pkg.Imports[path], initialPkgs, actions, actAlloc)
 		act.Deps = append(act.Deps, dep)
@@ -208,7 +208,7 @@ func (r *runner) prepareAnalysis(pkgs []*packages.Package,
 		}
 	}
 
-	allActions = maps.Values(actions)
+	allActions = slices.Collect(maps.Values(actions))
 
 	debugf("Built %d actions", len(actions))
 

--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -5,18 +5,17 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
+	"maps"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 
 	"github.com/go-critic/go-critic/checkers"
 	gocriticlinter "github.com/go-critic/go-critic/linter"
 	_ "github.com/quasilyte/go-ruleguard/dsl"
-	"golang.org/x/exp/maps"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
@@ -184,8 +183,7 @@ func (w *goCriticWrapper) configureCheckerInfo(
 				info.Name, k)
 		}
 
-		supportedKeys := maps.Keys(info.Params)
-		sort.Strings(supportedKeys)
+		supportedKeys := slices.Sorted(maps.Keys(info.Params))
 
 		return fmt.Errorf("checker %s config param %s doesn't exist, all existing: %s",
 			info.Name, k, supportedKeys)
@@ -297,8 +295,7 @@ func newSettingsWrapper(settings *config.GoCriticSettings, logger logutils.Log) 
 		}
 	}
 
-	allTagsSorted := maps.Keys(allChecksByTag)
-	sort.Strings(allTagsSorted)
+	allTagsSorted := slices.Sorted(maps.Keys(allChecksByTag))
 
 	return &settingsWrapper{
 		GoCriticSettings:                settings,
@@ -585,6 +582,5 @@ func debugChecksListf(checks []string, format string, args ...any) {
 }
 
 func sprintSortedStrings(v []string) string {
-	sort.Strings(slices.Clone(v))
-	return fmt.Sprint(v)
+	return fmt.Sprint(slices.Sorted(slices.Values(v)))
 }

--- a/pkg/golinters/gocritic/gocritic_test.go
+++ b/pkg/golinters/gocritic/gocritic_test.go
@@ -1,6 +1,7 @@
 package gocritic
 
 import (
+	"maps"
 	"slices"
 	"strings"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	gocriticlinter "github.com/go-critic/go-critic/linter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/logutils"
@@ -40,7 +40,7 @@ func Test_settingsWrapper_InferEnabledChecks(t *testing.T) {
 	t.Logf("enabled by default checks:\n%s", strings.Join(enabledByDefaultChecks, "\n"))
 
 	insert := func(in []string, toInsert ...string) []string {
-		return append(slices.Clone(in), toInsert...)
+		return slices.Concat(in, toInsert)
 	}
 
 	remove := func(in []string, toRemove ...string) []string {
@@ -54,9 +54,7 @@ func Test_settingsWrapper_InferEnabledChecks(t *testing.T) {
 	}
 
 	uniq := func(in []string) []string {
-		result := slices.Clone(in)
-		slices.Sort(result)
-		return slices.Compact(result)
+		return slices.Compact(slices.Sorted(slices.Values(in)))
 	}
 
 	cases := []struct {
@@ -269,7 +267,7 @@ func Test_settingsWrapper_InferEnabledChecks(t *testing.T) {
 			wr := newSettingsWrapper(tt.sett, lg)
 
 			wr.InferEnabledChecks()
-			assert.ElementsMatch(t, tt.expectedEnabledChecks, maps.Keys(wr.inferredEnabledChecks))
+			assert.ElementsMatch(t, tt.expectedEnabledChecks, slices.Collect(maps.Keys(wr.inferredEnabledChecks)))
 			assert.NoError(t, wr.Validate())
 		})
 	}

--- a/pkg/golinters/thelper/thelper.go
+++ b/pkg/golinters/thelper/thelper.go
@@ -1,10 +1,11 @@
 package thelper
 
 import (
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/kulti/thelper/pkg/analyzer"
-	"golang.org/x/exp/maps"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/pkg/config"
@@ -44,7 +45,7 @@ func New(settings *config.ThelperSettings) *goanalysis.Linter {
 		internal.LinterLogger.Fatalf("thelper: at least one option must be enabled")
 	}
 
-	args := maps.Keys(opts)
+	args := slices.Collect(maps.Keys(opts))
 
 	cfg := map[string]map[string]any{
 		a.Name: {

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -167,10 +167,6 @@ func IsGoLowerThanGo122() func(cfg *config.Config) error {
 	return isGoLowerThanGo("1.22")
 }
 
-func IsGoLowerThanGo124() func(cfg *config.Config) error {
-	return isGoLowerThanGo("1.24")
-}
-
 func isGoLowerThanGo(v string) func(cfg *config.Config) error {
 	return func(cfg *config.Config) error {
 		if cfg == nil || config.IsGoGreaterThanOrEqual(cfg.Run.Go, v) {

--- a/pkg/printers/checkstyle.go
+++ b/pkg/printers/checkstyle.go
@@ -4,10 +4,11 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"sort"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/go-xmlfmt/xmlfmt"
-	"golang.org/x/exp/maps"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -75,10 +76,8 @@ func (p Checkstyle) Print(issues []result.Issue) error {
 		file.Errors = append(file.Errors, newError)
 	}
 
-	out.Files = maps.Values(files)
-
-	sort.Slice(out.Files, func(i, j int) bool {
-		return out.Files[i].Name < out.Files[j].Name
+	out.Files = slices.SortedFunc(maps.Values(files), func(a *checkstyleFile, b *checkstyleFile) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	data, err := xml.Marshal(&out)

--- a/pkg/printers/junitxml.go
+++ b/pkg/printers/junitxml.go
@@ -4,10 +4,9 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -84,10 +83,9 @@ func (p JunitXML) Print(issues []result.Issue) error {
 	}
 
 	var res testSuitesXML
-	res.TestSuites = maps.Values(suites)
 
-	sort.Slice(res.TestSuites, func(i, j int) bool {
-		return res.TestSuites[i].Suite < res.TestSuites[j].Suite
+	res.TestSuites = slices.SortedFunc(maps.Values(suites), func(a testSuiteXML, b testSuiteXML) int {
+		return strings.Compare(a.Suite, b.Suite)
 	})
 
 	enc := xml.NewEncoder(p.w)

--- a/pkg/result/processors/nolint.go
+++ b/pkg/result/processors/nolint.go
@@ -4,11 +4,11 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"maps"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/golangci/golangci-lint/pkg/golinters/nolintlint"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
@@ -101,8 +101,7 @@ func (p *Nolint) Finish() {
 		return
 	}
 
-	unknownLinters := maps.Keys(p.unknownLintersSet)
-	sort.Strings(unknownLinters)
+	unknownLinters := slices.Sorted(maps.Keys(p.unknownLintersSet))
 
 	p.log.Warnf("Found unknown linters in //nolint directives: %s", strings.Join(unknownLinters, ", "))
 }

--- a/scripts/website/expand_templates/thanks.go
+++ b/scripts/website/expand_templates/thanks.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
@@ -65,9 +64,8 @@ func getThanksList() string {
 		}
 	}
 
-	authors := maps.Keys(addedAuthors)
-	sort.Slice(authors, func(i, j int) bool {
-		return strings.ToLower(authors[i]) < strings.ToLower(authors[j])
+	authors := slices.SortedFunc(maps.Keys(addedAuthors), func(a string, b string) int {
+		return strings.Compare(strings.ToLower(a), strings.ToLower(b))
 	})
 
 	lines := []string{


### PR DESCRIPTION
This PR is to evaluate and prepare golangci-lint to [go1.24](https://tip.golang.org/doc/go1.24)

This PR will evolve during the beta and RC phases of [go1.24](https://tip.golang.org/doc/go1.24).
The PR is a draft and will be rebased and modified several times during the RC phase.

https://go.dev/wiki/Go-Release-Cycle

**Questions and problems related to go1.24 should be reported in the issue #XXX.**

---

`golangci-lint` is a free and open-source project built by volunteers.

If you value it, please consider donating or asking your company to do so, we appreciate it! :heart:

[![Open Collective backers and sponsors](https://img.shields.io/badge/OpenCollective-Donate-blue?logo=opencollective&style=for-the-badge)](https://opencollective.com/golangci-lint) [![GitHub Sponsors](https://img.shields.io/badge/GitHub-Donate-blue?logo=github&style=for-the-badge)](https://github.com/sponsors/golangci)
