### PR TITLE
docs: remove outdated update contributors instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,6 @@ website_dump_info:
 	go run ./scripts/website/dump_info/
 .PHONY: website_dump_info
 
-update_contributors_list:
-	cd .github/contributors && npm run all
-
 # Functions
 
 # Check that given variables are set and all have non-empty values,

--- a/docs/src/docs/contributing/workflow.mdx
+++ b/docs/src/docs/contributing/workflow.mdx
@@ -56,14 +56,8 @@ First, see [our versioning policy](/product/roadmap/#versioning-policy).
 To make a new release create a tag `vx.y.z`. Don't forget to add zero patch version for a new minor release, e.g. `v1.99.0`.
 A GitHub Action [workflow](https://github.com/golangci/golangci-lint/blob/master/.github/workflows/tag.yml) will start building and publishing release after that.
 
-After making a release you need to update:
-
-1. GitHub [Action config](https://github.com/golangci/golangci-lint/blob/master/assets/github-action-config.json) by running:
+After making a release you need to update
+GitHub [Action config](https://github.com/golangci/golangci-lint/blob/master/assets/github-action-config.json) by running:
 ```sh
 make assets/github-action-config.json
-```
-
-2. Contributors list:
-```sh
-make update_contributors_list # may take 15 min
 ```

--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -60,8 +60,6 @@ This project exists thanks to all the people who contribute. [How to contribute]
 
 [![golangci-lint contributors](https://opencollective.com/golangci-lint/contributors.svg?width=890&button=false&skip=golangcidev,CLAassistant,renovate,fossabot,golangcibot,kortschak,golangci-releaser,dependabot%5Bbot%5D)](https://github.com/golangci/golangci-lint/graphs/contributors)
 
-<!-- TODO: use `allcontributors` -->
-
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/golangci/golangci-lint.svg)](https://starchart.cc/golangci/golangci-lint)


### PR DESCRIPTION
The PR removes:

- Outdated update contributors instructions from the workflow page.
- Unused `make` target `update_contributors_list`.
- Irrelevant `TODO` on the index page.

Follows #5148.