### PR TITLE
goheader: fix invalid position

### DIFF
--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -91,16 +91,25 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 		}
 
 		if fix := issue.Fix(); fix != nil {
-			end := len(fix.Actual)
+			current := len(fix.Actual)
 			for _, s := range fix.Actual {
-				end += len(s)
+				current += len(s)
+			}
+
+			end := start + token.Pos(current)
+
+			header := strings.Join(fix.Expected, "\n") + "\n"
+
+			// Adds an extra line between the package and the header.
+			if end == file.Package {
+				header += "\n"
 			}
 
 			diag.SuggestedFixes = []analysis.SuggestedFix{{
 				TextEdits: []analysis.TextEdit{{
 					Pos:     start,
-					End:     start + token.Pos(end),
-					NewText: []byte(strings.Join(fix.Expected, "\n") + "\n"),
+					End:     end,
+					NewText: []byte(header),
 				}},
 			}}
 		}

--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -76,17 +76,8 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 
 		f := pass.Fset.File(file.Pos())
 
-		commentLine := 1
-
-		// Inspired by https://github.com/denis-tingaikin/go-header/blob/4c75a6a2332f025705325d6c71fff4616aedf48f/analyzer.go#L85-L92
-		if len(file.Comments) > 0 && file.Comments[0].Pos() < file.Package {
-			commentLine = goanalysis.GetFilePositionFor(pass.Fset, file.Comments[0].Pos()).Line
-		}
-
-		start := f.LineStart(commentLine)
-
 		diag := analysis.Diagnostic{
-			Pos:     start,
+			Pos:     f.LineStart(issue.Location().Line+1) + token.Pos(issue.Location().Position), // The position of the first divergence.
 			Message: issue.Message(),
 		}
 
@@ -95,6 +86,15 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 			for _, s := range fix.Actual {
 				current += len(s)
 			}
+
+			commentLine := 1
+
+			// Inspired by https://github.com/denis-tingaikin/go-header/blob/4c75a6a2332f025705325d6c71fff4616aedf48f/analyzer.go#L85-L92
+			if len(file.Comments) > 0 && file.Comments[0].Pos() < file.Package {
+				commentLine = goanalysis.GetFilePositionFor(pass.Fset, file.Comments[0].Pos()).Line
+			}
+
+			start := f.LineStart(commentLine)
 
 			end := start + token.Pos(current)
 

--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -65,6 +65,10 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 	for _, file := range pass.Files {
 		position := goanalysis.GetFilePosition(pass, file)
 
+		if !strings.HasSuffix(position.Filename, ".go") {
+			continue
+		}
+
 		issue := a.Analyze(&goheader.Target{File: file, Path: position.Filename})
 		if issue == nil {
 			continue

--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -72,7 +72,14 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 
 		f := pass.Fset.File(file.Pos())
 
-		start := f.LineStart(issue.Location().Line + 1)
+		commentLine := 1
+
+		// Inspired by https://github.com/denis-tingaikin/go-header/blob/4c75a6a2332f025705325d6c71fff4616aedf48f/analyzer.go#L85-L92
+		if len(file.Comments) > 0 && file.Comments[0].Pos() < file.Package {
+			commentLine = goanalysis.GetFilePositionFor(pass.Fset, file.Comments[0].Pos()).Line
+		}
+
+		start := f.LineStart(commentLine)
 
 		diag := analysis.Diagnostic{
 			Pos:     start,

--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -76,8 +76,20 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 
 		f := pass.Fset.File(file.Pos())
 
+		commentLine := 1
+		var offset int
+
+		// Inspired by https://github.com/denis-tingaikin/go-header/blob/4c75a6a2332f025705325d6c71fff4616aedf48f/analyzer.go#L85-L92
+		if len(file.Comments) > 0 && file.Comments[0].Pos() < file.Package {
+			if !strings.HasPrefix(file.Comments[0].List[0].Text, "/*") {
+				// When the comment are "//" there is a one character offset.
+				offset = 1
+			}
+			commentLine = goanalysis.GetFilePositionFor(pass.Fset, file.Comments[0].Pos()).Line
+		}
+
 		diag := analysis.Diagnostic{
-			Pos:     f.LineStart(issue.Location().Line+1) + token.Pos(issue.Location().Position), // The position of the first divergence.
+			Pos:     f.LineStart(issue.Location().Line+1) + token.Pos(issue.Location().Position-offset), // The position of the first divergence.
 			Message: issue.Message(),
 		}
 
@@ -85,13 +97,6 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 			current := len(fix.Actual)
 			for _, s := range fix.Actual {
 				current += len(s)
-			}
-
-			commentLine := 1
-
-			// Inspired by https://github.com/denis-tingaikin/go-header/blob/4c75a6a2332f025705325d6c71fff4616aedf48f/analyzer.go#L85-L92
-			if len(file.Comments) > 0 && file.Comments[0].Pos() < file.Package {
-				commentLine = goanalysis.GetFilePositionFor(pass.Fset, file.Comments[0].Pos()).Line
 			}
 
 			start := f.LineStart(commentLine)

--- a/pkg/golinters/goheader/testdata/fix/in/goheader_4.go
+++ b/pkg/golinters/goheader/testdata/fix/in/goheader_4.go
@@ -1,0 +1,10 @@
+/*
+	Copyright 2024 The Awesome Project Authors
+
+	Use of this source code is governed by LICENSE.md
+*/
+
+//golangcitest:args -Egoheader
+//golangcitest:expected_exitcode 0
+//golangcitest:config_path testdata/goheader-fix.yml
+package p

--- a/pkg/golinters/goheader/testdata/fix/out/goheader_4.go
+++ b/pkg/golinters/goheader/testdata/fix/out/goheader_4.go
@@ -1,0 +1,10 @@
+/*
+	Copyright 2024 The Awesome Project Authors
+
+	Use of this source code is governed by LICENSE
+*/
+
+//golangcitest:args -Egoheader
+//golangcitest:expected_exitcode 0
+//golangcitest:config_path testdata/goheader-fix.yml
+package p

--- a/pkg/result/processors/fixer.go
+++ b/pkg/result/processors/fixer.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"go/format"
-	"go/token"
 	"os"
 	"slices"
 
@@ -77,7 +76,8 @@ func (p Fixer) process(issues []result.Issue) ([]result.Issue, error) {
 	for i := range issues {
 		issue := issues[i]
 
-		if issue.SuggestedFixes == nil || skipTextEditWithoutPosition(&issue) {
+		if issue.SuggestedFixes == nil || skipNoTextEdit(&issue) {
+			println("Fixing", len(issues), "issues")
 			notFixableIssues = append(notFixableIssues, issue)
 			continue
 		}
@@ -197,16 +197,14 @@ func (p Fixer) printStat() {
 	p.sw.PrintStages()
 }
 
-func skipTextEditWithoutPosition(issue *result.Issue) bool {
+func skipNoTextEdit(issue *result.Issue) bool {
 	var onlyMessage int
 	var count int
 	for _, sf := range issue.SuggestedFixes {
-		for _, edit := range sf.TextEdits {
-			count++
-			if edit.Pos == token.NoPos && edit.End == token.NoPos {
-				onlyMessage++
-			}
+		if len(sf.TextEdits) == 0 {
+			onlyMessage++
 		}
+		count++
 	}
 
 	return count == onlyMessage

--- a/pkg/result/processors/fixer.go
+++ b/pkg/result/processors/fixer.go
@@ -77,7 +77,6 @@ func (p Fixer) process(issues []result.Issue) ([]result.Issue, error) {
 		issue := issues[i]
 
 		if issue.SuggestedFixes == nil || skipNoTextEdit(&issue) {
-			println("Fixing", len(issues), "issues")
 			notFixableIssues = append(notFixableIssues, issue)
 			continue
 		}
@@ -199,15 +198,13 @@ func (p Fixer) printStat() {
 
 func skipNoTextEdit(issue *result.Issue) bool {
 	var onlyMessage int
-	var count int
 	for _, sf := range issue.SuggestedFixes {
 		if len(sf.TextEdits) == 0 {
 			onlyMessage++
 		}
-		count++
 	}
 
-	return count == onlyMessage
+	return len(issue.SuggestedFixes) == onlyMessage
 }
 
 // validateEdits returns a list of edits that is sorted and


### PR DESCRIPTION
 `Location()` returns the position of the first element that needs to be changed, and `Expected` contains all the header lines.

If the first element to change is at L3 and the beginning of the header is at L1, you have a beautiful Christmas tree based on comment separators.

The problem has been here since the introduction of the auto fix for goheader (golangci-lint v1.57.0).

https://github.com/golangci/golangci-lint/pull/4396/files#diff-36750bd1c0da16befa607266d41aca09351630ed97e4ae48f96b63f60e6cbb6dR103

<details><summary>To reproduce</summary>

```go
/*
Copyright 2024 The Awesome Project Authors

Use of this source code is governed by LICENSE
*/
package sandbox

func Foo() {}
```

```yml
linters:
  disable-all: true
  enable:
    - goheader

linters-settings:
  goheader:
    values:
      const:
        AUTHOR: The Awesome Project Authors
    template: |-
        Copyright 2024 {{ AUTHOR }}
  
        Use of this source code is governed by LICENSE.md

```

Then run `golangci-lint run --fix`

</details>

---

Also now it displays the right position of the problem.

<details>

Before:

```console
$ golangci-lint run                                                
main.go:3:47: Missed string: .md (goheader)

Use of this source code is governed by LICENSE
*/

package sandbox
$ 
```

After:

```console
$ ./golangci-lint run
main.go:4:47: Missed string: .md (goheader)
Use of this source code is governed by LICENSE
                                              ^
$ 
```

</details>
