### PR TITLE
feat: disable timeout if timeout <= 0

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -4091,6 +4091,7 @@ output:
 # Options for analysis running.
 run:
   # Timeout for analysis, e.g. 30s, 5m.
+  # If the value is lower or equal to 0, the timeout is disabled.
   # Default: 1m
   timeout: 5m
 

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -49,7 +49,8 @@ func setupRunFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 	internal.AddFlagAndBind(v, fs, fs.String, "go", "run.go", "", color.GreenString("Targeted Go version"))
 	internal.AddHackedStringSlice(fs, "build-tags", color.GreenString("Build tags"))
 
-	internal.AddFlagAndBind(v, fs, fs.Duration, "timeout", "run.timeout", defaultTimeout, color.GreenString("Timeout for total work. If <= 0, the timeout is disabled"))
+	internal.AddFlagAndBind(v, fs, fs.Duration, "timeout", "run.timeout", defaultTimeout,
+		color.GreenString("Timeout for total work. If <= 0, the timeout is disabled"))
 
 	internal.AddFlagAndBind(v, fs, fs.Bool, "tests", "run.tests", true, color.GreenString("Analyze tests (*_test.go)"))
 

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -49,7 +49,7 @@ func setupRunFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 	internal.AddFlagAndBind(v, fs, fs.String, "go", "run.go", "", color.GreenString("Targeted Go version"))
 	internal.AddHackedStringSlice(fs, "build-tags", color.GreenString("Build tags"))
 
-	internal.AddFlagAndBind(v, fs, fs.Duration, "timeout", "run.timeout", defaultTimeout, color.GreenString("Timeout for total work"))
+	internal.AddFlagAndBind(v, fs, fs.Duration, "timeout", "run.timeout", defaultTimeout, color.GreenString("Timeout for total work. If <= 0, the timeout is disabled"))
 
 	internal.AddFlagAndBind(v, fs, fs.Bool, "tests", "run.tests", true, color.GreenString("Analyze tests (*_test.go)"))
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -238,19 +238,17 @@ func (c *runCommand) execute(_ *cobra.Command, args []string) {
 	needTrackResources := logutils.IsVerbose() || c.opts.PrintResourcesUsage
 
 	trackResourcesEndCh := make(chan struct{})
-	defer func() { // XXX: this defer must be before ctx.cancel defer
+	defer func() {            // XXX: this defer must be before ctx.cancel defer
 		if needTrackResources { // wait until resource tracking finished to print properly
 			<-trackResourcesEndCh
 		}
 	}()
 
-	var ctx context.Context
+	ctx := context.Background()
 	if c.cfg.Run.Timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), c.cfg.Run.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, c.cfg.Run.Timeout)
 		defer cancel()
-	} else {
-		ctx = context.Background()
 	}
 
 	if needTrackResources {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -241,7 +241,8 @@ func (c *runCommand) execute(_ *cobra.Command, args []string) {
 
 	// Note: this defer must be before ctx.cancel defer
 	defer func() {
-		if needTrackResources { // wait until resource tracking finished to print properly
+		// wait until resource tracking finished to print properly
+		if needTrackResources {
 			<-trackResourcesEndCh
 		}
 	}()

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -238,7 +238,9 @@ func (c *runCommand) execute(_ *cobra.Command, args []string) {
 	needTrackResources := logutils.IsVerbose() || c.opts.PrintResourcesUsage
 
 	trackResourcesEndCh := make(chan struct{})
-	defer func() {            // XXX: this defer must be before ctx.cancel defer
+
+	// Note: this defer must be before ctx.cancel defer
+	defer func() {
 		if needTrackResources { // wait until resource tracking finished to print properly
 			<-trackResourcesEndCh
 		}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -244,8 +244,14 @@ func (c *runCommand) execute(_ *cobra.Command, args []string) {
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.cfg.Run.Timeout)
-	defer cancel()
+	var ctx context.Context
+	if c.cfg.Run.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), c.cfg.Run.Timeout)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
 
 	if needTrackResources {
 		go watchResources(ctx, trackResourcesEndCh, c.log, c.debugf)


### PR DESCRIPTION
Currently, if the timeout is <=0, you have an immediate "context deadline exceeded".

This is useless, so now timeout <=0 means infinite timeout.

The default timeout is not changed.

Fixes #957