### PR TITLE
fix: move uniq-by-line field from output to issues

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -3984,6 +3984,10 @@ issues:
   # Default: 3
   max-same-issues: 0
 
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
+
   # Show only new issues: if there are unstaged changes or untracked files,
   # only those changes are analyzed, else only changes in HEAD~ are analyzed.
   # It's a super-useful option for integration of golangci-lint into existing large codebase.
@@ -4052,10 +4056,6 @@ output:
   # Print linter name in the end of issue text.
   # Default: true
   print-linter-name: false
-
-  # Make issues output unique by line.
-  # Default: true
-  uniq-by-line: false
 
   # Add a prefix to the output file references.
   # Default: ""

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -560,11 +560,6 @@
           "type": "boolean",
           "default": true
         },
-        "uniq-by-line": {
-          "description": "Make issues output unique by line.",
-          "type": "boolean",
-          "default": true
-        },
         "path-prefix": {
           "description": "Add a prefix to the output file references.",
           "type": "string",
@@ -3966,6 +3961,11 @@
           "description": "Fix found issues (if it's supported by the linter).",
           "type": "boolean",
           "default": false
+        },
+        "uniq-by-line": {
+          "description": "Make issues output unique by line.",
+          "type": "boolean",
+          "default": true
         },
         "whole-files": {
           "description": "Show issues in any part of update files (requires new-from-rev or new-from-patch).",

--- a/pkg/commands/flagsets.go
+++ b/pkg/commands/flagsets.go
@@ -75,8 +75,6 @@ func setupOutputFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 		color.GreenString("Print lines of code with issue"))
 	internal.AddFlagAndBind(v, fs, fs.Bool, "print-linter-name", "output.print-linter-name", true,
 		color.GreenString("Print linter name in issue line"))
-	internal.AddFlagAndBind(v, fs, fs.Bool, "uniq-by-line", "output.uniq-by-line", true,
-		color.GreenString("Make issues output unique by line"))
 	internal.AddFlagAndBind(v, fs, fs.Bool, "sort-results", "output.sort-results", false,
 		color.GreenString("Sort linter results"))
 	internal.AddFlagAndBind(v, fs, fs.StringSlice, "sort-order", "output.sort-order", nil,
@@ -98,6 +96,8 @@ func setupIssuesFlagSet(v *viper.Viper, fs *pflag.FlagSet) {
 		color.GreenString("Maximum issues count per one linter. Set to 0 to disable"))
 	internal.AddFlagAndBind(v, fs, fs.Int, "max-same-issues", "issues.max-same-issues", 3,
 		color.GreenString("Maximum count of issues with the same text. Set to 0 to disable"))
+	internal.AddFlagAndBind(v, fs, fs.Bool, "uniq-by-line", "issues.uniq-by-line", true,
+		color.GreenString("Make issues output unique by line"))
 
 	internal.AddHackedStringSlice(fs, "exclude-files", color.GreenString("Regexps of files to exclude"))
 	internal.AddHackedStringSlice(fs, "exclude-dirs", color.GreenString("Regexps of directories to exclude"))

--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -117,8 +117,9 @@ type Issues struct {
 
 	UseDefaultExcludeDirs bool `mapstructure:"exclude-dirs-use-default"`
 
-	MaxIssuesPerLinter int `mapstructure:"max-issues-per-linter"`
-	MaxSameIssues      int `mapstructure:"max-same-issues"`
+	MaxIssuesPerLinter int  `mapstructure:"max-issues-per-linter"`
+	MaxSameIssues      int  `mapstructure:"max-same-issues"`
+	UniqByLine         bool `mapstructure:"uniq-by-line"`
 
 	DiffFromRevision  string `mapstructure:"new-from-rev"`
 	DiffPatchFilePath string `mapstructure:"new-from-patch"`

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -304,6 +304,7 @@ func (l *Loader) handleGoVersion() {
 	os.Setenv("GOSECGOVERSION", l.cfg.Run.Go)
 }
 
+//nolint:gocyclo // The complexity is expected by the cases to handle.
 func (l *Loader) handleDeprecation() error {
 	if l.cfg.InternalTest || l.cfg.InternalCmdTest || os.Getenv(logutils.EnvTestRun) == "1" {
 		return nil
@@ -334,6 +335,13 @@ func (l *Loader) handleDeprecation() error {
 		l.log.Warnf("The configuration option `run.show-stats` is deprecated, please use `output.show-stats`")
 	}
 	l.cfg.Output.ShowStats = l.cfg.Run.ShowStats || l.cfg.Output.ShowStats
+
+	// The 2 options are true by default.
+	// Deprecated since v1.63.0
+	if !l.cfg.Output.UniqByLine {
+		l.log.Warnf("The configuration option `output.uniq-by-line` is deprecated, please use `issues.uniq-by-line`")
+		l.cfg.Issues.UniqByLine = l.cfg.Output.UniqByLine
+	}
 
 	// Deprecated since v1.57.0
 	if l.cfg.Output.Format != "" {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -336,11 +336,10 @@ func (l *Loader) handleDeprecation() error {
 	}
 	l.cfg.Output.ShowStats = l.cfg.Run.ShowStats || l.cfg.Output.ShowStats
 
-	// The 2 options are true by default.
 	// Deprecated since v1.63.0
-	if !l.cfg.Output.UniqByLine {
+	if l.cfg.Output.UniqByLine != nil {
 		l.log.Warnf("The configuration option `output.uniq-by-line` is deprecated, please use `issues.uniq-by-line`")
-		l.cfg.Issues.UniqByLine = l.cfg.Output.UniqByLine
+		l.cfg.Issues.UniqByLine = *l.cfg.Output.UniqByLine
 	}
 
 	// Deprecated since v1.57.0

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -43,7 +43,6 @@ type Output struct {
 	Formats         OutputFormats `mapstructure:"formats"`
 	PrintIssuedLine bool          `mapstructure:"print-issued-lines"`
 	PrintLinterName bool          `mapstructure:"print-linter-name"`
-	UniqByLine      bool          `mapstructure:"uniq-by-line"`
 	SortResults     bool          `mapstructure:"sort-results"`
 	SortOrder       []string      `mapstructure:"sort-order"`
 	PathPrefix      string        `mapstructure:"path-prefix"`
@@ -51,6 +50,9 @@ type Output struct {
 
 	// Deprecated: use Formats instead.
 	Format string `mapstructure:"format"`
+
+	// Deprecated: use [Issues.UniqByLine] instead.
+	UniqByLine bool `mapstructure:"uniq-by-line"`
 }
 
 func (o *Output) Validate() error {

--- a/pkg/config/output.go
+++ b/pkg/config/output.go
@@ -52,7 +52,7 @@ type Output struct {
 	Format string `mapstructure:"format"`
 
 	// Deprecated: use [Issues.UniqByLine] instead.
-	UniqByLine bool `mapstructure:"uniq-by-line"`
+	UniqByLine *bool `mapstructure:"uniq-by-line"`
 }
 
 func (o *Output) Validate() error {

--- a/pkg/result/processors/uniq_by_line.go
+++ b/pkg/result/processors/uniq_by_line.go
@@ -26,7 +26,7 @@ func (*UniqByLine) Name() string {
 }
 
 func (p *UniqByLine) Process(issues []result.Issue) ([]result.Issue, error) {
-	if !p.cfg.Output.UniqByLine {
+	if !p.cfg.Issues.UniqByLine {
 		return issues, nil
 	}
 

--- a/pkg/result/processors/uniq_by_line_test.go
+++ b/pkg/result/processors/uniq_by_line_test.go
@@ -19,7 +19,7 @@ func newFLIssue(file string, line int) result.Issue {
 
 func TestUniqByLine(t *testing.T) {
 	cfg := config.Config{}
-	cfg.Output.UniqByLine = true
+	cfg.Issues.UniqByLine = true
 
 	p := NewUniqByLine(&cfg)
 	i1 := newFLIssue("f1", 1)
@@ -34,7 +34,7 @@ func TestUniqByLine(t *testing.T) {
 
 func TestUniqByLineDisabled(t *testing.T) {
 	cfg := config.Config{}
-	cfg.Output.UniqByLine = false
+	cfg.Issues.UniqByLine = false
 
 	p := NewUniqByLine(&cfg)
 	i1 := newFLIssue("f1", 1)


### PR DESCRIPTION
This PR deprecated the old `output.uniq-by-line`, and replaced it with `issues.uniq-by-line`.

This option has a meaning close to `max-issues-per-linter` and `max-same-issues`.

The flag `--uniq-by-line` is not impacted, it's only about the file configuration.

The old `output.uniq-by-line` still works but with a deprecation log message.
