### PR TITLE
Add exptostd linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -35,6 +35,7 @@ linters:
     - exhaustive
     - exhaustruct
     - exportloopref
+    - exptostd
     - fatcontext
     - forbidigo
     - forcetypeassert
@@ -153,6 +154,7 @@ linters:
     - exhaustive
     - exhaustruct
     - exportloopref
+    - exptostd
     - fatcontext
     - forbidigo
     - forcetypeassert

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/kunwardeep/paralleltest v1.0.10
 	github.com/kyoh86/exportloopref v0.1.11
 	github.com/lasiar/canonicalheader v1.1.2
+	github.com/ldez/exptostd v0.1.0
 	github.com/ldez/gomoddirectives v0.6.0
 	github.com/ldez/grignotin v0.7.0
 	github.com/ldez/tagliatelle v0.7.1

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/kunwardeep/paralleltest v1.0.10
 	github.com/kyoh86/exportloopref v0.1.11
 	github.com/lasiar/canonicalheader v1.1.2
-	github.com/ldez/exptostd v0.2.0
+	github.com/ldez/exptostd v0.3.0
 	github.com/ldez/gomoddirectives v0.6.0
 	github.com/ldez/grignotin v0.7.0
 	github.com/ldez/tagliatelle v0.7.1

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/kunwardeep/paralleltest v1.0.10
 	github.com/kyoh86/exportloopref v0.1.11
 	github.com/lasiar/canonicalheader v1.1.2
-	github.com/ldez/exptostd v0.1.0
+	github.com/ldez/exptostd v0.2.0
 	github.com/ldez/gomoddirectives v0.6.0
 	github.com/ldez/grignotin v0.7.0
 	github.com/ldez/tagliatelle v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
 github.com/lasiar/canonicalheader v1.1.2 h1:vZ5uqwvDbyJCnMhmFYimgMZnJMjwljN5VGY0VKbMXb4=
 github.com/lasiar/canonicalheader v1.1.2/go.mod h1:qJCeLFS0G/QlLQ506T+Fk/fWMa2VmBUiEI2cuMK4djI=
+github.com/ldez/exptostd v0.1.0 h1:/QkFfYxGpr8z1w7/BxBC49vm/kWLX5wi3TSxWC/DpVI=
+github.com/ldez/exptostd v0.1.0/go.mod h1:iZBRYaUmcW5jwCR3KROEZ1KivQQp6PHXbDPk9hqJKCQ=
 github.com/ldez/gomoddirectives v0.6.0 h1:Jyf1ZdTeiIB4dd+2n4qw+g4aI9IJ6JyfOZ8BityWvnA=
 github.com/ldez/gomoddirectives v0.6.0/go.mod h1:TuwOGYoPAoENDWQpe8DMqEm5nIfjrxZXmxX/CExWyZ4=
 github.com/ldez/grignotin v0.7.0 h1:vh0dI32WhHaq6LLPZ38g7WxXuZ1+RzyrJ7iPG9JMa8c=

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
 github.com/lasiar/canonicalheader v1.1.2 h1:vZ5uqwvDbyJCnMhmFYimgMZnJMjwljN5VGY0VKbMXb4=
 github.com/lasiar/canonicalheader v1.1.2/go.mod h1:qJCeLFS0G/QlLQ506T+Fk/fWMa2VmBUiEI2cuMK4djI=
-github.com/ldez/exptostd v0.1.0 h1:/QkFfYxGpr8z1w7/BxBC49vm/kWLX5wi3TSxWC/DpVI=
-github.com/ldez/exptostd v0.1.0/go.mod h1:iZBRYaUmcW5jwCR3KROEZ1KivQQp6PHXbDPk9hqJKCQ=
+github.com/ldez/exptostd v0.2.0 h1:pyYXO5I5tyxcJqmg2q+UQtA/ckTRZy6J88lQ348KwqI=
+github.com/ldez/exptostd v0.2.0/go.mod h1:iZBRYaUmcW5jwCR3KROEZ1KivQQp6PHXbDPk9hqJKCQ=
 github.com/ldez/gomoddirectives v0.6.0 h1:Jyf1ZdTeiIB4dd+2n4qw+g4aI9IJ6JyfOZ8BityWvnA=
 github.com/ldez/gomoddirectives v0.6.0/go.mod h1:TuwOGYoPAoENDWQpe8DMqEm5nIfjrxZXmxX/CExWyZ4=
 github.com/ldez/grignotin v0.7.0 h1:vh0dI32WhHaq6LLPZ38g7WxXuZ1+RzyrJ7iPG9JMa8c=

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/kyoh86/exportloopref v0.1.11 h1:1Z0bcmTypkL3Q4k+IDHMWTcnCliEZcaPiIe0/
 github.com/kyoh86/exportloopref v0.1.11/go.mod h1:qkV4UF1zGl6EkF1ox8L5t9SwyeBAZ3qLMd6up458uqA=
 github.com/lasiar/canonicalheader v1.1.2 h1:vZ5uqwvDbyJCnMhmFYimgMZnJMjwljN5VGY0VKbMXb4=
 github.com/lasiar/canonicalheader v1.1.2/go.mod h1:qJCeLFS0G/QlLQ506T+Fk/fWMa2VmBUiEI2cuMK4djI=
-github.com/ldez/exptostd v0.2.0 h1:pyYXO5I5tyxcJqmg2q+UQtA/ckTRZy6J88lQ348KwqI=
-github.com/ldez/exptostd v0.2.0/go.mod h1:iZBRYaUmcW5jwCR3KROEZ1KivQQp6PHXbDPk9hqJKCQ=
+github.com/ldez/exptostd v0.3.0 h1:iKdMtUedzov89jDvuwmo0qpo+ARpZJg9hMp3428WwNg=
+github.com/ldez/exptostd v0.3.0/go.mod h1:iZBRYaUmcW5jwCR3KROEZ1KivQQp6PHXbDPk9hqJKCQ=
 github.com/ldez/gomoddirectives v0.6.0 h1:Jyf1ZdTeiIB4dd+2n4qw+g4aI9IJ6JyfOZ8BityWvnA=
 github.com/ldez/gomoddirectives v0.6.0/go.mod h1:TuwOGYoPAoENDWQpe8DMqEm5nIfjrxZXmxX/CExWyZ4=
 github.com/ldez/grignotin v0.7.0 h1:vh0dI32WhHaq6LLPZ38g7WxXuZ1+RzyrJ7iPG9JMa8c=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -350,6 +350,7 @@
             "exhaustive",
             "exhaustruct",
             "exportloopref",
+            "exptostd",
             "fatcontext",
             "forbidigo",
             "forcetypeassert",

--- a/pkg/golinters/exptostd/exptostd.go
+++ b/pkg/golinters/exptostd/exptostd.go
@@ -1,0 +1,19 @@
+package exptostd
+
+import (
+	"github.com/ldez/exptostd"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	a := exptostd.NewAnalyzer()
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/exptostd/exptostd_integration_test.go
+++ b/pkg/golinters/exptostd/exptostd_integration_test.go
@@ -9,3 +9,11 @@ import (
 func TestFromTestdata(t *testing.T) {
 	integration.RunTestdata(t)
 }
+
+func TestFix(t *testing.T) {
+	integration.RunFix(t)
+}
+
+func TestFixPathPrefix(t *testing.T) {
+	integration.RunFixPathPrefix(t)
+}

--- a/pkg/golinters/exptostd/exptostd_integration_test.go
+++ b/pkg/golinters/exptostd/exptostd_integration_test.go
@@ -1,0 +1,11 @@
+package exptostd
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/exptostd/testdata/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/exptostd.go
@@ -1,0 +1,85 @@
+//golangcitest:args -Eexptostd
+package testdata
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+func _(m, a map[string]string) {
+	maps.Clone(m) // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+
+	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
+
+	maps.EqualFunc(m, a, func(i, j string) bool { // want `golang.org/x/exp/maps.EqualFunc\(\) can be replaced by maps.EqualFunc\(\)`
+		return true
+	})
+
+	maps.Copy(m, a) // want `golang.org/x/exp/maps.Copy\(\) can be replaced by maps.Copy\(\)`
+
+	maps.DeleteFunc(m, func(_, _ string) bool { // want `golang.org/x/exp/maps.DeleteFunc\(\) can be replaced by maps.DeleteFunc\(\)`
+		return true
+	})
+
+	maps.Clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
+
+	fmt.Println("Hello")
+}
+
+func _(a, b []string) {
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+		return true
+	})
+	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+		return 0
+	})
+	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+		return true
+	})
+	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+		return true
+	})
+	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+		return true
+	})
+	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+		return true
+	})
+	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+		return 0
+	})
+	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+		return 0
+	})
+	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+		return 0
+	})
+	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+		return 0
+	})
+	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+		return 0
+	})
+	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+		return 0
+	})
+}

--- a/pkg/golinters/exptostd/testdata/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/exptostd.go
@@ -4,8 +4,8 @@ package testdata
 import (
 	"fmt"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"golang.org/x/exp/maps"   // want `Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'`
+	"golang.org/x/exp/slices" // want `Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'`
 )
 
 func _(m, a map[string]string) {

--- a/pkg/golinters/exptostd/testdata/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/exptostd.go
@@ -29,57 +29,57 @@ func _(m, a map[string]string) {
 }
 
 func _(a, b []string) {
-	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
-	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+	slices.Equal(a, b)
+	slices.EqualFunc(a, b, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
-	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+	slices.Compare(a, b)
+	slices.CompareFunc(a, b, func(_ string, _ string) int {
 		return 0
 	})
-	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
-	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+	slices.Index(a, "a")
+	slices.IndexFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
-	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+	slices.Contains(a, "a")
+	slices.ContainsFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
-	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
-	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+	slices.Insert(a, 0, "a", "b")
+	slices.Delete(a, 0, 1)
+	slices.DeleteFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
-	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
-	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
-	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+	slices.Replace(a, 0, 1, "a")
+	slices.Clone(a)
+	slices.Compact(a)
+	slices.CompactFunc(a, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
-	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
-	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
-	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
-	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+	slices.Grow(a, 2)
+	slices.Clip(a)
+	slices.Reverse(a)
+	slices.Sort(a)
+	slices.SortFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+	slices.SortStableFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
-	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+	slices.IsSorted(a)
+	slices.IsSortedFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
-	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+	slices.Min(a)
+	slices.MinFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
-	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+	slices.Max(a)
+	slices.MaxFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
-	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+	slices.BinarySearch(a, "a")
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int {
 		return 0
 	})
 }

--- a/pkg/golinters/exptostd/testdata/exptostd_cgo.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_cgo.go
@@ -46,57 +46,57 @@ func _(m, a map[string]string) {
 }
 
 func _(a, b []string) {
-	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
-	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+	slices.Equal(a, b)
+	slices.EqualFunc(a, b, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
-	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+	slices.Compare(a, b)
+	slices.CompareFunc(a, b, func(_ string, _ string) int {
 		return 0
 	})
-	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
-	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+	slices.Index(a, "a")
+	slices.IndexFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
-	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+	slices.Contains(a, "a")
+	slices.ContainsFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
-	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
-	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+	slices.Insert(a, 0, "a", "b")
+	slices.Delete(a, 0, 1)
+	slices.DeleteFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
-	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
-	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
-	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+	slices.Replace(a, 0, 1, "a")
+	slices.Clone(a)
+	slices.Compact(a)
+	slices.CompactFunc(a, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
-	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
-	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
-	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
-	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+	slices.Grow(a, 2)
+	slices.Clip(a)
+	slices.Reverse(a)
+	slices.Sort(a)
+	slices.SortFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+	slices.SortStableFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
-	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+	slices.IsSorted(a)
+	slices.IsSortedFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
-	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+	slices.Min(a)
+	slices.MinFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
-	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+	slices.Max(a)
+	slices.MaxFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
-	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+	slices.BinarySearch(a, "a")
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int {
 		return 0
 	})
 }

--- a/pkg/golinters/exptostd/testdata/exptostd_cgo.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_cgo.go
@@ -1,0 +1,102 @@
+//golangcitest:args -Eexptostd
+package testdata
+
+/*
+ #include <stdio.h>
+ #include <stdlib.h>
+
+ void myprint(char* s) {
+ 	printf("%d\n", s);
+ }
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+func _() {
+	cs := C.CString("Hello from stdio\n")
+	C.myprint(cs)
+	C.free(unsafe.Pointer(cs))
+}
+
+func _(m, a map[string]string) {
+	maps.Clone(m) // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+
+	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
+
+	maps.EqualFunc(m, a, func(i, j string) bool { // want `golang.org/x/exp/maps.EqualFunc\(\) can be replaced by maps.EqualFunc\(\)`
+		return true
+	})
+
+	maps.Copy(m, a) // want `golang.org/x/exp/maps.Copy\(\) can be replaced by maps.Copy\(\)`
+
+	maps.DeleteFunc(m, func(_, _ string) bool { // want `golang.org/x/exp/maps.DeleteFunc\(\) can be replaced by maps.DeleteFunc\(\)`
+		return true
+	})
+
+	maps.Clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
+
+	fmt.Println("Hello")
+}
+
+func _(a, b []string) {
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+		return true
+	})
+	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+		return 0
+	})
+	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+		return true
+	})
+	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+		return true
+	})
+	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+		return true
+	})
+	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+		return true
+	})
+	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+		return 0
+	})
+	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+		return 0
+	})
+	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+		return 0
+	})
+	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+		return 0
+	})
+	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+		return 0
+	})
+	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+		return 0
+	})
+}

--- a/pkg/golinters/exptostd/testdata/exptostd_cgo.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_cgo.go
@@ -15,8 +15,8 @@ import (
 	"fmt"
 	"unsafe"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"golang.org/x/exp/maps"   // want `Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'`
+	"golang.org/x/exp/slices" // want `Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'`
 )
 
 func _() {

--- a/pkg/golinters/exptostd/testdata/exptostd_go123.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_go123.go
@@ -1,0 +1,91 @@
+//go:build go1.23
+
+//golangcitest:args -Eexptostd
+package testdata
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+func _(m, a map[string]string) {
+	maps.Clone(m) // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+
+	maps.Keys(m) // want `golang.org/x/exp/maps.Keys\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
+
+	maps.Values(m) // want `golang.org/x/exp/maps.Values\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
+
+	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
+
+	maps.EqualFunc(m, a, func(i, j string) bool { // want `golang.org/x/exp/maps.EqualFunc\(\) can be replaced by maps.EqualFunc\(\)`
+		return true
+	})
+
+	maps.Copy(m, a) // want `golang.org/x/exp/maps.Copy\(\) can be replaced by maps.Copy\(\)`
+
+	maps.DeleteFunc(m, func(_, _ string) bool { // want `golang.org/x/exp/maps.DeleteFunc\(\) can be replaced by maps.DeleteFunc\(\)`
+		return true
+	})
+
+	maps.Clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
+
+	fmt.Println("Hello")
+}
+
+func _(a, b []string) {
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+		return true
+	})
+	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+		return 0
+	})
+	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+		return true
+	})
+	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+		return true
+	})
+	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+		return true
+	})
+	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+		return true
+	})
+	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+		return 0
+	})
+	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+		return 0
+	})
+	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+		return 0
+	})
+	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+		return 0
+	})
+	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+		return 0
+	})
+	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+		return 0
+	})
+}

--- a/pkg/golinters/exptostd/testdata/exptostd_go123.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_go123.go
@@ -6,8 +6,8 @@ package testdata
 import (
 	"fmt"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"golang.org/x/exp/maps"   // want `Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'`
+	"golang.org/x/exp/slices" // want `Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'`
 )
 
 func _(m, a map[string]string) {
@@ -15,7 +15,7 @@ func _(m, a map[string]string) {
 
 	maps.Keys(m) // want `golang.org/x/exp/maps.Keys\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
 
-	maps.Values(m) // want `golang.org/x/exp/maps.Values\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
+	maps.Values(m) // want `golang.org/x/exp/maps.Values\(\) can be replaced by slices.Collect\(maps.Values\(\)\)`
 
 	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
 

--- a/pkg/golinters/exptostd/testdata/exptostd_go123.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_go123.go
@@ -35,57 +35,57 @@ func _(m, a map[string]string) {
 }
 
 func _(a, b []string) {
-	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
-	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+	slices.Equal(a, b)
+	slices.EqualFunc(a, b, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
-	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+	slices.Compare(a, b)
+	slices.CompareFunc(a, b, func(_ string, _ string) int {
 		return 0
 	})
-	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
-	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+	slices.Index(a, "a")
+	slices.IndexFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
-	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+	slices.Contains(a, "a")
+	slices.ContainsFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
-	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
-	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+	slices.Insert(a, 0, "a", "b")
+	slices.Delete(a, 0, 1)
+	slices.DeleteFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
-	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
-	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
-	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+	slices.Replace(a, 0, 1, "a")
+	slices.Clone(a)
+	slices.Compact(a)
+	slices.CompactFunc(a, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
-	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
-	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
-	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
-	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+	slices.Grow(a, 2)
+	slices.Clip(a)
+	slices.Reverse(a)
+	slices.Sort(a)
+	slices.SortFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+	slices.SortStableFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
-	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+	slices.IsSorted(a)
+	slices.IsSortedFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
-	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+	slices.Min(a)
+	slices.MinFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
-	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+	slices.Max(a)
+	slices.MaxFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
-	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+	slices.BinarySearch(a, "a")
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int {
 		return 0
 	})
 }

--- a/pkg/golinters/exptostd/testdata/exptostd_go123_cgo.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_go123_cgo.go
@@ -1,0 +1,108 @@
+//go:build go1.23
+
+//golangcitest:args -Eexptostd
+package testdata
+
+/*
+ #include <stdio.h>
+ #include <stdlib.h>
+
+ void myprint(char* s) {
+ 	printf("%d\n", s);
+ }
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+func _() {
+	cs := C.CString("Hello from stdio\n")
+	C.myprint(cs)
+	C.free(unsafe.Pointer(cs))
+}
+
+func _(m, a map[string]string) {
+	maps.Clone(m) // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+
+	maps.Keys(m) // want `golang.org/x/exp/maps.Keys\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
+
+	maps.Values(m) // want `golang.org/x/exp/maps.Values\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
+
+	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
+
+	maps.EqualFunc(m, a, func(i, j string) bool { // want `golang.org/x/exp/maps.EqualFunc\(\) can be replaced by maps.EqualFunc\(\)`
+		return true
+	})
+
+	maps.Copy(m, a) // want `golang.org/x/exp/maps.Copy\(\) can be replaced by maps.Copy\(\)`
+
+	maps.DeleteFunc(m, func(_, _ string) bool { // want `golang.org/x/exp/maps.DeleteFunc\(\) can be replaced by maps.DeleteFunc\(\)`
+		return true
+	})
+
+	maps.Clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
+
+	fmt.Println("Hello")
+}
+
+func _(a, b []string) {
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+		return true
+	})
+	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+		return 0
+	})
+	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+		return true
+	})
+	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+		return true
+	})
+	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+		return true
+	})
+	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+		return true
+	})
+	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+		return 0
+	})
+	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+		return 0
+	})
+	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+		return 0
+	})
+	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+		return 0
+	})
+	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+		return 0
+	})
+	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+		return 0
+	})
+}

--- a/pkg/golinters/exptostd/testdata/exptostd_go123_cgo.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_go123_cgo.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"unsafe"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"golang.org/x/exp/maps"   // want `Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'`
+	"golang.org/x/exp/slices" // want `Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'`
 )
 
 func _() {
@@ -32,7 +32,7 @@ func _(m, a map[string]string) {
 
 	maps.Keys(m) // want `golang.org/x/exp/maps.Keys\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
 
-	maps.Values(m) // want `golang.org/x/exp/maps.Values\(\) can be replaced by slices.Collect\(maps.Keys\(\)\)`
+	maps.Values(m) // want `golang.org/x/exp/maps.Values\(\) can be replaced by slices.Collect\(maps.Values\(\)\)`
 
 	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
 

--- a/pkg/golinters/exptostd/testdata/exptostd_go123_cgo.go
+++ b/pkg/golinters/exptostd/testdata/exptostd_go123_cgo.go
@@ -52,57 +52,57 @@ func _(m, a map[string]string) {
 }
 
 func _(a, b []string) {
-	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
-	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+	slices.Equal(a, b)
+	slices.EqualFunc(a, b, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
-	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+	slices.Compare(a, b)
+	slices.CompareFunc(a, b, func(_ string, _ string) int {
 		return 0
 	})
-	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
-	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+	slices.Index(a, "a")
+	slices.IndexFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
-	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+	slices.Contains(a, "a")
+	slices.ContainsFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
-	slices.Delete(a, 0, 1)        // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
-	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+	slices.Insert(a, 0, "a", "b")
+	slices.Delete(a, 0, 1)
+	slices.DeleteFunc(a, func(_ string) bool {
 		return true
 	})
-	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
-	slices.Clone(a)              // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
-	slices.Compact(a)            // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
-	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+	slices.Replace(a, 0, 1, "a")
+	slices.Clone(a)
+	slices.Compact(a)
+	slices.CompactFunc(a, func(_ string, _ string) bool {
 		return true
 	})
-	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
-	slices.Clip(a)    // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
-	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
-	slices.Sort(a)    // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
-	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+	slices.Grow(a, 2)
+	slices.Clip(a)
+	slices.Reverse(a)
+	slices.Sort(a)
+	slices.SortFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+	slices.SortStableFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
-	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+	slices.IsSorted(a)
+	slices.IsSortedFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
-	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+	slices.Min(a)
+	slices.MinFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
-	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+	slices.Max(a)
+	slices.MaxFunc(a, func(_, _ string) int {
 		return 0
 	})
-	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
-	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+	slices.BinarySearch(a, "a")
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int {
 		return 0
 	})
 }

--- a/pkg/golinters/exptostd/testdata/fix/in/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/fix/in/exptostd.go
@@ -29,85 +29,85 @@ func _(m, a map[string]string) {
 }
 
 func _(a, b []string) {
-	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+	slices.Equal(a, b)
 
-	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+	slices.EqualFunc(a, b, func(_ string, _ string) bool {
 		return true
 	})
 
-	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+	slices.Compare(a, b)
 
-	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+	slices.CompareFunc(a, b, func(_ string, _ string) int {
 		return 0
 	})
 
-	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+	slices.Index(a, "a")
 
-	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+	slices.IndexFunc(a, func(_ string) bool {
 		return true
 	})
 
-	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+	slices.Contains(a, "a")
 
-	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+	slices.ContainsFunc(a, func(_ string) bool {
 		return true
 	})
 
-	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+	slices.Insert(a, 0, "a", "b")
 
-	slices.Delete(a, 0, 1) // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+	slices.Delete(a, 0, 1)
 
-	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+	slices.DeleteFunc(a, func(_ string) bool {
 		return true
 	})
 
-	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+	slices.Replace(a, 0, 1, "a")
 
-	slices.Clone(a) // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+	slices.Clone(a)
 
-	slices.Compact(a) // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+	slices.Compact(a)
 
-	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+	slices.CompactFunc(a, func(_ string, _ string) bool {
 		return true
 	})
 
-	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+	slices.Grow(a, 2)
 
-	slices.Clip(a) // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+	slices.Clip(a)
 
-	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+	slices.Reverse(a)
 
-	slices.Sort(a) // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+	slices.Sort(a)
 
-	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+	slices.SortFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+	slices.SortStableFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+	slices.IsSorted(a)
 
-	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+	slices.IsSortedFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+	slices.Min(a)
 
-	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+	slices.MinFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+	slices.Max(a)
 
-	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+	slices.MaxFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+	slices.BinarySearch(a, "a")
 
-	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int {
 		return 0
 	})
 }

--- a/pkg/golinters/exptostd/testdata/fix/in/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/fix/in/exptostd.go
@@ -4,8 +4,8 @@ package testdata
 import (
 	"fmt"
 
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
+	"golang.org/x/exp/maps"   // want `Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'`
+	"golang.org/x/exp/slices" // want `Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'`
 )
 
 func _(m, a map[string]string) {

--- a/pkg/golinters/exptostd/testdata/fix/in/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/fix/in/exptostd.go
@@ -1,0 +1,113 @@
+//golangcitest:args -Eexptostd
+package testdata
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+func _(m, a map[string]string) {
+	maps.Clone(m) // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+
+	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
+
+	maps.EqualFunc(m, a, func(i, j string) bool { // want `golang.org/x/exp/maps.EqualFunc\(\) can be replaced by maps.EqualFunc\(\)`
+		return true
+	})
+
+	maps.Copy(m, a) // want `golang.org/x/exp/maps.Copy\(\) can be replaced by maps.Copy\(\)`
+
+	maps.DeleteFunc(m, func(_, _ string) bool { // want `golang.org/x/exp/maps.DeleteFunc\(\) can be replaced by maps.DeleteFunc\(\)`
+		return true
+	})
+
+	maps.Clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
+
+	fmt.Println("Hello")
+}
+
+func _(a, b []string) {
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+
+	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+		return true
+	})
+
+	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+
+	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+		return 0
+	})
+
+	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+
+	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+		return true
+	})
+
+	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+
+	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+		return true
+	})
+
+	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+
+	slices.Delete(a, 0, 1) // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+
+	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+		return true
+	})
+
+	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+
+	slices.Clone(a) // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+
+	slices.Compact(a) // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+
+	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+		return true
+	})
+
+	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+
+	slices.Clip(a) // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+
+	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+
+	slices.Sort(a) // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+
+	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+		return 0
+	})
+
+	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+		return 0
+	})
+
+	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+
+	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+		return 0
+	})
+
+	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+
+	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+		return 0
+	})
+
+	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+
+	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+		return 0
+	})
+
+	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+		return 0
+	})
+}

--- a/pkg/golinters/exptostd/testdata/fix/out/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/fix/out/exptostd.go
@@ -4,8 +4,8 @@ package testdata
 import (
 	"fmt"
 
-	"maps"
-	"slices"
+	"maps"   // want `Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'`
+	"slices" // want `Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'`
 )
 
 func _(m, a map[string]string) {

--- a/pkg/golinters/exptostd/testdata/fix/out/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/fix/out/exptostd.go
@@ -1,0 +1,113 @@
+//golangcitest:args -Eexptostd
+package testdata
+
+import (
+	"fmt"
+
+	"maps"
+	"slices"
+)
+
+func _(m, a map[string]string) {
+	maps.Clone(m) // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+
+	maps.Equal(m, a) // want `golang.org/x/exp/maps.Equal\(\) can be replaced by maps.Equal\(\)`
+
+	maps.EqualFunc(m, a, func(i, j string) bool { // want `golang.org/x/exp/maps.EqualFunc\(\) can be replaced by maps.EqualFunc\(\)`
+		return true
+	})
+
+	maps.Copy(m, a) // want `golang.org/x/exp/maps.Copy\(\) can be replaced by maps.Copy\(\)`
+
+	maps.DeleteFunc(m, func(_, _ string) bool { // want `golang.org/x/exp/maps.DeleteFunc\(\) can be replaced by maps.DeleteFunc\(\)`
+		return true
+	})
+
+	clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
+
+	fmt.Println("Hello")
+}
+
+func _(a, b []string) {
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+
+	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+		return true
+	})
+
+	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+
+	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+		return 0
+	})
+
+	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+
+	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+		return true
+	})
+
+	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+
+	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+		return true
+	})
+
+	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+
+	slices.Delete(a, 0, 1) // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+
+	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+		return true
+	})
+
+	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+
+	slices.Clone(a) // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+
+	slices.Compact(a) // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+
+	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+		return true
+	})
+
+	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+
+	slices.Clip(a) // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+
+	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+
+	slices.Sort(a) // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+
+	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+		return 0
+	})
+
+	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+		return 0
+	})
+
+	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+
+	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+		return 0
+	})
+
+	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+
+	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+		return 0
+	})
+
+	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+
+	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+		return 0
+	})
+
+	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+		return 0
+	})
+}

--- a/pkg/golinters/exptostd/testdata/fix/out/exptostd.go
+++ b/pkg/golinters/exptostd/testdata/fix/out/exptostd.go
@@ -29,85 +29,85 @@ func _(m, a map[string]string) {
 }
 
 func _(a, b []string) {
-	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+	slices.Equal(a, b)
 
-	slices.EqualFunc(a, b, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.EqualFunc\(\) can be replaced by slices\.EqualFunc\(\)`
+	slices.EqualFunc(a, b, func(_ string, _ string) bool {
 		return true
 	})
 
-	slices.Compare(a, b) // want `golang.org/x/exp/slices\.Compare\(\) can be replaced by slices\.Compare\(\)`
+	slices.Compare(a, b)
 
-	slices.CompareFunc(a, b, func(_ string, _ string) int { // want `golang.org/x/exp/slices\.CompareFunc\(\) can be replaced by slices\.CompareFunc\(\)`
+	slices.CompareFunc(a, b, func(_ string, _ string) int {
 		return 0
 	})
 
-	slices.Index(a, "a") // want `golang.org/x/exp/slices\.Index\(\) can be replaced by slices\.Index\(\)`
+	slices.Index(a, "a")
 
-	slices.IndexFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.IndexFunc\(\) can be replaced by slices\.IndexFunc\(\)`
+	slices.IndexFunc(a, func(_ string) bool {
 		return true
 	})
 
-	slices.Contains(a, "a") // want `golang.org/x/exp/slices\.Contains\(\) can be replaced by slices\.Contains\(\)`
+	slices.Contains(a, "a")
 
-	slices.ContainsFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.ContainsFunc\(\) can be replaced by slices\.ContainsFunc\(\)`
+	slices.ContainsFunc(a, func(_ string) bool {
 		return true
 	})
 
-	slices.Insert(a, 0, "a", "b") // want `golang.org/x/exp/slices\.Insert\(\) can be replaced by slices\.Insert\(\)`
+	slices.Insert(a, 0, "a", "b")
 
-	slices.Delete(a, 0, 1) // want `golang.org/x/exp/slices\.Delete\(\) can be replaced by slices\.Delete\(\)`
+	slices.Delete(a, 0, 1)
 
-	slices.DeleteFunc(a, func(_ string) bool { // want `golang.org/x/exp/slices\.DeleteFunc\(\) can be replaced by slices\.DeleteFunc\(\)`
+	slices.DeleteFunc(a, func(_ string) bool {
 		return true
 	})
 
-	slices.Replace(a, 0, 1, "a") // want `golang.org/x/exp/slices\.Replace\(\) can be replaced by slices\.Replace\(\)`
+	slices.Replace(a, 0, 1, "a")
 
-	slices.Clone(a) // want `golang.org/x/exp/slices\.Clone\(\) can be replaced by slices\.Clone\(\)`
+	slices.Clone(a)
 
-	slices.Compact(a) // want `golang.org/x/exp/slices\.Compact\(\) can be replaced by slices\.Compact\(\)`
+	slices.Compact(a)
 
-	slices.CompactFunc(a, func(_ string, _ string) bool { // want `golang.org/x/exp/slices\.CompactFunc\(\) can be replaced by slices\.CompactFunc\(\)`
+	slices.CompactFunc(a, func(_ string, _ string) bool {
 		return true
 	})
 
-	slices.Grow(a, 2) // want `golang.org/x/exp/slices\.Grow\(\) can be replaced by slices\.Grow\(\)`
+	slices.Grow(a, 2)
 
-	slices.Clip(a) // want `golang.org/x/exp/slices\.Clip\(\) can be replaced by slices\.Clip\(\)`
+	slices.Clip(a)
 
-	slices.Reverse(a) // want `golang.org/x/exp/slices\.Reverse\(\) can be replaced by slices\.Reverse\(\)`
+	slices.Reverse(a)
 
-	slices.Sort(a) // want `golang.org/x/exp/slices\.Sort\(\) can be replaced by slices\.Sort\(\)`
+	slices.Sort(a)
 
-	slices.SortFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortFunc\(\) can be replaced by slices\.SortFunc\(\)`
+	slices.SortFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.SortStableFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.SortStableFunc\(\) can be replaced by slices\.SortStableFunc\(\)`
+	slices.SortStableFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.IsSorted(a) // want `golang.org/x/exp/slices\.IsSorted\(\) can be replaced by slices\.IsSorted\(\)`
+	slices.IsSorted(a)
 
-	slices.IsSortedFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.IsSortedFunc\(\) can be replaced by slices\.IsSortedFunc\(\)`
+	slices.IsSortedFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.Min(a) // want `golang.org/x/exp/slices\.Min\(\) can be replaced by slices\.Min\(\)`
+	slices.Min(a)
 
-	slices.MinFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MinFunc\(\) can be replaced by slices\.MinFunc\(\)`
+	slices.MinFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.Max(a) // want `golang.org/x/exp/slices\.Max\(\) can be replaced by slices\.Max\(\)`
+	slices.Max(a)
 
-	slices.MaxFunc(a, func(_, _ string) int { // want `golang.org/x/exp/slices\.MaxFunc\(\) can be replaced by slices\.MaxFunc\(\)`
+	slices.MaxFunc(a, func(_, _ string) int {
 		return 0
 	})
 
-	slices.BinarySearch(a, "a") // want `golang.org/x/exp/slices\.BinarySearch\(\) can be replaced by slices\.BinarySearch\(\)`
+	slices.BinarySearch(a, "a")
 
-	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int { // want `golang.org/x/exp/slices\.BinarySearchFunc\(\) can be replaced by slices\.BinarySearchFunc\(\)`
+	slices.BinarySearchFunc(a, b, func(_ string, _ []string) int {
 		return 0
 	})
 }

--- a/pkg/golinters/exptostd/testdata/go.mod
+++ b/pkg/golinters/exptostd/testdata/go.mod
@@ -1,0 +1,5 @@
+module exptostd
+
+go 1.22.0
+
+require golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67

--- a/pkg/golinters/exptostd/testdata/go.sum
+++ b/pkg/golinters/exptostd/testdata/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -288,6 +288,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.63.0").
 			WithPresets(linter.PresetStyle).
 			WithLoadForGoAnalysis().
+			WithAutoFix().
 			WithURL("https://github.com/ldez/exptostd"),
 
 		linter.NewConfig(forbidigo.New(&cfg.LintersSettings.Forbidigo)).

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/exhaustive"
 	"github.com/golangci/golangci-lint/pkg/golinters/exhaustruct"
 	"github.com/golangci/golangci-lint/pkg/golinters/exportloopref"
+	"github.com/golangci/golangci-lint/pkg/golinters/exptostd"
 	"github.com/golangci/golangci-lint/pkg/golinters/fatcontext"
 	"github.com/golangci/golangci-lint/pkg/golinters/forbidigo"
 	"github.com/golangci/golangci-lint/pkg/golinters/forcetypeassert"
@@ -282,6 +283,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kyoh86/exportloopref").
 			DeprecatedWarning("Since Go1.22 (loopvar) this linter is no longer relevant.", "v1.60.2", "copyloopvar"),
+
+		linter.NewConfig(exptostd.New()).
+			WithSince("v1.63.0").
+			WithPresets(linter.PresetStyle).
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/ldez/exptostd"),
 
 		linter.NewConfig(forbidigo.New(&cfg.LintersSettings.Forbidigo)).
 			WithSince("v1.34.0").


### PR DESCRIPTION
This linter detects functions from `golang.org/x/exp/` that can be replaced by std functions.

https://github.com/ldez/exptostd

<details><summary>Example</summary>


```go
package foo

import (
	"fmt"

	"golang.org/x/exp/maps"
)

func foo(m map[string]string) {
	clone := maps.Clone(m)

	fmt.Println(clone)
}
```

It can be replaced by:

```go
package foo

import (
	"fmt"
	"maps"
)

func foo(m map[string]string) {
	clone := maps.Clone(m)

	fmt.Println(clone)
}

```

</details>
