### PR TITLE
goheader: skip issues with invalid positions

### DIFF
--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -81,10 +81,16 @@ func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {
 		// Inspired by https://github.com/denis-tingaikin/go-header/blob/4c75a6a2332f025705325d6c71fff4616aedf48f/analyzer.go#L85-L92
 		if len(file.Comments) > 0 && file.Comments[0].Pos() < file.Package {
 			if !strings.HasPrefix(file.Comments[0].List[0].Text, "/*") {
-				// When the comment are "//" there is a one character offset.
+				// When the comment is "//" there is a one character offset.
 				offset = 1
 			}
 			commentLine = goanalysis.GetFilePositionFor(pass.Fset, file.Comments[0].Pos()).Line
+		}
+
+		// Skip issues related to build directives.
+		// https://github.com/denis-tingaikin/go-header/issues/18
+		if issue.Location().Position-offset < 0 {
+			continue
 		}
 
 		diag := analysis.Diagnostic{


### PR DESCRIPTION
1. When there is a build directives, goheader reports invalid issues.
2. Inside golangci-lint we are using the same code as goheader to fix the missing offset when `//` comment.

The problem is that a build directive starts with `//` so we apply the offset.
This produces a negative position (`-1`) and then the report will refer to the previous file inside the fileset.
