### PR TITLE
fix: filter Go filenames

### DIFF
--- a/pkg/goanalysis/position.go
+++ b/pkg/goanalysis/position.go
@@ -8,10 +8,6 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-func GetFilePosition(pass *analysis.Pass, f *ast.File) token.Position {
-	return GetFilePositionFor(pass.Fset, f.Pos())
-}
-
 func GetGoFilePosition(pass *analysis.Pass, f *ast.File) (token.Position, bool) {
 	position := GetFilePositionFor(pass.Fset, f.Pos())
 

--- a/pkg/golinters/dupl/dupl.go
+++ b/pkg/golinters/dupl/dupl.go
@@ -3,7 +3,6 @@ package dupl
 import (
 	"fmt"
 	"go/token"
-	"strings"
 	"sync"
 
 	duplAPI "github.com/golangci/dupl"
@@ -55,19 +54,7 @@ func New(settings *config.DuplSettings) *goanalysis.Linter {
 }
 
 func runDupl(pass *analysis.Pass, settings *config.DuplSettings) ([]goanalysis.Issue, error) {
-	fileNames := internal.GetFileNames(pass)
-
-	var onlyGofiles []string
-	for _, name := range fileNames {
-		// Related to Windows
-		if !strings.HasSuffix(name, ".go") {
-			continue
-		}
-
-		onlyGofiles = append(onlyGofiles, name)
-	}
-
-	issues, err := duplAPI.Run(onlyGofiles, settings.Threshold)
+	issues, err := duplAPI.Run(internal.GetGoFileNames(pass), settings.Threshold)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/golinters/gomodguard/gomodguard.go
+++ b/pkg/golinters/gomodguard/gomodguard.go
@@ -73,7 +73,7 @@ func New(settings *config.GoModGuardSettings) *goanalysis.Linter {
 		}
 
 		analyzer.Run = func(pass *analysis.Pass) (any, error) {
-			gomodguardIssues := processor.ProcessFiles(internal.GetFileNames(pass))
+			gomodguardIssues := processor.ProcessFiles(internal.GetGoFileNames(pass))
 
 			mu.Lock()
 			defer mu.Unlock()

--- a/pkg/golinters/internal/util.go
+++ b/pkg/golinters/internal/util.go
@@ -18,10 +18,17 @@ func FormatCode(code string, _ *config.Config) string {
 	return fmt.Sprintf("`%s`", code)
 }
 
-func GetFileNames(pass *analysis.Pass) []string {
+func GetGoFileNames(pass *analysis.Pass) []string {
 	var filenames []string
+
 	for _, f := range pass.Files {
-		filenames = append(filenames, goanalysis.GetFilePosition(pass, f).Filename)
+		position, b := goanalysis.GetGoFilePosition(pass, f)
+		if !b {
+			continue
+		}
+
+		filenames = append(filenames, position.Filename)
 	}
+
 	return filenames
 }

--- a/pkg/golinters/revive/revive_integration_test.go
+++ b/pkg/golinters/revive/revive_integration_test.go
@@ -9,3 +9,11 @@ import (
 func TestFromTestdata(t *testing.T) {
 	integration.RunTestdata(t)
 }
+
+func TestFix(t *testing.T) {
+	integration.RunFix(t)
+}
+
+func TestFixPathPrefix(t *testing.T) {
+	integration.RunFixPathPrefix(t)
+}

--- a/pkg/golinters/revive/testdata/fix/in/revive.go
+++ b/pkg/golinters/revive/testdata/fix/in/revive.go
@@ -1,0 +1,14 @@
+//golangcitest:args -Erevive
+//golangcitest:config_path testdata/revive-fix.yml
+//golangcitest:expected_exitcode 0
+package in
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+func _() error {
+	return errors.New(fmt.Sprintf("foo: %d", math.MaxInt))
+}

--- a/pkg/golinters/revive/testdata/fix/out/revive.go
+++ b/pkg/golinters/revive/testdata/fix/out/revive.go
@@ -1,0 +1,14 @@
+//golangcitest:args -Erevive
+//golangcitest:config_path testdata/revive-fix.yml
+//golangcitest:expected_exitcode 0
+package in
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+func _() error {
+	return fmt.Errorf("foo: %d", math.MaxInt)
+}

--- a/pkg/golinters/revive/testdata/revive-fix.yml
+++ b/pkg/golinters/revive/testdata/revive-fix.yml
@@ -1,0 +1,7 @@
+linters-settings:
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: errorf
+      - name: range


### PR DESCRIPTION
Keep only Go files to avoid build artifacts.