### PR TITLE
Add mutcheck linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint
 
-go 1.22.1
+go 1.23.4
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1
@@ -10,6 +10,7 @@ require (
 	github.com/Antonboom/errname v1.0.0
 	github.com/Antonboom/nilnil v1.0.1
 	github.com/Antonboom/testifylint v1.5.2
+	github.com/BeyCoder/gomutcheck v1.1.0
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	github.com/Crocmagnon/fatcontext v0.5.3
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/Antonboom/nilnil v1.0.1 h1:C3Tkm0KUxgfO4Duk3PM+ztPncTFlOf0b2qadmS0s4x
 github.com/Antonboom/nilnil v1.0.1/go.mod h1:CH7pW2JsRNFgEh8B2UaPZTEPhCMuFowP/e8Udp9Nnb0=
 github.com/Antonboom/testifylint v1.5.2 h1:4s3Xhuv5AvdIgbd8wOOEeo0uZG7PbDKQyKY5lGoQazk=
 github.com/Antonboom/testifylint v1.5.2/go.mod h1:vxy8VJ0bc6NavlYqjZfmp6EfqXMtBgQ4+mhCojwC1P8=
+github.com/BeyCoder/gomutcheck v1.1.0 h1:Aa8dAucjKVqqnzwpUwo/1pWDEQJO09XCf4FW43j2zao=
+github.com/BeyCoder/gomutcheck v1.1.0/go.mod h1:inzGIQUezsz6bsrjEhiTv63dkWfKYU4/WzA4om734D4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/pkg/golinters/gomutcheck/gomutcheck.go
+++ b/pkg/golinters/gomutcheck/gomutcheck.go
@@ -1,0 +1,16 @@
+package gomutcheck
+
+import (
+	"github.com/BeyCoder/gomutcheck/pkg/analyzer"
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+	"golang.org/x/tools/go/analysis"
+)
+
+func New() *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		"gomutcheck",
+		"Detect struct field mutations in value receiver methods.",
+		[]*analysis.Analyzer{analyzer.New()},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/gomutcheck/gomutcheck_test.go
+++ b/pkg/golinters/gomutcheck/gomutcheck_test.go
@@ -1,0 +1,10 @@
+package gomutcheck
+
+import (
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+	"testing"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/gomutcheck/testdata/gomutcheck.go
+++ b/pkg/golinters/gomutcheck/testdata/gomutcheck.go
@@ -1,0 +1,31 @@
+package testdata
+
+type GomutcheckStruct struct {
+	TestField string
+}
+
+func (s *GomutcheckStruct) GomutcheckMutateWithPointer() {
+	s.TestField = "new value"
+}
+
+func (s GomutcheckStruct) GomutcheckCallWithPointerMethod() {
+	sPtr := &s
+	sPtr.GomutcheckMutateWithPointer()
+}
+
+func (s GomutcheckStruct) GomutcheckCreateNewInstance() {
+	newStruct := GomutcheckStruct{TestField: "new instance"}
+	_ = newStruct
+}
+
+func (s GomutcheckStruct) GomutcheckMutateField() {
+	s.TestField = "new value" // want `struct field 'TestField' is being mutated in value receiver method`
+}
+
+func (s GomutcheckStruct) GomutcheckReadOnly() {
+	_ = s.TestField
+}
+
+func (s GomutcheckStruct) GomutcheckCorrectUsage() {
+	println(s.TestField)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -49,6 +49,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/goimports"
 	"github.com/golangci/golangci-lint/pkg/golinters/gomoddirectives"
 	"github.com/golangci/golangci-lint/pkg/golinters/gomodguard"
+	"github.com/golangci/golangci-lint/pkg/golinters/gomutcheck"
 	"github.com/golangci/golangci-lint/pkg/golinters/goprintffuncname"
 	"github.com/golangci/golangci-lint/pkg/golinters/gosec"
 	"github.com/golangci/golangci-lint/pkg/golinters/gosimple"
@@ -443,6 +444,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.25.0").
 			WithPresets(linter.PresetStyle, linter.PresetImport, linter.PresetModule).
 			WithURL("https://github.com/ryancurrah/gomodguard"),
+
+		linter.NewConfig(gomutcheck.New()).
+			WithSince("v1.0.0").
+			WithPresets(linter.PresetStyle, linter.PresetBugs).
+			WithURL("https://github.com/BeyCoder/gomutcheck"),
 
 		linter.NewConfig(goprintffuncname.New()).
 			WithSince("v1.23.0").


### PR DESCRIPTION
The linter detects struct field mutations in value receiver methods.

[gomutcheck](https://github.com/BeyCoder/gomutcheck)

### Example:
```go
package gomutcheck

type ExampleStruct struct {
    ExampleField string
}

func (s ExampleStruct) MutateField() {
    s.ExampleField = "new value"
}
```

### Result
`example.go:8:2: struct field 'ExampleField' is being mutated in value receiver method`