### PR TITLE
dev: avoid string conversion by passing byte slice

### DIFF
--- a/pkg/goformatters/analyzer.go
+++ b/pkg/goformatters/analyzer.go
@@ -40,11 +40,11 @@ func NewAnalyzer(logger logutils.Log, doc string, formatter Formatter) *analysis
 					newName := filepath.ToSlash(position.Filename)
 					oldName := newName + ".orig"
 
-					theDiff := diff.Diff(oldName, input, newName, output)
+					patch := diff.Diff(oldName, input, newName, output)
 
-					err = internal.ExtractDiagnosticFromPatch(pass, file, string(theDiff), logger)
+					err = internal.ExtractDiagnosticFromPatch(pass, file, patch, logger)
 					if err != nil {
-						return nil, fmt.Errorf("can't extract issues from %s diff output %q: %w", formatter.Name(), string(theDiff), err)
+						return nil, fmt.Errorf("can't extract issues from %s diff output %q: %w", formatter.Name(), patch, err)
 					}
 				}
 			}

--- a/pkg/goformatters/analyzer.go
+++ b/pkg/goformatters/analyzer.go
@@ -21,8 +21,8 @@ func NewAnalyzer(logger logutils.Log, doc string, formatter Formatter) *analysis
 		Doc:  doc,
 		Run: func(pass *analysis.Pass) (any, error) {
 			for _, file := range pass.Files {
-				position, isGoFiles := goanalysis.GetGoFilePosition(pass, file)
-				if !isGoFiles {
+				position, isGoFile := goanalysis.GetGoFilePosition(pass, file)
+				if !isGoFile {
 					continue
 				}
 

--- a/pkg/goformatters/internal/commons.go
+++ b/pkg/goformatters/internal/commons.go
@@ -2,5 +2,5 @@ package internal
 
 import "github.com/golangci/golangci-lint/pkg/logutils"
 
-// FormatterLogger must be use only when the context logger is not available.
+// FormatterLogger must be used only when the context logger is not available.
 var FormatterLogger = logutils.NewStderrLog(logutils.DebugKeyFormatter)

--- a/pkg/goformatters/internal/diff.go
+++ b/pkg/goformatters/internal/diff.go
@@ -213,16 +213,16 @@ func parseDiffLines(h *diffpkg.Hunk) []diffLine {
 func ExtractDiagnosticFromPatch(
 	pass *analysis.Pass,
 	file *ast.File,
-	patch string,
+	patch []byte,
 	logger logutils.Log,
 ) error {
-	diffs, err := diffpkg.ParseMultiFileDiff([]byte(patch))
+	diffs, err := diffpkg.ParseMultiFileDiff(patch)
 	if err != nil {
 		return fmt.Errorf("can't parse patch: %w", err)
 	}
 
 	if len(diffs) == 0 {
-		return fmt.Errorf("got no diffs from patch parser: %v", patch)
+		return fmt.Errorf("got no diffs from patch parser: %s", patch)
 	}
 
 	ft := pass.Fset.File(file.Pos())


### PR DESCRIPTION
The PR refactors code:

- Change `patch string` to `patch []byte` in  `ExtractDiagnosticFromPatch`.
- Rename `theDiff` to `patch` in the `goformatters.NewAnalyzer`.
- Use `patch` instead of `string(patch)` as `%q` will correctly output byte slice as string.