### PR TITLE
fix: avoid panic with plugin without description

### DIFF
--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -210,6 +210,12 @@ func printLinters(lcs []*linter.Config) {
 }
 
 func formatDescription(desc string) string {
+	desc = strings.TrimSpace(desc)
+
+	if desc == "" {
+		return desc
+	}
+
 	// If the linter description spans multiple lines, truncate everything following the first newline
 	endFirstLine := strings.IndexRune(desc, '\n')
 	if endFirstLine > 0 {

--- a/pkg/commands/help_test.go
+++ b/pkg/commands/help_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_formatDescription(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		doc      string
+		expected string
+	}{
+		{
+			desc:     "empty description",
+			doc:      "",
+			expected: "",
+		},
+		{
+			desc:     "simple description",
+			doc:      "this is a test",
+			expected: "This is a test.",
+		},
+		{
+			desc:     "formatted description",
+			doc:      "This is a test.",
+			expected: "This is a test.",
+		},
+		{
+			desc:     "multiline description",
+			doc:      "this is a test\nanother line\n",
+			expected: "This is a test.",
+		},
+		{
+			desc:     "leading newline",
+			doc:      "\nThis is a test.",
+			expected: "This is a test.",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			v := formatDescription(test.doc)
+
+			assert.Equal(t, test.expected, v)
+		})
+	}
+}


### PR DESCRIPTION
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/golangci/golangci-lint/pkg/commands.formatDescription({0x0, 0x0})
        /tmp/custom-gcl2430187412/golangci-lint/pkg/commands/help.go:222 +0x125
github.com/golangci/golangci-lint/pkg/commands.printLinters({0xc0006251c0, 0x7, 0xc0006ad428?})
        /tmp/custom-gcl2430187412/golangci-lint/pkg/commands/help.go:187 +0x1d9
github.com/golangci/golangci-lint/pkg/commands.(*lintersCommand).execute(0xc000926f50, 0xc000743a90?, {0x0?, 0x0?, 0x0?})
        /tmp/custom-gcl2430187412/golangci-lint/pkg/commands/linters.go:102 +0x285
github.com/spf13/cobra.(*Command).execute(0xc000910308, {0x2a45c40, 0x0, 0x0})
        /home/ldez/sources/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc000910008)
        /home/ldez/sources/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/ldez/sources/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/golangci/golangci-lint/pkg/commands.(*rootCommand).Execute(0xc00090c750)
        /tmp/custom-gcl2430187412/golangci-lint/pkg/commands/root.go:83 +0x3d
github.com/golangci/golangci-lint/pkg/commands.Execute({{0x1e16388, 0x8}, {0x1e1e5f0, 0x12}, {0x1e0d768, 0x1}, {0x1e2c040, 0x27}})
        /tmp/custom-gcl2430187412/golangci-lint/pkg/commands/root.go:17 +0x5a
main.main()
        /tmp/custom-gcl2430187412/golangci-lint/cmd/golangci-lint/main.go:25 +0xc5
```