### PR TITLE
Add yaml language server config

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
 # This file contains all available configuration options
 # with their default values (in comments).
 #

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
 # This file contains all available configuration options
 # with their default values (in comments).
 #

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
 # This configuration file is not a recommendation.
 #
 # We intentionally use a limited set of linters.


### PR DESCRIPTION
For those who use yaml-language-server in their IDE, the IDE can verify the config, which is nice:
https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#using-inlined-schema
https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#clients

And can help prevent issues like https://github.com/golangci/golangci-lint/issues/5313

![image](https://github.com/user-attachments/assets/6b295bcd-0f04-475c-8a8c-9a9dfc93b06b)

Let's add it to the default/example config files?