### PR TITLE
Test failing on extra fields  parsing 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@
 #
 # See the file `.golangci.reference.yml` to have a list of all available configuration options.
 
-linters:
+lintersS:
   disable-all: true
   # This list of linters is not a recommendation (same thing for all this configuration file).
   # We intentionally use a limited set of linters.

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -8,8 +8,9 @@ import (
 	"path/filepath"
 	"slices"
 
-	"github.com/go-viper/mapstructure/v2"
+	// "github.com/go-viper/mapstructure/v2"
 	"github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -214,8 +215,12 @@ func (l *Loader) parseConfig() error {
 		return err
 	}
 
+	customDecoderConfig := func(c *mapstructure.DecoderConfig) {
+		c.ErrorUnused = true
+	}
+
 	// Load configuration from all sources (flags, file).
-	if err := l.viper.Unmarshal(l.cfg, customDecoderHook()); err != nil {
+	if err := l.viper.Unmarshal(l.cfg, customDecoderHook(), customDecoderConfig); err != nil {
 		return fmt.Errorf("can't unmarshal config by viper (flags, file): %w", err)
 	}
 


### PR DESCRIPTION
```
# go run ./cmd/golangci-lint/ run -v
INFO golangci-lint has version (devel) built with go1.23.4 from (unknown, modified: ?, mod sum: "") on (unknown)
INFO [config_reader] Config search paths: [./ /home/alex/code/golangci-lint /home/alex/code /home/alex /home /]
INFO [config_reader] Used config file .golangci.yml
Error: can't load config: can't unmarshal config by viper (flags, file): 2 error(s) decoding:

* '' has invalid keys: linterss
* 'output.formats[0]' expected a map, got 'string'
Failed executing command with error: can't load config: can't unmarshal config by viper (flags, file): 2 error(s) decoding:

* '' has invalid keys: linterss
* 'output.formats[0]' expected a map, got 'string'
exit status 3

[❌ ERROR]
```