### PR TITLE
chore: remove duplicate linter inside the configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     - funlen
     - gocheckcompilerdirectives
     - gochecknoinits
-    - gochecknoinits
     - goconst
     - gocritic
     - gocyclo


### PR DESCRIPTION
Fixes #5317 