### PR TITLE
dev: displays revive rules inside debug logs

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2371,7 +2371,7 @@ linters-settings:
     # This means that linting errors with less than 0.8 confidence will be ignored.
     # Default: 0.8
     confidence: 0.1
-
+    # Run `GL_DEBUG=revive golangci-lint run --enable-only=revive` to see default, all available rules, and enabled rules.
     rules:
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
       - name: add-constant

--- a/pkg/golinters/revive/revive.go
+++ b/pkg/golinters/revive/revive.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"reflect"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 
@@ -466,7 +465,7 @@ func displayRules(conf *lint.Config) {
 		}
 	}
 
-	sort.Strings(enabledRules)
+	slices.Sort(enabledRules)
 
 	debugf("All available rules (%d): %s.", len(allRules), strings.Join(extractRulesName(allRules), ", "))
 	debugf("Default rules (%d): %s.", len(allRules), strings.Join(extractRulesName(allRules), ", "))

--- a/pkg/golinters/revive/revive.go
+++ b/pkg/golinters/revive/revive.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -481,7 +482,7 @@ func extractRulesName(rules []lint.Rule) []string {
 		names = append(names, r.Name())
 	}
 
-	sort.Strings(names)
+	slices.Sort(names)
 
 	return names
 }


### PR DESCRIPTION
Here is the result

```
$ GL_DEBUG=revive go run cmd/golangci-lint/main.go run --enable-only=revive

DEBU [revive] All available analyzers checks (81): [add-constant argument-limit atomic banned-characters bare-return blank-imports bool-literal-in-expr call-to-gc cognitive-complexity comment-spacings comments-density confusing-naming confusing-results constant-logical-expr context-as-argument context-keys-type cyclomatic datarace deep-exit defer dot-imports duplicated-imports early-return empty-block empty-lines enforce-map-style enforce-repeated-arg-type-style enforce-slice-style error-naming error-return error-strings errorf exported file-header file-length-limit filename-format flag-parameter function-length function-result-limit get-return identical-branches if-return import-alias-naming import-shadowing imports-blocklist increment-decrement indent-error-flow line-length-limit max-control-nesting max-public-structs modifies-parameter modifies-value-receiver nested-structs optimize-operands-order package-comments range range-val-address range-val-in-closure receiver-naming redefines-builtin-id redundant-import-alias string-format string-of-int struct-tag superfluous-else time-equal time-naming unchecked-type-assertion unconditional-recursion unexported-naming unexported-return unhandled-error unnecessary-stmt unreachable-code unused-parameter unused-receiver use-any useless-break var-declaration var-naming waitgroup-by-value] 
DEBU [revive] Default analyzers checks (23): [blank-imports context-as-argument context-keys-type dot-imports empty-block error-naming error-return error-strings errorf exported increment-decrement indent-error-flow package-comments range receiver-naming redefines-builtin-id superfluous-else time-naming unexported-return unreachable-code unused-parameter var-declaration var-naming] 
DEBU [revive] Enabled by config analyzers checks (3): [indent-error-flow unused-parameter unused-receiver] 
DEBU [revive] revive configuration: &lint.Config{IgnoreGeneratedHeader:false, Confidence:0.8, Severity:"warning", EnableAllRules:false, Rules:map[string]lint.RuleConfig{"indent-error-flow":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unexported-return":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:true, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unused-parameter":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unused-receiver":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}}, ErrorCode:0, WarningCode:0, Directives:map[string]lint.DirectiveConfig(nil), Exclude:[]string(nil), GoVersion:(*version.Version)(nil)} 
```

The last line comes from the existing debug message available for revive linter.

```
$ GL_DEBUG=revive golangci-lint run --enable-only=revive

DEBU [revive] revive configuration: &lint.Config{IgnoreGeneratedHeader:false, Confidence:0.8, Severity:"warning", EnableAllRules:false, Rules:map[string]lint.RuleConfig{"indent-error-flow":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unexported-return":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:true, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unused-parameter":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unused-receiver":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}}, ErrorCode:0, WarningCode:0, Directives:map[string]lint.DirectiveConfig(nil), Exclude:[]string(nil), GoVersion:(*version.Version)(nil)} 
```

 It was kept for compatibility purpose.