### PR TITLE
dev: linter log consistency

### DIFF
--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -316,6 +316,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 
 	if len(s.EnabledTags) != 0 {
 		enabledFromTags := s.expandTagsToChecks(s.EnabledTags)
+
 		debugChecksListf(enabledFromTags, "Enabled by config tags %s", s.EnabledTags)
 
 		for _, check := range enabledFromTags {
@@ -337,6 +338,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 
 	if len(s.DisabledTags) != 0 {
 		disabledFromTags := s.expandTagsToChecks(s.DisabledTags)
+
 		debugChecksListf(disabledFromTags, "Disabled by config tags %s", s.DisabledTags)
 
 		for _, check := range disabledFromTags {
@@ -358,6 +360,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 
 	s.inferredEnabledChecks = enabledChecks
 	s.inferredEnabledChecksLowerCased = normalizeMap(s.inferredEnabledChecks)
+
 	s.debugChecksFinalState()
 }
 

--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -133,6 +133,7 @@ func (w *goCriticWrapper) buildEnabledCheckers(linterCtx *gocriticlinter.Context
 		if err != nil {
 			return nil, err
 		}
+
 		enabledCheckers = append(enabledCheckers, c)
 	}
 
@@ -294,6 +295,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 	s.debugChecksInitialState()
 
 	enabledByDefaultChecks, disabledByDefaultChecks := s.buildEnabledAndDisabledByDefaultChecks()
+
 	debugChecksListf(enabledByDefaultChecks, "Enabled by default")
 	debugChecksListf(disabledByDefaultChecks, "Disabled by default")
 
@@ -314,7 +316,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 
 	if len(s.EnabledTags) != 0 {
 		enabledFromTags := s.expandTagsToChecks(s.EnabledTags)
-		debugChecksListf(enabledFromTags, "Enabled by config tags %s", sprintSortedStrings(s.EnabledTags))
+		debugChecksListf(enabledFromTags, "Enabled by config tags %s", s.EnabledTags)
 
 		for _, check := range enabledFromTags {
 			enabledChecks[check] = struct{}{}
@@ -335,7 +337,7 @@ func (s *settingsWrapper) InferEnabledChecks() {
 
 	if len(s.DisabledTags) != 0 {
 		disabledFromTags := s.expandTagsToChecks(s.DisabledTags)
-		debugChecksListf(disabledFromTags, "Disabled by config tags %s", sprintSortedStrings(s.DisabledTags))
+		debugChecksListf(disabledFromTags, "Disabled by config tags %s", s.DisabledTags)
 
 		for _, check := range disabledFromTags {
 			delete(enabledChecks, check)
@@ -549,10 +551,8 @@ func debugChecksListf(checks []string, format string, args ...any) {
 		return
 	}
 
-	debugf("%s checks (%d): %s", fmt.Sprintf(format, args...), len(checks), sprintSortedStrings(checks))
-}
+	v := slices.Clone(checks)
+	slices.Sort(v)
 
-func sprintSortedStrings(v []string) string {
-	sort.Strings(slices.Clone(v))
-	return fmt.Sprint(v)
+	debugf("%s checks (%d): %s", fmt.Sprintf(format, args...), len(checks), strings.Join(v, ", "))
 }

--- a/pkg/golinters/govet/govet.go
+++ b/pkg/golinters/govet/govet.go
@@ -2,7 +2,7 @@ package govet
 
 import (
 	"slices"
-	"sort"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/appends"
@@ -164,8 +164,8 @@ func New(settings *config.GovetSettings) *goanalysis.Linter {
 }
 
 func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
-	debugAnalyzersListf(allAnalyzers, "All available analyzers")
-	debugAnalyzersListf(defaultAnalyzers, "Default analyzers")
+	logAnalyzers("All available analyzers", allAnalyzers)
+	logAnalyzers("Default analyzers", defaultAnalyzers)
 
 	if settings == nil {
 		return defaultAnalyzers
@@ -178,7 +178,7 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 		}
 	}
 
-	debugAnalyzersListf(enabledAnalyzers, "Enabled by config analyzers")
+	logAnalyzers("Enabled by config analyzers", enabledAnalyzers)
 
 	return enabledAnalyzers
 }
@@ -212,7 +212,7 @@ func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers 
 	}
 }
 
-func debugAnalyzersListf(analyzers []*analysis.Analyzer, message string) {
+func logAnalyzers(message string, analyzers []*analysis.Analyzer) {
 	if !isDebug {
 		return
 	}
@@ -222,7 +222,7 @@ func debugAnalyzersListf(analyzers []*analysis.Analyzer, message string) {
 		analyzerNames = append(analyzerNames, a.Name)
 	}
 
-	sort.Strings(analyzerNames)
+	slices.Sort(analyzerNames)
 
-	debugf("%s (%d): %s", message, len(analyzerNames), analyzerNames)
+	debugf("%s (%d): %s", message, len(analyzerNames), strings.Join(analyzerNames, ", "))
 }


### PR DESCRIPTION
Uses the same format as #5325


<details><summary>govet before</summary>

```console
$ GL_DEBUG=govet golangci-lint run --enable-only=govet      
DEBU [govet] All available analyzers (43): [appends asmdecl assign atomic atomicalign bools buildtag cgocall composites copylocks deepequalerrors defers directive errorsas fieldalignment findcall framepointer httpresponse ifaceassert loopclosure lostcancel nilfunc nilness printf reflectvaluecompare shadow shift sigchanyzer slog sortslice stdmethods stdversion stringintconv structtag testinggoroutine tests timeformat unmarshal unreachable unsafeptr unusedresult unusedwrite waitgroup] 
DEBU [govet] Default analyzers (33): [appends asmdecl assign atomic bools buildtag cgocall composites copylocks defers directive errorsas framepointer httpresponse ifaceassert loopclosure lostcancel nilfunc printf shift sigchanyzer slog stdmethods stdversion stringintconv structtag testinggoroutine tests timeformat unmarshal unreachable unsafeptr unusedresult] 
DEBU [govet] Enabled by config analyzers (34): [appends asmdecl assign atomic bools buildtag cgocall composites copylocks defers directive errorsas framepointer httpresponse ifaceassert lostcancel nilfunc nilness printf shadow shift sigchanyzer slog stdmethods stdversion stringintconv structtag testinggoroutine tests timeformat unmarshal unreachable unsafeptr unusedresult]
```

</details>

<details><summary>govet after</summary>

```console
$ GL_DEBUG=govet go run ./cmd/golangci-lint/ run --enable-only=govet
DEBU [govet] All available analyzers (43): appends, asmdecl, assign, atomic, atomicalign, bools, buildtag, cgocall, composites, copylocks, deepequalerrors, defers, directive, errorsas, fieldalignment, findcall, framepointer, httpresponse, ifaceassert, loopclosure, lostcancel, nilfunc, nilness, printf, reflectvaluecompare, shadow, shift, sigchanyzer, slog, sortslice, stdmethods, stdversion, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr, unusedresult, unusedwrite, waitgroup 
DEBU [govet] Default analyzers (33): appends, asmdecl, assign, atomic, bools, buildtag, cgocall, composites, copylocks, defers, directive, errorsas, framepointer, httpresponse, ifaceassert, loopclosure, lostcancel, nilfunc, printf, shift, sigchanyzer, slog, stdmethods, stdversion, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr, unusedresult 
DEBU [govet] Enabled by config analyzers (34): appends, asmdecl, assign, atomic, bools, buildtag, cgocall, composites, copylocks, defers, directive, errorsas, framepointer, httpresponse, ifaceassert, lostcancel, nilfunc, nilness, printf, shadow, shift, sigchanyzer, slog, stdmethods, stdversion, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr, unusedresult 
```

</details>

<details><summary>gocritic before</summary>

```console
$ GL_DEBUG=gocritic golangci-lint run --enable-only=gocritic
DEBU [gocritic] All gocritic existing tags and checks: 
DEBU [gocritic]   tag "diagnostic" checks (43): [appendAssign argOrder badCall badCond badLock badRegexp badSorting badSyncOnceFunc builtinShadowDecl caseOrder codegenComment commentedOutCode deferInLoop deprecatedComment dupArg dupBranchBody dupCase dupSubExpr dynamicFmtString emptyDecl evalOrder exitAfterDefer externalErrorReassign filepathJoin flagDeref flagName mapKey nilValReturn offBy1 rangeAppendAll regexpPattern returnAfterHttpError sloppyLen sloppyReassign sloppyTypeAssert sortSlice sprintfQuotedString sqlQuery syncMapLoadAndDelete truncateCmp uncheckedInlineErr unnecessaryDefer weakCond] 
DEBU [gocritic]   tag "experimental" checks (62): [badLock badRegexp badSorting badSyncOnceFunc boolExprSimplify builtinShadowDecl commentedOutCode commentedOutImport deferInLoop deferUnlambda docStub dupImport dynamicFmtString emptyDecl emptyFallthrough emptyStringTest equalFold evalOrder exposedSyncMutex externalErrorReassign filepathJoin hexLiteral httpNoBody initClause methodExprCall nestingReduce nilValReturn octalLiteral preferDecodeRune preferFilepathJoin preferFprint preferStringWriter preferWriteByte ptrToRefParam rangeAppendAll redundantSprint regexpPattern regexpSimplify returnAfterHttpError ruleguard sliceClear sloppyReassign sortSlice sprintfQuotedString sqlQuery stringConcatSimplify stringsCompare syncMapLoadAndDelete timeExprSimplify todoCommentWithoutDetail tooManyResultsChecker truncateCmp typeAssertChain typeDefFirst uncheckedInlineErr unlabelStmt unnamedResult unnecessaryBlock unnecessaryDefer weakCond whyNoLint yodaStyleExpr] 
DEBU [gocritic]   tag "opinionated" checks (14): [builtinShadow importShadow initClause nestingReduce octalLiteral paramTypeCombine preferWriteByte ptrToRefParam regexpSimplify todoCommentWithoutDetail tooManyResultsChecker typeUnparen unnamedResult unnecessaryBlock] 
DEBU [gocritic]   tag "performance" checks (12): [appendCombine equalFold hugeParam indexAlloc preferDecodeRune preferFprint preferStringWriter preferWriteByte rangeExprCopy rangeValCopy sliceClear stringXbytes] 
DEBU [gocritic]   tag "style" checks (51): [assignOp boolExprSimplify builtinShadow captLocal commentFormatting commentedOutImport defaultCaseOrder deferUnlambda docStub dupImport elseif emptyFallthrough emptyStringTest exposedSyncMutex hexLiteral httpNoBody ifElseChain importShadow initClause methodExprCall nestingReduce newDeref octalLiteral paramTypeCombine preferFilepathJoin ptrToRefParam redundantSprint regexpMust regexpSimplify ruleguard singleCaseSwitch stringConcatSimplify stringsCompare switchTrue timeExprSimplify todoCommentWithoutDetail tooManyResultsChecker typeAssertChain typeDefFirst typeSwitchVar typeUnparen underef unlabelStmt unlambda unnamedResult unnecessaryBlock unslice valSwap whyNoLint wrapperFunc yodaStyleExpr] 
DEBU [gocritic] Enabled by default checks (34): [appendAssign argOrder assignOp badCall badCond captLocal caseOrder codegenComment commentFormatting defaultCaseOrder deprecatedComment dupArg dupBranchBody dupCase dupSubExpr elseif exitAfterDefer flagDeref flagName ifElseChain mapKey newDeref offBy1 regexpMust singleCaseSwitch sloppyLen sloppyTypeAssert switchTrue typeSwitchVar underef unlambda unslice valSwap wrapperFunc] 
DEBU [gocritic] Disabled by default checks (72): [appendCombine badLock badRegexp badSorting badSyncOnceFunc boolExprSimplify builtinShadow builtinShadowDecl commentedOutCode commentedOutImport deferInLoop deferUnlambda docStub dupImport dynamicFmtString emptyDecl emptyFallthrough emptyStringTest equalFold evalOrder exposedSyncMutex externalErrorReassign filepathJoin hexLiteral httpNoBody hugeParam importShadow indexAlloc initClause methodExprCall nestingReduce nilValReturn octalLiteral paramTypeCombine preferDecodeRune preferFilepathJoin preferFprint preferStringWriter preferWriteByte ptrToRefParam rangeAppendAll rangeExprCopy rangeValCopy redundantSprint regexpPattern regexpSimplify returnAfterHttpError ruleguard sliceClear sloppyReassign sortSlice sprintfQuotedString sqlQuery stringConcatSimplify stringXbytes stringsCompare syncMapLoadAndDelete timeExprSimplify todoCommentWithoutDetail tooManyResultsChecker truncateCmp typeAssertChain typeDefFirst typeUnparen uncheckedInlineErr unlabelStmt unnamedResult unnecessaryBlock unnecessaryDefer weakCond whyNoLint yodaStyleExpr] 
DEBU [gocritic] Enabled by config tags [diagnostic experimental opinionated performance style] checks (182): [appendAssign argOrder badCall badCond badLock badRegexp badSorting badSyncOnceFunc builtinShadowDecl caseOrder codegenComment commentedOutCode deferInLoop deprecatedComment dupArg dupBranchBody dupCase dupSubExpr dynamicFmtString emptyDecl evalOrder exitAfterDefer externalErrorReassign filepathJoin flagDeref flagName mapKey nilValReturn offBy1 rangeAppendAll regexpPattern returnAfterHttpError sloppyLen sloppyReassign sloppyTypeAssert sortSlice sprintfQuotedString sqlQuery syncMapLoadAndDelete truncateCmp uncheckedInlineErr unnecessaryDefer weakCond badLock badRegexp badSorting badSyncOnceFunc boolExprSimplify builtinShadowDecl commentedOutCode commentedOutImport deferInLoop deferUnlambda docStub dupImport dynamicFmtString emptyDecl emptyFallthrough emptyStringTest equalFold evalOrder exposedSyncMutex externalErrorReassign filepathJoin hexLiteral httpNoBody initClause methodExprCall nestingReduce nilValReturn octalLiteral preferDecodeRune preferFilepathJoin preferFprint preferStringWriter preferWriteByte ptrToRefParam rangeAppendAll redundantSprint regexpPattern regexpSimplify returnAfterHttpError ruleguard sliceClear sloppyReassign sortSlice sprintfQuotedString sqlQuery stringConcatSimplify stringsCompare syncMapLoadAndDelete timeExprSimplify todoCommentWithoutDetail tooManyResultsChecker truncateCmp typeAssertChain typeDefFirst uncheckedInlineErr unlabelStmt unnamedResult unnecessaryBlock unnecessaryDefer weakCond whyNoLint yodaStyleExpr builtinShadow importShadow initClause nestingReduce octalLiteral paramTypeCombine preferWriteByte ptrToRefParam regexpSimplify todoCommentWithoutDetail tooManyResultsChecker typeUnparen unnamedResult unnecessaryBlock appendCombine equalFold hugeParam indexAlloc preferDecodeRune preferFprint preferStringWriter preferWriteByte rangeExprCopy rangeValCopy sliceClear stringXbytes assignOp boolExprSimplify builtinShadow captLocal commentFormatting commentedOutImport defaultCaseOrder deferUnlambda docStub dupImport elseif emptyFallthrough emptyStringTest exposedSyncMutex hexLiteral httpNoBody ifElseChain importShadow initClause methodExprCall nestingReduce newDeref octalLiteral paramTypeCombine preferFilepathJoin ptrToRefParam redundantSprint regexpMust regexpSimplify ruleguard singleCaseSwitch stringConcatSimplify stringsCompare switchTrue timeExprSimplify todoCommentWithoutDetail tooManyResultsChecker typeAssertChain typeDefFirst typeSwitchVar typeUnparen underef unlabelStmt unlambda unnamedResult unnecessaryBlock unslice valSwap whyNoLint wrapperFunc yodaStyleExpr] 
DEBU [gocritic] Disabled by config checks (4): [dupImport ifElseChain octalLiteral whyNoLint] 
DEBU [gocritic] Final used checks (102): [appendAssign appendCombine argOrder assignOp badCall badCond badLock badRegexp badSorting badSyncOnceFunc boolExprSimplify builtinShadow builtinShadowDecl captLocal caseOrder codegenComment commentFormatting commentedOutCode commentedOutImport defaultCaseOrder deferInLoop deferUnlambda deprecatedComment docStub dupArg dupBranchBody dupCase dupSubExpr dynamicFmtString elseif emptyDecl emptyFallthrough emptyStringTest equalFold evalOrder exitAfterDefer exposedSyncMutex externalErrorReassign filepathJoin flagDeref flagName hexLiteral httpNoBody hugeParam importShadow indexAlloc initClause mapKey methodExprCall nestingReduce newDeref nilValReturn offBy1 paramTypeCombine preferDecodeRune preferFilepathJoin preferFprint preferStringWriter preferWriteByte ptrToRefParam rangeAppendAll rangeExprCopy rangeValCopy redundantSprint regexpMust regexpPattern regexpSimplify returnAfterHttpError ruleguard singleCaseSwitch sliceClear sloppyLen sloppyReassign sloppyTypeAssert sortSlice sprintfQuotedString sqlQuery stringConcatSimplify stringXbytes stringsCompare switchTrue syncMapLoadAndDelete timeExprSimplify todoCommentWithoutDetail tooManyResultsChecker truncateCmp typeAssertChain typeDefFirst typeSwitchVar typeUnparen uncheckedInlineErr underef unlabelStmt unlambda unnamedResult unnecessaryBlock unnecessaryDefer unslice valSwap weakCond wrapperFunc yodaStyleExpr] 
DEBU [gocritic] Final not used checks (4): [dupImport ifElseChain octalLiteral whyNoLint]
```

</details>

<details><summary>gocritic after</summary>

```console
$ GL_DEBUG=gocritic go run ./cmd/golangci-lint/ run --enable-only=gocritic
DEBU [gocritic] All gocritic existing tags and checks: 
DEBU [gocritic]   tag "diagnostic" checks (43): appendAssign, argOrder, badCall, badCond, badLock, badRegexp, badSorting, badSyncOnceFunc, builtinShadowDecl, caseOrder, codegenComment, commentedOutCode, deferInLoop, deprecatedComment, dupArg, dupBranchBody, dupCase, dupSubExpr, dynamicFmtString, emptyDecl, evalOrder, exitAfterDefer, externalErrorReassign, filepathJoin, flagDeref, flagName, mapKey, nilValReturn, offBy1, rangeAppendAll, regexpPattern, returnAfterHttpError, sloppyLen, sloppyReassign, sloppyTypeAssert, sortSlice, sprintfQuotedString, sqlQuery, syncMapLoadAndDelete, truncateCmp, uncheckedInlineErr, unnecessaryDefer, weakCond 
DEBU [gocritic]   tag "experimental" checks (62): badLock, badRegexp, badSorting, badSyncOnceFunc, boolExprSimplify, builtinShadowDecl, commentedOutCode, commentedOutImport, deferInLoop, deferUnlambda, docStub, dupImport, dynamicFmtString, emptyDecl, emptyFallthrough, emptyStringTest, equalFold, evalOrder, exposedSyncMutex, externalErrorReassign, filepathJoin, hexLiteral, httpNoBody, initClause, methodExprCall, nestingReduce, nilValReturn, octalLiteral, preferDecodeRune, preferFilepathJoin, preferFprint, preferStringWriter, preferWriteByte, ptrToRefParam, rangeAppendAll, redundantSprint, regexpPattern, regexpSimplify, returnAfterHttpError, ruleguard, sliceClear, sloppyReassign, sortSlice, sprintfQuotedString, sqlQuery, stringConcatSimplify, stringsCompare, syncMapLoadAndDelete, timeExprSimplify, todoCommentWithoutDetail, tooManyResultsChecker, truncateCmp, typeAssertChain, typeDefFirst, uncheckedInlineErr, unlabelStmt, unnamedResult, unnecessaryBlock, unnecessaryDefer, weakCond, whyNoLint, yodaStyleExpr 
DEBU [gocritic]   tag "opinionated" checks (14): builtinShadow, importShadow, initClause, nestingReduce, octalLiteral, paramTypeCombine, preferWriteByte, ptrToRefParam, regexpSimplify, todoCommentWithoutDetail, tooManyResultsChecker, typeUnparen, unnamedResult, unnecessaryBlock 
DEBU [gocritic]   tag "performance" checks (12): appendCombine, equalFold, hugeParam, indexAlloc, preferDecodeRune, preferFprint, preferStringWriter, preferWriteByte, rangeExprCopy, rangeValCopy, sliceClear, stringXbytes 
DEBU [gocritic]   tag "style" checks (51): assignOp, boolExprSimplify, builtinShadow, captLocal, commentFormatting, commentedOutImport, defaultCaseOrder, deferUnlambda, docStub, dupImport, elseif, emptyFallthrough, emptyStringTest, exposedSyncMutex, hexLiteral, httpNoBody, ifElseChain, importShadow, initClause, methodExprCall, nestingReduce, newDeref, octalLiteral, paramTypeCombine, preferFilepathJoin, ptrToRefParam, redundantSprint, regexpMust, regexpSimplify, ruleguard, singleCaseSwitch, stringConcatSimplify, stringsCompare, switchTrue, timeExprSimplify, todoCommentWithoutDetail, tooManyResultsChecker, typeAssertChain, typeDefFirst, typeSwitchVar, typeUnparen, underef, unlabelStmt, unlambda, unnamedResult, unnecessaryBlock, unslice, valSwap, whyNoLint, wrapperFunc, yodaStyleExpr 
DEBU [gocritic] Enabled by default checks (34): appendAssign, argOrder, assignOp, badCall, badCond, captLocal, caseOrder, codegenComment, commentFormatting, defaultCaseOrder, deprecatedComment, dupArg, dupBranchBody, dupCase, dupSubExpr, elseif, exitAfterDefer, flagDeref, flagName, ifElseChain, mapKey, newDeref, offBy1, regexpMust, singleCaseSwitch, sloppyLen, sloppyTypeAssert, switchTrue, typeSwitchVar, underef, unlambda, unslice, valSwap, wrapperFunc 
DEBU [gocritic] Disabled by default checks (72): appendCombine, badLock, badRegexp, badSorting, badSyncOnceFunc, boolExprSimplify, builtinShadow, builtinShadowDecl, commentedOutCode, commentedOutImport, deferInLoop, deferUnlambda, docStub, dupImport, dynamicFmtString, emptyDecl, emptyFallthrough, emptyStringTest, equalFold, evalOrder, exposedSyncMutex, externalErrorReassign, filepathJoin, hexLiteral, httpNoBody, hugeParam, importShadow, indexAlloc, initClause, methodExprCall, nestingReduce, nilValReturn, octalLiteral, paramTypeCombine, preferDecodeRune, preferFilepathJoin, preferFprint, preferStringWriter, preferWriteByte, ptrToRefParam, rangeAppendAll, rangeExprCopy, rangeValCopy, redundantSprint, regexpPattern, regexpSimplify, returnAfterHttpError, ruleguard, sliceClear, sloppyReassign, sortSlice, sprintfQuotedString, sqlQuery, stringConcatSimplify, stringXbytes, stringsCompare, syncMapLoadAndDelete, timeExprSimplify, todoCommentWithoutDetail, tooManyResultsChecker, truncateCmp, typeAssertChain, typeDefFirst, typeUnparen, uncheckedInlineErr, unlabelStmt, unnamedResult, unnecessaryBlock, unnecessaryDefer, weakCond, whyNoLint, yodaStyleExpr 
DEBU [gocritic] Enabled by config tags [diagnostic experimental opinionated performance style] checks (182): appendAssign, appendCombine, argOrder, assignOp, badCall, badCond, badLock, badLock, badRegexp, badRegexp, badSorting, badSorting, badSyncOnceFunc, badSyncOnceFunc, boolExprSimplify, boolExprSimplify, builtinShadow, builtinShadow, builtinShadowDecl, builtinShadowDecl, captLocal, caseOrder, codegenComment, commentFormatting, commentedOutCode, commentedOutCode, commentedOutImport, commentedOutImport, defaultCaseOrder, deferInLoop, deferInLoop, deferUnlambda, deferUnlambda, deprecatedComment, docStub, docStub, dupArg, dupBranchBody, dupCase, dupImport, dupImport, dupSubExpr, dynamicFmtString, dynamicFmtString, elseif, emptyDecl, emptyDecl, emptyFallthrough, emptyFallthrough, emptyStringTest, emptyStringTest, equalFold, equalFold, evalOrder, evalOrder, exitAfterDefer, exposedSyncMutex, exposedSyncMutex, externalErrorReassign, externalErrorReassign, filepathJoin, filepathJoin, flagDeref, flagName, hexLiteral, hexLiteral, httpNoBody, httpNoBody, hugeParam, ifElseChain, importShadow, importShadow, indexAlloc, initClause, initClause, initClause, mapKey, methodExprCall, methodExprCall, nestingReduce, nestingReduce, nestingReduce, newDeref, nilValReturn, nilValReturn, octalLiteral, octalLiteral, octalLiteral, offBy1, paramTypeCombine, paramTypeCombine, preferDecodeRune, preferDecodeRune, preferFilepathJoin, preferFilepathJoin, preferFprint, preferFprint, preferStringWriter, preferStringWriter, preferWriteByte, preferWriteByte, preferWriteByte, ptrToRefParam, ptrToRefParam, ptrToRefParam, rangeAppendAll, rangeAppendAll, rangeExprCopy, rangeValCopy, redundantSprint, redundantSprint, regexpMust, regexpPattern, regexpPattern, regexpSimplify, regexpSimplify, regexpSimplify, returnAfterHttpError, returnAfterHttpError, ruleguard, ruleguard, singleCaseSwitch, sliceClear, sliceClear, sloppyLen, sloppyReassign, sloppyReassign, sloppyTypeAssert, sortSlice, sortSlice, sprintfQuotedString, sprintfQuotedString, sqlQuery, sqlQuery, stringConcatSimplify, stringConcatSimplify, stringXbytes, stringsCompare, stringsCompare, switchTrue, syncMapLoadAndDelete, syncMapLoadAndDelete, timeExprSimplify, timeExprSimplify, todoCommentWithoutDetail, todoCommentWithoutDetail, todoCommentWithoutDetail, tooManyResultsChecker, tooManyResultsChecker, tooManyResultsChecker, truncateCmp, truncateCmp, typeAssertChain, typeAssertChain, typeDefFirst, typeDefFirst, typeSwitchVar, typeUnparen, typeUnparen, uncheckedInlineErr, uncheckedInlineErr, underef, unlabelStmt, unlabelStmt, unlambda, unnamedResult, unnamedResult, unnamedResult, unnecessaryBlock, unnecessaryBlock, unnecessaryBlock, unnecessaryDefer, unnecessaryDefer, unslice, valSwap, weakCond, weakCond, whyNoLint, whyNoLint, wrapperFunc, yodaStyleExpr, yodaStyleExpr 
DEBU [gocritic] Disabled by config checks (4): dupImport, ifElseChain, octalLiteral, whyNoLint 
DEBU [gocritic] Final used checks (102): appendAssign, appendCombine, argOrder, assignOp, badCall, badCond, badLock, badRegexp, badSorting, badSyncOnceFunc, boolExprSimplify, builtinShadow, builtinShadowDecl, captLocal, caseOrder, codegenComment, commentFormatting, commentedOutCode, commentedOutImport, defaultCaseOrder, deferInLoop, deferUnlambda, deprecatedComment, docStub, dupArg, dupBranchBody, dupCase, dupSubExpr, dynamicFmtString, elseif, emptyDecl, emptyFallthrough, emptyStringTest, equalFold, evalOrder, exitAfterDefer, exposedSyncMutex, externalErrorReassign, filepathJoin, flagDeref, flagName, hexLiteral, httpNoBody, hugeParam, importShadow, indexAlloc, initClause, mapKey, methodExprCall, nestingReduce, newDeref, nilValReturn, offBy1, paramTypeCombine, preferDecodeRune, preferFilepathJoin, preferFprint, preferStringWriter, preferWriteByte, ptrToRefParam, rangeAppendAll, rangeExprCopy, rangeValCopy, redundantSprint, regexpMust, regexpPattern, regexpSimplify, returnAfterHttpError, ruleguard, singleCaseSwitch, sliceClear, sloppyLen, sloppyReassign, sloppyTypeAssert, sortSlice, sprintfQuotedString, sqlQuery, stringConcatSimplify, stringXbytes, stringsCompare, switchTrue, syncMapLoadAndDelete, timeExprSimplify, todoCommentWithoutDetail, tooManyResultsChecker, truncateCmp, typeAssertChain, typeDefFirst, typeSwitchVar, typeUnparen, uncheckedInlineErr, underef, unlabelStmt, unlambda, unnamedResult, unnecessaryBlock, unnecessaryDefer, unslice, valSwap, weakCond, wrapperFunc, yodaStyleExpr 
DEBU [gocritic] Final not used checks (4): dupImport, ifElseChain, octalLiteral, whyNoLint 
```

</details>
