### PR TITLE
docs: add default exclusion names to the JSONSchema

### DIFF
--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -3958,7 +3958,9 @@
           "description": "The list of ids of default excludes to include or disable.",
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^EXC[0-9]{4}$",
+            "examples": ["EXC0001", "EXC0002", "EXC0015"]
           },
           "default": []
         },

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -3958,9 +3958,23 @@
           "description": "The list of ids of default excludes to include or disable.",
           "type": "array",
           "items": {
-            "type": "string",
-            "pattern": "^EXC[0-9]{4}$",
-            "examples": ["EXC0001", "EXC0002", "EXC0015"]
+            "enum": [
+              "EXC0001",
+              "EXC0002",
+              "EXC0003",
+              "EXC0004",
+              "EXC0005",
+              "EXC0006",
+              "EXC0007",
+              "EXC0008",
+              "EXC0009",
+              "EXC0010",
+              "EXC0011",
+              "EXC0012",
+              "EXC0013",
+              "EXC0014",
+              "EXC0015"
+            ]
           },
           "default": []
         },


### PR DESCRIPTION
I would like to suggest this simple addition

It could avoid loosing time as I did.
I was using EXC014 (instead of EXC0014) and I had to debug everything to figure our the problem was between keyboard and chair.

I validated it worked with the following command:
```shell
go run cmd/golangci-lint/main.go config verify --schema jsonschema/golangci.next.jsonschema.json --config /path/golangci.yml
```

I also checked at the code and it should be safe

https://github.com/golangci/golangci-lint/blob/v1.63.4/pkg/config/issues.go#L233-L247