### PR TITLE
docs: remove "good first issue" mention

### DIFF
--- a/docs/src/docs/contributing/quick-start.mdx
+++ b/docs/src/docs/contributing/quick-start.mdx
@@ -8,5 +8,3 @@ title: Contributing Quick Start
 4. [Debugging golangci-lint](/contributing/debug/)
 5. [Contributing FAQ](/contributing/faq/)
 6. [Contributing to the website](/contributing/website/)
-
-We have [good issues for first-time contributing](https://github.com/golangci/golangci-lint/issues?q=is%3Aopen+label%3A%22good+first+issue%22+sort%3Areactions-%2B1-desc).


### PR DESCRIPTION
We don't maintain issues with the `label:"good first issue"`, so it's not useful information and I propose to remove it.