### PR TITLE
fix: fallback on unknown severities for code climate

### DIFF
--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -54,7 +54,7 @@ func (p CodeClimate) Print(issues []result.Issue) error {
 		codeClimateIssue.Fingerprint = issue.Fingerprint()
 		codeClimateIssue.Severity = defaultCodeClimateSeverity
 
-		if issue.Severity != "" && slices.Contains(p.allowedSeverities, issue.Severity) {
+		if slices.Contains(p.allowedSeverities, issue.Severity) {
 			codeClimateIssue.Severity = issue.Severity
 		}
 

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -3,6 +3,7 @@ package printers
 import (
 	"encoding/json"
 	"io"
+	"slices"
 
 	"github.com/golangci/golangci-lint/pkg/result"
 )
@@ -28,10 +29,15 @@ type CodeClimateIssue struct {
 
 type CodeClimate struct {
 	w io.Writer
+
+	allowedSeverities []string
 }
 
 func NewCodeClimate(w io.Writer) *CodeClimate {
-	return &CodeClimate{w: w}
+	return &CodeClimate{
+		w:                 w,
+		allowedSeverities: []string{"info", "minor", "major", defaultCodeClimateSeverity, "blocker"},
+	}
 }
 
 func (p CodeClimate) Print(issues []result.Issue) error {
@@ -48,7 +54,7 @@ func (p CodeClimate) Print(issues []result.Issue) error {
 		codeClimateIssue.Fingerprint = issue.Fingerprint()
 		codeClimateIssue.Severity = defaultCodeClimateSeverity
 
-		if issue.Severity != "" {
+		if issue.Severity != "" && slices.Contains(p.allowedSeverities, issue.Severity) {
 			codeClimateIssue.Severity = issue.Severity
 		}
 

--- a/pkg/printers/codeclimate_test.go
+++ b/pkg/printers/codeclimate_test.go
@@ -26,7 +26,7 @@ func TestCodeClimate_Print(t *testing.T) {
 		},
 		{
 			FromLinter: "linter-b",
-			Severity:   "error",
+			Severity:   "major",
 			Text:       "another issue",
 			SourceLines: []string{
 				"func foo() {",
@@ -63,7 +63,7 @@ func TestCodeClimate_Print(t *testing.T) {
 	err := printer.Print(issues)
 	require.NoError(t, err)
 
-	expected := `[{"description":"linter-a: some issue","check_name":"linter-a","severity":"warning","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"linter-b: another issue","check_name":"linter-b","severity":"error","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"linter-c: issue c","check_name":"linter-c","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]
+	expected := `[{"description":"linter-a: some issue","check_name":"linter-a","severity":"critical","fingerprint":"BA73C5DF4A6FD8462FFF1D3140235777","location":{"path":"path/to/filea.go","lines":{"begin":10}}},{"description":"linter-b: another issue","check_name":"linter-b","severity":"major","fingerprint":"0777B4FE60242BD8B2E9B7E92C4B9521","location":{"path":"path/to/fileb.go","lines":{"begin":300}}},{"description":"linter-c: issue c","check_name":"linter-c","severity":"critical","fingerprint":"BEE6E9FBB6BFA4B7DB9FB036697FB036","location":{"path":"path/to/filec.go","lines":{"begin":200}}}]
 `
 
 	assert.Equal(t, expected, buf.String())


### PR DESCRIPTION
Keeps only supported severity names: https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types

Closes #5349
