### PR TITLE
dev: factorize base rule parsing

### DIFF
--- a/pkg/result/processors/base_rule.go
+++ b/pkg/result/processors/base_rule.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"regexp"
 
+	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
@@ -19,6 +20,33 @@ type baseRule struct {
 
 	// For compatibility with exclude-use-default/include.
 	internalReference string `mapstructure:"-"`
+}
+
+// The usage of `regexp.MustCompile()` is safe here,
+// because the regular expressions are checked before inside [config.BaseRule.Validate].
+func newBaseRule(rule *config.BaseRule, prefix string) baseRule {
+	base := baseRule{
+		linters:           rule.Linters,
+		internalReference: rule.InternalReference,
+	}
+
+	if rule.Text != "" {
+		base.text = regexp.MustCompile(prefix + rule.Text)
+	}
+
+	if rule.Source != "" {
+		base.source = regexp.MustCompile(prefix + rule.Source)
+	}
+
+	if rule.Path != "" {
+		base.path = regexp.MustCompile(fsutils.NormalizePathInRegex(rule.Path))
+	}
+
+	if rule.PathExcept != "" {
+		base.pathExcept = regexp.MustCompile(fsutils.NormalizePathInRegex(rule.PathExcept))
+	}
+
+	return base
 }
 
 func (r *baseRule) isEmpty() bool {
@@ -68,4 +96,18 @@ func (r *baseRule) matchSource(issue *result.Issue, lineCache *fsutils.LineCache
 	}
 
 	return r.source.MatchString(sourceLine)
+}
+
+func parseRules[T, V any](rules []T, prefix string, newFn func(*T, string) V) []V {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	parsedRules := make([]V, 0, len(rules))
+
+	for _, r := range rules {
+		parsedRules = append(parsedRules, newFn(&r, prefix))
+	}
+
+	return parsedRules
 }

--- a/pkg/result/processors/severity.go
+++ b/pkg/result/processors/severity.go
@@ -2,7 +2,6 @@ package processors
 
 import (
 	"cmp"
-	"regexp"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/fsutils"
@@ -13,11 +12,6 @@ import (
 const severityFromLinter = "@linter"
 
 var _ Processor = (*Severity)(nil)
-
-type severityRule struct {
-	baseRule
-	severity string
-}
 
 // Severity modifies report severity.
 // It uses the same `baseRule` structure as [ExcludeRules] processor.
@@ -48,7 +42,7 @@ func NewSeverity(log logutils.Log, files *fsutils.Files, cfg *config.Severity) *
 		p.name = "severity-rules-case-sensitive"
 	}
 
-	p.rules = createSeverityRules(cfg.Rules, prefix)
+	p.rules = parseRules(cfg.Rules, prefix, newSeverityRule)
 
 	return p
 }
@@ -85,34 +79,14 @@ func (p *Severity) transform(issue *result.Issue) *result.Issue {
 	return issue
 }
 
-func createSeverityRules(rules []config.SeverityRule, prefix string) []severityRule {
-	parsedRules := make([]severityRule, 0, len(rules))
+type severityRule struct {
+	baseRule
+	severity string
+}
 
-	for _, rule := range rules {
-		parsedRule := severityRule{}
-		parsedRule.linters = rule.Linters
-		parsedRule.severity = rule.Severity
-
-		if rule.Text != "" {
-			parsedRule.text = regexp.MustCompile(prefix + rule.Text)
-		}
-
-		if rule.Source != "" {
-			parsedRule.source = regexp.MustCompile(prefix + rule.Source)
-		}
-
-		if rule.Path != "" {
-			path := fsutils.NormalizePathInRegex(rule.Path)
-			parsedRule.path = regexp.MustCompile(path)
-		}
-
-		if rule.PathExcept != "" {
-			pathExcept := fsutils.NormalizePathInRegex(rule.PathExcept)
-			parsedRule.pathExcept = regexp.MustCompile(pathExcept)
-		}
-
-		parsedRules = append(parsedRules, parsedRule)
+func newSeverityRule(rule *config.SeverityRule, prefix string) severityRule {
+	return severityRule{
+		baseRule: newBaseRule(&rule.BaseRule, prefix),
+		severity: rule.Severity,
 	}
-
-	return parsedRules
 }


### PR DESCRIPTION
`ExclusionRules` and `Severity` processors use the same structure `baseRule`.

The construction of this structure can be factorized to ease the maintenance.

Note: The usage of `regexp.MustCompile()` is safe in this context because the regular expressions are checked during the validation of the configuration.