### PR TITLE
feat: add new issues.new-from-merge-base option

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -4043,6 +4043,10 @@ issues:
   # Default: false
   new: true
 
+  # Show only new issues created after the best common ancestor (merge-base against HEAD).
+  # Default: ""
+  new-from-merge-base: main
+
   # Show only new issues created after git revision `REV`.
   # Default: ""
   new-from-rev: HEAD

--- a/docs/src/docs/welcome/faq.mdx
+++ b/docs/src/docs/welcome/faq.mdx
@@ -76,17 +76,20 @@ Or you can create a [GitHub Issue](https://github.com/golangci/golangci-lint/iss
 
 We are sure that every project can easily integrate `golangci-lint`, even the large one.
 
-The idea is to not fix all existing issues. Fix only newly added issue: issues in new code.
-To do this setup CI to run `golangci-lint` with option `--new-from-rev=HEAD~1`.
+The idea is to not fix all existing issues.
+Fix only newly added issue: issues in new code.
 
-Also, take a look at option `--new`, but consider that CI scripts that generate unstaged files will make `--new` only point out issues in those files and not in the last commit.
-In that regard `--new-from-rev=HEAD~1` is safer.
+To do this setup CI to run `golangci-lint` with options `--new-from-merge-base=main` or `--new-from-rev=HEAD~1`.
+
+Also, take a look at option `--new`,
+but consider that CI scripts that generate unstaged files will make `--new` only point out issues in those files and not in the last commit.
+In that regard `--new-from-merge-base=main` or `--new-from-rev=HEAD~1` are safer.
 
 By doing this you won't create new issues in your code and can choose fix existing issues (or not).
 
-## Why `--new-from-rev` or `--new-from-patch` don't seem to be working in some cases?
+## Why `--new-from-xxx` don't seem to be working in some cases?
 
-The options `--new-from-rev` and `--new-from-patch` work by comparing `git diff` output and issues.
+The options `--new-from-merge-base`, `--new-from-rev`, and `--new-from-patch` work by comparing `git diff` output and issues.
 
 If an issue is not reported as the same line as the changes then the issue will be skipped.
 This is the line of the issue is not inside the lines changed.

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d
 	github.com/golangci/misspell v0.6.0
 	github.com/golangci/plugin-module-register v0.1.1
-	github.com/golangci/revgrep v0.7.0
+	github.com/golangci/revgrep v0.8.0
 	github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed
 	github.com/gordonklaus/ineffassign v0.1.0
 	github.com/gostaticanalysis/forcetypeassert v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/golangci/misspell v0.6.0 h1:JCle2HUTNWirNlDIAUO44hUsKhOFqGPoC4LZxlaSX
 github.com/golangci/misspell v0.6.0/go.mod h1:keMNyY6R9isGaSAu+4Q8NMBwMPkh15Gtc8UCVoDtAWo=
 github.com/golangci/plugin-module-register v0.1.1 h1:TCmesur25LnyJkpsVrupv1Cdzo+2f7zX0H6Jkw1Ol6c=
 github.com/golangci/plugin-module-register v0.1.1/go.mod h1:TTpqoB6KkwOJMV8u7+NyXMrkwwESJLOkfl9TxR1DGFc=
-github.com/golangci/revgrep v0.7.0 h1:mSYf3qUqhxo5Vx9O3BdahCTj58CW97FYvOEzEm7/rkM=
-github.com/golangci/revgrep v0.7.0/go.mod h1:U4R/s9dlXZsg8uJmaR1GrloUr14D7qDl8gi2iPXJH8k=
+github.com/golangci/revgrep v0.8.0 h1:EZBctwbVd0aMeRnNUsFogoyayvKHyxlV3CdUA46FX2s=
+github.com/golangci/revgrep v0.8.0/go.mod h1:U4R/s9dlXZsg8uJmaR1GrloUr14D7qDl8gi2iPXJH8k=
 github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed h1:IURFTjxeTfNFP0hTEi1YKjB/ub8zkpaOqFFMApi2EAs=
 github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed/go.mod h1:XLXN8bNw4CGRPaqgl3bv/lhz7bsGPh4/xSaMTbo2vkQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -4081,6 +4081,10 @@
           "type": "boolean",
           "default": false
         },
+        "new-from-merge-base": {
+          "description": "Show only new issues created after the best common ancestor (merge-base against HEAD).",
+          "type": "string"
+        },
         "new-from-rev": {
           "description": "Show only new issues created after this git revision.",
           "type": "string"

--- a/pkg/config/issues.go
+++ b/pkg/config/issues.go
@@ -118,6 +118,7 @@ type Issues struct {
 	UniqByLine         bool `mapstructure:"uniq-by-line"`
 
 	DiffFromRevision  string `mapstructure:"new-from-rev"`
+	DiffFromMergeBase string `mapstructure:"new-from-merge-base"`
 	DiffPatchFilePath string `mapstructure:"new-from-patch"`
 	WholeFiles        bool   `mapstructure:"whole-files"`
 	Diff              bool   `mapstructure:"new"`

--- a/pkg/result/processors/diff.go
+++ b/pkg/result/processors/diff.go
@@ -27,6 +27,7 @@ var _ Processor = (*Diff)(nil)
 type Diff struct {
 	onlyNew       bool
 	fromRev       string
+	fromMergeBase string
 	patchFilePath string
 	wholeFiles    bool
 	patch         string
@@ -36,6 +37,7 @@ func NewDiff(cfg *config.Issues) *Diff {
 	return &Diff{
 		onlyNew:       cfg.Diff,
 		fromRev:       cfg.DiffFromRevision,
+		fromMergeBase: cfg.DiffFromMergeBase,
 		patchFilePath: cfg.DiffPatchFilePath,
 		wholeFiles:    cfg.WholeFiles,
 		patch:         os.Getenv(envGolangciDiffProcessorPatch),
@@ -47,7 +49,7 @@ func (*Diff) Name() string {
 }
 
 func (p *Diff) Process(issues []result.Issue) ([]result.Issue, error) {
-	if !p.onlyNew && p.fromRev == "" && p.patchFilePath == "" && p.patch == "" {
+	if !p.onlyNew && p.fromRev == "" && p.fromMergeBase == "" && p.patchFilePath == "" && p.patch == "" {
 		return issues, nil
 	}
 
@@ -68,6 +70,7 @@ func (p *Diff) Process(issues []result.Issue) ([]result.Issue, error) {
 	checker := revgrep.Checker{
 		Patch:        patchReader,
 		RevisionFrom: p.fromRev,
+		MergeBase:    p.fromMergeBase,
 		WholeFiles:   p.wholeFiles,
 	}
 


### PR DESCRIPTION
Adds new `issues.new-from-merge-base` option.

`git merge-base` is a better approach than an explicit revision:

```mermaid
gitGraph:
commit id:"a"
commit id:"b" type:HIGHLIGHT
branch my_branch
checkout main
commit id:"c"
checkout my_branch
commit id:"d"
commit  id:"e"tag:"HEAD" type:HIGHLIGHT
checkout main
commit id:"f"
commit id:"g" type:HIGHLIGHT
```

When using `issues.new-from-rev=main`, the diff will be between `e` and `g`, which is wrong.

With `issues.new-from-merge-base=main`, the diff will be between `e` and `b`, which is right.

The new option uses `git merge-base <ref> HEAD` internally. (https://github.com/golangci/revgrep/blob/43995b04fc9795de8791e8a9d82206f95d8acaf1/patch.go#L182)

Reference: https://git-scm.com/docs/git-merge-base

Some real-life examples:
- https://github.com/kubernetes/kubernetes/blob/4bf6cdb60ce764a9ae698c8559da5cf6c3c176dc/hack/verify-golangci-lint.sh#L62
- https://github.com/kubernetes/kubernetes/blob/4bf6cdb60ce764a9ae698c8559da5cf6c3c176dc/hack/verify-golangci-lint.sh#L114
- https://github.com/Kava-Labs/kava/blob/e24bd68ee03ba76c116ba347d5cff777daecc632/build/lint.mk#L16
- https://github.com/hashicorp/packer/blob/6096b86b0e1c9d0c63c6d33cebb2cfb3cf909b83/Makefile#L102
- https://github.com/ionos-cloud/terraform-provider-ionoscloud/blob/6ca4426f97089111b27977ae5be97a6e8ab43da2/GNUmakefile#L15


Fixes #460