### PR TITLE
feat: use run.relative-path-mode for output format paths

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -194,7 +194,7 @@ func (c *runCommand) preRunE(_ *cobra.Command, args []string) error {
 
 	c.dbManager = dbManager
 
-	printer, err := printers.NewPrinter(c.log, &c.cfg.Output, c.reportData)
+	printer, err := printers.NewPrinter(c.log, &c.cfg.Output, c.reportData, c.cfg.GetBasePath())
 	if err != nil {
 		return err
 	}

--- a/pkg/printers/printer.go
+++ b/pkg/printers/printer.go
@@ -25,6 +25,7 @@ type issuePrinter interface {
 type Printer struct {
 	cfg        *config.Output
 	reportData *report.Data
+	basePath   string
 
 	log logutils.Log
 
@@ -33,7 +34,7 @@ type Printer struct {
 }
 
 // NewPrinter creates a new Printer.
-func NewPrinter(log logutils.Log, cfg *config.Output, reportData *report.Data) (*Printer, error) {
+func NewPrinter(log logutils.Log, cfg *config.Output, reportData *report.Data, basePath string) (*Printer, error) {
 	if log == nil {
 		return nil, errors.New("missing log argument in constructor")
 	}
@@ -47,6 +48,7 @@ func NewPrinter(log logutils.Log, cfg *config.Output, reportData *report.Data) (
 	return &Printer{
 		cfg:        cfg,
 		reportData: reportData,
+		basePath:   basePath,
 		log:        log,
 		stdOut:     logutils.StdOut,
 		stdErr:     logutils.StdErr,
@@ -96,6 +98,10 @@ func (c *Printer) createWriter(path string) (io.Writer, bool, error) {
 
 	if path == "stderr" {
 		return c.stdErr, false, nil
+	}
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(c.basePath, path)
 	}
 
 	err := os.MkdirAll(filepath.Dir(path), os.ModePerm)

--- a/pkg/printers/printer_test.go
+++ b/pkg/printers/printer_test.go
@@ -67,7 +67,7 @@ func TestPrinter_Print_stdout(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
-			p, err := NewPrinter(logger, test.cfg, data)
+			p, err := NewPrinter(logger, test.cfg, data, "")
 			require.NoError(t, err)
 
 			var stdOutBuffer bytes.Buffer
@@ -106,7 +106,7 @@ func TestPrinter_Print_stderr(t *testing.T) {
 		},
 	}
 
-	p, err := NewPrinter(logger, cfg, data)
+	p, err := NewPrinter(logger, cfg, data, "")
 	require.NoError(t, err)
 
 	var stdOutBuffer bytes.Buffer
@@ -145,7 +145,7 @@ func TestPrinter_Print_file(t *testing.T) {
 		},
 	}
 
-	p, err := NewPrinter(logger, cfg, data)
+	p, err := NewPrinter(logger, cfg, data, "")
 	require.NoError(t, err)
 
 	var stdOutBuffer bytes.Buffer
@@ -197,7 +197,7 @@ func TestPrinter_Print_multiple(t *testing.T) {
 		},
 	}
 
-	p, err := NewPrinter(logger, cfg, data)
+	p, err := NewPrinter(logger, cfg, data, "")
 	require.NoError(t, err)
 
 	var stdOutBuffer bytes.Buffer


### PR DESCRIPTION
I missed this element of the configuration when I introduced `run.relative-path-mod`.

Related to #5339
Related to #5297

Fixes #3656