### PR TITLE
tenv: deprecation

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -106,7 +106,6 @@ linters:
     - stylecheck
     - tagalign
     - tagliatelle
-    - tenv
     - testableexamples
     - testifylint
     - testpackage
@@ -225,7 +224,6 @@ linters:
     - stylecheck
     - tagalign
     - tagliatelle
-    - tenv
     - testableexamples
     - testifylint
     - testpackage
@@ -245,13 +243,14 @@ linters:
     - deadcode # Deprecated
     - exhaustivestruct # Deprecated
     - golint # Deprecated
+    - gomnd # Deprecated
     - ifshort # Deprecated
     - interfacer # Deprecated
     - maligned # Deprecated
-    - gomnd # Deprecated
     - nosnakecase # Deprecated
     - scopelint # Deprecated
     - structcheck # Deprecated
+    - tenv # Deprecated
     - varcheck # Deprecated
 
   # Enable presets.
@@ -3656,8 +3655,8 @@ linters-settings:
     os-mkdir-temp: false
 
     # Enable/disable `os.Setenv()` detections.
-    # Default: false
-    os-setenv: true
+    # Default: true
+    os-setenv: false
 
     # Enable/disable `os.TempDir()` detections.
     # Default: false

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -3488,7 +3488,7 @@
             },
             "os-setenv": {
               "type": "boolean",
-              "default": false
+              "default": true
             },
             "os-create-temp": {
               "type": "boolean",

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -183,7 +183,7 @@ var defaultLintersSettings = LintersSettings{
 		ContextTodo:       true,
 		OSChdir:           true,
 		OSMkdirTemp:       true,
-		OSSetenv:          false,
+		OSSetenv:          true,
 		OSTempDir:         false,
 		OSCreateTemp:      true,
 	},

--- a/pkg/golinters/usetesting/testdata/usetesting.go
+++ b/pkg/golinters/usetesting/testdata/usetesting.go
@@ -11,7 +11,7 @@ func Test_osMkdirTemp(t *testing.T) {
 }
 
 func Test_osSetenv(t *testing.T) {
-	os.Setenv("", "")
+	os.Setenv("", "") // want `s\.Setenv\(\) could be replaced by t\.Setenv\(\) in .+`
 }
 
 func Test_osTempDir(t *testing.T) {

--- a/pkg/golinters/usetesting/testdata/usetesting.go
+++ b/pkg/golinters/usetesting/testdata/usetesting.go
@@ -11,7 +11,7 @@ func Test_osMkdirTemp(t *testing.T) {
 }
 
 func Test_osSetenv(t *testing.T) {
-	os.Setenv("", "") // want `s\.Setenv\(\) could be replaced by t\.Setenv\(\) in .+`
+	os.Setenv("", "") // want `os\.Setenv\(\) could be replaced by t\.Setenv\(\) in .+`
 }
 
 func Test_osTempDir(t *testing.T) {

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -769,7 +769,8 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.43.0").
 			WithPresets(linter.PresetTest).
 			WithLoadForGoAnalysis().
-			WithURL("https://github.com/sivchari/tenv"),
+			WithURL("https://github.com/sivchari/tenv").
+			DeprecatedWarning("Duplicate feature another linter.", "v1.64.0", "usetesting"),
 
 		linter.NewConfig(testableexamples.New()).
 			WithSince("v1.50.0").


### PR DESCRIPTION
The PR deprecates `tenv` in favor of `usetesting`.

The default configuration of `usetesting` is updated accordingly.