### PR TITLE
dev: optimize string handling and slice allocations

### DIFF
--- a/pkg/goformatters/internal/diff_bench_test.go
+++ b/pkg/goformatters/internal/diff_bench_test.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"bytes"
+	"testing"
+
+	diffpkg "github.com/sourcegraph/go-diff/diff"
+)
+
+func BenchmarkParseDiffLines(b *testing.B) {
+	h := &diffpkg.Hunk{
+		OrigStartLine: 1,
+		Body: []byte(`-old line 1
++new line 1
+ unchanged
+-old line 2
++new line 2
++added line
+`),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		parseDiffLines(h)
+	}
+}
+
+func BenchmarkHunkChangesParser(b *testing.B) {
+	h := &diffpkg.Hunk{
+		OrigStartLine: 1,
+		Body: []byte(`-deleted line 1
++added line 1
+ unchanged
++added line 2
+-deleted line 2
++added line 3
+`),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		p := hunkChangesParser{}
+		p.parse(h)
+	}
+}
+
+func BenchmarkLargeDiff(b *testing.B) {
+	var buf bytes.Buffer
+	for i := range 1000 {
+		buf.WriteString("-old line ")
+		buf.WriteString(string(rune('0' + i%10)))
+		buf.WriteString("\n")
+		buf.WriteString("+new line ")
+		buf.WriteString(string(rune('0' + i%10)))
+		buf.WriteString("\n")
+	}
+
+	h := &diffpkg.Hunk{
+		OrigStartLine: 1,
+		Body:          buf.Bytes(),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		p := hunkChangesParser{}
+		p.parse(h)
+		parseDiffLines(h)
+	}
+}


### PR DESCRIPTION
Improve performance in the goformatters internal `diff` implementation by:
- Using byte operations instead of string conversions
- Preallocating slices with exact capacity
- Replacing `slices.Concat` with manual appends

Benchmarks show faster line parsing, less memory usage and fewer memory allocations per operation.

Current `main`:

```
BenchmarkParseDiffLines-8        2649880               430.3 ns/op           880 B/op         11 allocs/op
BenchmarkHunkChangesParser-8     1414388               864.1 ns/op          1424 B/op         23 allocs/op
BenchmarkLargeDiff-8                4202            292897 ns/op          822887 B/op       7039 allocs/op
```

Proposed changes:

```
BenchmarkParseDiffLines-8        3590509               327.1 ns/op           560 B/op          8 allocs/op
BenchmarkHunkChangesParser-8     1596944               741.9 ns/op          1104 B/op         20 allocs/op
BenchmarkLargeDiff-8                4635            263006 ns/op          495908 B/op       7015 allocs/op
```

