### PR TITLE
dev: use HEAD as references

### DIFF
--- a/.github/peril/README.md
+++ b/.github/peril/README.md
@@ -1,4 +1,4 @@
-Based on https://github.com/gatsbyjs/gatsby/tree/master/peril.
+Based on https://github.com/gatsbyjs/gatsby/tree/HEAD/peril.
 
 ## Update a code
 

--- a/.github/peril/settings.json
+++ b/.github/peril/settings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/danger/peril/master/peril-settings-json.schema",
+  "$schema": "https://raw.githubusercontent.com/danger/peril/HEAD/peril-settings-json.schema",
   "settings": {
     "ignored_repos": [],
     "env_vars": ["SLACK_WEBHOOK_URL", "GITHUB_ACCESS_TOKEN"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,10 +7,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches:
+      - master
+      - main
   schedule:
     - cron: '0 17 * * 5'
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 jobs:
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -71,4 +71,4 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "./install-golangci-lint"
+      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "./install-golangci-lint"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
 
 env:

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2378,7 +2378,7 @@ linters-settings:
     confidence: 0.1
     # Run `GL_DEBUG=revive golangci-lint run --enable-only=revive` to see default, all available rules, and enabled rules.
     rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#add-constant
       - name: add-constant
         severity: warning
         disabled: false
@@ -2388,50 +2388,50 @@ linters-settings:
             allowStrs: '""'
             allowInts: "0,1,2"
             allowFloats: "0.0,0.,1.0,1.,2.0,2."
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#argument-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#argument-limit
       - name: argument-limit
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 4 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#atomic
       - name: atomic
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#banned-characters
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#banned-characters
       - name: banned-characters
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ "Ω","Σ","σ", "7" ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#bare-return
       - name: bare-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#blank-imports
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#blank-imports
       - name: blank-imports
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#bool-literal-in-expr
       - name: bool-literal-in-expr
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#call-to-gc
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#call-to-gc
       - name: call-to-gc
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#cognitive-complexity
       - name: cognitive-complexity
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 7 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#comment-spacings
       - name: comment-spacings
         severity: warning
         disabled: false
@@ -2439,74 +2439,74 @@ linters-settings:
         arguments:
           - mypragma
           - otherpragma
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comments-density
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#comments-density
       - name: comments-density
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 15 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#confusing-naming
       - name: confusing-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-results
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#confusing-results
       - name: confusing-results
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#constant-logical-expr
       - name: constant-logical-expr
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
       - name: context-as-argument
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - allowTypesBefore: "*testing.T,*github.com/user/repo/testing.Harness"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-keys-type
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-keys-type
       - name: context-keys-type
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#cyclomatic
       - name: cyclomatic
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#datarace
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#datarace
       - name: datarace
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#deep-exit
       - name: deep-exit
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#defer
       - name: defer
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - [ "call-chain", "loop" ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#dot-imports
       - name: dot-imports
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#duplicated-imports
       - name: duplicated-imports
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
       - name: early-return
         severity: warning
         disabled: false
@@ -2514,58 +2514,58 @@ linters-settings:
         arguments:
           - "preserveScope"
           - "allowJump"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#empty-block
       - name: empty-block
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#empty-lines
       - name: empty-lines
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-map-style
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
       - name: enforce-map-style
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "make"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style
       - name: enforce-repeated-arg-type-style
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "short"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-slice-style
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
       - name: enforce-slice-style
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "make"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-naming
       - name: error-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-return
       - name: error-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-strings
       - name: error-strings
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#errorf
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#errorf
       - name: errorf
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#exported
       - name: exported
         severity: warning
         disabled: false
@@ -2575,14 +2575,14 @@ linters-settings:
           - "disableStutteringCheck"
           - "checkPublicInterface"
           - "disableChecksOnFunctions"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#file-header
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#file-header
       - name: file-header
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - This is the text that must appear at the top of source files.
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#file-length-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#file-length-limit
       - name: file-length-limit
         severity: warning
         disabled: false
@@ -2591,58 +2591,58 @@ linters-settings:
           - max: 100
             skipComments: true
             skipBlankLines: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#filename-format
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
       - name: filename-format
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "^[_a-z][_a-z0-9]*\\.go$"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#flag-parameter
       - name: flag-parameter
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#function-length
       - name: function-length
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 10, 0 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#function-result-limit
       - name: function-result-limit
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#get-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#get-return
       - name: get-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#identical-branches
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#identical-branches
       - name: identical-branches
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#if-return
       - name: if-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-alias-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#import-alias-naming
       - name: import-alias-naming
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "^[a-z][a-z0-9]{0,}$"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#import-shadowing
       - name: import-shadowing
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#imports-blocklist
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#imports-blocklist
       - name: imports-blocklist
         severity: warning
         disabled: false
@@ -2650,99 +2650,99 @@ linters-settings:
         arguments:
           - "crypto/md5"
           - "crypto/sha1"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#increment-decrement
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#increment-decrement
       - name: increment-decrement
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#indent-error-flow
       - name: indent-error-flow
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "preserveScope"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#line-length-limit
       - name: line-length-limit
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 80 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-control-nesting
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#max-control-nesting
       - name: max-control-nesting
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#max-public-structs
       - name: max-public-structs
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-parameter
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#modifies-parameter
       - name: modifies-parameter
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-value-receiver
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#modifies-value-receiver
       - name: modifies-value-receiver
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#nested-structs
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#nested-structs
       - name: nested-structs
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#optimize-operands-order
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
       - name: optimize-operands-order
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#package-comments
       - name: package-comments
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#range
       - name: range
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#range-val-address
       - name: range-val-address
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#range-val-in-closure
       - name: range-val-in-closure
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#receiver-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#receiver-naming
       - name: receiver-naming
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - maxLength: 2
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redefines-builtin-id
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#redefines-builtin-id
       - name: redefines-builtin-id
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-build-tag
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#redundant-build-tag
       - name: redundant-build-tag
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#redundant-import-alias
       - name: redundant-import-alias
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#string-format
       - name: string-format
         severity: warning
         disabled: false
@@ -2757,12 +2757,12 @@ linters-settings:
           - - panic
             - '/^[^\n]*$/'
             - must not contain line breaks
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-of-int
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#string-of-int
       - name: string-of-int
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#struct-tag
       - name: struct-tag
         severity: warning
         disabled: false
@@ -2770,46 +2770,46 @@ linters-settings:
         arguments:
           - "json,inline"
           - "bson,outline,gnu"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#superfluous-else
       - name: superfluous-else
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "preserveScope"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#time-equal
       - name: time-equal
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#time-naming
       - name: time-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unchecked-type-assertion
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unchecked-type-assertion
       - name: unchecked-type-assertion
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - acceptIgnoredAssertionResult: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unconditional-recursion
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unconditional-recursion
       - name: unconditional-recursion
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unexported-naming
       - name: unexported-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unexported-return
       - name: unexported-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unhandled-error
       - name: unhandled-error
         severity: warning
         disabled: false
@@ -2817,51 +2817,51 @@ linters-settings:
         arguments:
           - "fmt.Printf"
           - "myFunction"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unnecessary-stmt
       - name: unnecessary-stmt
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unreachable-code
       - name: unreachable-code
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-parameter
       - name: unused-parameter
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - allowRegex: "^_"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-receiver
       - name: unused-receiver
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - allowRegex: "^_"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#use-any
       - name: use-any
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-errors-new
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#use-errors-new
       - name: use-errors-new
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#useless-break
       - name: useless-break
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-declaration
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-declaration
       - name: var-declaration
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-naming
       - name: var-naming
         severity: warning
         disabled: false
@@ -2870,7 +2870,7 @@ linters-settings:
           - [ "ID" ] # AllowList
           - [ "VM" ] # DenyList
           - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#waitgroup-by-value
       - name: waitgroup-by-value
         severity: warning
         disabled: false
@@ -3814,45 +3814,45 @@ linters-settings:
     # Do strict checking when assigning from append (x = append(x, y)).
     # If this is set to true - the append call must append either a variable
     # assigned, called or used on the line above.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#strict-append
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#strict-append
     # Default: true
     strict-append: false
 
     # Allows assignments to be cuddled with variables used in calls on
     # line above and calls to be cuddled with assignments of variables
     # used in call on line above.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-assign-and-call
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-assign-and-call
     # Default: true
     allow-assign-and-call: false
 
     # Allows assignments to be cuddled with anything.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-assign-and-anything
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-assign-and-anything
     # Default: false
     allow-assign-and-anything: true
 
     # Allows cuddling to assignments even if they span over multiple lines.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-multiline-assign
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-multiline-assign
     # Default: true
     allow-multiline-assign: false
 
     # If the number of lines in a case block is equal to or lager than this number,
     # the case *must* end white a newline.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#force-case-trailing-whitespace
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#force-case-trailing-whitespace
     # Default: 0
     force-case-trailing-whitespace: 1
 
     # Allow blocks to end with comments.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-trailing-comment
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-trailing-comment
     # Default: false
     allow-trailing-comment: true
 
     # Allow multiple comments in the beginning of a block separated with newline.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-separated-leading-comment
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-separated-leading-comment
     # Default: false
     allow-separated-leading-comment: true
 
     # Allow multiple var/declaration statements to be cuddled.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-cuddle-declarations
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-cuddle-declarations
     # Default: false
     allow-cuddle-declarations: true
 
@@ -3867,7 +3867,7 @@ linters-settings:
 
     # Causes an error when an If statement that checks an error variable doesn't
     # cuddle with the assignment of that variable.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#force-err-cuddling
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#force-err-cuddling
     # Default: false
     force-err-cuddling: true
 
@@ -3879,7 +3879,7 @@ linters-settings:
     # Causes an error if a short declaration (:=) cuddles with anything other than
     # another short declaration.
     # This logic overrides force-err-cuddling among others.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#force-short-decl-cuddling
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#force-short-decl-cuddling
     # Default: false
     force-short-decl-cuddling: true
 

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2373,7 +2373,7 @@ linters-settings:
     confidence: 0.1
 
     rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#add-constant
       - name: add-constant
         severity: warning
         disabled: false
@@ -2383,50 +2383,50 @@ linters-settings:
             allowStrs: '""'
             allowInts: "0,1,2"
             allowFloats: "0.0,0.,1.0,1.,2.0,2."
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#argument-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#argument-limit
       - name: argument-limit
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 4 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#atomic
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#atomic
       - name: atomic
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#banned-characters
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#banned-characters
       - name: banned-characters
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ "Ω","Σ","σ", "7" ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bare-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#bare-return
       - name: bare-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#blank-imports
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#blank-imports
       - name: blank-imports
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#bool-literal-in-expr
       - name: bool-literal-in-expr
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#call-to-gc
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#call-to-gc
       - name: call-to-gc
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cognitive-complexity
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#cognitive-complexity
       - name: cognitive-complexity
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 7 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comment-spacings
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#comment-spacings
       - name: comment-spacings
         severity: warning
         disabled: false
@@ -2434,132 +2434,132 @@ linters-settings:
         arguments:
           - mypragma
           - otherpragma
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#comments-density
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#comments-density
       - name: comments-density
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 15 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#confusing-naming
       - name: confusing-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-results
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#confusing-results
       - name: confusing-results
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#constant-logical-expr
       - name: constant-logical-expr
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-as-argument
       - name: context-as-argument
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - allowTypesBefore: "*testing.T,*github.com/user/repo/testing.Harness"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-keys-type
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#context-keys-type
       - name: context-keys-type
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#cyclomatic
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#cyclomatic
       - name: cyclomatic
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#datarace
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#datarace
       - name: datarace
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#deep-exit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#deep-exit
       - name: deep-exit
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#defer
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#defer
       - name: defer
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - [ "call-chain", "loop" ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#dot-imports
       - name: dot-imports
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#duplicated-imports
       - name: duplicated-imports
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return
       - name: early-return
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "preserveScope"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#empty-block
       - name: empty-block
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#empty-lines
       - name: empty-lines
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-map-style
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-map-style
       - name: enforce-map-style
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "make"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style
       - name: enforce-repeated-arg-type-style
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "short"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-slice-style
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#enforce-slice-style
       - name: enforce-slice-style
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "make"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-naming
       - name: error-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-return
       - name: error-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#error-strings
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-strings
       - name: error-strings
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#errorf
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#errorf
       - name: errorf
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#exported
       - name: exported
         severity: warning
         disabled: false
@@ -2569,14 +2569,14 @@ linters-settings:
           - "disableStutteringCheck"
           - "checkPublicInterface"
           - "disableChecksOnFunctions"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#file-header
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#file-header
       - name: file-header
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - This is the text that must appear at the top of source files.
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#file-length-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#file-length-limit
       - name: file-length-limit
         severity: warning
         disabled: false
@@ -2585,58 +2585,58 @@ linters-settings:
           - max: 100
             skipComments: true
             skipBlankLines: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#filename-format
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#filename-format
       - name: filename-format
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "^[_a-z][_a-z0-9]*.go$"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#flag-parameter
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#flag-parameter
       - name: flag-parameter
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-length
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#function-length
       - name: function-length
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 10, 0 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#function-result-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#function-result-limit
       - name: function-result-limit
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#get-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#get-return
       - name: get-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#identical-branches
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#identical-branches
       - name: identical-branches
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#if-return
       - name: if-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-alias-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#import-alias-naming
       - name: import-alias-naming
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "^[a-z][a-z0-9]{0,}$"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#import-shadowing
       - name: import-shadowing
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#imports-blocklist
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#imports-blocklist
       - name: imports-blocklist
         severity: warning
         disabled: false
@@ -2644,94 +2644,94 @@ linters-settings:
         arguments:
           - "crypto/md5"
           - "crypto/sha1"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#increment-decrement
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#increment-decrement
       - name: increment-decrement
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#indent-error-flow
       - name: indent-error-flow
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "preserveScope"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#line-length-limit
       - name: line-length-limit
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 80 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-control-nesting
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#max-control-nesting
       - name: max-control-nesting
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#max-public-structs
       - name: max-public-structs
         severity: warning
         disabled: false
         exclude: [""]
         arguments: [ 3 ]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-parameter
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#modifies-parameter
       - name: modifies-parameter
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#modifies-value-receiver
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#modifies-value-receiver
       - name: modifies-value-receiver
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#nested-structs
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#nested-structs
       - name: nested-structs
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#optimize-operands-order
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#optimize-operands-order
       - name: optimize-operands-order
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#package-comments
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#package-comments
       - name: package-comments
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#range
       - name: range
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-address
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#range-val-address
       - name: range-val-address
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#range-val-in-closure
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#range-val-in-closure
       - name: range-val-in-closure
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#receiver-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#receiver-naming
       - name: receiver-naming
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - maxLength: 2
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redefines-builtin-id
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#redefines-builtin-id
       - name: redefines-builtin-id
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#redundant-import-alias
       - name: redundant-import-alias
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#string-format
       - name: string-format
         severity: warning
         disabled: false
@@ -2746,12 +2746,12 @@ linters-settings:
           - - panic
             - '/^[^\n]*$/'
             - must not contain line breaks
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-of-int
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#string-of-int
       - name: string-of-int
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#struct-tag
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#struct-tag
       - name: struct-tag
         severity: warning
         disabled: false
@@ -2759,46 +2759,46 @@ linters-settings:
         arguments:
           - "json,inline"
           - "bson,outline,gnu"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#superfluous-else
       - name: superfluous-else
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - "preserveScope"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-equal
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#time-equal
       - name: time-equal
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#time-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#time-naming
       - name: time-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unchecked-type-assertion
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unchecked-type-assertion
       - name: unchecked-type-assertion
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - acceptIgnoredAssertionResult: true
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unconditional-recursion
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unconditional-recursion
       - name: unconditional-recursion
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unexported-naming
       - name: unexported-naming
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unexported-return
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unexported-return
       - name: unexported-return
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unhandled-error
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unhandled-error
       - name: unhandled-error
         severity: warning
         disabled: false
@@ -2806,46 +2806,46 @@ linters-settings:
         arguments:
           - "fmt.Printf"
           - "myFunction"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unnecessary-stmt
       - name: unnecessary-stmt
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unreachable-code
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unreachable-code
       - name: unreachable-code
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-parameter
       - name: unused-parameter
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - allowRegex: "^_"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-receiver
       - name: unused-receiver
         severity: warning
         disabled: false
         exclude: [""]
         arguments:
           - allowRegex: "^_"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#use-any
       - name: use-any
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#useless-break
       - name: useless-break
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-declaration
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-declaration
       - name: var-declaration
         severity: warning
         disabled: false
         exclude: [""]
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-naming
       - name: var-naming
         severity: warning
         disabled: false
@@ -2854,7 +2854,7 @@ linters-settings:
           - [ "ID" ] # AllowList
           - [ "VM" ] # DenyList
           - - upperCaseConst: true # Extra parameter (upperCaseConst|skipPackageNameChecks)
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#waitgroup-by-value
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#waitgroup-by-value
       - name: waitgroup-by-value
         severity: warning
         disabled: false
@@ -3798,45 +3798,45 @@ linters-settings:
     # Do strict checking when assigning from append (x = append(x, y)).
     # If this is set to true - the append call must append either a variable
     # assigned, called or used on the line above.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#strict-append
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#strict-append
     # Default: true
     strict-append: false
 
     # Allows assignments to be cuddled with variables used in calls on
     # line above and calls to be cuddled with assignments of variables
     # used in call on line above.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-assign-and-call
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-assign-and-call
     # Default: true
     allow-assign-and-call: false
 
     # Allows assignments to be cuddled with anything.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-assign-and-anything
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-assign-and-anything
     # Default: false
     allow-assign-and-anything: true
 
     # Allows cuddling to assignments even if they span over multiple lines.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-multiline-assign
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-multiline-assign
     # Default: true
     allow-multiline-assign: false
 
     # If the number of lines in a case block is equal to or lager than this number,
     # the case *must* end white a newline.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#force-case-trailing-whitespace
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#force-case-trailing-whitespace
     # Default: 0
     force-case-trailing-whitespace: 1
 
     # Allow blocks to end with comments.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-trailing-comment
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-trailing-comment
     # Default: false
     allow-trailing-comment: true
 
     # Allow multiple comments in the beginning of a block separated with newline.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-separated-leading-comment
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-separated-leading-comment
     # Default: false
     allow-separated-leading-comment: true
 
     # Allow multiple var/declaration statements to be cuddled.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#allow-cuddle-declarations
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#allow-cuddle-declarations
     # Default: false
     allow-cuddle-declarations: true
 
@@ -3851,7 +3851,7 @@ linters-settings:
 
     # Causes an error when an If statement that checks an error variable doesn't
     # cuddle with the assignment of that variable.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#force-err-cuddling
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#force-err-cuddling
     # Default: false
     force-err-cuddling: true
 
@@ -3863,7 +3863,7 @@ linters-settings:
     # Causes an error if a short declaration (:=) cuddles with anything other than
     # another short declaration.
     # This logic overrides force-err-cuddling among others.
-    # https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#force-short-decl-cuddling
+    # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#force-short-decl-cuddling
     # Default: false
     force-short-decl-cuddling: true
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -127,8 +127,8 @@ chocolateys:
     authors: golangci
     copyright: 2024 GolangCI
     url_template: "https://github.com/golangci/golangci-lint/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    icon_url: "https://cdn.rawgit.com/golangci/golangci-lint/master/assets/go.png"
-    license_url: https://github.com/golangci/golangci-lint/blob/master/LICENSE
+    icon_url: "https://cdn.rawgit.com/golangci/golangci-lint/HEAD/assets/go.png"
+    license_url: https://github.com/golangci/golangci-lint/blob/HEAD/LICENSE
     require_license_acceptance: false
     project_source_url: https://github.com/golangci/golangci-lint
     package_source_url: https://github.com/golangci/golangci-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,7 +309,7 @@ Cancelled due to a CI problem.
    * Don't hide `typecheck` errors inside diff processor
 5. Misc.
    * ⚠️ log an error when using previously deprecated linters ([Linter Deprecation Cycle](https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle))
-      * [`deadcode`](https://github.com/remyoudompheng/go-misc/tree/master/deadcode): deprecated since v1.49.0 (2022-08-23).
+      * [`deadcode`](https://github.com/remyoudompheng/go-misc/tree/HEAD/deadcode): deprecated since v1.49.0 (2022-08-23).
       * [`exhaustivestruct`](https://github.com/mbilski/exhaustivestruct): deprecated since v1.46.0 (2022-05-08).
       * [`golint`](https://github.com/golang/lint): deprecated since v1.41.0 (2021-06-15).
       * [`ifshort`](https://github.com/esimonov/ifshort): deprecated since v1.48.0 (2022-08-04).

--- a/assets/linters-info.json
+++ b/assets/linters-info.json
@@ -639,7 +639,7 @@
     "alternativeNames": [
       "megacheck"
     ],
-    "originalURL": "https://github.com/dominikh/go-tools/tree/master/simple",
+    "originalURL": "https://github.com/dominikh/go-tools/tree/HEAD/simple",
     "internal": false,
     "canAutoFix": true,
     "isSlow": true,
@@ -1167,7 +1167,7 @@
     "inPresets": [
       "style"
     ],
-    "originalURL": "https://github.com/dominikh/go-tools/tree/master/stylecheck",
+    "originalURL": "https://github.com/dominikh/go-tools/tree/HEAD/stylecheck",
     "internal": false,
     "canAutoFix": true,
     "isSlow": true,
@@ -1318,7 +1318,7 @@
     "alternativeNames": [
       "megacheck"
     ],
-    "originalURL": "https://github.com/dominikh/go-tools/tree/master/unused",
+    "originalURL": "https://github.com/dominikh/go-tools/tree/HEAD/unused",
     "internal": false,
     "isSlow": true,
     "doesChangeTypes": true,
@@ -1432,7 +1432,7 @@
     "inPresets": [
       "style"
     ],
-    "originalURL": "https://github.com/golangci/golangci-lint/tree/master/pkg/golinters/nolintlint/internal",
+    "originalURL": "https://github.com/golangci/golangci-lint/tree/HEAD/pkg/golinters/nolintlint/internal",
     "internal": false,
     "canAutoFix": true,
     "isSlow": false,

--- a/docs/src/components/SearchBar/README.md
+++ b/docs/src/components/SearchBar/README.md
@@ -1,3 +1,3 @@
-The source code copy-pasted from [here](https://github.com/facebook/docusaurus/blob/master/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/).
+The source code copy-pasted from [here](https://github.com/facebook/docusaurus/blob/HEAD/packages/docusaurus-theme-search-algolia/src/theme/SearchBar/).
 
 Waiting for [the official component](https://github.com/algolia/docsearch/issues/689).

--- a/docs/src/docs/contributing/debug.mdx
+++ b/docs/src/docs/contributing/debug.mdx
@@ -11,7 +11,7 @@ golangci-lint run -v
 If you would like to see more detailed logs you can use the environment variable `GL_DEBUG`.
 Its value is a list of debug tags.
 
-The existing debug tags are documented in the following file: https://github.com/golangci/golangci-lint/blob/master/pkg/logutils/logutils.go
+The existing debug tags are documented in the following file: https://github.com/golangci/golangci-lint/blob/HEAD/pkg/logutils/logutils.go
 
 For example:
 

--- a/docs/src/docs/contributing/faq.mdx
+++ b/docs/src/docs/contributing/faq.mdx
@@ -19,8 +19,8 @@ No pull requests to update a linter will be accepted unless you are the author o
 
 ## How to add a configuration option to an existing linter
 
-Add a new field to the [linter settings struct](https://github.com/golangci/golangci-lint/blob/master/pkg/config/linters_settings.go).
-Document it in [.golangci.next.reference.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.next.reference.yml).
+Add a new field to the [linter settings struct](https://github.com/golangci/golangci-lint/blob/HEAD/pkg/config/linters_settings.go).
+Document it in [.golangci.next.reference.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.next.reference.yml).
 Pass it to the linter.
 
 ## How to see `INFO` or `DEBUG` logs

--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -19,16 +19,16 @@ After that:
 2. Add a new file `pkg/golinters/{yourlintername}/{yourlintername}.go`.
    Other linters implementation can help you.
 3. Add the new struct for the linter (which you've implemented in `pkg/golinters/{yourlintername}/{yourlintername}.go`) to the
-   list of all supported linters in [`pkg/lint/lintersdb/builder_linter.go`](https://github.com/golangci/golangci-lint/blob/master/pkg/lint/lintersdb/builder_linter.go)
+   list of all supported linters in [`pkg/lint/lintersdb/builder_linter.go`](https://github.com/golangci/golangci-lint/blob/HEAD/pkg/lint/lintersdb/builder_linter.go)
    to the method `LinterBuilder.Build`.
     - Add `WithSince("next_version")`, where `next_version` must be replaced by the next minor version. (ex: v1.2.0 if the current version is v1.1.0)
 4. Find out what options do you need to configure for the linter.
-   For example, `nakedret` has only 1 option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml).
+   For example, `nakedret` has only 1 option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml).
    Choose default values to not being annoying for users of golangci-lint. Add configuration options to:
-    - [.golangci.next.reference.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.next.reference.yml): the example of a configuration file.
-      You can also add them to [.golangci.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.yml)
+    - [.golangci.next.reference.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.next.reference.yml): the example of a configuration file.
+      You can also add them to [.golangci.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.yml)
       if you think that this project needs not default values.
-    - [config struct](https://github.com/golangci/golangci-lint/blob/master/pkg/config/config.go):
+    - [config struct](https://github.com/golangci/golangci-lint/blob/HEAD/pkg/config/config.go):
       don't forget about `mapstructure` tags for proper configuration files parsing.
 5. Take a look at the example of [pull requests with new linter support](https://github.com/golangci/golangci-lint/pulls?q=is%3Apr+is%3Amerged+label%3A%22linter%3A+new%22).
 6. Run the tests:

--- a/docs/src/docs/contributing/workflow.mdx
+++ b/docs/src/docs/contributing/workflow.mdx
@@ -47,17 +47,17 @@ Push your branch to your `golangci-lint` fork and open a pull request against th
 
 First, please, accept [CLA](https://gist.github.com/jirfag/26a39fd375da84b2d5ad4296fecb0668) - [CLA assistant](https://cla-assistant.io/) will make a comment on the pull request about it.
 
-Also, we run a few checks in CI by using GitHub Actions, you can see them [here](https://github.com/golangci/golangci-lint/blob/master/.github/workflows/pr.yml).
+Also, we run a few checks in CI by using GitHub Actions, you can see them [here](https://github.com/golangci/golangci-lint/blob/HEAD/.github/workflows/pr.yml).
 
 ## New releases
 
 First, see [our versioning policy](/product/roadmap/#versioning-policy).
 
 To make a new release create a tag `vx.y.z`. Don't forget to add zero patch version for a new minor release, e.g. `v1.99.0`.
-A GitHub Action [workflow](https://github.com/golangci/golangci-lint/blob/master/.github/workflows/tag.yml) will start building and publishing release after that.
+A GitHub Action [workflow](https://github.com/golangci/golangci-lint/blob/HEAD/.github/workflows/tag.yml) will start building and publishing release after that.
 
 After making a release you need to update
-GitHub [Action config](https://github.com/golangci/golangci-lint/blob/master/assets/github-action-config.json) by running:
+GitHub [Action config](https://github.com/golangci/golangci-lint/blob/HEAD/assets/github-action-config.json) by running:
 ```sh
 make assets/github-action-config.json
 ```

--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -5,7 +5,7 @@ title: Introduction
 import { FaTwitter, FaSlack } from "react-icons/fa";
 import { IconContainer } from "lib/icons";
 
-[![License](https://img.shields.io/github/license/golangci/golangci-lint)](https://github.com/golangci/golangci-lint/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/golangci/golangci-lint)](https://github.com/golangci/golangci-lint/blob/HEAD/LICENSE)
 [![Release](https://img.shields.io/github/release/golangci/golangci-lint.svg)](https://github.com/golangci/golangci-lint/releases/latest)
 [![Docker](https://img.shields.io/docker/pulls/golangci/golangci-lint)](https://hub.docker.com/r/golangci/golangci-lint)
 [![GitHub Releases Stats of golangci-lint](https://img.shields.io/github/downloads/golangci/golangci-lint/total.svg?logo=github)](https://somsubhra.github.io/github-release-stats/?username=golangci&repository=golangci-lint)

--- a/docs/src/docs/plugins/go-plugins.mdx
+++ b/docs/src/docs/plugins/go-plugins.mdx
@@ -30,7 +30,7 @@ func New(conf any) ([]*analysis.Analyzer, error) {
 }
 ```
 
-See [plugin/example.go](https://github.com/golangci/example-plugin-linter/blob/master/plugin/example.go) for more info.
+See [plugin/example.go](https://github.com/golangci/example-plugin-linter/blob/HEAD/plugin/example.go) for more info.
 
 To build the plugin, from the root project directory, run:
 ```bash
@@ -47,7 +47,7 @@ An example linter can be found at [here](https://github.com/golangci/example-plu
 
 If you're looking for instructions on how to configure your own custom linter, they can be found further down.
 
-1. If the project you want to lint does not have one already, copy the [.golangci.yml](https://github.com/golangci/golangci-lint/blob/master/.golangci.yml) to the root directory.
+1. If the project you want to lint does not have one already, copy the [.golangci.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.yml) to the root directory.
 2. Adjust the YAML to appropriate `linters-settings.custom` entries as so:
   ```yaml title=.golangci.yml
   linters-settings:

--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -28,7 +28,7 @@ To see which config file is being used and where it was sourced from run golangc
 Config options inside the file are identical to command-line options.
 You can configure specific linters' options only within the config file (not the command-line).
 
-There is a [`.golangci.reference.yml`](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml) file with all supported options, their description, and default values.
+There is a [`.golangci.reference.yml`](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml) file with all supported options, their description, and default values.
 This file is neither a working example nor a recommended configuration, it's just a reference to display all the configuration options.
 
 The configuration file can be validated with the JSON Schema: https://golangci-lint.run/jsonschema/golangci.jsonschema.json

--- a/docs/src/docs/usage/false-positives.mdx
+++ b/docs/src/docs/usage/false-positives.mdx
@@ -165,7 +165,7 @@ func someLegacyFunction() *string {
 }
 ```
 
-You can see more examples of using `//nolint` in [our tests](https://github.com/golangci/golangci-lint/tree/master/pkg/result/processors/testdata) for it.
+You can see more examples of using `//nolint` in [our tests](https://github.com/golangci/golangci-lint/tree/HEAD/pkg/result/processors/testdata) for it.
 
 Use `//nolint` instead of `// nolint` because machine-readable comments should have no space by Go convention.
 

--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -31,13 +31,13 @@ Here is the other way to install golangci-lint:
 
 ```sh
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
 
 # or install it into ./bin/
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s {.LatestVersion}
 
 # In Alpine Linux (as it does not come with curl by default)
-wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s {.LatestVersion}
+wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s {.LatestVersion}
 
 golangci-lint --version
 ```
@@ -53,7 +53,7 @@ and is constantly being improved. For any problems with `golangci-lint`, check o
 
 ```sh
 # binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin {.LatestVersion}
 
 golangci-lint --version
 ```

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,7 @@ cat /dev/null <<EOF
 ------------------------------------------------------------------------
 https://github.com/client9/shlib - portable posix shell functions
 Public domain - http://unlicense.org
-https://github.com/client9/shlib/blob/master/LICENSE.md
+https://github.com/client9/shlib/blob/HEAD/LICENSE.md
 but credit (and pull requests) appreciated.
 ------------------------------------------------------------------------
 EOF

--- a/pkg/golinters/gocritic/testdata/ruleguard/README.md
+++ b/pkg/golinters/gocritic/testdata/ruleguard/README.md
@@ -3,4 +3,4 @@ This directory contains ruleguard files that are used in functional tests.
 Helpful:
 
 - https://go-critic.com/overview.html
-- https://github.com/go-critic/go-critic/blob/master/checkers/rules/rules.go
+- https://github.com/go-critic/go-critic/blob/HEAD/checkers/rules/rules.go

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -198,7 +198,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		linter.NewConfig(linter.NewNoopDeprecated("deadcode", cfg, linter.DeprecationError)).
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetUnused).
-			WithURL("https://github.com/remyoudompheng/go-misc/tree/master/deadcode").
+			WithURL("https://github.com/remyoudompheng/go-misc/tree/HEAD/deadcode").
 			DeprecatedError("The owner seems to have abandoned the linter.", "v1.49.0", "unused"),
 
 		linter.NewConfig(depguard.New(&cfg.LintersSettings.Depguard, cfg.GetBasePath())).
@@ -464,7 +464,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetStyle).
 			WithAlternativeNames(megacheckName).
 			WithAutoFix().
-			WithURL("https://github.com/dominikh/go-tools/tree/master/simple"),
+			WithURL("https://github.com/dominikh/go-tools/tree/HEAD/simple"),
 
 		linter.NewConfig(gosmopolitan.New(&cfg.LintersSettings.Gosmopolitan)).
 			WithSince("v1.53.0").
@@ -751,7 +751,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithPresets(linter.PresetStyle).
 			WithAutoFix().
-			WithURL("https://github.com/dominikh/go-tools/tree/master/stylecheck"),
+			WithURL("https://github.com/dominikh/go-tools/tree/HEAD/stylecheck"),
 
 		linter.NewConfig(tagalign.New(&cfg.LintersSettings.TagAlign)).
 			WithSince("v1.53.0").
@@ -826,7 +826,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithAlternativeNames(megacheckName).
 			ConsiderSlow().
 			WithChangeTypes().
-			WithURL("https://github.com/dominikh/go-tools/tree/master/unused"),
+			WithURL("https://github.com/dominikh/go-tools/tree/HEAD/unused"),
 
 		linter.NewConfig(usestdlibvars.New(&cfg.LintersSettings.UseStdlibVars)).
 			WithSince("v1.48.0").
@@ -888,6 +888,6 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.26.0").
 			WithPresets(linter.PresetStyle).
 			WithAutoFix().
-			WithURL("https://github.com/golangci/golangci-lint/tree/master/pkg/golinters/nolintlint/internal"),
+			WithURL("https://github.com/golangci/golangci-lint/tree/HEAD/pkg/golinters/nolintlint/internal"),
 	}, nil
 }

--- a/pkg/printers/codeclimate.go
+++ b/pkg/printers/codeclimate.go
@@ -11,7 +11,7 @@ import (
 const defaultCodeClimateSeverity = "critical"
 
 // CodeClimate prints issues in the Code Climate format.
-// https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md
+// https://github.com/codeclimate/platform/blob/HEAD/spec/analyzers/SPEC.md
 type CodeClimate struct {
 	log       logutils.Log
 	w         io.Writer
@@ -23,7 +23,7 @@ func NewCodeClimate(log logutils.Log, w io.Writer) *CodeClimate {
 		log: log.Child(logutils.DebugKeyCodeClimatePrinter),
 		w:   w,
 		sanitizer: severitySanitizer{
-			// https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
+			// https://github.com/codeclimate/platform/blob/HEAD/spec/analyzers/SPEC.md#data-types
 			allowedSeverities: []string{"info", "minor", "major", defaultCodeClimateSeverity, "blocker"},
 			defaultSeverity:   defaultCodeClimateSeverity,
 		},
@@ -58,7 +58,7 @@ func (p *CodeClimate) Print(issues []result.Issue) error {
 }
 
 // codeClimateIssue is a subset of the Code Climate spec.
-// https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
+// https://github.com/codeclimate/platform/blob/HEAD/spec/analyzers/SPEC.md#data-types
 // It is just enough to support GitLab CI Code Quality.
 // https://docs.gitlab.com/ee/ci/testing/code_quality.html#code-quality-report-format
 type codeClimateIssue struct {

--- a/scripts/bench/bench_local.sh
+++ b/scripts/bench/bench_local.sh
@@ -33,7 +33,7 @@ trap cleanBinaries EXIT
 
 ## Download version
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "./temp-${VERSION}" "${VERSION}"
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "./temp-${VERSION}" "${VERSION}"
 
 mv "temp-${VERSION}/golangci-lint" "./golangci-lint-${VERSION}"
 rm -rf "temp-${VERSION}"

--- a/scripts/bench/bench_version.sh
+++ b/scripts/bench/bench_version.sh
@@ -37,7 +37,7 @@ trap cleanBinaries EXIT
 function install() {
   local VERSION=$1
 
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "./temp-${VERSION}" "${VERSION}"
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "./temp-${VERSION}" "${VERSION}"
 
   mv "temp-${VERSION}/golangci-lint" "./golangci-lint-${VERSION}"
   rm -rf "temp-${VERSION}"


### PR DESCRIPTION
For external references, this has the advantage of not breaking if a project changes its default branch.
For internal references, it allows us to change the default branch.

More changes are required to change the default branch, and this PR doesn't imply a change of the default branch.
This can be useful to handle v2.

Related to #4866
