### PR TITLE
dev: introduce deprecated functions with reasons

### DIFF
--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -136,7 +136,19 @@ func (lc *Config) DeprecatedWarning(message, version, replacement string) *Confi
 	return lc.Deprecated(message, version, replacement, DeprecationWarning)
 }
 
-func (lc *Config) DeprecatedError(message, version, replacement string) *Config {
+func (lc *Config) DeprecatedBecauseAbandoned(version, replacement string) *Config {
+	return lc.deprecatedError("The owner seems to have abandoned the linter.", version, replacement)
+}
+
+func (lc *Config) DeprecatedBecauseArchived(version, replacement string) *Config {
+	return lc.deprecatedError("The repository of the linter has been archived by the owner.", version, replacement)
+}
+
+func (lc *Config) DeprecatedBecauseRenamed(version, replacement string) *Config {
+	return lc.deprecatedError("The linter has been renamed.", version, replacement)
+}
+
+func (lc *Config) deprecatedError(message, version, replacement string) *Config {
 	return lc.Deprecated(message, version, replacement, DeprecationError)
 }
 

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -199,7 +199,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetUnused).
 			WithURL("https://github.com/remyoudompheng/go-misc/tree/HEAD/deadcode").
-			DeprecatedError("The owner seems to have abandoned the linter.", "v1.49.0", "unused"),
+			DeprecatedBecauseAbandoned("v1.49.0", "unused"),
 
 		linter.NewConfig(depguard.New(&cfg.LintersSettings.Depguard, cfg.GetBasePath())).
 			WithSince("v1.4.0").
@@ -258,7 +258,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.46.0").
 			WithPresets(linter.PresetSQL).
 			WithURL("https://github.com/1uf3/execinquery").
-			DeprecatedError("The repository of the linter has been archived by the owner.", "v1.58.0", ""),
+			DeprecatedBecauseArchived("v1.58.0", ""),
 
 		linter.NewConfig(exhaustive.New(&cfg.LintersSettings.Exhaustive)).
 			WithSince(" v1.28.0").
@@ -270,7 +270,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.32.0").
 			WithPresets(linter.PresetStyle, linter.PresetTest).
 			WithURL("https://github.com/mbilski/exhaustivestruct").
-			DeprecatedError("The repository of the linter has been deprecated by the owner.", "v1.46.0", "exhaustruct"),
+			DeprecatedBecauseArchived("v1.46.0", "exhaustruct"),
 
 		linter.NewConfig(exhaustruct.New(&cfg.LintersSettings.Exhaustruct)).
 			WithSince("v1.46.0").
@@ -283,7 +283,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetBugs).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kyoh86/exportloopref").
-			DeprecatedWarning("Since Go1.22 (loopvar) this linter is no longer relevant.", "v1.60.2", "copyloopvar"),
+			DeprecatedWarning("Since Go 1.22 (loopvar) this linter is no longer relevant.", "v1.60.2", "copyloopvar"),
 
 		linter.NewConfig(exptostd.New()).
 			WithSince("v1.63.0").
@@ -422,7 +422,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/golang/lint").
-			DeprecatedError("The repository of the linter has been archived by the owner.", "v1.41.0", "revive"),
+			DeprecatedBecauseArchived("v1.41.0", "revive"),
 
 		linter.NewConfig(mnd.New(&cfg.LintersSettings.Mnd)).
 			WithSince("v1.22.0").
@@ -433,7 +433,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.22.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/tommy-muehle/go-mnd").
-			DeprecatedError("The linter has been renamed.", "v1.58.0", "mnd"),
+			DeprecatedBecauseRenamed("v1.58.0", "mnd"),
 
 		linter.NewConfig(gomoddirectives.New(&cfg.LintersSettings.GoModDirectives)).
 			WithSince("v1.39.0").
@@ -490,7 +490,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.36.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/esimonov/ifshort").
-			DeprecatedError("The repository of the linter has been deprecated by the owner.", "v1.48.0", ""),
+			DeprecatedBecauseArchived("v1.48.0", ""),
 
 		linter.NewConfig(iface.New(&cfg.LintersSettings.Iface)).
 			WithSince("v1.62.0").
@@ -526,7 +526,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/mvdan/interfacer").
-			DeprecatedError("The repository of the linter has been archived by the owner.", "v1.38.0", ""),
+			DeprecatedBecauseArchived("v1.38.0", ""),
 
 		linter.NewConfig(intrange.New()).
 			WithSince("v1.57.0").
@@ -568,7 +568,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetPerformance).
 			WithURL("https://github.com/mdempsky/maligned").
-			DeprecatedError("The repository of the linter has been archived by the owner.", "v1.38.0", "govet 'fieldalignment'"),
+			DeprecatedBecauseArchived("v1.38.0", "govet 'fieldalignment'"),
 
 		linter.NewConfig(mirror.New()).
 			WithSince("v1.53.0").
@@ -640,7 +640,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.47.0").
 			WithPresets(linter.PresetStyle).
 			WithURL("https://github.com/sivchari/nosnakecase").
-			DeprecatedError("The repository of the linter has been deprecated by the owner.", "v1.48.1", "revive 'var-naming'"),
+			DeprecatedBecauseArchived("v1.48.1", "revive 'var-naming'"),
 
 		linter.NewConfig(nosprintfhostport.New()).
 			WithSince("v1.46.0").
@@ -717,7 +717,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.12.0").
 			WithPresets(linter.PresetBugs).
 			WithURL("https://github.com/kyoh86/scopelint").
-			DeprecatedError("The repository of the linter has been deprecated by the owner.", "v1.39.0", "exportloopref"),
+			DeprecatedBecauseArchived("v1.39.0", "exportloopref"),
 
 		linter.NewConfig(sqlclosecheck.New()).
 			WithSince("v1.28.0").
@@ -744,7 +744,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetUnused).
 			WithURL("https://github.com/opennota/check").
-			DeprecatedError("The owner seems to have abandoned the linter.", "v1.49.0", "unused"),
+			DeprecatedBecauseAbandoned("v1.49.0", "unused"),
 
 		linter.NewConfig(stylecheck.New(&cfg.LintersSettings.Stylecheck)).
 			WithSince("v1.20.0").
@@ -770,7 +770,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetTest).
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/sivchari/tenv").
-			DeprecatedWarning("Duplicate feature another linter.", "v1.64.0", "usetesting"),
+			DeprecatedWarning("Duplicate feature in another linter.", "v1.64.0", "usetesting"),
 
 		linter.NewConfig(testableexamples.New()).
 			WithSince("v1.50.0").
@@ -845,7 +845,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithPresets(linter.PresetUnused).
 			WithURL("https://github.com/opennota/check").
-			DeprecatedError("The owner seems to have abandoned the linter.", "v1.49.0", "unused"),
+			DeprecatedBecauseAbandoned("v1.49.0", "unused"),
 
 		linter.NewConfig(varnamelen.New(&cfg.LintersSettings.Varnamelen)).
 			WithSince("v1.43.0").


### PR DESCRIPTION
This PR introduces helper functions that wrap `DeprecatedError`.

There are only three reasons why the linter might be deprecated:

- The repository of the linter has been archived by the owner
- The owner seems to have abandoned the linter
- The linter has been renamed