### PR TITLE
Specify `go` and `toolchain` versions separately

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/golangci/golangci-lint
 
-go 1.23.0
+go 1.23
+
+toolchain go1.23.6
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1


### PR DESCRIPTION
That makes it easier to consume via 1.24's `go tool`.