### PR TITLE
gci: fix section parsing

### DIFF
--- a/pkg/goformatters/gci/internal/config/config.go
+++ b/pkg/goformatters/gci/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/daixiang0/gci/pkg/config"
 	"github.com/daixiang0/gci/pkg/section"
+	sectioni "github.com/golangci/golangci-lint/pkg/goformatters/gci/internal/section"
 )
 
 var defaultOrder = map[string]int{
@@ -39,12 +40,12 @@ type YamlConfig struct {
 func (g YamlConfig) Parse() (*Config, error) {
 	var err error
 
-	sections, err := section.Parse(g.SectionStrings)
+	sections, err := sectioni.Parse(g.SectionStrings)
 	if err != nil {
 		return nil, err
 	}
 	if sections == nil {
-		sections = section.DefaultSections()
+		sections = sectioni.DefaultSections()
 	}
 	if err := configureSections(sections, g.ModPath); err != nil {
 		return nil, err
@@ -63,7 +64,7 @@ func (g YamlConfig) Parse() (*Config, error) {
 		})
 	}
 
-	sectionSeparators, err := section.Parse(g.SectionSeparatorStrings)
+	sectionSeparators, err := sectioni.Parse(g.SectionSeparatorStrings)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/goformatters/gci/internal/section/section.go
+++ b/pkg/goformatters/gci/internal/section/section.go
@@ -1,0 +1,7 @@
+package section
+
+import "github.com/daixiang0/gci/pkg/section"
+
+func DefaultSections() section.SectionList {
+	return section.SectionList{Standard{}, section.Default{}}
+}

--- a/pkg/golinters/gci/testdata/gci_go124.go
+++ b/pkg/golinters/gci/testdata/gci_go124.go
@@ -1,0 +1,16 @@
+//go:build go1.24
+
+//golangcitest:args -Egci
+//golangcitest:expected_exitcode 0
+package testdata
+
+import (
+	"crypto/sha3"
+	"errors"
+	"fmt"
+)
+
+func _() {
+	fmt.Print(errors.New("x"))
+	sha3.New224()
+}


### PR DESCRIPTION
The modified versions of `section.Parse` and `section.DefaultSections` were not called.

Related to #5402