### PR TITLE
dev: prepare CI for v2

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - master
-      - main
+      # TODO(ldez): remove master and uncomment the next line when v2 will be released.
+      # - main
 
 jobs:
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          base: master
+          base: main
           token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
           branch-suffix: timestamp
           title: "docs: update GitHub Action assets"
@@ -58,7 +58,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          base: master
+          base: main
           token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
           branch-suffix: timestamp
           title: "docs: update documentation assets"

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -102,7 +102,7 @@ exports.createPages = ({ graphql, actions: { createPage }, reporter }) => {
 
       const githubEditUrl =
         githubUrl &&
-        `${githubUrl}/tree/master/${baseDir}/${docsPath}/${relativePath}`;
+        `${githubUrl}/tree/main/${baseDir}/${docsPath}/${relativePath}`;
 
       const currentPageIndex = listOfItems.findIndex(
         (page) => page.link === slug

--- a/docs/src/docs/contributing/website.mdx
+++ b/docs/src/docs/contributing/website.mdx
@@ -37,7 +37,7 @@ It runs script `scripts/website/expand_templates/` that rewrites `mdx` files wit
 
 We use GitHub Pages as static website hosting and CD.
 
-GitHub deploys the website to production after merging anything to a `master` branch.
+GitHub deploys the website to production after merging anything to a `main` branch.
 
 ## Local Testing
 

--- a/docs/src/docs/contributing/workflow.mdx
+++ b/docs/src/docs/contributing/workflow.mdx
@@ -41,7 +41,7 @@ Add your new or updated parameters to `.golangci.next.reference.yml` so they wil
 ## Submit a pull request
 
 Push your branch to your `golangci-lint` fork and open a pull request against the
-`master` branch.
+`main` branch.
 
 ## Pull request checks
 


### PR DESCRIPTION
Most feedback about go1.24/golangci-lint v1.64 is done, so it's time to move forward.

Instead of creating a branch `v2`, we will use a branch `main`.

There are several advantages:
- when the v2 is ready we will not have to merge the branch into `master`, we will just switch the default branch
- `main` is now standard: this is the git and GitHub default.
- a major version is the best moment to break things
- fixes #4866
- the branch `master` is still the default, so we can release v1 bug fixes.

Note: the branch `master` will not be deleted to avoid breaking old GitHub actions, I will just create a ruleset that blocks any updates of this branch.

The PR mainly disabled the publication of the doc for the branch `main`, and updated the documentation.

I will merge the other PRs after the merge of this one.