### PR TITLE
feat: golines formatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a
 	github.com/golangci/go-printf-func-name v0.1.0
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d
+	github.com/golangci/golines v0.0.0-20250217134842-442fd0091d95
 	github.com/golangci/misspell v0.6.0
 	github.com/golangci/plugin-module-register v0.1.1
 	github.com/golangci/revgrep v0.8.0
@@ -140,6 +141,7 @@ require (
 	github.com/ccojocar/zxcvbn-go v1.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chavacava/garif v0.1.0 // indirect
+	github.com/dave/dst v0.27.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,10 @@ github.com/curioswitch/go-reassign v0.3.0 h1:dh3kpQHuADL3cobV/sSGETA8DOv457dwl+f
 github.com/curioswitch/go-reassign v0.3.0/go.mod h1:nApPCCTtqLJN/s8HfItCcKV0jIPwluBOvZP+dsJGA88=
 github.com/daixiang0/gci v0.13.5 h1:kThgmH1yBmZSBCh1EJVxQ7JsHpm5Oms0AMed/0LaH4c=
 github.com/daixiang0/gci v0.13.5/go.mod h1:12etP2OniiIdP4q+kjUGrC/rUagga7ODbqsom5Eo5Yk=
+github.com/dave/dst v0.27.3 h1:P1HPoMza3cMEquVf9kKy8yXsFirry4zEnWOdYPOoIzY=
+github.com/dave/dst v0.27.3/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
+github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
+github.com/dave/jennifer v1.7.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -239,6 +243,8 @@ github.com/golangci/go-printf-func-name v0.1.0 h1:dVokQP+NMTO7jwO4bwsRwLWeudOVUP
 github.com/golangci/go-printf-func-name v0.1.0/go.mod h1:wqhWFH5mUdJQhweRnldEywnR5021wTdZSNgwYceV14s=
 github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d h1:viFft9sS/dxoYY0aiOTsLKO2aZQAPT4nlQCsimGcSGE=
 github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d/go.mod h1:ivJ9QDg0XucIkmwhzCDsqcnxxlDStoTl89jDMIoNxKY=
+github.com/golangci/golines v0.0.0-20250217134842-442fd0091d95 h1:AkK+w9FZBXlU/xUmBtSJN1+tAI4FIvy5WtnUnY8e4p8=
+github.com/golangci/golines v0.0.0-20250217134842-442fd0091d95/go.mod h1:k9mmcyWKSTMcPPvQUCfRWWQ9VHJ1U9Dc0R7kaXAgtnQ=
 github.com/golangci/misspell v0.6.0 h1:JCle2HUTNWirNlDIAUO44hUsKhOFqGPoC4LZxlaSXDs=
 github.com/golangci/misspell v0.6.0/go.mod h1:keMNyY6R9isGaSAu+4Q8NMBwMPkh15Gtc8UCVoDtAWo=
 github.com/golangci/plugin-module-register v0.1.1 h1:TCmesur25LnyJkpsVrupv1Cdzo+2f7zX0H6Jkw1Ol6c=
@@ -492,6 +498,8 @@ github.com/sashamelentyev/usestdlibvars v1.28.0 h1:jZnudE2zKCtYlGzLVreNp5pmCdOxX
 github.com/sashamelentyev/usestdlibvars v1.28.0/go.mod h1:9nl0jgOfHKWNFS43Ojw0i7aRoS4j6EBye3YBhmAIRF8=
 github.com/securego/gosec/v2 v2.22.1 h1:IcBt3TpI5Y9VN1YlwjSpM2cHu0i3Iw52QM+PQeg7jN8=
 github.com/securego/gosec/v2 v2.22.1/go.mod h1:4bb95X4Jz7VSEPdVjC0hD7C/yR6kdeUBvCPOy9gDQ0g=
+github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil/v4 v4.25.1 h1:QSWkTc+fu9LTAWfkZwZ6j8MSUk4A2LV7rbH0ZqmLjXs=
 github.com/shirou/gopsutil/v4 v4.25.1/go.mod h1:RoUCUpndaJFtT+2zsZzzmhvbfGoDCJ7nFXKJf8GqJbI=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=

--- a/pkg/config/formatters_settings.go
+++ b/pkg/config/formatters_settings.go
@@ -8,6 +8,12 @@ var defaultFormatterSettings = FormatterSettings{
 		Sections:      []string{"standard", "default"},
 		SkipGenerated: true,
 	},
+	GoLines: GoLinesSettings{
+		MaxLen:         100,
+		TabLen:         4,
+		ReformatTags:   true,
+		ChainSplitDots: true,
+	},
 }
 
 type FormatterSettings struct {
@@ -15,6 +21,7 @@ type FormatterSettings struct {
 	GoFmt     GoFmtSettings     `mapstructure:"gofmt"`
 	GoFumpt   GoFumptSettings   `mapstructure:"gofumpt"`
 	GoImports GoImportsSettings `mapstructure:"goimports"`
+	GoLines   GoLinesSettings   `mapstructure:"golines"`
 }
 
 type GciSettings struct {
@@ -49,4 +56,12 @@ type GoFumptSettings struct {
 
 type GoImportsSettings struct {
 	LocalPrefixes string `mapstructure:"local-prefixes"`
+}
+
+type GoLinesSettings struct {
+	MaxLen          int  `mapstructure:"max-len"`
+	TabLen          int  `mapstructure:"tab-len"`
+	ShortenComments bool `mapstructure:"shorten-comments"`
+	ReformatTags    bool `mapstructure:"reformat-tags"`
+	ChainSplitDots  bool `mapstructure:"chain-split-dots"`
 }

--- a/pkg/goformatters/golines/golines.go
+++ b/pkg/goformatters/golines/golines.go
@@ -1,0 +1,41 @@
+package golines
+
+import (
+	"github.com/golangci/golines"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+)
+
+const Name = "golines"
+
+type Formatter struct {
+	shortener *golines.Shortener
+}
+
+func New(settings *config.GoLinesSettings) *Formatter {
+	options := golines.ShortenerConfig{}
+
+	if settings != nil {
+		options = golines.ShortenerConfig{
+			MaxLen:           settings.MaxLen,
+			TabLen:           settings.TabLen,
+			KeepAnnotations:  false, // debug
+			ShortenComments:  settings.ShortenComments,
+			ReformatTags:     settings.ReformatTags,
+			IgnoreGenerated:  false, // handle globally
+			DotFile:          "",    // debug
+			ChainSplitDots:   settings.ChainSplitDots,
+			BaseFormatterCmd: "fmt", // fake cmd
+		}
+	}
+
+	return &Formatter{shortener: golines.NewShortener(options)}
+}
+
+func (*Formatter) Name() string {
+	return Name
+}
+
+func (f *Formatter) Format(_ string, src []byte) ([]byte, error) {
+	return f.shortener.Shorten(src)
+}

--- a/pkg/goformatters/meta_formatter.go
+++ b/pkg/goformatters/meta_formatter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goformatters/gofmt"
 	"github.com/golangci/golangci-lint/pkg/goformatters/gofumpt"
 	"github.com/golangci/golangci-lint/pkg/goformatters/goimports"
+	"github.com/golangci/golangci-lint/pkg/goformatters/golines"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 )
 
@@ -50,6 +51,11 @@ func NewMetaFormatter(log logutils.Log, cfg *config.Formatters, runCfg *config.R
 		m.formatters = append(m.formatters, formatter)
 	}
 
+	// golines calls `format.Source()` internally so no need to format after it.
+	if slices.Contains(cfg.Enable, golines.Name) {
+		m.formatters = append(m.formatters, golines.New(&cfg.Settings.GoLines))
+	}
+
 	return m, nil
 }
 
@@ -80,5 +86,5 @@ func (m *MetaFormatter) Format(filename string, src []byte) []byte {
 }
 
 func IsFormatter(name string) bool {
-	return slices.Contains([]string{gofmt.Name, gofumpt.Name, goimports.Name, gci.Name}, name)
+	return slices.Contains([]string{gofmt.Name, gofumpt.Name, goimports.Name, gci.Name, golines.Name}, name)
 }

--- a/pkg/golinters/golines/golines.go
+++ b/pkg/golinters/golines/golines.go
@@ -1,0 +1,28 @@
+package golines
+
+import (
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/goformatters"
+	golinesbase "github.com/golangci/golangci-lint/pkg/goformatters/golines"
+	"github.com/golangci/golangci-lint/pkg/golinters/internal"
+)
+
+const linterName = "golines"
+
+func New(settings *config.GoLinesSettings) *goanalysis.Linter {
+	a := goformatters.NewAnalyzer(
+		internal.LinterLogger.Child(linterName),
+		"Checks if code is formatted, and fixes long lines",
+		golinesbase.New(settings),
+	)
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/golines/golines_integration_test.go
+++ b/pkg/golinters/golines/golines_integration_test.go
@@ -1,0 +1,19 @@
+package golines
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}
+
+func TestFix(t *testing.T) {
+	integration.RunFix(t)
+}
+
+func TestFixPathPrefix(t *testing.T) {
+	integration.RunFixPathPrefix(t)
+}

--- a/pkg/golinters/golines/testdata/fix/in/golines.go
+++ b/pkg/golinters/golines/testdata/fix/in/golines.go
@@ -1,0 +1,83 @@
+//golangcitest:args -Egolines
+//golangcitest:expected_exitcode 0
+package testdata
+
+import "fmt"
+
+var (
+	abc = []string{"a really long string", "another really long string", "a third really long string", "a fourth really long string", fmt.Sprintf("%s %s %s %s >>>>> %s %s", "first argument", "second argument", "third argument", "fourth argument", "fifth argument", "sixth argument")}
+)
+
+type MyStruct struct {
+	aLongProperty       int `help:"This is a really long string for this property"`
+	anotherLongProperty int `help:"This is a really long string for this property, part 2"`
+	athirdLongProperty  int `help:"This is a really long string for this property, part 3...."`
+}
+
+type MyInterface interface {
+	aReallyLongFunctionName(argument1 string, argument2 string, argument3 string, argument4 string, argument5 string, argument6 string) (string, error)
+}
+
+// Something here
+
+// Another comment
+// A third comment
+// This is a really really long comment that needs to be split up into multiple lines. I don't know how easy it will be to do, but I think we can do it!
+func longLine(aReallyLongName string, anotherLongName string, aThirdLongName string) (string, error) {
+	argument1 := "argument1"
+	argument2 := "argument2"
+	argument3 := "argument3"
+	argument4 := "argument4"
+
+	fmt.Printf("This is a really long string with a bunch of arguments: %s %s %s %s >>>>>>>>>>>>>>>>>>>>>>", argument1, argument2, argument3, argument4)
+	fmt.Printf("This is a short statement: %d %d %d", 1, 2, 3)
+
+	z := argument1 + argument2 + fmt.Sprintf("This is a really long statement that should be broken up %s %s %s", argument1, argument2, argument3)
+
+	fmt.Printf("This is a really long line that can be broken up twice %s %s", fmt.Sprintf("This is a really long sub-line that should be broken up more because %s %s", argument1, argument2), fmt.Sprintf("A short one %d", 3))
+
+	fmt.Print("This is a function with a really long single argument. We want to see if it's properly split")
+
+	fmt.Println(z)
+
+	// This is a really long comment on an indented line. Do you think we can split it up or should we just leave it as is?
+	if argument4 == "5" {
+		return "", fmt.Errorf("a very long query with ID %d failed. Check Query History in AWS UI", 12341251)
+	}
+
+	go func() {
+		fmt.Printf("This is a really long line inside of a go routine call. It should be split if at all possible.")
+	}()
+
+	if "hello this is a big string" == "this is a small string" && "this is another big string" == "this is an even bigger string >>>" {
+		fmt.Print("inside if statement")
+	}
+
+	fmt.Println(map[string]string{"key1": "a very long value", "key2": "a very long value", "key3": "another very long value"})
+
+	return "", nil
+}
+
+func shortFunc(a int, b int) error {
+	c := make(chan int)
+
+	for {
+		select {
+		case <-c:
+			switch a {
+			case 1:
+				return fmt.Errorf("This is a really long line that can be broken up twice %s %s", fmt.Sprintf("This is a really long sub-line that should be broken up more because %s %s", "xxxx", "yyyy"), fmt.Sprintf("A short one %d", 3))
+			case 2:
+			}
+		}
+
+		break
+	}
+
+	if a > 5 {
+		panic(fmt.Sprintf(">>>>>>>>>>>>>>>>>>> %s %s %s %s", "really long argument", "another really long argument", "a third really long arguement", abc[1:2]))
+	}
+
+	return nil
+	// This is an end decoration
+}

--- a/pkg/golinters/golines/testdata/fix/out/golines.go
+++ b/pkg/golinters/golines/testdata/fix/out/golines.go
@@ -1,0 +1,157 @@
+//golangcitest:args -Egolines
+//golangcitest:expected_exitcode 0
+package testdata
+
+import "fmt"
+
+var (
+	abc = []string{
+		"a really long string",
+		"another really long string",
+		"a third really long string",
+		"a fourth really long string",
+		fmt.Sprintf(
+			"%s %s %s %s >>>>> %s %s",
+			"first argument",
+			"second argument",
+			"third argument",
+			"fourth argument",
+			"fifth argument",
+			"sixth argument",
+		),
+	}
+)
+
+type MyStruct struct {
+	aLongProperty       int `help:"This is a really long string for this property"`
+	anotherLongProperty int `help:"This is a really long string for this property, part 2"`
+	athirdLongProperty  int `help:"This is a really long string for this property, part 3...."`
+}
+
+type MyInterface interface {
+	aReallyLongFunctionName(
+		argument1 string,
+		argument2 string,
+		argument3 string,
+		argument4 string,
+		argument5 string,
+		argument6 string,
+	) (string, error)
+}
+
+// Something here
+
+// Another comment
+// A third comment
+// This is a really really long comment that needs to be split up into multiple lines. I don't know how easy it will be to do, but I think we can do it!
+func longLine(
+	aReallyLongName string,
+	anotherLongName string,
+	aThirdLongName string,
+) (string, error) {
+	argument1 := "argument1"
+	argument2 := "argument2"
+	argument3 := "argument3"
+	argument4 := "argument4"
+
+	fmt.Printf(
+		"This is a really long string with a bunch of arguments: %s %s %s %s >>>>>>>>>>>>>>>>>>>>>>",
+		argument1,
+		argument2,
+		argument3,
+		argument4,
+	)
+	fmt.Printf("This is a short statement: %d %d %d", 1, 2, 3)
+
+	z := argument1 + argument2 + fmt.Sprintf(
+		"This is a really long statement that should be broken up %s %s %s",
+		argument1,
+		argument2,
+		argument3,
+	)
+
+	fmt.Printf(
+		"This is a really long line that can be broken up twice %s %s",
+		fmt.Sprintf(
+			"This is a really long sub-line that should be broken up more because %s %s",
+			argument1,
+			argument2,
+		),
+		fmt.Sprintf("A short one %d", 3),
+	)
+
+	fmt.Print(
+		"This is a function with a really long single argument. We want to see if it's properly split",
+	)
+
+	fmt.Println(z)
+
+	// This is a really long comment on an indented line. Do you think we can split it up or should we just leave it as is?
+	if argument4 == "5" {
+		return "", fmt.Errorf(
+			"a very long query with ID %d failed. Check Query History in AWS UI",
+			12341251,
+		)
+	}
+
+	go func() {
+		fmt.Printf(
+			"This is a really long line inside of a go routine call. It should be split if at all possible.",
+		)
+	}()
+
+	if "hello this is a big string" == "this is a small string" &&
+		"this is another big string" == "this is an even bigger string >>>" {
+		fmt.Print("inside if statement")
+	}
+
+	fmt.Println(
+		map[string]string{
+			"key1": "a very long value",
+			"key2": "a very long value",
+			"key3": "another very long value",
+		},
+	)
+
+	return "", nil
+}
+
+func shortFunc(a int, b int) error {
+	c := make(chan int)
+
+	for {
+		select {
+		case <-c:
+			switch a {
+			case 1:
+				return fmt.Errorf(
+					"This is a really long line that can be broken up twice %s %s",
+					fmt.Sprintf(
+						"This is a really long sub-line that should be broken up more because %s %s",
+						"xxxx",
+						"yyyy",
+					),
+					fmt.Sprintf("A short one %d", 3),
+				)
+			case 2:
+			}
+		}
+
+		break
+	}
+
+	if a > 5 {
+		panic(
+			fmt.Sprintf(
+				">>>>>>>>>>>>>>>>>>> %s %s %s %s",
+				"really long argument",
+				"another really long argument",
+				"a third really long arguement",
+				abc[1:2],
+			),
+		)
+	}
+
+	return nil
+	// This is an end decoration
+}

--- a/pkg/golinters/golines/testdata/golines.go
+++ b/pkg/golinters/golines/testdata/golines.go
@@ -1,0 +1,83 @@
+//golangcitest:args -Egolines
+package testdata
+
+import "fmt"
+
+var (
+	// want +1 "File is not properly formatted"
+	abc = []string{"a really long string", "another really long string", "a third really long string", "a fourth really long string", fmt.Sprintf("%s %s %s %s >>>>> %s %s", "first argument", "second argument", "third argument", "fourth argument", "fifth argument", "sixth argument")}
+)
+
+type MyStruct struct {
+	aLongProperty       int `help:"This is a really long string for this property"`
+	anotherLongProperty int `help:"This is a really long string for this property, part 2"`
+	athirdLongProperty  int `help:"This is a really long string for this property, part 3...."`
+}
+
+type MyInterface interface {
+	aReallyLongFunctionName(argument1 string, argument2 string, argument3 string, argument4 string, argument5 string, argument6 string) (string, error)
+}
+
+// Something here
+
+// Another comment
+// A third comment
+// This is a really really long comment that needs to be split up into multiple lines. I don't know how easy it will be to do, but I think we can do it!
+func longLine(aReallyLongName string, anotherLongName string, aThirdLongName string) (string, error) {
+	argument1 := "argument1"
+	argument2 := "argument2"
+	argument3 := "argument3"
+	argument4 := "argument4"
+
+	fmt.Printf("This is a really long string with a bunch of arguments: %s %s %s %s >>>>>>>>>>>>>>>>>>>>>>", argument1, argument2, argument3, argument4)
+	fmt.Printf("This is a short statement: %d %d %d", 1, 2, 3)
+
+	z := argument1 + argument2 + fmt.Sprintf("This is a really long statement that should be broken up %s %s %s", argument1, argument2, argument3)
+
+	fmt.Printf("This is a really long line that can be broken up twice %s %s", fmt.Sprintf("This is a really long sub-line that should be broken up more because %s %s", argument1, argument2), fmt.Sprintf("A short one %d", 3))
+
+	fmt.Print("This is a function with a really long single argument. We want to see if it's properly split")
+
+	fmt.Println(z)
+
+	// This is a really long comment on an indented line. Do you think we can split it up or should we just leave it as is?
+	if argument4 == "5" {
+		return "", fmt.Errorf("a very long query with ID %d failed. Check Query History in AWS UI", 12341251)
+	}
+
+	go func() {
+		fmt.Printf("This is a really long line inside of a go routine call. It should be split if at all possible.")
+	}()
+
+	if "hello this is a big string" == "this is a small string" && "this is another big string" == "this is an even bigger string >>>" {
+		fmt.Print("inside if statement")
+	}
+
+	fmt.Println(map[string]string{"key1": "a very long value", "key2": "a very long value", "key3": "another very long value"})
+
+	return "", nil
+}
+
+func shortFunc(a int, b int) error {
+	c := make(chan int)
+
+	for {
+		select {
+		case <-c:
+			switch a {
+			case 1:
+				return fmt.Errorf("This is a really long line that can be broken up twice %s %s", fmt.Sprintf("This is a really long sub-line that should be broken up more because %s %s", "xxxx", "yyyy"), fmt.Sprintf("A short one %d", 3))
+			case 2:
+			}
+		}
+
+		break
+	}
+
+	if a > 5 {
+		panic(fmt.Sprintf(">>>>>>>>>>>>>>>>>>> %s %s %s %s", "really long argument", "another really long argument", "a third really long arguement", abc[1:2]))
+	}
+
+	return nil
+	// This is an end decoration
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -46,6 +46,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/golinters/gofumpt"
 	"github.com/golangci/golangci-lint/pkg/golinters/goheader"
 	"github.com/golangci/golangci-lint/pkg/golinters/goimports"
+	"github.com/golangci/golangci-lint/pkg/golinters/golines"
 	"github.com/golangci/golangci-lint/pkg/golinters/gomoddirectives"
 	"github.com/golangci/golangci-lint/pkg/golinters/gomodguard"
 	"github.com/golangci/golangci-lint/pkg/golinters/goprintffuncname"
@@ -405,6 +406,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithPresets(linter.PresetFormatting).
 			WithAutoFix().
 			WithURL("https://github.com/mvdan/gofumpt"),
+
+		linter.NewConfig(golines.New(&cfg.LintersSettings.GoLines)).
+			WithSince("v1.64.0").
+			WithPresets(linter.PresetFormatting).
+			WithAutoFix().
+			WithURL("https://github.com/segmentio/golines"),
 
 		linter.NewConfig(goheader.New(&cfg.LintersSettings.Goheader, cfg.GetBasePath())).
 			WithSince("v1.28.0").

--- a/pkg/result/processors/fixer.go
+++ b/pkg/result/processors/fixer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golangci/golangci-lint/pkg/goformatters/gofmt"
 	"github.com/golangci/golangci-lint/pkg/goformatters/gofumpt"
 	"github.com/golangci/golangci-lint/pkg/goformatters/goimports"
+	"github.com/golangci/golangci-lint/pkg/goformatters/golines"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 	"github.com/golangci/golangci-lint/pkg/result"
 	"github.com/golangci/golangci-lint/pkg/timeutils"
@@ -78,7 +79,7 @@ func (p Fixer) process(issues []result.Issue) ([]result.Issue, error) {
 	// filenames / linters / edits
 	editsByLinter := make(map[string]map[string][]diff.Edit)
 
-	formatters := []string{gofumpt.Name, goimports.Name, gofmt.Name, gci.Name}
+	formatters := []string{gofumpt.Name, goimports.Name, gofmt.Name, gci.Name, golines.Name}
 
 	var notFixableIssues []result.Issue
 

--- a/pkg/result/processors/max_per_file_from_linter.go
+++ b/pkg/result/processors/max_per_file_from_linter.go
@@ -22,6 +22,7 @@ func NewMaxPerFileFromLinter(cfg *config.Config) *MaxPerFileFromLinter {
 		maxPerFileFromLinterConfig["gofmt"] = 1
 		maxPerFileFromLinterConfig["goimports"] = 1
 		maxPerFileFromLinterConfig["gci"] = 1
+		maxPerFileFromLinterConfig["golines"] = 1
 	}
 
 	return &MaxPerFileFromLinter{


### PR DESCRIPTION
Add `golines` as formatter.

`golines` is defined as a CLI, so I created a fork with minimal changes.

https://github.com/golangci/golines

The readme of the repository explains all the changes.

Fixes #1914