### PR TITLE
chore: ignore globally test fix artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage.xml
 /custom-gcl
 .custom-gcl.yml
 .custom-gcl.yaml
+**/testdata/fix.tmp/

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,0 @@
-/testdata/fix.tmp/


### PR DESCRIPTION
Since the test about `fix` are also inside linter packages, the artifacts are created inside `testdata` of all the linters.