### PR TITLE
docs: add arguments to `revive.error-strings`

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2580,6 +2580,8 @@ linters-settings:
         severity: warning
         disabled: false
         exclude: [""]
+        arguments:
+          - "xerrors.New"
       # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#errorf
       - name: errorf
         severity: warning

--- a/pkg/golinters/revive/testdata/revive.go
+++ b/pkg/golinters/revive/testdata/revive.go
@@ -5,6 +5,8 @@ package testdata
 import (
 	"net/http"
 	"time"
+
+	"golang.org/x/xerrors"
 )
 
 func SampleRevive(t *time.Duration) error {
@@ -27,4 +29,8 @@ func testReviveComplexity(s string) { // want "cyclomatic: function testReviveCo
 	if s == "1" || s == "2" || s == "3" || s == "4" || s == "5" || s == "6" || s == "7" {
 		return
 	}
+}
+
+func testErrorStrings() {
+	_ = xerrors.New("Some error!") // want "error strings should not be capitalized or end with punctuation or a newline"
 }

--- a/pkg/golinters/revive/testdata/revive.yml
+++ b/pkg/golinters/revive/testdata/revive.yml
@@ -17,3 +17,6 @@ linters-settings:
         arguments: [ 10 ]
       - name: max-public-structs
         arguments: [ 3 ]
+      - name: error-strings
+        arguments:
+          - "xerrors.New"


### PR DESCRIPTION
It's possible to define user functions for the `revive.error-strings` rule.

See mgechev/revive#1245