### PR TITLE
feat: configuration options renaming

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2383,7 +2383,7 @@ linters-settings:
     # Comma-separated list of predeclared identifiers to not report on.
     # Default: ""
     ignore: "new,int"
-    # Include method names and field names (i.e., qualified names) in checks.
+    # Include method names and field names in checks.
     # Default: false
     qualified-name: true
 

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -3878,9 +3878,9 @@ linters-settings:
 
   wrapcheck:
     # An array of strings specifying additional substrings of signatures to ignore.
-    # Unlike 'ignoreSigs', this option extends the default set (or the set specified in 'ignoreSigs') without replacing it entirely.
+    # Unlike 'ignore-sigs', this option extends the default set (or the set specified in 'ignore-sigs') without replacing it entirely.
     # This allows you to add specific signatures to the ignore list
-    # while retaining the defaults or any items in 'ignoreSigs'.
+    # while retaining the defaults or any items in 'ignore-sigs'.
     # Default: []
     extra-ignore-sigs:
       - .CustomError(
@@ -3890,7 +3890,7 @@ linters-settings:
     # If this set, it will override the default set of ignored signatures.
     # See https://github.com/tomarrell/wrapcheck#configuration for more information.
     # Default: [".Errorf(", "errors.New(", "errors.Unwrap(", "errors.Join(", ".Wrap(", ".Wrapf(", ".WithMessage(", ".WithMessagef(", ".WithStack("]
-    ignoreSigs:
+    ignore-sigs:
       - .Errorf(
       - errors.New(
       - errors.Unwrap(
@@ -3902,16 +3902,16 @@ linters-settings:
       - .WithStack(
     # An array of strings that specify regular expressions of signatures to ignore.
     # Default: []
-    ignoreSigRegexps:
+    ignore-sig-regexps:
       - \.New.*Error\(
     # An array of strings that specify globs of packages to ignore.
     # Default: []
-    ignorePackageGlobs:
+    ignore-package-globs:
       - encoding/*
       - github.com/pkg/*
     # An array of strings that specify regular expressions of interfaces to ignore.
     # Default: []
-    ignoreInterfaceRegexps:
+    ignore-interface-regexps:
       - ^(?i)c(?-i)ach(ing|e)
 
   wsl:

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -708,20 +708,20 @@ linters-settings:
     # Default: ["^(fmt\\.Print(|f|ln)|print|println)$"]
     forbid:
       # Built-in bootstrapping functions.
-      - ^print(ln)?$
+      - pattern: ^print(ln)?$
       # Optional message that gets included in error reports.
-      - p: ^fmt\.Print.*$
+      - pattern: ^fmt\.Print.*$
         msg: Do not commit print statements.
       # Alternatively, put messages at the end of the regex, surrounded by `(# )?`
       # Escape any special characters. Those messages get included in error reports.
-      - 'fmt\.Print.*(# Do not commit print statements\.)?'
+      - pattern: 'fmt\.Print.*(# Do not commit print statements\.)?'
       # Forbid spew Dump, whether it is called as function or method.
       # Depends on analyze-types below.
-      - ^spew\.(ConfigState\.)?Dump$
+      - pattern: ^spew\.(ConfigState\.)?Dump$
       # The package name might be ambiguous.
       # The full import path can be used as additional criteria.
       # Depends on analyze-types below.
-      - p: ^v1.Dump$
+      - pattern: ^v1.Dump$
         pkg: ^example.com/pkg/api/v1$
     # Exclude godoc examples from forbidigo checks.
     # Default: true

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1530,7 +1530,7 @@ linters-settings:
             reason: "testing if blocked version constraint works."
       # Set to true to raise lint issues for packages that are loaded from a local path via replace directive.
       # Default: false
-      local_replace_directives: false
+      local-replace-directives: false
 
   gosimple:
     # Sxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -4236,7 +4236,7 @@ severity:
   # `@linter` can be used as severity value to keep the severity from linters (e.g. revive, gosec, ...)
   #
   # Default: ""
-  default-severity: error
+  default: error
 
   # If set to true `severity-rules` regular expressions become case-sensitive.
   # Default: false

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2385,7 +2385,7 @@ linters-settings:
     ignore: "new,int"
     # Include method names and field names (i.e., qualified names) in checks.
     # Default: false
-    q: true
+    qualified-name: true
 
   promlinter:
     # Promlinter cannot infer all metrics name in static analysis.

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2215,7 +2215,7 @@ linters-settings:
     # Typos to ignore.
     # Should be in lower case.
     # Default: []
-    ignore-words:
+    ignore-rules:
       - someword
     # Extra word corrections.
     # `typo` and `correction` should only contain letters.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -187,7 +187,7 @@ linters-settings:
     line-length: 140
   misspell:
     locale: US
-    ignore-words:
+    ignore-rules:
       - "importas" # linter name
   nolintlint:
     allow-unused: false # report any unused nolint directives

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -4417,7 +4417,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "default-severity": {
+        "default": {
           "description": "Set the default severity for issues. If severity rules are defined and the issues do not match or no severity is provided to the rule this will be the default severity applied. Severities should match the supported severity names of the selected out format.",
           "type": "string",
           "default": ""
@@ -4468,7 +4468,7 @@
           "default": []
         }
       },
-      "required": ["default-severity"]
+      "required": ["default"]
     }
   }
 }

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -3586,7 +3586,7 @@
                 "type": "string"
               }
             },
-            "ignoreSigs": {
+            "ignore-sigs": {
               "description": "An array of strings which specify substrings of signatures to ignore.",
               "default": [
                 ".Errorf(",
@@ -3603,7 +3603,7 @@
                 "type": "string"
               }
             },
-            "ignoreSigRegexps": {
+            "ignore-sig-regexps": {
               "description": "An array of strings which specify regular expressions of signatures to ignore.",
               "default": [""],
               "type": "array",
@@ -3611,7 +3611,7 @@
                 "type": "string"
               }
             },
-            "ignorePackageGlobs": {
+            "ignore-package-globs": {
               "description": "An array of glob patterns which, if any match the package of the function returning the error, will skip wrapcheck analysis for this error.",
               "default": [""],
               "type": "array",
@@ -3619,7 +3619,7 @@
                 "type": "string"
               }
             },
-            "ignoreInterfaceRegexps": {
+            "ignore-interface-regexps": {
               "description": "An array of glob patterns which, if matched to an underlying interface name, will ignore unwrapped errors returned from a function whose call is defined on the given interface.",
               "default": [""],
               "type": "array",

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -2135,8 +2135,8 @@
             "locale": {
               "enum": ["US", "UK"]
             },
-            "ignore-words": {
-              "description": "List of words to ignore.",
+            "ignore-rules": {
+              "description": "List of rules to ignore.",
               "type": "array",
               "items": {
                 "type": "string"

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -942,31 +942,23 @@
             "forbid": {
               "description": "List of identifiers to forbid (written using `regexp`)",
               "type": "array",
-              "examples": ["^print(ln)?$"],
               "items": {
-                "anyOf": [
-                  {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "pattern": {
+                    "description": "Pattern",
                     "type": "string"
                   },
-                  {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "p": {
-                        "description": "Pattern",
-                        "type": "string"
-                      },
-                      "pkg": {
-                        "description": "Package",
-                        "type": "string"
-                      },
-                      "msg": {
-                        "description": "Message",
-                        "type": "string"
-                      }
-                    }
+                  "pkg": {
+                    "description": "Package",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "Message",
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           }

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -2452,7 +2452,7 @@
               "type": "string"
             },
             "qualified-name": {
-              "description": "Include method names and field names (i.e., qualified names) in checks.",
+              "description": "Include method names and field names in checks.",
               "type": "boolean",
               "default": false
             }

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1727,7 +1727,7 @@
                     }
                   }
                 },
-                "local_replace_directives": {
+                "local-replace-directives": {
                   "description": "Raise lint issues if loading local path with replace directive",
                   "type": "boolean",
                   "default": true

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -2459,7 +2459,7 @@
               "description": "Comma-separated list of predeclared identifiers to not report on.",
               "type": "string"
             },
-            "q": {
+            "qualified-name": {
               "description": "Include method names and field names (i.e., qualified names) in checks.",
               "type": "boolean",
               "default": false

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -563,7 +563,7 @@ type GoModGuardSettings struct {
 			Version string `mapstructure:"version"`
 			Reason  string `mapstructure:"reason"`
 		} `mapstructure:"versions"`
-		LocalReplaceDirectives bool `mapstructure:"local_replace_directives"`
+		LocalReplaceDirectives bool `mapstructure:"local-replace-directives"`
 	} `mapstructure:"blocked"`
 }
 

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -1,12 +1,9 @@
 package config
 
 import (
-	"encoding"
 	"errors"
 	"fmt"
 	"runtime"
-
-	"gopkg.in/yaml.v3"
 )
 
 var defaultLintersSettings = LintersSettings{
@@ -425,40 +422,10 @@ type ForbidigoSettings struct {
 	AnalyzeTypes         bool               `mapstructure:"analyze-types"`
 }
 
-var _ encoding.TextUnmarshaler = &ForbidigoPattern{}
-
-// ForbidigoPattern corresponds to forbidigo.pattern and adds mapstructure support.
-// The YAML field names must match what forbidigo expects.
 type ForbidigoPattern struct {
-	// patternString gets populated when the config contains a string as entry in ForbidigoSettings.Forbid[]
-	// because ForbidigoPattern implements encoding.TextUnmarshaler
-	// and the reader uses the mapstructure.TextUnmarshallerHookFunc as decoder hook.
-	//
-	// If the entry is a map, then the other fields are set as usual by mapstructure.
-	patternString string
-
-	Pattern string `yaml:"p" mapstructure:"p"`
+	Pattern string `yaml:"p" mapstructure:"pattern"`
 	Package string `yaml:"pkg,omitempty" mapstructure:"pkg,omitempty"`
 	Msg     string `yaml:"msg,omitempty" mapstructure:"msg,omitempty"`
-}
-
-func (p *ForbidigoPattern) UnmarshalText(text []byte) error {
-	// Validation happens when instantiating forbidigo.
-	p.patternString = string(text)
-	return nil
-}
-
-// MarshalString converts the pattern into a string as needed by forbidigo.NewLinter.
-//
-// MarshalString is intentionally not called MarshalText,
-// although it has the same signature
-// because implementing encoding.TextMarshaler led to infinite recursion when yaml.Marshal called MarshalText.
-func (p *ForbidigoPattern) MarshalString() ([]byte, error) {
-	if p.patternString != "" {
-		return []byte(p.patternString), nil
-	}
-
-	return yaml.Marshal(p)
 }
 
 type FunlenSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -987,12 +987,11 @@ type WhitespaceSettings struct {
 }
 
 type WrapcheckSettings struct {
-	ExtraIgnoreSigs []string `mapstructure:"extra-ignore-sigs"`
-	// TODO(ldez): v2 the options must be renamed to use hyphen.
-	IgnoreSigs             []string `mapstructure:"ignoreSigs"`
-	IgnoreSigRegexps       []string `mapstructure:"ignoreSigRegexps"`
-	IgnorePackageGlobs     []string `mapstructure:"ignorePackageGlobs"`
-	IgnoreInterfaceRegexps []string `mapstructure:"ignoreInterfaceRegexps"`
+	ExtraIgnoreSigs        []string `mapstructure:"extra-ignore-sigs"`
+	IgnoreSigs             []string `mapstructure:"ignore-sigs"`
+	IgnoreSigRegexps       []string `mapstructure:"ignore-sig-regexps"`
+	IgnorePackageGlobs     []string `mapstructure:"ignore-package-globs"`
+	IgnoreInterfaceRegexps []string `mapstructure:"ignore-interface-regexps"`
 }
 
 type WSLSettings struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -673,11 +673,10 @@ type MakezeroSettings struct {
 }
 
 type MisspellSettings struct {
-	Mode       string               `mapstructure:"mode"`
-	Locale     string               `mapstructure:"locale"`
-	ExtraWords []MisspellExtraWords `mapstructure:"extra-words"`
-	// TODO(ldez): v2 the option must be renamed to `IgnoredRules`.
-	IgnoreWords []string `mapstructure:"ignore-words"`
+	Mode        string               `mapstructure:"mode"`
+	Locale      string               `mapstructure:"locale"`
+	ExtraWords  []MisspellExtraWords `mapstructure:"extra-words"`
+	IgnoreRules []string             `mapstructure:"ignore-rules"`
 }
 
 type MisspellExtraWords struct {

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -757,7 +757,7 @@ type PreallocSettings struct {
 
 type PredeclaredSettings struct {
 	Ignore    string `mapstructure:"ignore"`
-	Qualified bool   `mapstructure:"q"`
+	Qualified bool   `mapstructure:"qualified-name"`
 }
 
 type PromlinterSettings struct {

--- a/pkg/config/severity.go
+++ b/pkg/config/severity.go
@@ -8,7 +8,7 @@ import (
 const severityRuleMinConditionsCount = 1
 
 type Severity struct {
-	Default       string         `mapstructure:"default-severity"`
+	Default       string         `mapstructure:"default"`
 	CaseSensitive bool           `mapstructure:"case-sensitive"`
 	Rules         []SeverityRule `mapstructure:"rules"`
 }

--- a/pkg/golinters/forbidigo/forbidigo.go
+++ b/pkg/golinters/forbidigo/forbidigo.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ashanbrown/forbidigo/forbidigo"
 	"golang.org/x/tools/go/analysis"
+	"gopkg.in/yaml.v3"
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
@@ -49,7 +50,7 @@ func runForbidigo(pass *analysis.Pass, settings *config.ForbidigoSettings) error
 	// Convert patterns back to strings because that is what NewLinter accepts.
 	var patterns []string
 	for _, pattern := range settings.Forbid {
-		buffer, err := pattern.MarshalString()
+		buffer, err := yaml.Marshal(pattern)
 		if err != nil {
 			return err
 		}

--- a/pkg/golinters/forbidigo/testdata/forbidigo.yml
+++ b/pkg/golinters/forbidigo/testdata/forbidigo.yml
@@ -3,5 +3,5 @@ version: "2"
 linters-settings:
   forbidigo:
     forbid:
-      - fmt\.Print.*
-      - time.Sleep(# no sleeping!)?
+      - pattern: fmt\.Print.*
+      - pattern: time.Sleep(# no sleeping!)?

--- a/pkg/golinters/forbidigo/testdata/forbidigo_struct.yml
+++ b/pkg/golinters/forbidigo/testdata/forbidigo_struct.yml
@@ -4,7 +4,7 @@ linters-settings:
   forbidigo:
     analyze-types: true
     forbid:
-      - p: fmt\.Print.*
+      - pattern: fmt\.Print.*
         pkg: ^fmt$
-      - p: time.Sleep
+      - pattern: time.Sleep
         msg: no sleeping!

--- a/pkg/golinters/misspell/misspell.go
+++ b/pkg/golinters/misspell/misspell.go
@@ -68,8 +68,8 @@ func createMisspellReplacer(settings *config.MisspellSettings) (*misspell.Replac
 		return nil, fmt.Errorf("process extra words: %w", err)
 	}
 
-	if len(settings.IgnoreWords) != 0 {
-		replacer.RemoveRule(settings.IgnoreWords)
+	if len(settings.IgnoreRules) != 0 {
+		replacer.RemoveRule(settings.IgnoreRules)
 	}
 
 	// It can panic.

--- a/pkg/golinters/misspell/testdata/misspell.yml
+++ b/pkg/golinters/misspell/testdata/misspell.yml
@@ -3,6 +3,6 @@ version: "2"
 linters-settings:
   misspell:
     locale: US
-    ignore-words:
+    ignore-rules:
       - langauge
       - Dialogue

--- a/pkg/golinters/predeclared/testdata/predeclared_custom.yml
+++ b/pkg/golinters/predeclared/testdata/predeclared_custom.yml
@@ -3,4 +3,4 @@ version: "2"
 linters-settings:
   predeclared:
     ignore: "real,recover"
-    q: true
+    qualified-name: true

--- a/test/testdata/configs/output.yml
+++ b/test/testdata/configs/output.yml
@@ -3,7 +3,7 @@ version: "2"
 linters-settings:
   misspell:
     locale: US
-    ignore-words:
+    ignore-rules:
       - langauge
       - Dialogue
 

--- a/test/testdata/configs/path-except.yml
+++ b/test/testdata/configs/path-except.yml
@@ -3,8 +3,8 @@ version: "2"
 linters-settings:
   forbidigo:
     forbid:
-      - fmt\.Print.*
-      - time.Sleep(# no sleeping!)?
+      - pattern: fmt\.Print.*
+      - pattern: time.Sleep(# no sleeping!)?
 
 linters:
   exclusions:


### PR DESCRIPTION
- `severity.default-severity` ->`severity.default`
- forbidigo: multi-type (string, slice) -> slice
- `forbidigo.forbid[].p` -> `forbidigo.forbid[].pattern`
- `predeclared.q` -> `predeclared.qualified-name`
- `wrapcheck.ignoreInterfaceRegexps` -> `wrapcheck.ignore-interface-regexps`
- `wrapcheck.ignorePackageGlobs` -> `wrapcheck.ignore-package-globs`
- `wrapcheck.ignoreSigRegexps` -> `wrapcheck.ignore-sig-regexps`
- `wrapcheck.ignoreSigs` ->	`wrapcheck.ignore-sigs`
- `misspell.ignore-words` -> `misspell.ignore-rules`
- `gomodguard.blocked.local_replace_directives` -> `gomodguard.blocked.local-replace-directives`
