### PR TITLE
govet: skip fieldalignment test on 32bit platforms

### DIFF
--- a/pkg/golinters/govet/testdata/govet_fieldalignment.go
+++ b/pkg/golinters/govet/testdata/govet_fieldalignment.go
@@ -1,3 +1,4 @@
+//go:build !(386 || arm || mips || mipsle)
 //golangcitest:args -Egovet
 //golangcitest:config_path testdata/govet_fieldalignment.yml
 package testdata

--- a/test/testshared/directives.go
+++ b/test/testshared/directives.go
@@ -136,6 +136,10 @@ func evaluateBuildTags(tb testing.TB, line string) bool {
 			return true
 		}
 
+		if tag == runtime.GOARCH {
+			return true
+		}
+
 		if buildTagGoVersion(tag) {
 			return true
 		}


### PR DESCRIPTION
the govet fieldalignment test currently fails on 32bit targets because it assumes `uintptr` always has a size of 8 bytes.
this pr (edited after some discussion) adds build tags to skip it on platforms where that is not the case.