### PR TITLE
chore: apply same default limitations on all formatters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,28 +72,6 @@ linters:
           - mnd
           - lll
 
-      # Deprecated linter options.
-      - path: pkg/golinters/errcheck/errcheck.go
-        linters: [staticcheck]
-        text: "SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead"
-      - path: pkg/golinters/errcheck/errcheck.go
-        linters: [staticcheck]
-        text: "SA1019: errCfg.Ignore is deprecated: use ExcludeFunctions instead"
-      - path: pkg/golinters/govet/govet.go
-        linters: [staticcheck]
-        text: "SA1019: cfg.CheckShadowing is deprecated: the linter should be enabled inside Enable."
-      - path: pkg/golinters/godot/godot.go
-        linters: [staticcheck]
-        text: "SA1019: settings.CheckAll is deprecated: use Scope instead"
-      - path: pkg/goformatters/gci/gci.go
-        linters: [staticcheck]
-        text: "SA1019: settings.LocalPrefixes is deprecated: use Sections instead."
-
-      # Related to `run.go`, it cannot be removed.
-      - path: pkg/golinters/gofumpt/gofumpt.go
-        linters: [staticcheck]
-        text: "SA1019: settings.LangVersion is deprecated: use the global `run.go` instead."
-
       # Based on existing code, the modifications should be limited to make maintenance easier.
       - path: pkg/golinters/unused/unused.go
         linters: [gocritic]

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -4214,7 +4214,7 @@
               "type": "boolean",
               "default": false
             },
-            "presets":  {
+            "presets": {
               "type": "array",
               "items": {
                 "enum": [

--- a/pkg/result/processors/max_per_file_from_linter.go
+++ b/pkg/result/processors/max_per_file_from_linter.go
@@ -2,6 +2,11 @@ package processors
 
 import (
 	"github.com/golangci/golangci-lint/pkg/config"
+	"github.com/golangci/golangci-lint/pkg/goformatters/gci"
+	"github.com/golangci/golangci-lint/pkg/goformatters/gofmt"
+	"github.com/golangci/golangci-lint/pkg/goformatters/gofumpt"
+	"github.com/golangci/golangci-lint/pkg/goformatters/goimports"
+	"github.com/golangci/golangci-lint/pkg/goformatters/golines"
 	"github.com/golangci/golangci-lint/pkg/result"
 )
 
@@ -19,10 +24,9 @@ func NewMaxPerFileFromLinter(cfg *config.Config) *MaxPerFileFromLinter {
 	if !cfg.Issues.NeedFix {
 		// if we don't fix we do this limiting to not annoy user;
 		// otherwise we need to fix all issues in the file at once
-		maxPerFileFromLinterConfig["gofmt"] = 1
-		maxPerFileFromLinterConfig["goimports"] = 1
-		maxPerFileFromLinterConfig["gci"] = 1
-		maxPerFileFromLinterConfig["golines"] = 1
+		for _, f := range []string{gofmt.Name, gofumpt.Name, goimports.Name, gci.Name, golines.Name} {
+			maxPerFileFromLinterConfig[f] = 1
+		}
 	}
 
 	return &MaxPerFileFromLinter{


### PR DESCRIPTION
Applies the same default limitations on all formatters.
