### PR TITLE
docs: update goheader.template reference

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1346,27 +1346,25 @@ linters-settings:
         # Define here regexp type values.
         # for example:
         AUTHOR: .*@mycompany\.com
-    # The template use for checking.
+    # The template used for checking.
+    # Put here copyright header template for source code files
+    # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
     # Default: ""
     template: |-
-      # Put here copyright header template for source code files
-      # For example:
-      # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
-      #
-      # {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
-      # SPDX-License-Identifier: Apache-2.0
+      {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
+      SPDX-License-Identifier: Apache-2.0
 
-      # Licensed under the Apache License, Version 2.0 (the "License");
-      # you may not use this file except in compliance with the License.
-      # You may obtain a copy of the License at:
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at:
 
-      #   http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
-      # Unless required by applicable law or agreed to in writing, software
-      # distributed under the License is distributed on an "AS IS" BASIS,
-      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      # See the License for the specific language governing permissions and
-      # limitations under the License.
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
     # As alternative of directive 'template', you may put the path to file with the template source.
     # Useful if you need to load the template from a specific file.
     # Default: ""


### PR DESCRIPTION
Reading the reference, I found that the `goheader.template` missed comments `#` when marking empty lines:

<details><summary>Details</summary>
<p>

Before:

```yaml
    template: |-
      # Put here copyright header template for source code files
      # For example:
      # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
      #
      # {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
      # SPDX-License-Identifier: Apache-2.0

      # Licensed under the Apache License, Version 2.0 (the "License");
      # you may not use this file except in compliance with the License.
      # You may obtain a copy of the License at:

      #   http://www.apache.org/licenses/LICENSE-2.0

      # Unless required by applicable law or agreed to in writing, software
      # distributed under the License is distributed on an "AS IS" BASIS,
      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      # See the License for the specific language governing permissions and
      # limitations under the License.
```

After:

```yaml
    template: |-
      # Put here copyright header template for source code files
      # For example:
      # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
      #
      # {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
      # SPDX-License-Identifier: Apache-2.0
      #
      # Licensed under the Apache License, Version 2.0 (the "License");
      # you may not use this file except in compliance with the License.
      # You may obtain a copy of the License at:
      #
      #   http://www.apache.org/licenses/LICENSE-2.0
      #
      # Unless required by applicable law or agreed to in writing, software
      # distributed under the License is distributed on an "AS IS" BASIS,
      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      # See the License for the specific language governing permissions and
      # limitations under the License.
```

</p>
</details> 

But then I realized, why do we need to comment the example header at all? Better is to put copyright text right into the template, so that people can use it as is:

```yaml
    # The template used for checking.
    # Put here copyright header template for source code files
    # Note: {{ YEAR }} is a builtin value that returns the year relative to the current machine time.
    # Default: ""
    template: |-
      {{ AUTHOR }} {{ COMPANY }} {{ YEAR }}
      SPDX-License-Identifier: Apache-2.0

      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at:

        http://www.apache.org/licenses/LICENSE-2.0

      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      See the License for the specific language governing permissions and
      limitations under the License.
```