### PR TITLE
dev: fix schema not accepting valid timeout

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -4159,7 +4159,7 @@ output:
 
 # Options for analysis running.
 run:
-  # Timeout for analysis, e.g. 30s, 5m.
+  # Timeout for analysis, e.g. 30s, 5m, 5m30s.
   # If the value is lower or equal to 0, the timeout is disabled.
   # Default: 1m
   timeout: 5m

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -4159,7 +4159,7 @@ output:
 
 # Options for analysis running.
 run:
-  # Timeout for analysis, e.g. 30s, 5m.
+  # Timeout for analysis, e.g. 30s, 5m, 5m30s.
   # If the value is lower or equal to 0, the timeout is disabled.
   # Default: 1m
   timeout: 5m

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -472,7 +472,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -472,9 +472,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -472,7 +472,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -472,7 +472,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -472,9 +472,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -472,7 +472,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.57.jsonschema.json
+++ b/jsonschema/golangci.v1.57.jsonschema.json
@@ -351,7 +351,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.57.jsonschema.json
+++ b/jsonschema/golangci.v1.57.jsonschema.json
@@ -351,7 +351,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.57.jsonschema.json
+++ b/jsonschema/golangci.v1.57.jsonschema.json
@@ -351,9 +351,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.v1.58.jsonschema.json
+++ b/jsonschema/golangci.v1.58.jsonschema.json
@@ -353,9 +353,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.v1.58.jsonschema.json
+++ b/jsonschema/golangci.v1.58.jsonschema.json
@@ -353,7 +353,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.58.jsonschema.json
+++ b/jsonschema/golangci.v1.58.jsonschema.json
@@ -353,7 +353,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.59.jsonschema.json
+++ b/jsonschema/golangci.v1.59.jsonschema.json
@@ -435,7 +435,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.59.jsonschema.json
+++ b/jsonschema/golangci.v1.59.jsonschema.json
@@ -435,9 +435,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.v1.59.jsonschema.json
+++ b/jsonschema/golangci.v1.59.jsonschema.json
@@ -435,7 +435,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.60.jsonschema.json
+++ b/jsonschema/golangci.v1.60.jsonschema.json
@@ -441,9 +441,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.v1.60.jsonschema.json
+++ b/jsonschema/golangci.v1.60.jsonschema.json
@@ -441,7 +441,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.60.jsonschema.json
+++ b/jsonschema/golangci.v1.60.jsonschema.json
@@ -441,7 +441,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.61.jsonschema.json
+++ b/jsonschema/golangci.v1.61.jsonschema.json
@@ -440,7 +440,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.61.jsonschema.json
+++ b/jsonschema/golangci.v1.61.jsonschema.json
@@ -440,7 +440,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.61.jsonschema.json
+++ b/jsonschema/golangci.v1.61.jsonschema.json
@@ -440,9 +440,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.v1.62.jsonschema.json
+++ b/jsonschema/golangci.v1.62.jsonschema.json
@@ -442,7 +442,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.62.jsonschema.json
+++ b/jsonschema/golangci.v1.62.jsonschema.json
@@ -442,7 +442,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.62.jsonschema.json
+++ b/jsonschema/golangci.v1.62.jsonschema.json
@@ -442,9 +442,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.v1.63.jsonschema.json
+++ b/jsonschema/golangci.v1.63.jsonschema.json
@@ -463,9 +463,9 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^\\d*[sm]$",
+          "pattern": "^(\\d*m)?\\d*[sm]$",
           "default": "1m",
-          "examples": ["30s", "5m"]
+          "examples": ["30s", "5m", "5m30s"]
         },
         "issues-exit-code": {
           "description": "Exit code when at least one issue was found.",

--- a/jsonschema/golangci.v1.63.jsonschema.json
+++ b/jsonschema/golangci.v1.63.jsonschema.json
@@ -463,7 +463,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d*m)?\\d*[sm]$",
+          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },

--- a/jsonschema/golangci.v1.63.jsonschema.json
+++ b/jsonschema/golangci.v1.63.jsonschema.json
@@ -463,7 +463,7 @@
         "timeout": {
           "description": "Timeout for the analysis.",
           "type": "string",
-          "pattern": "^(\\d+m\\d+s|\\d+m|\\d+s|\\d)$",
+          "pattern": "^((\\d+h)?(\\d+m)?(\\d+(?:\\.\\d)?s)?|0)$",
           "default": "1m",
           "examples": ["30s", "5m", "5m30s"]
         },


### PR DESCRIPTION
Tested with https://regex101.com/r/7h45UC/1

While doing https://github.com/sapcc/go-makefile-maker/pull/248 we noticed that valid time.Durations are not accepted in the schema which got validated by the github action with verify=true (https://github.com/sapcc/go-makefile-maker/actions/runs/13635720861/job/38113890543?pr=248) but the command itself ran fine locally.

After this change everything works fine when running the following locally:

```
./golangci-lint config verify -c ~/go-makefile-maker/.golangci.yaml --schema jsonschema/golangci.jsonschema.json
```