### PR TITLE
fix: formatters can't be enabled/disabled as linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -194,4 +194,10 @@ formatters:
     goimports:
       local-prefixes:
         - github.com/golangci/golangci-lint
-
+  exclusions:
+    paths:
+      - test/testdata_etc # test files
+      - internal/go # extracted from Go code
+      - internal/x # extracted from x/tools code
+      - pkg/goformatters/gci/internal # extracted from gci code
+      - pkg/goanalysis/runner_checker.go # extracted from x/tools code

--- a/internal/go/cache/cache.go
+++ b/internal/go/cache/cache.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rogpeppe/go-internal/lockedfile"
+
 	"github.com/golangci/golangci-lint/internal/go/mmap"
 	"github.com/golangci/golangci-lint/internal/go/robustio"
-	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
 // An ActionID is a cache action key, the hash of a complete description of a

--- a/pkg/config/linters.go
+++ b/pkg/config/linters.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"fmt"
+	"slices"
+)
+
 const (
 	GroupStandard = "standard"
 	GroupAll      = "all"
@@ -21,6 +26,8 @@ type Linters struct {
 func (l *Linters) Validate() error {
 	validators := []func() error{
 		l.Exclusions.Validate,
+		l.validateNoFormattersEnabled,
+		l.validateNoFormattersDisabled,
 	}
 
 	for _, v := range validators {
@@ -30,4 +37,28 @@ func (l *Linters) Validate() error {
 	}
 
 	return nil
+}
+
+func (l *Linters) validateNoFormattersEnabled() error {
+	for _, n := range l.Enable {
+		if slices.Contains(getAllFormatterNames(), n) {
+			return fmt.Errorf("%s is a formatter", n)
+		}
+	}
+
+	return nil
+}
+
+func (l *Linters) validateNoFormattersDisabled() error {
+	for _, n := range l.Enable {
+		if slices.Contains(getAllFormatterNames(), n) {
+			return fmt.Errorf("%s is a formatter", n)
+		}
+	}
+
+	return nil
+}
+
+func getAllFormatterNames() []string {
+	return []string{"gci", "gofmt", "gofumpt", "goimports"}
 }

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -167,9 +167,13 @@ func (l *Loader) handleEnableOnlyOption() error {
 
 	if len(only) > 0 {
 		l.cfg.Linters = Linters{
-			Enable:  only,
-			Default: GroupNone,
+			Default:    GroupNone,
+			Enable:     only,
+			Settings:   l.cfg.Linters.Settings,
+			Exclusions: l.cfg.Linters.Exclusions,
 		}
+
+		l.cfg.Formatters = Formatters{}
 	}
 
 	return nil

--- a/pkg/goformatters/gofumpt/gofumpt.go
+++ b/pkg/goformatters/gofumpt/gofumpt.go
@@ -37,10 +37,5 @@ func (f *Formatter) Format(_ string, src []byte) ([]byte, error) {
 }
 
 func getLangVersion(v string) string {
-	if v == "" {
-		// TODO: defaults to "1.15", in the future (v2) must be removed.
-		return "go1.15"
-	}
-
 	return "go" + strings.TrimPrefix(v, "go")
 }

--- a/pkg/golinters/gci/testdata/fix/in/gci.go
+++ b/pkg/golinters/gci/testdata/fix/in/gci.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egci
 //golangcitest:config_path testdata/gci.yml
 //golangcitest:expected_exitcode 0
 package gci

--- a/pkg/golinters/gci/testdata/fix/out/gci.go
+++ b/pkg/golinters/gci/testdata/fix/out/gci.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egci
 //golangcitest:config_path testdata/gci.yml
 //golangcitest:expected_exitcode 0
 package gci

--- a/pkg/golinters/gci/testdata/gci.go
+++ b/pkg/golinters/gci/testdata/gci.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egci
 //golangcitest:config_path testdata/gci.yml
 package testdata
 

--- a/pkg/golinters/gci/testdata/gci_cgo.go
+++ b/pkg/golinters/gci/testdata/gci_cgo.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egci
 //golangcitest:config_path testdata/gci.yml
 package testdata
 

--- a/pkg/golinters/gci/testdata/gci_go124.go
+++ b/pkg/golinters/gci/testdata/gci_go124.go
@@ -1,6 +1,6 @@
 //go:build go1.24
 
-//golangcitest:args -Egci
+//golangcitest:config_path testdata/gci_go124.yml
 //golangcitest:expected_exitcode 0
 package testdata
 

--- a/pkg/golinters/gci/testdata/gci_go124.yml
+++ b/pkg/golinters/gci/testdata/gci_go124.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gci

--- a/pkg/golinters/gofmt/testdata/fix/in/gofmt.go
+++ b/pkg/golinters/gofmt/testdata/fix/in/gofmt.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/gofmt.yml
 //golangcitest:expected_exitcode 0
 package p
 

--- a/pkg/golinters/gofmt/testdata/fix/in/gofmt_rewrite_rules.go
+++ b/pkg/golinters/gofmt/testdata/fix/in/gofmt_rewrite_rules.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofmt
 //golangcitest:config_path testdata/gofmt_rewrite_rules.yml
 //golangcitest:expected_exitcode 0
 package p

--- a/pkg/golinters/gofmt/testdata/fix/out/gofmt.go
+++ b/pkg/golinters/gofmt/testdata/fix/out/gofmt.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/gofmt.yml
 //golangcitest:expected_exitcode 0
 package p
 

--- a/pkg/golinters/gofmt/testdata/fix/out/gofmt_rewrite_rules.go
+++ b/pkg/golinters/gofmt/testdata/fix/out/gofmt_rewrite_rules.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofmt
 //golangcitest:config_path testdata/gofmt_rewrite_rules.yml
 //golangcitest:expected_exitcode 0
 package p

--- a/pkg/golinters/gofmt/testdata/gofmt.go
+++ b/pkg/golinters/gofmt/testdata/gofmt.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/gofmt.yml
 package testdata
 
 import "fmt"

--- a/pkg/golinters/gofmt/testdata/gofmt.yml
+++ b/pkg/golinters/gofmt/testdata/gofmt.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt

--- a/pkg/golinters/gofmt/testdata/gofmt_cgo.go
+++ b/pkg/golinters/gofmt/testdata/gofmt_cgo.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/gofmt.yml
 package testdata
 
 /*

--- a/pkg/golinters/gofmt/testdata/gofmt_no_simplify.go
+++ b/pkg/golinters/gofmt/testdata/gofmt_no_simplify.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofmt
 //golangcitest:config_path testdata/gofmt_no_simplify.yml
 package testdata
 

--- a/pkg/golinters/gofmt/testdata/gofmt_rewrite_rules.go
+++ b/pkg/golinters/gofmt/testdata/gofmt_rewrite_rules.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofmt
 //golangcitest:config_path testdata/gofmt_rewrite_rules.yml
 package testdata
 

--- a/pkg/golinters/gofmt/testdata/gofmt_too_many_empty_lines.go
+++ b/pkg/golinters/gofmt/testdata/gofmt_too_many_empty_lines.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofmt
+//golangcitest:config_path testdata/gofmt.yml
 package testdata
 
 import "fmt"

--- a/pkg/golinters/gofumpt/testdata/fix/in/gofumpt.go
+++ b/pkg/golinters/gofumpt/testdata/fix/in/gofumpt.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofumpt
 //golangcitest:config_path testdata/gofumpt-fix.yml
 //golangcitest:expected_exitcode 0
 package p

--- a/pkg/golinters/gofumpt/testdata/fix/in/gofumpt_cgo.go
+++ b/pkg/golinters/gofumpt/testdata/fix/in/gofumpt_cgo.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofumpt
 //golangcitest:config_path testdata/gofumpt-fix.yml
 //golangcitest:expected_exitcode 0
 package p

--- a/pkg/golinters/gofumpt/testdata/fix/out/gofumpt.go
+++ b/pkg/golinters/gofumpt/testdata/fix/out/gofumpt.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofumpt
 //golangcitest:config_path testdata/gofumpt-fix.yml
 //golangcitest:expected_exitcode 0
 package p

--- a/pkg/golinters/gofumpt/testdata/fix/out/gofumpt_cgo.go
+++ b/pkg/golinters/gofumpt/testdata/fix/out/gofumpt_cgo.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofumpt
 //golangcitest:config_path testdata/gofumpt-fix.yml
 //golangcitest:expected_exitcode 0
 package p

--- a/pkg/golinters/gofumpt/testdata/gofumpt.go
+++ b/pkg/golinters/gofumpt/testdata/gofumpt.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofumpt
+//golangcitest:config_path testdata/gofumpt.yml
 package testdata
 
 import "fmt"

--- a/pkg/golinters/gofumpt/testdata/gofumpt.yml
+++ b/pkg/golinters/gofumpt/testdata/gofumpt.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofumpt

--- a/pkg/golinters/gofumpt/testdata/gofumpt_cgo.go
+++ b/pkg/golinters/gofumpt/testdata/gofumpt_cgo.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofumpt
+//golangcitest:config_path testdata/gofumpt.yml
 package testdata
 
 /*

--- a/pkg/golinters/gofumpt/testdata/gofumpt_too_many_empty_lines.go
+++ b/pkg/golinters/gofumpt/testdata/gofumpt_too_many_empty_lines.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofumpt
+//golangcitest:config_path testdata/gofumpt.yml
 package testdata
 
 import "fmt"

--- a/pkg/golinters/gofumpt/testdata/gofumpt_with_extra.go
+++ b/pkg/golinters/gofumpt/testdata/gofumpt_with_extra.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egofumpt
 //golangcitest:config_path testdata/gofumpt_with_extra.yml
 package testdata
 

--- a/pkg/golinters/goimports/testdata/fix/in/goimports.go
+++ b/pkg/golinters/goimports/testdata/fix/in/goimports.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egoimports
+//golangcitest:config_path testdata/goimports.yml
 //golangcitest:expected_exitcode 0
 package p
 

--- a/pkg/golinters/goimports/testdata/fix/in/goimports_cgo.go
+++ b/pkg/golinters/goimports/testdata/fix/in/goimports_cgo.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egoimports
+//golangcitest:config_path testdata/goimports.yml
 //golangcitest:expected_exitcode 0
 package p
 

--- a/pkg/golinters/goimports/testdata/fix/out/goimports.go
+++ b/pkg/golinters/goimports/testdata/fix/out/goimports.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egoimports
+//golangcitest:config_path testdata/goimports.yml
 //golangcitest:expected_exitcode 0
 package p
 

--- a/pkg/golinters/goimports/testdata/fix/out/goimports_cgo.go
+++ b/pkg/golinters/goimports/testdata/fix/out/goimports_cgo.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egoimports
+//golangcitest:config_path testdata/goimports.yml
 //golangcitest:expected_exitcode 0
 package p
 

--- a/pkg/golinters/goimports/testdata/goimports.go
+++ b/pkg/golinters/goimports/testdata/goimports.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egoimports
+//golangcitest:config_path testdata/goimports.yml
 package testdata
 
 import (

--- a/pkg/golinters/goimports/testdata/goimports.yml
+++ b/pkg/golinters/goimports/testdata/goimports.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - goimports

--- a/pkg/golinters/goimports/testdata/goimports_cgo.go
+++ b/pkg/golinters/goimports/testdata/goimports_cgo.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egoimports
+//golangcitest:config_path testdata/goimports.yml
 package testdata
 
 /*

--- a/pkg/golinters/goimports/testdata/goimports_local.go
+++ b/pkg/golinters/goimports/testdata/goimports_local.go
@@ -1,4 +1,3 @@
-//golangcitest:args -Egoimports
 //golangcitest:config_path testdata/goimports_local.yml
 package testdata
 

--- a/pkg/golinters/golines/testdata/fix/in/golines.go
+++ b/pkg/golinters/golines/testdata/fix/in/golines.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egolines
+//golangcitest:config_path testdata/golines.yml
 //golangcitest:expected_exitcode 0
 package testdata
 

--- a/pkg/golinters/golines/testdata/fix/out/golines.go
+++ b/pkg/golinters/golines/testdata/fix/out/golines.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egolines
+//golangcitest:config_path testdata/golines.yml
 //golangcitest:expected_exitcode 0
 package testdata
 

--- a/pkg/golinters/golines/testdata/golines.go
+++ b/pkg/golinters/golines/testdata/golines.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egolines
+//golangcitest:config_path testdata/golines.yml
 package testdata
 
 import "fmt"

--- a/pkg/golinters/golines/testdata/golines.yml
+++ b/pkg/golinters/golines/testdata/golines.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - golines

--- a/pkg/lint/lintersdb/manager.go
+++ b/pkg/lint/lintersdb/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golangci/golangci-lint/pkg/config"
 	"github.com/golangci/golangci-lint/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/pkg/goformatters"
 	"github.com/golangci/golangci-lint/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/pkg/logutils"
 )
@@ -276,6 +277,10 @@ func linterConfigsToMap(lcs []*linter.Config) map[string]*linter.Config {
 	ret := map[string]*linter.Config{}
 	for _, lc := range lcs {
 		if lc.IsDeprecated() && lc.Deprecation.Level > linter.DeprecationWarning {
+			continue
+		}
+
+		if goformatters.IsFormatter(lc.Name()) {
 			continue
 		}
 

--- a/test/enabled_linters_test.go
+++ b/test/enabled_linters_test.go
@@ -49,12 +49,12 @@ func TestEnabledLinters(t *testing.T) {
 			enabledLinters: getEnabledByDefaultLintersExcept(t, "govet"),
 		},
 		{
-			name: "enable gofmt in cmd and enable revive in config",
-			args: []string{"-Egofmt"},
+			name: "enable revive in cmd and enable gofmt in config",
+			args: []string{"-Erevive"},
 			cfg: `
-			linters:
+			formatters:
 				enable:
-					- revive
+					- gofmt
 			`,
 			enabledLinters: getEnabledByDefaultLintersWith(t, "revive", "gofmt"),
 		},

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -157,12 +157,6 @@ func TestCgoWithIssues(t *testing.T) {
 			expected: "SA5009: Printf format %t has arg #1 of wrong type",
 		},
 		{
-			desc:     "gofmt",
-			args:     []string{"--no-config", "--default=none", "-Egofmt"},
-			dir:      "cgo_with_issues",
-			expected: "File is not properly formatted (gofmt)",
-		},
-		{
 			desc:     "revive",
 			args:     []string{"--no-config", "--default=none", "-Erevive"},
 			dir:      "cgo_with_issues",
@@ -205,24 +199,6 @@ func TestLineDirective(t *testing.T) {
 			configPath: "testdata/linedirective/dupl.yml",
 			targetPath: "linedirective",
 			expected:   "21-23 lines are duplicate of `testdata/linedirective/hello.go:25-27` (dupl)",
-		},
-		{
-			desc: "gofmt",
-			args: []string{
-				"-Egofmt",
-				"--default=none",
-			},
-			targetPath: "linedirective",
-			expected:   "File is not properly formatted (gofmt)",
-		},
-		{
-			desc: "goimports",
-			args: []string{
-				"-Egoimports",
-				"--default=none",
-			},
-			targetPath: "linedirective",
-			expected:   "File is not properly formatted (goimports)",
 		},
 		{
 			desc: "gomodguard",

--- a/test/testdata/fix/in/multiple-issues-fix.go
+++ b/test/testdata/fix/in/multiple-issues-fix.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofumpt,misspell
+//golangcitest:args -Emisspell
 //golangcitest:config_path testdata/configs/multiple-issues-fix.yml
 //golangcitest:expected_exitcode 0
 package p

--- a/test/testdata/fix/out/multiple-issues-fix.go
+++ b/test/testdata/fix/out/multiple-issues-fix.go
@@ -1,4 +1,4 @@
-//golangcitest:args -Egofumpt,misspell
+//golangcitest:args -Emisspell
 //golangcitest:config_path testdata/configs/multiple-issues-fix.yml
 //golangcitest:expected_exitcode 0
 package p


### PR DESCRIPTION
When I created the `fmt` command, it was for the v1, so I created a compatibility layer.

The formatters should be enabled only inside the `formatters` section and not inside the `linters` section.

The enabled formatters will still be run as linters when using the `run` command.
