### PR TITLE
feat: drop v1 compatibility with exclude-dirs-use-default for fmt

### DIFF
--- a/pkg/commands/internal/migrate/migrate_formatters.go
+++ b/pkg/commands/internal/migrate/migrate_formatters.go
@@ -18,7 +18,7 @@ func toFormatters(old *versionone.Config) versiontwo.Formatters {
 	}
 
 	if old.Issues.UseDefaultExcludeDirs == nil || ptr.Deref(old.Issues.UseDefaultExcludeDirs) {
-		paths = append(paths, "examples$")
+		paths = append(paths, "third_party$", "builtin$", "examples$")
 	}
 
 	paths = append(paths, toFormattersPathsFromRules(old.Issues)...)

--- a/pkg/commands/internal/migrate/testdata/json/empty.golden.json
+++ b/pkg/commands/internal/migrate/testdata/json/empty.golden.json
@@ -3,6 +3,8 @@
     "exclusions": {
       "generated": "lax",
       "paths": [
+        "third_party$",
+        "builtin$",
         "examples$"
       ]
     }

--- a/pkg/commands/internal/migrate/testdata/toml/empty.golden.toml
+++ b/pkg/commands/internal/migrate/testdata/toml/empty.golden.toml
@@ -19,5 +19,7 @@ paths = [
 [formatters.exclusions]
 generated = 'lax'
 paths = [
+  'third_party$',
+  'builtin$',
   'examples$'
 ]

--- a/pkg/commands/internal/migrate/testdata/yaml/empty.golden.yml
+++ b/pkg/commands/internal/migrate/testdata/yaml/empty.golden.yml
@@ -15,4 +15,6 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      - third_party$
+      - builtin$
       - examples$

--- a/pkg/commands/internal/migrate/testdata/yaml/issues_07_a.golden.yml
+++ b/pkg/commands/internal/migrate/testdata/yaml/issues_07_a.golden.yml
@@ -8,4 +8,6 @@ linters:
 formatters:
   exclusions:
     paths:
+      - third_party$
+      - builtin$
       - examples$

--- a/pkg/commands/internal/migrate/testdata/yaml/issues_07_b.golden.yml
+++ b/pkg/commands/internal/migrate/testdata/yaml/issues_07_b.golden.yml
@@ -11,4 +11,6 @@ formatters:
     - goimports
   exclusions:
     paths:
+      - third_party$
+      - builtin$
       - examples$

--- a/pkg/commands/internal/migrate/testdata/yaml/unknown-fields.golden.yml
+++ b/pkg/commands/internal/migrate/testdata/yaml/unknown-fields.golden.yml
@@ -15,4 +15,6 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      - third_party$
+      - builtin$
       - examples$

--- a/pkg/goformat/runner.go
+++ b/pkg/goformat/runner.go
@@ -194,9 +194,6 @@ func skipDir(name string) bool {
 	case "vendor", "testdata", "node_modules":
 		return true
 
-	case "third_party", "builtin": // For compatibility with `exclude-dirs-use-default`.
-		return true
-
 	default:
 		return strings.HasPrefix(name, ".")
 	}


### PR DESCRIPTION
When I created the `fmt` command, it was for the v1, so I created a compatibility layer.

With the v2, this command should follow the same rule as `run` (with some exceptions because the internal process is totally different from the `run`).
