### PR TITLE
feat: use homogeneous JSON flags

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -158,4 +158,7 @@ jobs:
       - run: ./golangci-lint linters
       - run: ./golangci-lint formatters
       - run: ./golangci-lint version
-      - run: ./golangci-lint version --format json
+      - run: ./golangci-lint version --short
+      - run: ./golangci-lint version --debug
+      - run: ./golangci-lint version --json
+      - run: ./golangci-lint version --json --debug

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -148,6 +148,7 @@ jobs:
 
       - run: ./golangci-lint config
       - run: ./golangci-lint config path
+      - run: ./golangci-lint config path --json
       # TODO(ldez) after v2: golangci.next.jsonschema.json -> golangci.jsonschema.json
       - run: ./golangci-lint config verify --schema jsonschema/golangci.next.jsonschema.json
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -154,9 +154,12 @@ jobs:
       - run: ./golangci-lint help
       - run: ./golangci-lint help linters
       - run: ./golangci-lint help linters --json
+      - run: ./golangci-lint help formatters
       - run: ./golangci-lint help formatters --json
       - run: ./golangci-lint linters
+      - run: ./golangci-lint linters --json
       - run: ./golangci-lint formatters
+      - run: ./golangci-lint formatters --json
       - run: ./golangci-lint version
       - run: ./golangci-lint version --short
       - run: ./golangci-lint version --debug

--- a/pkg/commands/help_formatters.go
+++ b/pkg/commands/help_formatters.go
@@ -24,6 +24,16 @@ type formatterHelp struct {
 	OriginalURL string `json:"originalURL,omitempty"`
 }
 
+func newFormatterHelp(lc *linter.Config) formatterHelp {
+	return formatterHelp{
+		Name:        lc.Name(),
+		Desc:        formatDescription(lc.Linter.Desc()),
+		Deprecated:  lc.IsDeprecated(),
+		Since:       lc.Since,
+		OriginalURL: lc.OriginalURL,
+	}
+}
+
 func (c *helpCommand) formattersPreRunE(_ *cobra.Command, _ []string) error {
 	// The command doesn't depend on the real configuration.
 	dbManager, err := lintersdb.NewManager(c.log.Child(logutils.DebugKeyLintersDB), config.NewDefault(), lintersdb.NewLinterBuilder())
@@ -58,13 +68,7 @@ func (c *helpCommand) formattersPrintJSON() error {
 			continue
 		}
 
-		formatters = append(formatters, formatterHelp{
-			Name:        lc.Name(),
-			Desc:        formatDescription(lc.Linter.Desc()),
-			Deprecated:  lc.IsDeprecated(),
-			Since:       lc.Since,
-			OriginalURL: lc.OriginalURL,
-		})
+		formatters = append(formatters, newFormatterHelp(lc))
 	}
 
 	return json.NewEncoder(c.cmd.OutOrStdout()).Encode(formatters)

--- a/pkg/commands/linters.go
+++ b/pkg/commands/linters.go
@@ -113,17 +113,17 @@ func (c *lintersCommand) execute(_ *cobra.Command, _ []string) error {
 	}
 
 	if c.opts.JSON {
-		formatters := lintersHelp{}
+		linters := lintersHelp{}
 
 		for _, lc := range enabledLinters {
-			formatters.Enabled = append(formatters.Enabled, newLinterHelp(lc))
+			linters.Enabled = append(linters.Enabled, newLinterHelp(lc))
 		}
 
 		for _, lc := range disabledLinters {
-			formatters.Disabled = append(formatters.Disabled, newLinterHelp(lc))
+			linters.Disabled = append(linters.Disabled, newLinterHelp(lc))
 		}
 
-		return json.NewEncoder(c.cmd.OutOrStdout()).Encode(formatters)
+		return json.NewEncoder(c.cmd.OutOrStdout()).Encode(linters)
 	}
 
 	color.Green("Enabled by your configuration linters:\n")

--- a/pkg/commands/migrate.go
+++ b/pkg/commands/migrate.go
@@ -134,7 +134,7 @@ func (c *migrateCommand) execute(_ *cobra.Command, _ []string) error {
 
 func (c *migrateCommand) preRunE(cmd *cobra.Command, _ []string) error {
 	switch strings.ToLower(c.opts.format) {
-	case "", "yml", "yaml", "toml", "json": //nolint:goconst // Constants are useless in this context.
+	case "", "yml", "yaml", "toml", "json":
 		// Valid format.
 	default:
 		return fmt.Errorf("unsupported format: %s", c.opts.format)


### PR DESCRIPTION

- adds `--json` flags to `golangci-lint formatters` command
- adds `--json` flags to `golangci-lint linters` command
- modify `golangci-lint version` command to use `--json` instead of `--format json`


<details><summary>before</summary>

```bash
golangci-lint version --format short
golangci-lint version --debug
golangci-lint version --format json
golangci-lint version --format json --debug
```

</details>

<details><summary>after</summary>

```bash
golangci-lint version --short
golangci-lint version --debug
golangci-lint version --json
golangci-lint version --json --debug
```

</details>
