### PR TITLE
feat: error if typecheck is enabled or disabled

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -60,6 +60,14 @@ func (l *Loader) Load(opts LoadOptions) error {
 		l.cfg.Linters.Exclusions.Generated = GeneratedModeStrict
 	}
 
+	if !l.cfg.InternalCmdTest {
+		for _, n := range slices.Concat(l.cfg.Linters.Enable, l.cfg.Linters.Disable) {
+			if n == "typecheck" {
+				return fmt.Errorf("%s is not a linter, it cannot be enabled or disabled", n)
+			}
+		}
+	}
+
 	l.handleFormatters()
 
 	if opts.CheckDeprecation {


### PR DESCRIPTION
Detects if a user tries to enable or disable `typecheck`.

`typecheck` is not a linter.

- https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors
- https://golangci-lint.run/welcome/faq/#why-is-it-not-possible-to-skipignore-typecheck-errors