### PR TITLE
docs: add a link to the documentation of the v1

### DIFF
--- a/docs/src/config/sidebar.yml
+++ b/docs/src/config/sidebar.yml
@@ -2,7 +2,7 @@
 
 - label: "Introduction"
   link: "/"
-- label: Welcome
+- label: "Welcome"
   items:
     - label: "Install"
       link: "/welcome/install/"
@@ -12,7 +12,7 @@
       link: "/welcome/integrations/"
     - label: "FAQ"
       link: "/welcome/faq/"
-- label: Usage
+- label: "Usage"
   items:
     - label: "Configuration"
       link: "/usage/configuration/"
@@ -22,7 +22,7 @@
       link: "/usage/false-positives/"
     - label: "Formatters"
       link: "/usage/formatters/"
-- label: Product
+- label: "Product"
   items:
     - label: "Thanks"
       link: "/product/thanks/"
@@ -36,25 +36,25 @@
       link: "/product/performance/"
     - label: "GitHub"
       link: "https://github.com/golangci/golangci-lint"
-- label: Contributing
+- label: "Contributing"
   items:
-    - label: Quick Start
-      link: /contributing/quick-start/
-    - label: Workflow
-      link: /contributing/workflow/
-    - label: Architecture
-      link: /contributing/architecture/
-    - label: New Linters
-      link: /contributing/new-linters/
+    - label: "Quick Start"
+      link: "/contributing/quick-start/"
+    - label: "Workflow"
+      link: "/contributing/workflow/"
+    - label: "Architecture"
+      link: "/contributing/architecture/"
+    - label: "New Linters"
+      link: "/contributing/new-linters/"
     - label: "Debug"
       link: "/contributing/debug/"
-    - label: FAQ
-      link: /contributing/faq/
-    - label: This Website
-      link: /contributing/website/
-- label: Plugins
+    - label: "FAQ"
+      link: "/contributing/faq/"
+    - label: "This Website"
+      link: "/contributing/website/"
+- label: "Plugins"
   items:
-    - label: Module Plugin System
-      link: /plugins/module-plugins/
-    - label: Go Plugin System
-      link: /plugins/go-plugins/
+    - label: "Module Plugin System"
+      link: "/plugins/module-plugins/"
+    - label: "Go Plugin System"
+      link: "/plugins/go-plugins/"

--- a/docs/src/config/sidebar.yml
+++ b/docs/src/config/sidebar.yml
@@ -12,6 +12,8 @@
       link: "/welcome/integrations/"
     - label: "FAQ"
       link: "/welcome/faq/"
+    - label: "Documentation v1"
+      link: "https://golangci.github.io/legacy-v1-doc/"
 - label: "Usage"
   items:
     - label: "Configuration"

--- a/docs/src/docs/index.mdx
+++ b/docs/src/docs/index.mdx
@@ -2,8 +2,7 @@
 title: Introduction
 ---
 
-import { FaSlack } from "react-icons/fa";
-import { IconContainer } from "lib/icons";
+
 
 [![License](https://img.shields.io/github/license/golangci/golangci-lint)](https://github.com/golangci/golangci-lint/blob/HEAD/LICENSE)
 [![Release](https://img.shields.io/github/release/golangci/golangci-lint.svg)](https://github.com/golangci/golangci-lint/releases/latest)
@@ -49,10 +48,6 @@ If you value it, consider supporting us, we appreciate it! ❤️
 ![golangci-lint demo](./demo.gif)
 
 [Get started now!](/welcome/install)
-
-## License Scan
-
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fgolangci%2Fgolangci-lint.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fgolangci%2Fgolangci-lint?ref=badge_large)
 
 ## Contributors
 


### PR DESCRIPTION
- Removes FOSSA image (not really useful, and we don't have real access to the data)
- Consistent quoting of the sidebar item (useful when you need to apply modification on several items)
- Adds a link to the legacy documentation of the v1