### PR TITLE
docs: improve Docker example with cache reuse

### DIFF
--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -139,10 +139,11 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} g
 Preserving caches between consecutive runs:
 ```bash
 docker run --rm -t -v $(pwd):/app -w /app \
-  --user $(id -u):$(id -g) \
-  -v $(go env GOCACHE):/root/.cache/go-build \
-  -v $(go env GOMODCACHE):/go/pkg/mod \
-  golangci/golangci-lint:{.LatestVersion} golangci-lint run
+--user $(id -u):$(id -g) \
+-v $(go env GOCACHE):/.cache/go-build -e GOCACHE=/.cache/go-build \
+-v $(go env GOMODCACHE):/.cache/mod -e GOMODCACHE=/.cache/mod \
+-v ~/.cache/golangci-lint:/.cache/golangci-lint -e GOLANGCI_LINT_CACHE=/.cache/golangci-lint \
+golangci/golangci-lint:{.LatestVersion} golangci-lint run
 ```
 
 Colored output:

--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -138,7 +138,7 @@ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} g
 
 Preserving caches between consecutive runs:
 ```bash
-docker run --rm -v $(pwd):/app -w /app \
+docker run --rm -t -v $(pwd):/app -w /app \
   --user $(id -u):$(id -g) \
   -v $(go env GOCACHE):/root/.cache/go-build \
   -v $(go env GOMODCACHE):/go/pkg/mod \

--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -133,17 +133,21 @@ The scoop package is not officially maintained by golangci team.
 ### Docker
 
 ```bash
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run -v
+docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run
 ```
 
-Preserving cache between consecutive runs:
+Preserving caches between consecutive runs:
 ```bash
-docker run --rm -v $(pwd):/app -v ~/.cache/golangci-lint/{.LatestVersion}:/root/.cache -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run -v
+docker run --rm -v $(pwd):/app -w /app \
+  --user $(id -u):$(id -g) \
+  -v $(go env GOCACHE):/root/.cache/go-build \
+  -v $(go env GOMODCACHE):/go/pkg/mod \
+  golangci/golangci-lint:{.LatestVersion} golangci-lint run
 ```
 
 Colored output:
 ```bash
-docker run -t --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run -v
+docker run -t --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run
 ```
 
 ### Install from Sources

--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -136,6 +136,11 @@ The scoop package is not officially maintained by golangci team.
 docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run
 ```
 
+Colored output:
+```bash
+docker run -t --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run
+```
+
 Preserving caches between consecutive runs:
 ```bash
 docker run --rm -t -v $(pwd):/app -w /app \
@@ -144,11 +149,6 @@ docker run --rm -t -v $(pwd):/app -w /app \
 -v $(go env GOMODCACHE):/.cache/mod -e GOMODCACHE=/.cache/mod \
 -v ~/.cache/golangci-lint:/.cache/golangci-lint -e GOLANGCI_LINT_CACHE=/.cache/golangci-lint \
 golangci/golangci-lint:{.LatestVersion} golangci-lint run
-```
-
-Colored output:
-```bash
-docker run -t --rm -v $(pwd):/app -w /app golangci/golangci-lint:{.LatestVersion} golangci-lint run
 ```
 
 ### Install from Sources


### PR DESCRIPTION
- remove `-v`
- fix the wrong cache path
- improve the command by reusing the Go cache too