### PR TITLE
fix: validate version before configuration

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -185,10 +185,6 @@ func (c *runCommand) persistentPostRunE(_ *cobra.Command, _ []string) error {
 }
 
 func (c *runCommand) preRunE(_ *cobra.Command, args []string) error {
-	if c.cfg.GetConfigDir() != "" && c.cfg.Version != "2" {
-		return fmt.Errorf("invalid version of the configuration: %q", c.cfg.Version)
-	}
-
 	dbManager, err := lintersdb.NewManager(c.log.Child(logutils.DebugKeyLintersDB), c.cfg,
 		lintersdb.NewLinterBuilder(), lintersdb.NewPluginModuleBuilder(c.log), lintersdb.NewPluginGoBuilder(c.log))
 	if err != nil {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -60,6 +60,10 @@ func (l *Loader) Load(opts LoadOptions) error {
 		l.cfg.Linters.Exclusions.Generated = GeneratedModeStrict
 	}
 
+	if l.cfg.GetConfigDir() != "" && l.cfg.Version != "2" {
+		return fmt.Errorf("unsupported version of the configuration: %q (require configuration v2)", l.cfg.Version)
+	}
+
 	if !l.cfg.InternalCmdTest {
 		for _, n := range slices.Concat(l.cfg.Linters.Enable, l.cfg.Linters.Disable) {
 			if n == "typecheck" {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -60,8 +60,9 @@ func (l *Loader) Load(opts LoadOptions) error {
 		l.cfg.Linters.Exclusions.Generated = GeneratedModeStrict
 	}
 
-	if l.cfg.GetConfigDir() != "" && l.cfg.Version != "2" {
-		return fmt.Errorf("unsupported version of the configuration: %q (require configuration v2)", l.cfg.Version)
+	err = l.checkConfigurationVersion()
+	if err != nil {
+		return err
 	}
 
 	if !l.cfg.InternalCmdTest {
@@ -129,6 +130,14 @@ func (l *Loader) appendStringSlice(name string, current *[]string) {
 		val, _ := l.fs.GetStringSlice(name)
 		*current = append(*current, val...)
 	}
+}
+
+func (l *Loader) checkConfigurationVersion() error {
+	if l.cfg.GetConfigDir() != "" && l.cfg.Version != "2" {
+		return fmt.Errorf("unsupported version of the configuration: %q (require configuration v2)", l.cfg.Version)
+	}
+
+	return nil
 }
 
 func (l *Loader) handleGoVersion() {

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -134,7 +134,8 @@ func (l *Loader) appendStringSlice(name string, current *[]string) {
 
 func (l *Loader) checkConfigurationVersion() error {
 	if l.cfg.GetConfigDir() != "" && l.cfg.Version != "2" {
-		return fmt.Errorf("unsupported version of the configuration: %q (require configuration v2). See https://golangci-lint.run/product/migration-guide for migration instructions.", l.cfg.Version)
+		return fmt.Errorf("unsupported version of the configuration: %q "+
+			"See https://golangci-lint.run/product/migration-guide for migration instructions", l.cfg.Version)
 	}
 
 	return nil

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -134,7 +134,7 @@ func (l *Loader) appendStringSlice(name string, current *[]string) {
 
 func (l *Loader) checkConfigurationVersion() error {
 	if l.cfg.GetConfigDir() != "" && l.cfg.Version != "2" {
-		return fmt.Errorf("unsupported version of the configuration: %q (require configuration v2)", l.cfg.Version)
+		return fmt.Errorf("unsupported version of the configuration: %q (require configuration v2). See https://golangci-lint.run/product/migration-guide for migration instructions.", l.cfg.Version)
 	}
 
 	return nil

--- a/test/enabled_linters_test.go
+++ b/test/enabled_linters_test.go
@@ -28,18 +28,20 @@ func TestEnabledLinters(t *testing.T) {
 		{
 			name: "disable govet in config",
 			cfg: `
-			linters:
-				disable:
-					- govet
+version: "2"
+linters:
+	disable:
+		- govet
 			`,
 			enabledLinters: getEnabledByDefaultLintersExcept(t, "govet"),
 		},
 		{
 			name: "enable revive in config",
 			cfg: `
-			linters:
-				enable:
-					- revive
+version: "2"
+linters:
+	enable:
+		- revive
 			`,
 			enabledLinters: getEnabledByDefaultLintersWith(t, "revive"),
 		},
@@ -52,17 +54,19 @@ func TestEnabledLinters(t *testing.T) {
 			name: "enable revive in cmd and enable gofmt in config",
 			args: []string{"-Erevive"},
 			cfg: `
-			formatters:
-				enable:
-					- gofmt
+version: "2"
+formatters:
+	enable:
+		- gofmt
 			`,
 			enabledLinters: getEnabledByDefaultLintersWith(t, "revive", "gofmt"),
 		},
 		{
 			name: "fast option in config",
 			cfg: `
-			linters:
-				default: fast
+version: "2"
+linters:
+	default: fast
 			`,
 			enabledLinters: getAllLintersFromGroupFast(t),
 		},
@@ -74,8 +78,9 @@ func TestEnabledLinters(t *testing.T) {
 		{
 			name: "fast option in command-line has higher priority to enable",
 			cfg: `
-			linters:
-				default: none
+version: "2"
+linters:
+	default: none
 			`,
 			args:           []string{"--default=fast"},
 			enabledLinters: getAllLintersFromGroupFast(t),


### PR DESCRIPTION
The version validation was done after the configuration validations.

Related to https://github.com/golangci/golangci-lint/issues/5597#issuecomment-2748533645
