### PR TITLE
fix: copy golines settings during linter settings load

### DIFF
--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -223,6 +223,10 @@ func (l *Loader) handleFormatterOverrides() {
 	if slices.Contains(l.cfg.Formatters.Enable, "gci") {
 		l.cfg.Linters.Settings.Gci = l.cfg.Formatters.Settings.Gci
 	}
+
+	if slices.Contains(l.cfg.Formatters.Enable, "golines") {
+		l.cfg.Linters.Settings.GoLines = l.cfg.Formatters.Settings.GoLines
+	}
 }
 
 // Add formatter exclusions to linters exclusions.

--- a/pkg/golinters/golines/testdata/fix/in/golines-custom.go
+++ b/pkg/golinters/golines/testdata/fix/in/golines-custom.go
@@ -1,0 +1,16 @@
+//golangcitest:config_path testdata/golines-custom.yml
+//golangcitest:expected_exitcode 0
+package testdata
+
+// the struct tags should not be reformatted here
+type Foo struct {
+	Bar `a:"b=\"c\"" d:"e"`
+	Baz `a:"f" d:"g"`
+}
+
+var (
+	// this ends at 80 columns with tab size 2, and would only be a little wider
+	// with tab size 8, not failing the default line-len, so it checks both
+	// settings are applied properly
+	abc = []string{"a string that is only wrapped at narrow widths and wide tabs"}
+)

--- a/pkg/golinters/golines/testdata/fix/out/golines-custom.go
+++ b/pkg/golinters/golines/testdata/fix/out/golines-custom.go
@@ -1,0 +1,18 @@
+//golangcitest:config_path testdata/golines-custom.yml
+//golangcitest:expected_exitcode 0
+package testdata
+
+// the struct tags should not be reformatted here
+type Foo struct {
+	Bar `a:"b=\"c\"" d:"e"`
+	Baz `a:"f" d:"g"`
+}
+
+var (
+	// this ends at 80 columns with tab size 2, and would only be a little wider
+	// with tab size 8, not failing the default line-len, so it checks both
+	// settings are applied properly
+	abc = []string{
+		"a string that is only wrapped at narrow widths and wide tabs",
+	}
+)

--- a/pkg/golinters/golines/testdata/golines-custom.yml
+++ b/pkg/golinters/golines/testdata/golines-custom.yml
@@ -1,0 +1,11 @@
+version: "2"
+
+formatters:
+  enable:
+    - golines
+  settings:
+    golines:
+      # override many settings
+      max-len: 80
+      tab-len: 8
+      reformat-tags: false


### PR DESCRIPTION
This fixes the issue retaining the existing code pattern, but I'm wondering why we don't just do this instead of checking for each enabled formatter:
```go
l.cfg.Linters.Settings.FormatterSettings = l.cfg.Formatters.Settings
```

I'm assuming for now that there is a good reason :)

Fixes #5603
