### PR TITLE
docs: adaptive stargazers image

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ This project exists thanks to all the people who contribute. [How to contribute]
 
 ## Stargazers over time
 
-[![Stargazers over time](https://starchart.cc/golangci/golangci-lint.svg)](https://starchart.cc/golangci/golangci-lint)
+[![Stargazers over time](https://starchart.cc/golangci/golangci-lint.svg?variant=adaptive)](https://starchart.cc/golangci/golangci-lint)


### PR DESCRIPTION
The `adaptive` property adjusts the image's style based on GitHub's dark/light theme.

<details><summary>Screenshots</summary>
<p>

Before:

<img width="1076" alt="image" src="https://github.com/user-attachments/assets/7317a7f9-2652-4bed-8efd-30c4a539fe2d" />

After:

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/aeb8977b-c36e-49c5-99b9-cad93a0c4799" />

</p>
</details> 