### PR TITLE
fix: formatter validation message

### DIFF
--- a/pkg/config/formatters.go
+++ b/pkg/config/formatters.go
@@ -14,7 +14,7 @@ type Formatters struct {
 func (f *Formatters) Validate() error {
 	for _, n := range f.Enable {
 		if !slices.Contains(getAllFormatterNames(), n) {
-			return fmt.Errorf("%s is a formatter", n)
+			return fmt.Errorf("%s is not a formatter", n)
 		}
 	}
 


### PR DESCRIPTION
Before:

```
$ go run ./cmd/golangci-lint fmt -E formatter
Error: can't load config: formatter is a formatter
Failed executing command with error: can't load config: formatter is a formatter
exit status 3
```

After:

```
$ go run ./cmd/golangci-lint fmt -E formatter
Error: can't load config: formatter is not a formatter
Failed executing command with error: can't load config: formatter is not a formatter
exit status 3
```