### PR TITLE
docs: add version field to configuration sample

### DIFF
--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -254,7 +254,7 @@ func (e *ExampleSnippetsExtractor) extractExampleSnippets(example []byte) (*Sett
 
 	for j, node := range root.Content {
 		switch node.Value {
-		case "run", "output", keyLinters, keyFormatters, "issues", "severity":
+		case "run", "output", keyLinters, keyFormatters, "issues", "severity", "version":
 		default:
 			continue
 		}
@@ -278,6 +278,11 @@ func (e *ExampleSnippetsExtractor) extractExampleSnippets(example []byte) (*Sett
 					Value: "value",
 				},
 			},
+		}
+
+		if node.Value == "version" {
+			node.HeadComment = `See the dedicated "version" documentation section.`
+			newNode = nextNode
 		}
 
 		globalNode.Content = append(globalNode.Content, node, newNode)


### PR DESCRIPTION
The [configuration example](https://golangci-lint.run/usage/configuration/) lacks the `version` field.

<details><summary>Details</summary>
<p>

Before:

<img width="890" alt="image" src="https://github.com/user-attachments/assets/de2f17f9-3aa6-4c09-b371-f53b16bf56a5" />

After:

<img width="889" alt="image" src="https://github.com/user-attachments/assets/f3f2a73c-d350-4560-93ba-1f8b67bc2678" />

</p>
</details> 

Follows #5609