### PR TITLE
docs: remove golint in nolint example

### DIFF
--- a/docs/src/docs/usage/false-positives.mdx
+++ b/docs/src/docs/usage/false-positives.mdx
@@ -122,7 +122,7 @@ var bad_name int //nolint:all
 To exclude issues from specific linters only:
 
 ```go
-var bad_name int //nolint:staticcheck,unused
+var bad_name int //nolint:wsl,unused
 ```
 
 To exclude issues for the block of code use this directive on the beginning of a line:

--- a/docs/src/docs/usage/false-positives.mdx
+++ b/docs/src/docs/usage/false-positives.mdx
@@ -122,7 +122,7 @@ var bad_name int //nolint:all
 To exclude issues from specific linters only:
 
 ```go
-var bad_name int //nolint:golint,unused
+var bad_name int //nolint:staticcheck,unused
 ```
 
 To exclude issues for the block of code use this directive on the beginning of a line:

--- a/pkg/result/processors/nolint_filter_test.go
+++ b/pkg/result/processors/nolint_filter_test.go
@@ -63,7 +63,7 @@ func TestTestNolintFilter_Process(t *testing.T) {
 	processAssertEmpty(t, p, newNolintFileIssue(6, "any"))
 	processAssertEmpty(t, p, newNolintFileIssue(7, "any"))
 
-	processAssertSame(t, p, newNolintFileIssue(1, "staticcheck")) // no directive
+	processAssertSame(t, p, newNolintFileIssue(1, "wsl")) // no directive
 
 	// test preceding comments
 	processAssertEmpty(t, p, newNolintFileIssue(10, "any")) // preceding comment for var

--- a/pkg/result/processors/nolint_filter_test.go
+++ b/pkg/result/processors/nolint_filter_test.go
@@ -63,7 +63,7 @@ func TestTestNolintFilter_Process(t *testing.T) {
 	processAssertEmpty(t, p, newNolintFileIssue(6, "any"))
 	processAssertEmpty(t, p, newNolintFileIssue(7, "any"))
 
-	processAssertSame(t, p, newNolintFileIssue(1, "golint")) // no directive
+	processAssertSame(t, p, newNolintFileIssue(1, "staticcheck")) // no directive
 
 	// test preceding comments
 	processAssertEmpty(t, p, newNolintFileIssue(10, "any")) // preceding comment for var


### PR DESCRIPTION
`golint` is deprecated and removed from golangci-lint.