### PR TITLE
docs: remove duplicated version section

### DIFF
--- a/docs/src/docs/usage/configuration.mdx
+++ b/docs/src/docs/usage/configuration.mdx
@@ -42,14 +42,6 @@ The configuration file can be validated with the JSON Schema: https://golangci-l
 
 { .ConfigurationExample }
 
-### `version` configuration
-
-```yaml
-# Defines the configuration version.
-# The only possible value is "2".
-version: "2"
-```
-
 ## Command-Line Options
 
 ### run

--- a/scripts/website/expand_templates/linters.go
+++ b/scripts/website/expand_templates/linters.go
@@ -281,7 +281,8 @@ func (e *ExampleSnippetsExtractor) extractExampleSnippets(example []byte) (*Sett
 		}
 
 		if node.Value == "version" {
-			node.HeadComment = `See the dedicated "version" documentation section.`
+			node.HeadComment = `Defines the configuration version.
+The only possible value is "2"`
 			newNode = nextNode
 		}
 


### PR DESCRIPTION
Currently, `version configuration` section duplicates. We have headings:

- https://golangci-lint.run/usage/configuration/#version-configuration
- https://golangci-lint.run/usage/configuration/#version-configuration-1

This PR removes this redundant section.

<details><summary>Screenshot of the website after expanding templates</summary>
<p>

<img width="896" alt="image" src="https://github.com/user-attachments/assets/74dfb893-311b-4500-bb07-da08c3442ba2" />

</p>
</details> 
 
Follows #5632