### PR TITLE
feat: add config path placeholder

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -335,6 +335,7 @@ linters:
           # List of file globs that will match this list of settings to compare against.
           # By default, if a path is relative, it is relative to the directory where the golangci-lint command is executed.
           # The placeholder '${base-path}' is substituted with a path relative to the mode defined with `run.relative-path-mode`.
+          # The placeholder '${config-path}' is substituted with a path relative to the configuration file.
           # Default: $all
           files:
             - "!**/*_a _file.go"
@@ -1161,6 +1162,7 @@ linters:
           # Comma-separated list of file paths containing ruleguard rules.
           # By default, if a path is relative, it is relative to the directory where the golangci-lint command is executed.
           # The placeholder '${base-path}' is substituted with a path relative to the mode defined with `run.relative-path-mode`.
+          # The placeholder '${config-path}' is substituted with a path relative to the configuration file.
           # Glob patterns such as 'rules-*.go' may be specified.
           # Default: ""
           rules: '${base-path}/ruleguard/rules-*.go,${base-path}/myrule1.go'
@@ -1256,6 +1258,7 @@ linters:
       # Useful if you need to load the template from a specific file.
       # By default, if a path is relative, it is relative to the directory where the golangci-lint command is executed.
       # The placeholder '${base-path}' is substituted with a path relative to the mode defined with `run.relative-path-mode`.
+      # The placeholder '${config-path}' is substituted with a path relative to the configuration file.
       # Default: ""
       template-path: /path/to/my/template.tmpl
 

--- a/pkg/config/placeholders.go
+++ b/pkg/config/placeholders.go
@@ -1,0 +1,18 @@
+package config
+
+import "strings"
+
+const (
+	// placeholderBasePath used inside linters to evaluate relative paths.
+	placeholderBasePath = "${base-path}"
+
+	// placeholderConfigPath used inside linters to paths relative to configuration.
+	placeholderConfigPath = "${config-path}"
+)
+
+func NewPlaceholderReplacer(cfg *Config) *strings.Replacer {
+	return strings.NewReplacer(
+		placeholderBasePath, cfg.GetBasePath(),
+		placeholderConfigPath, cfg.GetConfigDir(),
+	)
+}

--- a/pkg/golinters/depguard/depguard.go
+++ b/pkg/golinters/depguard/depguard.go
@@ -8,18 +8,17 @@ import (
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 )
 
-func New(settings *config.DepGuardSettings, basePath string) *goanalysis.Linter {
+func New(settings *config.DepGuardSettings, replacer *strings.Replacer) *goanalysis.Linter {
 	conf := depguard.LinterSettings{}
 
 	if settings != nil {
 		for s, rule := range settings.Rules {
 			var extendedPatterns []string
 			for _, file := range rule.Files {
-				extendedPatterns = append(extendedPatterns, strings.ReplaceAll(file, internal.PlaceholderBasePath, basePath))
+				extendedPatterns = append(extendedPatterns, replacer.Replace(file))
 			}
 
 			list := &depguard.List{

--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/logutils"
 )
@@ -31,7 +30,7 @@ var (
 	isDebug = logutils.HaveDebugTag(logutils.DebugKeyGoCritic)
 )
 
-func New(settings *config.GoCriticSettings) *goanalysis.Linter {
+func New(settings *config.GoCriticSettings, replacer *strings.Replacer) *goanalysis.Linter {
 	wrapper := &goCriticWrapper{
 		sizes: types.SizesFor("gc", runtime.GOARCH),
 	}
@@ -58,9 +57,7 @@ Dynamic rules are written declaratively with AST patterns, filters, report messa
 		nil,
 	).
 		WithContextSetter(func(context *linter.Context) {
-			wrapper.replacer = strings.NewReplacer(
-				internal.PlaceholderBasePath, context.Cfg.GetBasePath(),
-			)
+			wrapper.replacer = replacer
 
 			wrapper.init(context.Log, settings)
 		}).

--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"maps"
-	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -57,21 +55,18 @@ Dynamic rules are written declaratively with AST patterns, filters, report messa
 		nil,
 	).
 		WithContextSetter(func(context *linter.Context) {
-			wrapper.replacer = replacer
-
-			wrapper.init(context.Log, settings)
+			wrapper.init(context.Log, settings, replacer)
 		}).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 type goCriticWrapper struct {
 	settingsWrapper *settingsWrapper
-	replacer        *strings.Replacer
 	sizes           types.Sizes
 	once            sync.Once
 }
 
-func (w *goCriticWrapper) init(logger logutils.Log, settings *config.GoCriticSettings) {
+func (w *goCriticWrapper) init(logger logutils.Log, settings *config.GoCriticSettings, replacer *strings.Replacer) {
 	if settings == nil {
 		return
 	}
@@ -83,12 +78,9 @@ func (w *goCriticWrapper) init(logger logutils.Log, settings *config.GoCriticSet
 		}
 	})
 
-	settingsWrapper := newSettingsWrapper(settings, logger)
-	settingsWrapper.InferEnabledChecks()
+	settingsWrapper := newSettingsWrapper(logger, settings, replacer)
 
-	// Validate must be after InferEnabledChecks, not before.
-	// Because it uses gathered information about tags set and finally enabled checks.
-	if err := settingsWrapper.Validate(); err != nil {
+	if err := settingsWrapper.Load(); err != nil {
 		logger.Fatalf("%s: invalid settings: %s", linterName, err)
 	}
 
@@ -137,7 +129,8 @@ func (w *goCriticWrapper) buildEnabledCheckers(linterCtx *gocriticlinter.Context
 			continue
 		}
 
-		if err := w.configureCheckerInfo(info, allLowerCasedParams); err != nil {
+		err := w.settingsWrapper.setCheckerParams(info, allLowerCasedParams)
+		if err != nil {
 			return nil, err
 		}
 
@@ -150,59 +143,6 @@ func (w *goCriticWrapper) buildEnabledCheckers(linterCtx *gocriticlinter.Context
 	}
 
 	return enabledCheckers, nil
-}
-
-func (w *goCriticWrapper) configureCheckerInfo(
-	info *gocriticlinter.CheckerInfo,
-	allLowerCasedParams map[string]config.GoCriticCheckSettings,
-) error {
-	params := allLowerCasedParams[strings.ToLower(info.Name)]
-	if params == nil { // no config for this checker
-		return nil
-	}
-
-	// To lowercase info param keys here because golangci-lint's config parser lowercases all strings.
-	infoParams := normalizeMap(info.Params)
-	for k, p := range params {
-		v, ok := infoParams[k]
-		if ok {
-			v.Value = w.normalizeCheckerParamsValue(p)
-			continue
-		}
-
-		// param `k` isn't supported
-		if len(info.Params) == 0 {
-			return fmt.Errorf("checker %s config param %s doesn't exist: checker doesn't have params",
-				info.Name, k)
-		}
-
-		supportedKeys := slices.Sorted(maps.Keys(info.Params))
-
-		return fmt.Errorf("checker %s config param %s doesn't exist, all existing: %s",
-			info.Name, k, supportedKeys)
-	}
-
-	return nil
-}
-
-// normalizeCheckerParamsValue normalizes value types.
-// go-critic asserts that CheckerParam.Value has some specific types,
-// but the file parsers (TOML, YAML, JSON) don't create the same representation for raw type.
-// then we have to convert value types into the expected value types.
-// Maybe in the future, this kind of conversion will be done in go-critic itself.
-func (w *goCriticWrapper) normalizeCheckerParamsValue(p any) any {
-	rv := reflect.ValueOf(p)
-	switch rv.Type().Kind() {
-	case reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int:
-		return int(rv.Int())
-	case reflect.Bool:
-		return rv.Bool()
-	case reflect.String:
-		// Perform variable substitution.
-		return w.replacer.Replace(rv.String())
-	default:
-		return p
-	}
 }
 
 func runOnFile(pass *analysis.Pass, f *ast.File, checks []*gocriticlinter.Checker) {
@@ -229,20 +169,4 @@ func runOnFile(pass *analysis.Pass, f *ast.File, checks []*gocriticlinter.Checke
 			pass.Report(diag)
 		}
 	}
-}
-
-func normalizeMap[ValueT any](in map[string]ValueT) map[string]ValueT {
-	ret := make(map[string]ValueT, len(in))
-	for k, v := range in {
-		ret[strings.ToLower(k)] = v
-	}
-	return ret
-}
-
-func isEnabledByDefaultGoCriticChecker(info *gocriticlinter.CheckerInfo) bool {
-	// https://github.com/go-critic/go-critic/blob/5b67cfd487ae9fe058b4b19321901b3131810f65/cmd/gocritic/check.go#L342-L345
-	return !info.HasTag(gocriticlinter.ExperimentalTag) &&
-		!info.HasTag(gocriticlinter.OpinionatedTag) &&
-		!info.HasTag(gocriticlinter.PerformanceTag) &&
-		!info.HasTag(gocriticlinter.SecurityTag)
 }

--- a/pkg/golinters/gocritic/testdata/gocritic.yml
+++ b/pkg/golinters/gocritic/testdata/gocritic.yml
@@ -14,7 +14,7 @@ linters:
           sizeThreshold: 24
         ruleguard:
           failOn: dsl,import
-          rules: '${base-path}/ruleguard/preferWriteString.go,${base-path}/ruleguard/stringsSimplify.go'
+          rules: '${base-path}/ruleguard/preferWriteString.go,${config-path}/ruleguard/stringsSimplify.go'
 
 run:
   relative-path-mode: cfg

--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -9,18 +9,17 @@ import (
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
 const linterName = "goheader"
 
-func New(settings *config.GoHeaderSettings, basePath string) *goanalysis.Linter {
+func New(settings *config.GoHeaderSettings, replacer *strings.Replacer) *goanalysis.Linter {
 	conf := &goheader.Configuration{}
 	if settings != nil {
 		conf = &goheader.Configuration{
 			Values:       settings.Values,
 			Template:     settings.Template,
-			TemplatePath: strings.ReplaceAll(settings.TemplatePath, internal.PlaceholderBasePath, basePath),
+			TemplatePath: replacer.Replace(settings.TemplatePath),
 		}
 	}
 

--- a/pkg/golinters/internal/commons.go
+++ b/pkg/golinters/internal/commons.go
@@ -4,6 +4,3 @@ import "github.com/golangci/golangci-lint/v2/pkg/logutils"
 
 // LinterLogger must be use only when the context logger is not available.
 var LinterLogger = logutils.NewStderrLog(logutils.DebugKeyLinter)
-
-// PlaceholderBasePath used inside linters to evaluate relative paths.
-const PlaceholderBasePath = "${base-path}"

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -129,6 +129,8 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		return nil, nil
 	}
 
+	placeholderReplacer := config.NewPlaceholderReplacer(cfg)
+
 	// The linters are sorted in the alphabetical order (case-insensitive).
 	// When a new linter is added the version in `WithSince(...)` must be the next minor version of golangci-lint.
 	return []*linter.Config{
@@ -180,7 +182,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.44.0").
 			WithURL("https://gitlab.com/bosi/decorder"),
 
-		linter.NewConfig(depguard.New(&cfg.Linters.Settings.Depguard, cfg.GetBasePath())).
+		linter.NewConfig(depguard.New(&cfg.Linters.Settings.Depguard, placeholderReplacer)).
 			WithSince("v1.4.0").
 			WithURL("https://github.com/OpenPeeDeeP/depguard"),
 
@@ -300,7 +302,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithURL("https://github.com/jgautheron/goconst"),
 
-		linter.NewConfig(gocritic.New(&cfg.Linters.Settings.Gocritic)).
+		linter.NewConfig(gocritic.New(&cfg.Linters.Settings.Gocritic, placeholderReplacer)).
 			WithSince("v1.12.0").
 			WithLoadForGoAnalysis().
 			WithAutoFix().
@@ -340,7 +342,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithAutoFix().
 			WithURL("https://github.com/segmentio/golines"),
 
-		linter.NewConfig(goheader.New(&cfg.Linters.Settings.Goheader, cfg.GetBasePath())).
+		linter.NewConfig(goheader.New(&cfg.Linters.Settings.Goheader, placeholderReplacer)).
 			WithSince("v1.28.0").
 			WithAutoFix().
 			WithURL("https://github.com/denis-tingaikin/go-header"),


### PR DESCRIPTION
In the rare cases, the linter configuration should be relative to the configuration path, even when using other relative path modes other than `cfg`.

Those cases are relative to paths that reference "external files".

Fixes #5646