### PR TITLE
docs: improve default exclusions render

### DIFF
--- a/docs/src/@rocketseat/gatsby-theme-docs/src/styles/global.js
+++ b/docs/src/@rocketseat/gatsby-theme-docs/src/styles/global.js
@@ -66,6 +66,7 @@ export default function GlobalStyle() {
           font-weight: 400;
         }
 
+        span.inline-code,
         code.inline-code {
           display: inline-block;
           vertical-align: middle;

--- a/scripts/website/expand_templates/exclusions.go
+++ b/scripts/website/expand_templates/exclusions.go
@@ -11,21 +11,25 @@ import (
 const exclusionTmpl = `{{- $tick := "` + "`" + `" -}}
 {{- range $name, $rules := . }}
 ### {{ $tick }}{{ $name }}{{ $tick }}
-{{ range $rule := $rules }}
-{{ $tick }}{{ range $linter := $rule.Linters }}{{ $linter }}{{ end }}{{ $tick }}:
-{{ if $rule.Path -}}
-- Path: {{ $tick }}{{ $rule.Path }}{{ $tick }}
-{{ end -}}
-{{ if $rule.PathExcept -}}
-- Path Except: {{ $tick }}{{ $rule.PathExcept }}{{ $tick }}
-{{ end -}}
-{{ if $rule.Text -}}
-- Text: {{ $tick }}{{ $rule.Text }}{{ $tick }}
-{{ end -}}
-{{ if $rule.Source -}}
-- Source: {{ $tick }}{{ $rule.Source }}{{ $tick }}
-{{ end -}}
-{{ end }}{{ end }}`
+
+<table>
+    <thead>
+    <tr>
+        <th>linter</th>
+        <th>Issue Text</th>
+    </tr>
+    </thead>
+    <tbody>
+{{- range $rule := $rules }}
+    <tr>
+        <td>{{ range $linter := $rule.Linters }}{{ $linter }}{{ end }}</td>
+        <td><span class="inline-code">{{ if $rule.Text }}{{ $rule.Text }}{{ end }}</span></td>
+    </tr>
+{{- end }}
+		</tbody>
+</table>
+
+{{ end }}`
 
 func getExclusionPresets() (string, error) {
 	linterExclusionPresets, err := readJSONFile[map[string][]types.ExcludeRule](filepath.Join("assets", "exclusion-presets.json"))

--- a/scripts/website/expand_templates/exclusions.go
+++ b/scripts/website/expand_templates/exclusions.go
@@ -26,7 +26,7 @@ const exclusionTmpl = `{{- $tick := "` + "`" + `" -}}
         <td><span class="inline-code">{{ if $rule.Text }}{{ $rule.Text }}{{ end }}</span></td>
     </tr>
 {{- end }}
-		</tbody>
+    </tbody>
 </table>
 
 {{ end }}`

--- a/scripts/website/expand_templates/exclusions.go
+++ b/scripts/website/expand_templates/exclusions.go
@@ -10,12 +10,12 @@ import (
 
 const exclusionTmpl = `{{- $tick := "` + "`" + `" -}}
 {{- range $name, $rules := . }}
-### {{ $tick }}{{ $name }}{{ $tick }}
+### Preset {{ $tick }}{{ $name }}{{ $tick }}
 
 <table>
     <thead>
     <tr>
-        <th>linter</th>
+        <th>Linter</th>
         <th>Issue Text</th>
     </tr>
     </thead>


### PR DESCRIPTION
<details>

![Screenshot 2025-03-29 at 17-58-05 False Positives golangci-lint](https://github.com/user-attachments/assets/a1a1c9fa-50c9-4e94-9f42-4f5602926e6b)


</details>

Markdown table doesn't work because of a problem related to `|` character with the current Markdown parser (note, escaping doesn't work either).
The tag `<code>` cannot be used because it breaks the MDX parsing.

For now, we don't need to handle the other exclusion fields.