### PR TITLE
docs: remove tenv linter settings

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -3395,12 +3395,6 @@ linters:
             # Default: false
             ignore: true
 
-    tenv:
-      # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-      # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-      # Default: false
-      all: false
-
     testifylint:
       # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
       # Default: false

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -3395,12 +3395,6 @@ linters:
             # Default: false
             ignore: true
 
-    tenv:
-      # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-      # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-      # Default: false
-      all: false
-
     testifylint:
       # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
       # Default: false

--- a/jsonschema/golangci.jsonschema.json
+++ b/jsonschema/golangci.jsonschema.json
@@ -803,7 +803,6 @@
             "stylecheck",
             "tagalign",
             "tagliatelle",
-            "tenv",
             "testableexamples",
             "testifylint",
             "testpackage",
@@ -3339,17 +3338,6 @@
             }
           }
         },
-        "tenvSettings": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "all": {
-              "description": "The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.",
-              "type": "boolean",
-              "default": false
-            }
-          }
-        },
         "testifylintSettings": {
           "type": "object",
           "additionalProperties": false,
@@ -4474,9 +4462,6 @@
             },
             "tagliatelle": {
               "$ref": "#/definitions/settings/definitions/tagliatelleSettings"
-            },
-            "tenv": {
-              "$ref": "#/definitions/settings/definitions/tenvSettings"
             },
             "testifylint": {
               "$ref": "#/definitions/settings/definitions/testifylintSettings"

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -803,7 +803,6 @@
             "stylecheck",
             "tagalign",
             "tagliatelle",
-            "tenv",
             "testableexamples",
             "testifylint",
             "testpackage",
@@ -3339,17 +3338,6 @@
             }
           }
         },
-        "tenvSettings": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "all": {
-              "description": "The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.",
-              "type": "boolean",
-              "default": false
-            }
-          }
-        },
         "testifylintSettings": {
           "type": "object",
           "additionalProperties": false,
@@ -4474,9 +4462,6 @@
             },
             "tagliatelle": {
               "$ref": "#/definitions/settings/definitions/tagliatelleSettings"
-            },
-            "tenv": {
-              "$ref": "#/definitions/settings/definitions/tenvSettings"
             },
             "testifylint": {
               "$ref": "#/definitions/settings/definitions/testifylintSettings"


### PR DESCRIPTION
`tenv` is removed in v2, but we forgot to remove also its settings.