### PR TITLE
docs: fix `go get -tool` command

### DIFF
--- a/docs/src/docs/welcome/install.mdx
+++ b/docs/src/docs/welcome/install.mdx
@@ -203,7 +203,7 @@ go tool -modfile=golangci-lint.mod golangci-lint run
 
 ```sh
 # Update golangci-lint
-go get -tool -modfile=golangci-lint.mod github.com/golangci/v2/golangci-lint/cmd/golangci-lint@latest
+go get -tool -modfile=golangci-lint.mod github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 ```
 
 **Method 2: dedicated module**


### PR DESCRIPTION
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

This PR fixes the "`go tool` usage recommendations" section in the following documentation page: https://golangci-lint.run/welcome/install/#install-from-sources

### Preview

| Before | After
| :--: | :--:
| <img width="740" alt="image" src="https://github.com/user-attachments/assets/77a9e04d-c598-431c-ae3a-95c5c8e2029e" /> | <img width="704" alt="image" src="https://github.com/user-attachments/assets/e60aeb01-cb1b-461a-9674-7faf6194f316" />

