### PR TITLE
fix: memory leaks when using go1.(N) with golangci-lint built with with go1.(N-1)

### DIFF
--- a/pkg/goanalysis/pkgerrors/errors.go
+++ b/pkg/goanalysis/pkgerrors/errors.go
@@ -15,7 +15,7 @@ type IllTypedError struct {
 }
 
 func (e *IllTypedError) Error() string {
-	return fmt.Sprintf("errors in package: %v", e.Pkg.Errors)
+	return fmt.Sprintf("IllTypedError: errors in package: %v", e.Pkg.Errors)
 }
 
 func BuildIssuesFromIllTypedError(errs []error, lintCtx *linter.Context) ([]result.Issue, error) {


### PR DESCRIPTION
My previous PR #4938 was already detecting some cases, but in some contexts, this is not enough.  

I was able to create the right context to reproduce the memory leak.

I analyzed the memory and found the root cause of the leak: the errors were accumulated for all the packages and all the files (stdlib, dependencies, project packages).
The number of errors was massive, consuming all the memory, and the OS ended up killing the process or dying.

I use a `panic` because the problem is detected inside the typechecking process (no control of the error management), and this process should be stopped as soon as possible.

<details><summary>The new behavior</summary>

```console
$ ./golangci-lint run
panic: file requires newer Go version go1.24 (application built with go1.23) [recovered]
        panic: file requires newer Go version go1.24 (application built with go1.23)

goroutine 3748 [running]:
go/types.(*Checker).handleBailout(0xc00a302000, 0xc008887a80)
        /home/ldez/go1.23.8/src/go/types/check.go:404 +0x88
panic({0x1b01fa0?, 0xc009f6c450?})
        /home/ldez/go1.23.8/src/runtime/panic.go:791 +0x132
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).convertError(0xc0032c4720, {0x22c1f80?, 0xc00a025800})
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:447 +0x739
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).loadFromSource.func2({0x22c1f80?, 0xc00a025800?})
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:175 +0x37
go/types.(*Checker).handleError(0xc00a302000, 0x0, {0x22c2ec0, 0xc008d79dc0}, 0x97, {0xc0085909b0, 0x45}, 0x0)
        /home/ldez/go1.23.8/src/go/types/errors.go:221 +0x44a
go/types.(*error_).report(0xc0088878a8)
        /home/ldez/go1.23.8/src/go/types/errors.go:148 +0x2ce
go/types.(*Checker).errorf(0xc00030ae64?, {0x22c2ec0, 0xc008d79dc0}, 0x6?, {0x1e87811?, 0xa770e5?}, {0xc0088879b0?, 0xc008887960?, 0xa858c5?})
        /home/ldez/go1.23.8/src/go/types/errors.go:243 +0x14b
go/types.(*Checker).initFiles(0xc00a302000, {0xc0003f1b80, 0x29, 0x1c0?})
        /home/ldez/go1.23.8/src/go/types/check.go:380 +0x751
go/types.(*Checker).checkFiles(0xc00a302000, {0xc0003f1b80, 0x29, 0x29})
        /home/ldez/go1.23.8/src/go/types/check.go:453 +0x116
go/types.(*Checker).Files(0x1ba3a80?, {0xc0003f1b80?, 0xc00971f920?, 0x5?})
        /home/ldez/go1.23.8/src/go/types/check.go:422 +0x75
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).loadFromSource(0xc0032c4720, 0x2)
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:181 +0x777
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).loadImportedPackageWithFacts(0xc0032c4720, 0x2)
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:341 +0x3f6
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).loadWithFacts(0xad8d8e?, 0x2f9c0a0?)
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:286 +0x128
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyze(0xc0032c4720, 0x2, 0xc0030771f0)
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:67 +0xce
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyzeRecursive.func1()
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:54 +0x1aa
sync.(*Once).doSlow(0x687372614d2e316e?, 0x617066646b286c61?)
        /home/ldez/go1.23.8/src/sync/once.go:76 +0xb4
sync.(*Once).Do(...)
        /home/ldez/go1.23.8/src/sync/once.go:67
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyzeRecursive(0x74707972636e452e?, 0x6d656863536e6f69?, 0x69726f676c412e65?)
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:43 +0x45
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyzeRecursive.func1.1(0x6e452e736d617261?)
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:49 +0x25
created by github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyzeRecursive.func1 in goroutine 3345
        /home/ldez/sources/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:48 +0xb4

```

</details>

