### PR TITLE
docs: explicitly describe that the `migrate` command automatically migrate `linters.presets`

### DIFF
--- a/docs/src/docs/product/migration-guide.mdx
+++ b/docs/src/docs/product/migration-guide.mdx
@@ -37,13 +37,13 @@ The `migrate` command enforces the following default values:
 - `run.concurrency`: if the existing value was `0`, it is removed as `0` is the new default.
 - `run.relative-path-mode`: if the existing value was `cfg`, it is removed as `cfg` is the new default.
 
-`linters.presets` has been removed. The `migrate` command **automatically adds individual linters to `linters.enable`.**
-
 `issues.exclude-generated` has a new default value (v1 `lax`, v2 `strict`), so this field will be added during the migration to maintain the previous behavior.
 
 `issues.exclude-dirs-use-default` has been removed, so it is converted to `linters.exclusions.paths` and, if needed, `formatters.exclusions.paths`.
 
 Other fields explicitly defined in the configuration file are migrated even if the value is the same as the default value.
+
+The `migrate` command automatically migrates `linters.presets` in individual linters to `linters.enable`.
 
 ```txt
 Migrate configuration file from v1 to v2
@@ -191,7 +191,9 @@ There are 2 new options (they are not strictly equivalent to the previous option
 
 #### `linters.presets`
 
-This property has been removed. The `migrate` command **automatically adds individual linters to `linters.enable`.**
+This property has been removed.
+
+The `migrate` command automatically migrates `linters.presets` in individual linters to `linters.enable`.
 
 <details>
 <summary style={{color: '#737380', paddingLeft: '1rem'}}>v1</summary>

--- a/docs/src/docs/product/migration-guide.mdx
+++ b/docs/src/docs/product/migration-guide.mdx
@@ -37,6 +37,8 @@ The `migrate` command enforces the following default values:
 - `run.concurrency`: if the existing value was `0`, it is removed as `0` is the new default.
 - `run.relative-path-mode`: if the existing value was `cfg`, it is removed as `cfg` is the new default.
 
+`linters.presets` has been removed. The `migrate` command **automatically adds individual linters to `linters.enable`.**
+
 `issues.exclude-generated` has a new default value (v1 `lax`, v2 `strict`), so this field will be added during the migration to maintain the previous behavior.
 
 `issues.exclude-dirs-use-default` has been removed, so it is converted to `linters.exclusions.paths` and, if needed, `formatters.exclusions.paths`.
@@ -189,7 +191,7 @@ There are 2 new options (they are not strictly equivalent to the previous option
 
 #### `linters.presets`
 
-This property have been removed.
+This property has been removed. The `migrate` command **automatically adds individual linters to `linters.enable`.**
 
 <details>
 <summary style={{color: '#737380', paddingLeft: '1rem'}}>v1</summary>


### PR DESCRIPTION
Thanks for maintaining golangci-lint always!
golangci-lint helps me and my team prevent bugs by making static analysis easy to execute. 👏


When I read the migration guide to `v2`, I wondered, "How should I migrate preset linters to v2 config file? Should I indentify what linters belong to the preset, and write out each linter name to `v2` config file one by one?".
After executing the `migrate` command, I realized the `migrate` command did it instead of me. 😂

I believe it would be easier to understand if this were described in migration guide.
So I suggest adding description that shows the `migrate` command automatically migrates `linters.presets` to `linters.enable`.

<details>

![image](https://github.com/user-attachments/assets/bda4928c-96e3-48d2-93c8-4d1483f77d3f)
<img width="2002" alt="image" src="https://github.com/user-attachments/assets/5b9e78da-ae5e-4f49-851c-2c4e2f090457" />

</details>