### PR TITLE
Bump goconst to v1.8.0

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -632,6 +632,12 @@ linters:
       # Exclude strings matching the given regular expression.
       # Default: ""
       ignore-strings: 'foo.+'
+      # Look for duplicate consts with matching values.
+      # Default: false
+      find-duplicates: true
+      # Evaluate constant expressions when searching for constants.
+      # Default: false
+      eval-const-expressions: true
 
     gocritic:
       # Disable all checks.

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/gostaticanalysis/forcetypeassert v0.2.0
 	github.com/gostaticanalysis/nilerr v0.1.1
 	github.com/hashicorp/go-version v1.7.0
-	github.com/jgautheron/goconst v1.7.1
+	github.com/jgautheron/goconst v1.8.0
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jjti/go-spancheck v0.6.4
 	github.com/julz/importas v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jgautheron/goconst v1.7.1 h1:VpdAG7Ca7yvvJk5n8dMwQhfEZJh95kl/Hl9S1OI5Jkk=
-github.com/jgautheron/goconst v1.7.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
+github.com/jgautheron/goconst v1.8.0 h1:6XbYfLvGzSu8Fx9x1psDTsM61ecm2txB5CkGGLcfYG4=
+github.com/jgautheron/goconst v1.8.0/go.mod h1:A0oxgBCHy55NQn6sYpO7UdnA9p+h7cPtoOZUmvNIako=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=
 github.com/jjti/go-spancheck v0.6.4 h1:Tl7gQpYf4/TMU7AT84MN83/6PutY21Nb9fuQjFTpRRc=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -451,14 +451,16 @@ type GocognitSettings struct {
 }
 
 type GoConstSettings struct {
-	IgnoreStrings       string `mapstructure:"ignore-strings"`
-	MatchWithConstants  bool   `mapstructure:"match-constant"`
-	MinStringLen        int    `mapstructure:"min-len"`
-	MinOccurrencesCount int    `mapstructure:"min-occurrences"`
-	ParseNumbers        bool   `mapstructure:"numbers"`
-	NumberMin           int    `mapstructure:"min"`
-	NumberMax           int    `mapstructure:"max"`
-	IgnoreCalls         bool   `mapstructure:"ignore-calls"`
+	IgnoreStrings        string `mapstructure:"ignore-strings"`
+	MatchWithConstants   bool   `mapstructure:"match-constant"`
+	MinStringLen         int    `mapstructure:"min-len"`
+	MinOccurrencesCount  int    `mapstructure:"min-occurrences"`
+	FindDuplicates       bool   `mapstructure:"find-duplicates"`
+	EvalConstExpressions bool   `mapstructure:"eval-const-expressions"`
+	ParseNumbers         bool   `mapstructure:"numbers"`
+	NumberMin            int    `mapstructure:"min"`
+	NumberMax            int    `mapstructure:"max"`
+	IgnoreCalls          bool   `mapstructure:"ignore-calls"`
 }
 
 type GoCriticSettings struct {

--- a/pkg/golinters/goconst/testdata/goconst_eval_expressions.go
+++ b/pkg/golinters/goconst/testdata/goconst_eval_expressions.go
@@ -1,0 +1,23 @@
+//golangcitest:args -Egoconst
+//golangcitest:config_path testdata/goconst_eval_expressions.yml
+package testdata
+
+const Host = "www.golangci.com"
+const LinterPath = Host + "/goconst"
+
+const path = "www.golangci.com/goconst" // want "const definition is duplicate of `LinterPath` at goconst_eval_expressions.go:6:20"
+
+const KiB = 1 << 10
+
+func EvalExpr() {
+	println(path)
+
+	const duplicated = "www.golangci.com/goconst" // want "const definition is duplicate of `LinterPath` at goconst_eval_expressions.go:6:20"
+	println(duplicated)
+
+	var unique = "www.golangci.com/another-linter"
+	println(unique)
+
+	const Kilobytes = 1024 // want "const definition is duplicate of `KiB` at goconst_eval_expressions.go:10:13"
+	println(Kilobytes)
+}

--- a/pkg/golinters/goconst/testdata/goconst_eval_expressions.yml
+++ b/pkg/golinters/goconst/testdata/goconst_eval_expressions.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  settings:
+    goconst:
+      find-duplicates: true
+      eval-const-expressions: true
+      numbers: true
+

--- a/pkg/golinters/goconst/testdata/goconst_find_duplicates.go
+++ b/pkg/golinters/goconst/testdata/goconst_find_duplicates.go
@@ -1,0 +1,15 @@
+//golangcitest:args -Egoconst
+//golangcitest:config_path testdata/goconst_find_duplicates.yml
+package testdata
+
+const AConst = "test"
+const (
+	AnotherConst   = "test" // want "const definition is duplicate of `AConst` at goconst_find_duplicates.go:5:7"
+	UnrelatedConst = "i'm unrelated"
+)
+
+func Bazoo() {
+	const Duplicated = "test" // want "const definition is duplicate of `AConst` at goconst_find_duplicates.go:5:7"
+
+	const NotDuplicated = "i'm not duplicated"
+}

--- a/pkg/golinters/goconst/testdata/goconst_find_duplicates.yml
+++ b/pkg/golinters/goconst/testdata/goconst_find_duplicates.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+linters:
+  settings:
+    goconst:
+      find-duplicates: true
+

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -300,6 +300,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 
 		linter.NewConfig(goconst.New(&cfg.Linters.Settings.Goconst)).
 			WithSince("v1.0.0").
+			WithLoadForGoAnalysis().
 			WithURL("https://github.com/jgautheron/goconst"),
 
 		linter.NewConfig(gocritic.New(&cfg.Linters.Settings.Gocritic, placeholderReplacer)).


### PR DESCRIPTION
I realized too late that I can't expect this PR to be merged unless I am the author of the linter. Alas, the work is done.

In any case, we made some changes upstream to release v1.8.0 and `goconst` now uses the typechecker as a result. I'll open an issue downstream to alert the linter author.

goconst now finds duplicate constants and can evaluate constant expressions in some cases.