### PR TITLE
docs: update section about GoLand integration

### DIFF
--- a/docs/src/docs/welcome/integrations.mdx
+++ b/docs/src/docs/welcome/integrations.mdx
@@ -6,9 +6,9 @@ title: Integrations
 
 ### GoLand
 
-The integration for golangci-lint v2 is currently in work in progress: [GO-18363](https://youtrack.jetbrains.com/issue/GO-18363/Go-Linter-plugin-fails-with-golangci-lint-v2).
-
-Install [plugin](https://plugins.jetbrains.com/plugin/12496-go-linter).
+Starting from the version 2025.1, GoLand has built-in support of golangci-lint.
+For IntelliJ IDEA with the Go plugin, please install the [plugin](https://plugins.jetbrains.com/plugin/12496-go-linter).
+Both v1 and v2 versions are supported.
 
 ### Visual Studio Code
 


### PR DESCRIPTION
In GoLand 2025.1 we have reworked and bundled the plugin for golangci-lint support. We would like to update the integration in IDEs page accordingly and share it with the community.