### PR TITLE
fix: toStaticCheckSettings

### DIFF
--- a/pkg/commands/internal/migrate/migrate_linters_settings.go
+++ b/pkg/commands/internal/migrate/migrate_linters_settings.go
@@ -789,10 +789,22 @@ func toSpancheckSettings(old versionone.SpancheckSettings) versiontwo.SpancheckS
 }
 
 func toStaticCheckSettings(old versionone.LintersSettings) versiontwo.StaticCheckSettings {
-	checks := slices.Concat(old.Staticcheck.Checks, old.Stylecheck.Checks, old.Gosimple.Checks)
+	checks := Unique(slices.Concat(old.Staticcheck.Checks, old.Stylecheck.Checks, old.Gosimple.Checks))
+	// If an element is prefixed with `-` it means that we want to disable that check.
+	// So we have to resort and put everything after the non-minus elements.
+	slices.SortFunc(checks, func(e1, e2 string) int {
+		if strings.HasPrefix(e1, "-") && !strings.HasPrefix(e2, "-") {
+			return 1
+		}
+
+		if !strings.HasPrefix(e1, "-") && strings.HasPrefix(e2, "-") {
+			return -1
+		}
+		return strings.Compare(e1, e2)
+	})
 
 	return versiontwo.StaticCheckSettings{
-		Checks:                  Unique(checks),
+		Checks:                  checks,
 		Initialisms:             old.Stylecheck.Initialisms,
 		DotImportWhitelist:      old.Stylecheck.DotImportWhitelist,
 		HTTPStatusCodeWhitelist: old.Stylecheck.HTTPStatusCodeWhitelist,

--- a/pkg/commands/internal/migrate/migrate_linters_settings_test.go
+++ b/pkg/commands/internal/migrate/migrate_linters_settings_test.go
@@ -1,0 +1,26 @@
+package migrate
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/pkg/commands/internal/migrate/versionone"
+	"github.com/golangci/golangci-lint/v2/pkg/commands/internal/migrate/versiontwo"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_toStaticCheckSettings(t *testing.T) {
+	old := versionone.LintersSettings{
+		Staticcheck: versionone.StaticCheckSettings{
+			Checks: []string{"all", "-SA1000"},
+		},
+	}
+	new := toStaticCheckSettings(old)
+
+	expected := versiontwo.StaticCheckSettings{
+		Checks: []string{"all", "-SA1000"},
+	}
+
+	if diff := cmp.Diff(new, expected); diff != "" {
+		t.Errorf("toStaticCheckSettings() mismatch (-got +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

Currently, toStaticCheckSettings only treat order to make unique slice. So if we receive such as []string{"all", "-S1000"} from staticcheck, the output results in []string{"-S1000", "all"}. The rule that has minus symbol means the rule will be disabled from previous one. It means that current order must be failed if developer doesn't fix it, so I fixed it. 