### PR TITLE
dev: disable check-generated job

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,21 +27,22 @@ jobs:
           git diff --exit-code go.mod
           git diff --exit-code go.sum
 
+  # This check is disabled because of GitHub API instability: 504 Gateway Timeout.
   # Checks: GitHub action assets
-  check-generated:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Check generated files are up-to-date
-        run: make fast_check_generated
-        env:
-          # needed for github-action-config.json generation
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#  check-generated:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0
+#      - uses: actions/setup-go@v5
+#        with:
+#          go-version: ${{ env.GO_VERSION }}
+#      - name: Check generated files are up-to-date
+#        run: make fast_check_generated
+#        env:
+#          # needed for github-action-config.json generation
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   check-local-install-script:
     name: Installation script (local)


### PR DESCRIPTION
Since several weeks, the `check-generated` fails 50% of time, due to a GitHub API problem:

```
2025/04/16 14:50:06 failed to fetch all releases: failed to fetch releases page from GitHub: non-200 OK status code: 504 Gateway Timeout
```

In all cases, we don't need to always check it, as the asset is generated automatically after a release.
