### PR TITLE
fix: related information position

### DIFF
--- a/pkg/goanalysis/runners.go
+++ b/pkg/goanalysis/runners.go
@@ -136,10 +136,16 @@ func buildIssues(diags []Diagnostic, linterNameBuilder func(diag *Diagnostic) st
 
 		if len(diag.Related) > 0 {
 			for _, info := range diag.Related {
+				relatedPos := diag.Pkg.Fset.Position(info.Pos)
+
+				if relatedPos.Filename != diag.Position.Filename {
+					relatedPos = diag.Position
+				}
+
 				issues = append(issues, result.Issue{
 					FromLinter: linterName,
 					Text:       fmt.Sprintf("%s(related information): %s", diag.Analyzer.Name, info.Message),
-					Pos:        diag.Pkg.Fset.Position(info.Pos),
+					Pos:        relatedPos,
 					Pkg:        diag.Pkg,
 				})
 			}


### PR DESCRIPTION
Fixes #5744

FYI, in most cases, the related information will not be displayed because the reports will be on the same line (`uniq-by-line` is true by default.)