### PR TITLE
docs: GoLand IDE only support v1 for now

### DIFF
--- a/docs/src/docs/welcome/integrations.mdx
+++ b/docs/src/docs/welcome/integrations.mdx
@@ -6,9 +6,10 @@ title: Integrations
 
 ### GoLand
 
-Starting from the version 2025.1, GoLand has built-in support of golangci-lint.
+Starting from version 2025.1, GoLand has built-in support of golangci-lint.
 For IntelliJ IDEA with the Go plugin, please install the [plugin](https://plugins.jetbrains.com/plugin/12496-go-linter).
-Both v1 and v2 versions are supported.
+
+**Only v1 is supported for now.**
 
 ### Visual Studio Code
 


### PR DESCRIPTION
Related to https://github.com/golangci/golangci-lint/pull/5740#issuecomment-2816219744