### PR TITLE
build(deps): bump go.augendre.info/fatcontext from 0.7.2 to 0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/Antonboom/nilnil v1.1.0
 	github.com/Antonboom/testifylint v1.6.1
 	github.com/BurntSushi/toml v1.5.0
-	github.com/Crocmagnon/fatcontext v0.7.2
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1
@@ -127,6 +126,7 @@ require (
 	gitlab.com/bosi/decorder v0.4.2
 	go-simpler.org/musttag v0.13.0
 	go-simpler.org/sloglint v0.11.0
+	go.augendre.info/fatcontext v0.8.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/mod v0.24.0
 	golang.org/x/sys v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Crocmagnon/fatcontext v0.7.2 h1:BY5/dUhs2kuD3sDn7vZrgOneRib5EHk9GOiyK8Vg+14=
-github.com/Crocmagnon/fatcontext v0.7.2/go.mod h1:OAZCUteH59eiddbJZ9/bF4ppC140jYD/hepU2FDkFk4=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rWPdisA5ynNEsoARbiCBOyGcJM4/OzsM=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1 h1:Sz1JIXEcSfhz7fUi7xHnhpIE0thVASYjvosApmHuD2k=
@@ -630,6 +628,8 @@ go-simpler.org/musttag v0.13.0 h1:Q/YAW0AHvaoaIbsPj3bvEI5/QFP7w696IMUpnKXQfCE=
 go-simpler.org/musttag v0.13.0/go.mod h1:FTzIGeK6OkKlUDVpj0iQUXZLUO1Js9+mvykDQy9C5yM=
 go-simpler.org/sloglint v0.11.0 h1:JlR1X4jkbeaffiyjLtymeqmGDKBDO1ikC6rjiuFAOco=
 go-simpler.org/sloglint v0.11.0/go.mod h1:CFDO8R1i77dlciGfPEPvYke2ZMx4eyGiEIWkyeW2Pvw=
+go.augendre.info/fatcontext v0.8.0 h1:2dfk6CQbDGeu1YocF59Za5Pia7ULeAM6friJ3LP7lmk=
+go.augendre.info/fatcontext v0.8.0/go.mod h1:oVJfMgwngMsHO+KB2MdgzcO+RvtNdiCEOlWvSFtax/s=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/pkg/golinters/fatcontext/fatcontext.go
+++ b/pkg/golinters/fatcontext/fatcontext.go
@@ -1,7 +1,7 @@
 package fatcontext
 
 import (
-	"github.com/Crocmagnon/fatcontext/pkg/analyzer"
+	"go.augendre.info/fatcontext/pkg/analyzer"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"

--- a/scripts/website/expand_templates/thanks.go
+++ b/scripts/website/expand_templates/thanks.go
@@ -99,6 +99,9 @@ func extractInfo(lc *linter.Config) authorInfo {
 	case "misspell":
 		return authorInfo{Author: "client9", Host: hostGitHub}
 
+	case "fatcontext":
+		return authorInfo{Author: "Crocmagnon", Host: hostGitHub}
+
 	default:
 		if strings.HasPrefix(lc.OriginalURL, "https://pkg.go.dev/") {
 			return authorInfo{Author: "golang", Host: hostGitHub}


### PR DESCRIPTION
**This update is done by hand because Dependabot cannot handle a module name change.**

https://github.com/Crocmagnon/fatcontext/compare/v0.7.2...v0.8.0

related to https://github.com/golangci/golangci-lint/discussions/5756