### PR TITLE
docs: GoLand IDE support v2

### DIFF
--- a/docs/src/docs/welcome/integrations.mdx
+++ b/docs/src/docs/welcome/integrations.mdx
@@ -9,7 +9,7 @@ title: Integrations
 Starting from version 2025.1, GoLand has built-in support of golangci-lint.
 For IntelliJ IDEA with the Go plugin, please install the [plugin](https://plugins.jetbrains.com/plugin/12496-go-linter).
 
-**Only v1 is supported for now.**
+Both v1 and v2 versions are supported.
 
 ### Visual Studio Code
 


### PR DESCRIPTION
Related to #5750
Related to #5740

The changelog of Goland 2025.1 is wrong.

![Screenshot 2025-04-22 at 12-26-58 GoLand a JetBrains IDE](https://github.com/user-attachments/assets/d2cb7060-fe78-43b9-b94d-caa75a41a72d)
