### PR TITLE
chore: prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ If you value it, consider supporting us, we appreciate it! ❤️
 [![Open Collective backers and sponsors](https://img.shields.io/badge/OpenCollective-Donate-blue?logo=opencollective&style=for-the-badge)](https://opencollective.com/golangci-lint)
 [![GitHub Sponsors](https://img.shields.io/badge/GitHub-Donate-blue?logo=github&style=for-the-badge)](https://github.com/sponsors/golangci)
 
-### v2.1.2
+### v2.1.4
+
+Due to an error related to Snapcraft, some artifacts of the v2.1.3 release have not been published.
+
+This release contains the same things as v2.1.3.
+
+### v2.1.3
 
 1. Linters bug fixes
    * `fatcontext`: from 0.7.2 to 0.8.0


### PR DESCRIPTION
Due to an error related to Snapcraft, some artifacts of the v2.1.3 release have not been published.

```
  ⨯ release failed after 24m40s             
    error=
    │ 1 error occurred:
    │ 	* snapcraft packages: failed to push dist/golangci-lint_armv6.snap package: exit status 1: Uploading... (--->)
    │ Uploading... (<---)
    │ Issue encountered while processing your request: [500] Internal Server Error.
    │ Full execution log: '/home/runner/.local/state/snapcraft/log/snapcraft-20250424-171708.489628.log'
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.8.1/x64/goreleaser' failed with exit code 1
```
