### PR TITLE
chore: prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ If you value it, consider supporting us, we appreciate it! ❤️
 [![Open Collective backers and sponsors](https://img.shields.io/badge/OpenCollective-Donate-blue?logo=opencollective&style=for-the-badge)](https://opencollective.com/golangci-lint)
 [![GitHub Sponsors](https://img.shields.io/badge/GitHub-Donate-blue?logo=github&style=for-the-badge)](https://github.com/sponsors/golangci)
 
+### v2.1.5
+
+Due to an error related to Snapcraft, some artifacts of the v2.1.4 release have not been published.
+
+This release contains the same things as v2.1.3.
+
 ### v2.1.4
 
 Due to an error related to Snapcraft, some artifacts of the v2.1.3 release have not been published.


### PR DESCRIPTION
Due to an error related to Snapcraft, some artifacts of the v2.1.4 (and v2.1.3) release have not been published.

```
  ⨯ release failed after 24m57s             
    error=
    │ 1 error occurred:
    │ 	* snapcraft packages: failed to push dist/golangci-lint_amd64.snap package: exit status 1: Uploading... (--->)
    │ Uploading... (<---)
    │ Issue encountered while processing your request: [500] Internal Server Error.
    │ Full execution log: '/home/runner/.local/state/snapcraft/log/snapcraft-20250424-180109.349558.log'
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.8.1/x64/goreleaser' failed with exit code 1
```

https://github.com/golangci/golangci-lint/actions/runs/14647925042/job/41106612987

I tried to renew the Snapcraft token, we will see if this changes something.
If not, I will disable Snapcraft.

Related to #5763