### PR TITLE
docs: add note about golangci-lint v2 integration in VS Code

### DIFF
--- a/docs/src/docs/welcome/integrations.mdx
+++ b/docs/src/docs/welcome/integrations.mdx
@@ -15,6 +15,8 @@ Both v1 and v2 versions are supported.
 
 Install the [extension](https://marketplace.visualstudio.com/items?itemName=golang.Go).
 
+**Note:** To use golangci-lint v2, you may need to switch to the pre-release version of the extension: [vscode-go#3732](https://github.com/golang/vscode-go/issues/3732#issuecomment-2805974456).
+
 <details>
 <summary style={{color: '#737380'}}>Recommended settings for those who installed golangci-lint manually</summary>
 


### PR DESCRIPTION
## Motivation

#5706 removed the link to [vscode-go#3732](https://github.com/golang/vscode-go/issues/3732#issuecomment-2805974456) because it is resolved in the [`v0.47.2` pre-release](https://github.com/golang/vscode-go/releases/tag/v0.47.2) of the extension.  
However, the fix is not yet available for stable users — the next stable release ([`v0.48.0`](https://github.com/golang/vscode-go/milestone/72)) is still pending.

This causes confusion for stable users of the extension who still encounter the issue with golangci-lint v2 integration, as they need to search for a fix.

## Changes

Added a short note under the VS Code section of the integrations page to inform users that they may need to switch to the pre-release version of the vscode-go extension if they want golangci-lint v2 integration to work properly.

### Commits 

[docs: add note about golangci-lint v2 integration in Visual Studio Code](https://github.com/golangci/golangci-lint/commit/b0e9e00370cc61417316d3622459b6745349ffd2) 

This commit adds a note to the docs about how to integrate
golangci-lint v2 with VS Code since the Go extension's stable
version does not support it yet.

For more information on this, you can refer to the linked
[vscode-go#3732](https://github.com/golang/vscode-go/issues/3732#issuecomment-2805974456) issue comment.

Signed-off-by: lvlcn-t <75443136+lvlcn-t@users.noreply.github.com>

## Tests done

With the new note, the integration site looks like this:

![image](https://github.com/user-attachments/assets/206d587e-c8c2-4d78-987c-a78466628ddc)
