### PR TITLE
docs: update new linter template to specify that fix should also be s…

### DIFF
--- a/.github/new-linter-checklist.md
+++ b/.github/new-linter-checklist.md
@@ -27,6 +27,7 @@ In order for a pull request adding a linter to be reviewed, the linter and the P
 - [ ] They must have at least one std lib import.
 - [ ] They must have integration tests without configuration (default).
 - [ ] They must have integration tests with configuration (if the linter has a configuration).
+- [ ] If the linter also proposes fixes, they must also be covered.
 
 ### `.golangci.next.reference.yml`
 


### PR DESCRIPTION
…upported and covered in tests.

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

Stupid question:

Does it make sense to update the New Linter template specifying that the fix scenario should also be covered if applicable? Or is it kind of obvious that that's the case.
