### PR TITLE
dev: simplify linter constructors

### DIFF
--- a/pkg/goanalysis/linter.go
+++ b/pkg/goanalysis/linter.go
@@ -13,11 +13,6 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
-const (
-	TheOnlyAnalyzerName = "the_only_name"
-	TheOnlyanalyzerDoc  = "the_only_doc"
-)
-
 type LoadMode int
 
 func (loadMode LoadMode) String() string {
@@ -55,6 +50,10 @@ func NewLinter(name, desc string, analyzers []*analysis.Analyzer, cfg map[string
 	return &Linter{name: name, desc: desc, analyzers: analyzers, cfg: cfg}
 }
 
+func NewLinterFromAnalyzer(analyzer *analysis.Analyzer) *Linter {
+	return NewLinter(analyzer.Name, analyzer.Doc, []*analysis.Analyzer{analyzer}, nil)
+}
+
 func (lnt *Linter) Run(_ context.Context, lintCtx *linter.Context) ([]result.Issue, error) {
 	if err := lnt.preRun(lintCtx); err != nil {
 		return nil, err
@@ -69,6 +68,24 @@ func (lnt *Linter) UseOriginalPackages() {
 
 func (lnt *Linter) LoadMode() LoadMode {
 	return lnt.loadMode
+}
+
+func (lnt *Linter) WithDesc(desc string) *Linter {
+	lnt.desc = desc
+
+	return lnt
+}
+
+func (lnt *Linter) WithConfig(cfg map[string]any) *Linter {
+	if len(cfg) == 0 {
+		return lnt
+	}
+
+	lnt.cfg = map[string]map[string]any{
+		lnt.name: cfg,
+	}
+
+	return lnt
 }
 
 func (lnt *Linter) WithLoadMode(loadMode LoadMode) *Linter {

--- a/pkg/golinters/arangolint/arangolint.go
+++ b/pkg/golinters/arangolint/arangolint.go
@@ -2,18 +2,12 @@ package arangolint
 
 import (
 	"go.augendre.info/arangolint/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/asasalint/asasalint.go
+++ b/pkg/golinters/asasalint/asasalint.go
@@ -2,7 +2,6 @@ package asasalint
 
 import (
 	"github.com/alingse/asasalint"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -19,15 +18,12 @@ func New(settings *config.AsasalintSettings) *goanalysis.Linter {
 		cfg.IgnoreTest = false
 	}
 
-	a, err := asasalint.NewAnalyzer(cfg)
+	analyzer, err := asasalint.NewAnalyzer(cfg)
 	if err != nil {
 		internal.LinterLogger.Fatalf("asasalint: create analyzer: %v", err)
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/asciicheck/asciicheck.go
+++ b/pkg/golinters/asciicheck/asciicheck.go
@@ -2,18 +2,12 @@ package asciicheck
 
 import (
 	"github.com/tdakkota/asciicheck"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := asciicheck.NewAnalyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(asciicheck.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/bidichk/bidichk.go
+++ b/pkg/golinters/bidichk/bidichk.go
@@ -4,16 +4,14 @@ import (
 	"strings"
 
 	"github.com/breml/bidichk/pkg/bidichk"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.BiDiChkSettings) *goanalysis.Linter {
-	a := bidichk.NewAnalyzer()
+	var cfg map[string]any
 
-	cfg := map[string]map[string]any{}
 	if settings != nil {
 		var opts []string
 
@@ -45,15 +43,13 @@ func New(settings *config.BiDiChkSettings) *goanalysis.Linter {
 			opts = append(opts, "POP-DIRECTIONAL-ISOLATE")
 		}
 
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"disallowed-runes": strings.Join(opts, ","),
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		"Checks for dangerous unicode character sequences",
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(bidichk.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/bodyclose/bodyclose.go
+++ b/pkg/golinters/bodyclose/bodyclose.go
@@ -2,18 +2,12 @@ package bodyclose
 
 import (
 	"github.com/timakin/bodyclose/passes/bodyclose"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := bodyclose.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(bodyclose.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/canonicalheader/canonicalheader.go
+++ b/pkg/golinters/canonicalheader/canonicalheader.go
@@ -2,18 +2,12 @@ package canonicalheader
 
 import (
 	"github.com/lasiar/canonicalheader"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := canonicalheader.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(canonicalheader.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/containedctx/containedctx.go
+++ b/pkg/golinters/containedctx/containedctx.go
@@ -2,18 +2,12 @@ package containedctx
 
 import (
 	"github.com/sivchari/containedctx"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := containedctx.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(containedctx.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/contextcheck/contextcheck.go
+++ b/pkg/golinters/contextcheck/contextcheck.go
@@ -2,7 +2,6 @@ package contextcheck
 
 import (
 	"github.com/kkHAIKE/contextcheck"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
@@ -11,12 +10,10 @@ import (
 func New() *goanalysis.Linter {
 	analyzer := contextcheck.NewAnalyzer(contextcheck.Configuration{})
 
-	return goanalysis.NewLinter(
-		analyzer.Name,
-		analyzer.Doc,
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = contextcheck.NewRun(lintCtx.Packages, false)
-	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer).
+		WithContextSetter(func(lintCtx *linter.Context) {
+			analyzer.Run = contextcheck.NewRun(lintCtx.Packages, false)
+		}).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/copyloopvar/copyloopvar.go
+++ b/pkg/golinters/copyloopvar/copyloopvar.go
@@ -2,28 +2,22 @@ package copyloopvar
 
 import (
 	"github.com/karamaru-alpha/copyloopvar"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.CopyLoopVarSettings) *goanalysis.Linter {
-	a := copyloopvar.NewAnalyzer()
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				"check-alias": settings.CheckAlias,
-			},
+		cfg = map[string]any{
+			"check-alias": settings.CheckAlias,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(copyloopvar.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/cyclop/cyclop.go
+++ b/pkg/golinters/cyclop/cyclop.go
@@ -2,37 +2,29 @@ package cyclop
 
 import (
 	"github.com/bkielbasa/cyclop/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.CyclopSettings) *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
+	cfg := map[string]any{}
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		d := map[string]any{
-			// Should be managed with `linters.exclusions.rules`.
-			"skipTests": false,
-		}
+		// Should be managed with `linters.exclusions.rules`.
+		cfg["skipTests"] = false
 
 		if settings.MaxComplexity != 0 {
-			d["maxComplexity"] = settings.MaxComplexity
+			cfg["maxComplexity"] = settings.MaxComplexity
 		}
 
 		if settings.PackageAverage != 0 {
-			d["packageAverage"] = settings.PackageAverage
+			cfg["packageAverage"] = settings.PackageAverage
 		}
-
-		cfg = map[string]map[string]any{a.Name: d}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/decorder/decorder.go
+++ b/pkg/golinters/decorder/decorder.go
@@ -4,15 +4,12 @@ import (
 	"strings"
 
 	"gitlab.com/bosi/decorder"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.DecorderSettings) *goanalysis.Linter {
-	a := decorder.Analyzer
-
 	// disable all rules/checks by default
 	cfg := map[string]any{
 		"ignore-underscore-vars":        false,
@@ -35,10 +32,8 @@ func New(settings *config.DecorderSettings) *goanalysis.Linter {
 		cfg["disable-init-func-first-check"] = settings.DisableInitFuncFirstCheck
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		map[string]map[string]any{a.Name: cfg},
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(decorder.Analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/depguard/depguard.go
+++ b/pkg/golinters/depguard/depguard.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/OpenPeeDeeP/depguard/v2"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -41,17 +40,15 @@ func New(settings *config.DepGuardSettings, replacer *strings.Replacer) *goanaly
 		}
 	}
 
-	a := depguard.NewUncompiledAnalyzer(&conf)
+	analyzer := depguard.NewUncompiledAnalyzer(&conf)
 
-	return goanalysis.NewLinter(
-		a.Analyzer.Name,
-		a.Analyzer.Doc,
-		[]*analysis.Analyzer{a.Analyzer},
-		nil,
-	).WithContextSetter(func(lintCtx *linter.Context) {
-		err := a.Compile()
-		if err != nil {
-			lintCtx.Log.Errorf("create analyzer: %v", err)
-		}
-	}).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.Analyzer).
+		WithContextSetter(func(lintCtx *linter.Context) {
+			err := analyzer.Compile()
+			if err != nil {
+				lintCtx.Log.Errorf("create analyzer: %v", err)
+			}
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/dogsled/dogsled.go
+++ b/pkg/golinters/dogsled/dogsled.go
@@ -11,24 +11,17 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-const linterName = "dogsled"
-
 func New(settings *config.DogsledSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			return run(pass, settings.MaxBlankIdentifiers)
-		},
-		Requires: []*analysis.Analyzer{inspect.Analyzer},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "dogsled",
+			Doc:  "Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())",
+			Run: func(pass *analysis.Pass) (any, error) {
+				return run(pass, settings.MaxBlankIdentifiers)
+			},
+			Requires: []*analysis.Analyzer{inspect.Analyzer},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func run(pass *analysis.Pass, maxBlanks int) (any, error) {

--- a/pkg/golinters/dupword/dupword.go
+++ b/pkg/golinters/dupword/dupword.go
@@ -4,27 +4,24 @@ import (
 	"strings"
 
 	"github.com/Abirdcfly/dupword"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.DupWordSettings) *goanalysis.Linter {
-	a := dupword.NewAnalyzer()
+	var cfg map[string]any
 
-	cfg := map[string]map[string]any{}
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"keyword": strings.Join(settings.Keywords, ","),
 			"ignore":  strings.Join(settings.Ignore, ","),
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		"checks for duplicate words in the source code",
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(dupword.NewAnalyzer()).
+		WithDesc("Checks for duplicate words in the source code").
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/durationcheck/durationcheck.go
+++ b/pkg/golinters/durationcheck/durationcheck.go
@@ -2,18 +2,12 @@ package durationcheck
 
 import (
 	"github.com/charithe/durationcheck"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := durationcheck.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(durationcheck.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/embeddedstructfieldcheck/embeddedstructfieldcheck.go
+++ b/pkg/golinters/embeddedstructfieldcheck/embeddedstructfieldcheck.go
@@ -2,18 +2,12 @@ package embeddedstructfieldcheck
 
 import (
 	"github.com/manuelarte/embeddedstructfieldcheck/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/err113/err113.go
+++ b/pkg/golinters/err113/err113.go
@@ -2,18 +2,13 @@ package err113
 
 import (
 	"github.com/Djarvur/go-err113"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := err113.NewAnalyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"Go linter to check the errors handling expressions",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(err113.NewAnalyzer()).
+		WithDesc("Check errors handling expressions").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/errchkjson/errchkjson.go
+++ b/pkg/golinters/errchkjson/errchkjson.go
@@ -2,30 +2,25 @@ package errchkjson
 
 import (
 	"github.com/breml/errchkjson"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.ErrChkJSONSettings) *goanalysis.Linter {
-	a := errchkjson.NewAnalyzer()
-
-	cfg := map[string]map[string]any{}
-	cfg[a.Name] = map[string]any{
+	cfg := map[string]any{
 		"omit-safe": true,
 	}
+
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"omit-safe":          !settings.CheckErrorFreeEncoding,
 			"report-no-exported": settings.ReportNoExported,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(errchkjson.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/errname/errname.go
+++ b/pkg/golinters/errname/errname.go
@@ -2,18 +2,12 @@ package errname
 
 import (
 	"github.com/Antonboom/errname/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := analyzer.New()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.New()).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/errorlint/errorlint.go
+++ b/pkg/golinters/errorlint/errorlint.go
@@ -2,7 +2,6 @@ package errorlint
 
 import (
 	"github.com/polyfloyd/go-errorlint/errorlint"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -23,12 +22,10 @@ func New(settings *config.ErrorLintSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := errorlint.NewAnalyzer(opts...)
-
-	cfg := map[string]map[string]any{}
+	var cfg map[string]any
 
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"errorf":       settings.Errorf,
 			"errorf-multi": settings.ErrorfMulti,
 			"asserts":      settings.Asserts,
@@ -36,13 +33,11 @@ func New(settings *config.ErrorLintSettings) *goanalysis.Linter {
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		"errorlint is a linter for that can be used to find code "+
-			"that will cause problems with the error wrapping scheme introduced in Go 1.13.",
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(errorlint.NewAnalyzer(opts...)).
+		WithDesc("Find code that can cause problems with the error wrapping scheme introduced in Go 1.13.").
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func toAllowPairs(data []config.ErrorLintAllowPair) []errorlint.AllowPair {

--- a/pkg/golinters/exhaustive/exhaustive.go
+++ b/pkg/golinters/exhaustive/exhaustive.go
@@ -2,37 +2,31 @@ package exhaustive
 
 import (
 	"github.com/nishanths/exhaustive"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.ExhaustiveSettings) *goanalysis.Linter {
-	a := exhaustive.Analyzer
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				exhaustive.CheckFlag:                      settings.Check,
-				exhaustive.DefaultSignifiesExhaustiveFlag: settings.DefaultSignifiesExhaustive,
-				exhaustive.IgnoreEnumMembersFlag:          settings.IgnoreEnumMembers,
-				exhaustive.IgnoreEnumTypesFlag:            settings.IgnoreEnumTypes,
-				exhaustive.PackageScopeOnlyFlag:           settings.PackageScopeOnly,
-				exhaustive.ExplicitExhaustiveMapFlag:      settings.ExplicitExhaustiveMap,
-				exhaustive.ExplicitExhaustiveSwitchFlag:   settings.ExplicitExhaustiveSwitch,
-				exhaustive.DefaultCaseRequiredFlag:        settings.DefaultCaseRequired,
-				// Should be managed with `linters.exclusions.generated`.
-				exhaustive.CheckGeneratedFlag: true,
-			},
+		cfg = map[string]any{
+			exhaustive.CheckFlag:                      settings.Check,
+			exhaustive.DefaultSignifiesExhaustiveFlag: settings.DefaultSignifiesExhaustive,
+			exhaustive.IgnoreEnumMembersFlag:          settings.IgnoreEnumMembers,
+			exhaustive.IgnoreEnumTypesFlag:            settings.IgnoreEnumTypes,
+			exhaustive.PackageScopeOnlyFlag:           settings.PackageScopeOnly,
+			exhaustive.ExplicitExhaustiveMapFlag:      settings.ExplicitExhaustiveMap,
+			exhaustive.ExplicitExhaustiveSwitchFlag:   settings.ExplicitExhaustiveSwitch,
+			exhaustive.DefaultCaseRequiredFlag:        settings.DefaultCaseRequired,
+			// Should be managed with `linters.exclusions.generated`.
+			exhaustive.CheckGeneratedFlag: true,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(exhaustive.Analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/exhaustruct/exhaustruct.go
+++ b/pkg/golinters/exhaustruct/exhaustruct.go
@@ -1,8 +1,7 @@
 package exhaustruct
 
 import (
-	"github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer"
-	"golang.org/x/tools/go/analysis"
+	exhaustruct "github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -11,20 +10,18 @@ import (
 
 func New(settings *config.ExhaustructSettings) *goanalysis.Linter {
 	var include, exclude []string
+
 	if settings != nil {
 		include = settings.Include
 		exclude = settings.Exclude
 	}
 
-	a, err := analyzer.NewAnalyzer(include, exclude)
+	analyzer, err := exhaustruct.NewAnalyzer(include, exclude)
 	if err != nil {
 		internal.LinterLogger.Fatalf("exhaustruct configuration: %v", err)
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/exptostd/exptostd.go
+++ b/pkg/golinters/exptostd/exptostd.go
@@ -2,18 +2,12 @@ package exptostd
 
 import (
 	"github.com/ldez/exptostd"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := exptostd.NewAnalyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(exptostd.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/fatcontext/fatcontext.go
+++ b/pkg/golinters/fatcontext/fatcontext.go
@@ -2,27 +2,22 @@ package fatcontext
 
 import (
 	"go.augendre.info/fatcontext/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.FatcontextSettings) *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
-
-	cfg := map[string]map[string]any{}
+	var cfg map[string]any
 
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			analyzer.FlagCheckStructPointers: settings.CheckStructPointers,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/forbidigo/forbidigo.go
+++ b/pkg/golinters/forbidigo/forbidigo.go
@@ -15,28 +15,23 @@ import (
 const linterName = "forbidigo"
 
 func New(settings *config.ForbidigoSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			err := runForbidigo(pass, settings)
-			if err != nil {
-				return nil, err
-			}
-
-			return nil, nil
-		},
-	}
-
 	// Without AnalyzeTypes, LoadModeSyntax is enough.
 	// But we cannot make this depend on the settings and have to mirror the mode chosen in GetAllSupportedLinterConfigs,
-	// therefore we have to use LoadModeTypesInfo in all cases.
-	return goanalysis.NewLinter(
-		linterName,
-		"Forbids identifiers",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	// therefore, we have to use LoadModeTypesInfo in all cases.
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: linterName,
+			Doc:  "Forbids identifiers",
+			Run: func(pass *analysis.Pass) (any, error) {
+				err := runForbidigo(pass, settings)
+				if err != nil {
+					return nil, err
+				}
+
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func runForbidigo(pass *analysis.Pass, settings *config.ForbidigoSettings) error {

--- a/pkg/golinters/forcetypeassert/forcetypeassert.go
+++ b/pkg/golinters/forcetypeassert/forcetypeassert.go
@@ -2,18 +2,13 @@ package forcetypeassert
 
 import (
 	"github.com/gostaticanalysis/forcetypeassert"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := forcetypeassert.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"finds forced type assertions",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(forcetypeassert.Analyzer).
+		WithDesc("Find forced type assertions").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/funcorder/funcorder.go
+++ b/pkg/golinters/funcorder/funcorder.go
@@ -2,29 +2,24 @@ package funcorder
 
 import (
 	"github.com/manuelarte/funcorder/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.FuncOrderSettings) *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
-
-	cfg := map[string]map[string]any{}
+	var cfg map[string]any
 
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			analyzer.ConstructorCheckName:  settings.Constructor,
 			analyzer.StructMethodCheckName: settings.StructMethod,
 			analyzer.AlphabeticalCheckName: settings.Alphabetical,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/funlen/funlen.go
+++ b/pkg/golinters/funlen/funlen.go
@@ -2,7 +2,6 @@ package funlen
 
 import (
 	"github.com/ultraware/funlen"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -22,12 +21,7 @@ func New(settings *config.FunlenSettings) *goanalysis.Linter {
 		cfg.ignoreComments = settings.IgnoreComments
 	}
 
-	a := funlen.NewAnalyzer(cfg.lineLimit, cfg.stmtLimit, cfg.ignoreComments)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(funlen.NewAnalyzer(cfg.lineLimit, cfg.stmtLimit, cfg.ignoreComments)).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/gci/gci.go
+++ b/pkg/golinters/gci/gci.go
@@ -1,8 +1,6 @@
 package gci
 
 import (
-	"golang.org/x/tools/go/analysis"
-
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
@@ -18,16 +16,13 @@ func New(settings *config.GciSettings) *goanalysis.Linter {
 		internal.LinterLogger.Fatalf("%s: create analyzer: %v", linterName, err)
 	}
 
-	a := goformatters.NewAnalyzer(
-		internal.LinterLogger.Child(linterName),
-		"Checks if code and import statements are formatted, with additional rules.",
-		formatter,
-	)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(
+			goformatters.NewAnalyzer(
+				internal.LinterLogger.Child(linterName),
+				"Check if code and import statements are formatted, with additional rules.",
+				formatter,
+			),
+		).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/ginkgolinter/ginkgolinter.go
+++ b/pkg/golinters/ginkgolinter/ginkgolinter.go
@@ -3,7 +3,6 @@ package ginkgolinter
 import (
 	"github.com/nunnatsa/ginkgolinter"
 	"github.com/nunnatsa/ginkgolinter/types"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -29,12 +28,8 @@ func New(settings *config.GinkgoLinterSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := ginkgolinter.NewAnalyzerWithConfig(cfg)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"enforces standards of using ginkgo and gomega",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(ginkgolinter.NewAnalyzerWithConfig(cfg)).
+		WithDesc("enforces standards of using ginkgo and gomega").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/gocheckcompilerdirectives/gocheckcompilerdirectives.go
+++ b/pkg/golinters/gocheckcompilerdirectives/gocheckcompilerdirectives.go
@@ -2,18 +2,12 @@ package gocheckcompilerdirectives
 
 import (
 	"4d63.com/gocheckcompilerdirectives/checkcompilerdirectives"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := checkcompilerdirectives.Analyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(checkcompilerdirectives.Analyzer()).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/gochecknoglobals/gochecknoglobals.go
+++ b/pkg/golinters/gochecknoglobals/gochecknoglobals.go
@@ -2,18 +2,13 @@ package gochecknoglobals
 
 import (
 	"4d63.com/gochecknoglobals/checknoglobals"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := checknoglobals.Analyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"Check that no global variables exist.",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(checknoglobals.Analyzer()).
+		WithDesc("Check that no global variables exist.").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/gochecknoinits/gochecknoinits.go
+++ b/pkg/golinters/gochecknoinits/gochecknoinits.go
@@ -11,22 +11,15 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
-const linterName = "gochecknoinits"
-
 func New() *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name:     linterName,
-		Doc:      goanalysis.TheOnlyanalyzerDoc,
-		Run:      run,
-		Requires: []*analysis.Analyzer{inspect.Analyzer},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Checks that no init functions are present in Go code",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name:     "gochecknoinits",
+			Doc:      "Checks that no init functions are present in Go code",
+			Run:      run,
+			Requires: []*analysis.Analyzer{inspect.Analyzer},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func run(pass *analysis.Pass) (any, error) {

--- a/pkg/golinters/goconst/goconst.go
+++ b/pkg/golinters/goconst/goconst.go
@@ -20,35 +20,31 @@ func New(settings *config.GoConstSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			issues, err := runGoconst(pass, settings)
-			if err != nil {
-				return nil, err
-			}
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: linterName,
+			Doc:  "Finds repeated strings that could be replaced by a constant",
+			Run: func(pass *analysis.Pass) (any, error) {
+				issues, err := runGoconst(pass, settings)
+				if err != nil {
+					return nil, err
+				}
 
-			if len(issues) == 0 {
+				if len(issues) == 0 {
+					return nil, nil
+				}
+
+				mu.Lock()
+				resIssues = append(resIssues, issues...)
+				mu.Unlock()
+
 				return nil, nil
-			}
-
-			mu.Lock()
-			resIssues = append(resIssues, issues...)
-			mu.Unlock()
-
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Finds repeated strings that could be replaced by a constant",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
-		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
+			},
+		}).
+		WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
+			return resIssues
+		}).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func runGoconst(pass *analysis.Pass, settings *config.GoConstSettings) ([]goanalysis.Issue, error) {

--- a/pkg/golinters/gocritic/gocritic.go
+++ b/pkg/golinters/gocritic/gocritic.go
@@ -33,27 +33,21 @@ func New(settings *config.GoCriticSettings, replacer *strings.Replacer) *goanaly
 		sizes: types.SizesFor("gc", runtime.GOARCH),
 	}
 
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			err := wrapper.run(pass)
-			if err != nil {
-				return nil, err
-			}
-
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		`Provides diagnostics that check for bugs, performance and style issues.
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: linterName,
+			Doc: `Provides diagnostics that check for bugs, performance and style issues.
 Extensible without recompilation through dynamic rules.
 Dynamic rules are written declaratively with AST patterns, filters, report message and optional suggestion.`,
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).
+			Run: func(pass *analysis.Pass) (any, error) {
+				err := wrapper.run(pass)
+				if err != nil {
+					return nil, err
+				}
+
+				return nil, nil
+			},
+		}).
 		WithContextSetter(func(context *linter.Context) {
 			wrapper.init(context.Log, settings, replacer)
 		}).

--- a/pkg/golinters/gocyclo/gocyclo.go
+++ b/pkg/golinters/gocyclo/gocyclo.go
@@ -20,32 +20,28 @@ func New(settings *config.GoCycloSettings) *goanalysis.Linter {
 	var mu sync.Mutex
 	var resIssues []goanalysis.Issue
 
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			issues := runGoCyclo(pass, settings)
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: linterName,
+			Doc:  "Computes and checks the cyclomatic complexity of functions",
+			Run: func(pass *analysis.Pass) (any, error) {
+				issues := runGoCyclo(pass, settings)
 
-			if len(issues) == 0 {
+				if len(issues) == 0 {
+					return nil, nil
+				}
+
+				mu.Lock()
+				resIssues = append(resIssues, issues...)
+				mu.Unlock()
+
 				return nil, nil
-			}
-
-			mu.Lock()
-			resIssues = append(resIssues, issues...)
-			mu.Unlock()
-
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Computes and checks the cyclomatic complexity of functions",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
-		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeSyntax)
+			},
+		}).
+		WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
+			return resIssues
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func runGoCyclo(pass *analysis.Pass, settings *config.GoCycloSettings) []goanalysis.Issue {

--- a/pkg/golinters/godot/godot.go
+++ b/pkg/golinters/godot/godot.go
@@ -10,8 +10,6 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-const linterName = "godot"
-
 func New(settings *config.GodotSettings) *goanalysis.Linter {
 	var dotSettings godot.Settings
 
@@ -26,25 +24,20 @@ func New(settings *config.GodotSettings) *goanalysis.Linter {
 
 	dotSettings.Scope = cmp.Or(dotSettings.Scope, godot.DeclScope)
 
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			err := runGodot(pass, dotSettings)
-			if err != nil {
-				return nil, err
-			}
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "godot",
+			Doc:  "Check if comments end in a period",
+			Run: func(pass *analysis.Pass) (any, error) {
+				err := runGodot(pass, dotSettings)
+				if err != nil {
+					return nil, err
+				}
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Check if comments end in a period",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func runGodot(pass *analysis.Pass, settings godot.Settings) error {

--- a/pkg/golinters/godox/godox.go
+++ b/pkg/golinters/godox/godox.go
@@ -11,23 +11,16 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-const linterName = "godox"
-
 func New(settings *config.GodoxSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			return run(pass, settings), nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Detects usage of FIXME, TODO and other keywords inside comments",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "godox",
+			Doc:  "Detects usage of FIXME, TODO and other keywords inside comments",
+			Run: func(pass *analysis.Pass) (any, error) {
+				return run(pass, settings), nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func run(pass *analysis.Pass, settings *config.GodoxSettings) error {

--- a/pkg/golinters/gofmt/gofmt.go
+++ b/pkg/golinters/gofmt/gofmt.go
@@ -1,8 +1,6 @@
 package gofmt
 
 import (
-	"golang.org/x/tools/go/analysis"
-
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
@@ -10,19 +8,14 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
-const linterName = "gofmt"
-
 func New(settings *config.GoFmtSettings) *goanalysis.Linter {
-	a := goformatters.NewAnalyzer(
-		internal.LinterLogger.Child(linterName),
-		"Checks if the code is formatted according to 'gofmt' command.",
-		gofmtbase.New(settings),
-	)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(
+			goformatters.NewAnalyzer(
+				internal.LinterLogger.Child(gofmtbase.Name),
+				"Check if the code is formatted according to 'gofmt' command.",
+				gofmtbase.New(settings),
+			),
+		).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/gofumpt/gofumpt.go
+++ b/pkg/golinters/gofumpt/gofumpt.go
@@ -1,8 +1,6 @@
 package gofumpt
 
 import (
-	"golang.org/x/tools/go/analysis"
-
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
@@ -10,19 +8,14 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
-const linterName = "gofumpt"
-
 func New(settings *config.GoFumptSettings) *goanalysis.Linter {
-	a := goformatters.NewAnalyzer(
-		internal.LinterLogger.Child(linterName),
-		"Checks if code and import statements are formatted, with additional rules.",
-		gofumptbase.New(settings, settings.LangVersion),
-	)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(
+			goformatters.NewAnalyzer(
+				internal.LinterLogger.Child(gofumptbase.Name),
+				"Check if code and import statements are formatted, with additional rules.",
+				gofumptbase.New(settings, settings.LangVersion),
+			),
+		).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/goheader/goheader.go
+++ b/pkg/golinters/goheader/goheader.go
@@ -23,25 +23,20 @@ func New(settings *config.GoHeaderSettings, replacer *strings.Replacer) *goanaly
 		}
 	}
 
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			err := runGoHeader(pass, conf)
-			if err != nil {
-				return nil, err
-			}
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: linterName,
+			Doc:  "Check if file header matches to pattern",
+			Run: func(pass *analysis.Pass) (any, error) {
+				err := runGoHeader(pass, conf)
+				if err != nil {
+					return nil, err
+				}
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Checks if file header matches to pattern",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func runGoHeader(pass *analysis.Pass, conf *goheader.Configuration) error {

--- a/pkg/golinters/goimports/goimports.go
+++ b/pkg/golinters/goimports/goimports.go
@@ -1,8 +1,6 @@
 package goimports
 
 import (
-	"golang.org/x/tools/go/analysis"
-
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
@@ -10,19 +8,14 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
-const linterName = "goimports"
-
 func New(settings *config.GoImportsSettings) *goanalysis.Linter {
-	a := goformatters.NewAnalyzer(
-		internal.LinterLogger.Child(linterName),
-		"Checks if the code and import statements are formatted according to the 'goimports' command.",
-		goimportsbase.New(settings),
-	)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(
+			goformatters.NewAnalyzer(
+				internal.LinterLogger.Child(goimportsbase.Name),
+				"Checks if the code and import statements are formatted according to the 'goimports' command.",
+				goimportsbase.New(settings),
+			),
+		).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/golines/golines.go
+++ b/pkg/golinters/golines/golines.go
@@ -1,8 +1,6 @@
 package golines
 
 import (
-	"golang.org/x/tools/go/analysis"
-
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
@@ -10,19 +8,14 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
-const linterName = "golines"
-
 func New(settings *config.GoLinesSettings) *goanalysis.Linter {
-	a := goformatters.NewAnalyzer(
-		internal.LinterLogger.Child(linterName),
-		"Checks if code is formatted, and fixes long lines",
-		golinesbase.New(settings),
-	)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(
+			goformatters.NewAnalyzer(
+				internal.LinterLogger.Child(golinesbase.Name),
+				"Checks if code is formatted, and fixes long lines",
+				golinesbase.New(settings),
+			),
+		).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/gomoddirectives/gomoddirectives.go
+++ b/pkg/golinters/gomoddirectives/gomoddirectives.go
@@ -50,38 +50,37 @@ func New(settings *config.GoModDirectivesSettings) *goanalysis.Linter {
 	}
 
 	analyzer := &analysis.Analyzer{
-		Name: goanalysis.TheOnlyAnalyzerName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
+		Name: linterName,
+		Doc:  "Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.",
 		Run:  goanalysis.DummyRun,
 	}
 
-	return goanalysis.NewLinter(
-		linterName,
-		"Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithContextSetter(func(lintCtx *linter.Context) {
-		analyzer.Run = func(pass *analysis.Pass) (any, error) {
-			once.Do(func() {
-				results, err := gomoddirectives.AnalyzePass(pass, opts)
-				if err != nil {
-					lintCtx.Log.Warnf("running %s failed: %s: "+
-						"if you are not using go modules it is suggested to disable this linter", linterName, err)
-					return
-				}
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer).
+		WithContextSetter(func(lintCtx *linter.Context) {
+			analyzer.Run = func(pass *analysis.Pass) (any, error) {
+				once.Do(func() {
+					results, err := gomoddirectives.AnalyzePass(pass, opts)
+					if err != nil {
+						lintCtx.Log.Warnf("running %s failed: %s: "+
+							"if you are not using go modules it is suggested to disable this linter", linterName, err)
+						return
+					}
 
-				for _, p := range results {
-					issues = append(issues, goanalysis.NewIssue(&result.Issue{
-						FromLinter: linterName,
-						Pos:        p.Start,
-						Text:       p.Reason,
-					}, pass))
-				}
-			})
+					for _, p := range results {
+						issues = append(issues, goanalysis.NewIssue(&result.Issue{
+							FromLinter: linterName,
+							Pos:        p.Start,
+							Text:       p.Reason,
+						}, pass))
+					}
+				})
 
-			return nil, nil
-		}
-	}).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
-		return issues
-	}).WithLoadMode(goanalysis.LoadModeSyntax)
+				return nil, nil
+			}
+		}).
+		WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
+			return issues
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/goprintffuncname/goprintffuncname.go
+++ b/pkg/golinters/goprintffuncname/goprintffuncname.go
@@ -2,18 +2,12 @@ package goprintffuncname
 
 import (
 	"github.com/golangci/go-printf-func-name/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := analyzer.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.Analyzer).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/gosmopolitan/gosmopolitan.go
+++ b/pkg/golinters/gosmopolitan/gosmopolitan.go
@@ -4,18 +4,16 @@ import (
 	"strings"
 
 	"github.com/xen0n/gosmopolitan"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.GosmopolitanSettings) *goanalysis.Linter {
-	a := gosmopolitan.NewAnalyzer()
+	var cfg map[string]any
 
-	cfg := map[string]map[string]any{}
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"allowtimelocal":  settings.AllowTimeLocal,
 			"escapehatches":   strings.Join(settings.EscapeHatches, ","),
 			"watchforscripts": strings.Join(settings.WatchForScripts, ","),
@@ -25,10 +23,8 @@ func New(settings *config.GosmopolitanSettings) *goanalysis.Linter {
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(gosmopolitan.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/grouper/grouper.go
+++ b/pkg/golinters/grouper/grouper.go
@@ -2,18 +2,16 @@ package grouper
 
 import (
 	grouper "github.com/leonklingele/grouper/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.GrouperSettings) *goanalysis.Linter {
-	a := grouper.New()
+	var cfg map[string]any
 
-	cfg := map[string]map[string]any{}
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"const-require-single-const":   settings.ConstRequireSingleConst,
 			"const-require-grouping":       settings.ConstRequireGrouping,
 			"import-require-single-import": settings.ImportRequireSingleImport,
@@ -24,11 +22,9 @@ func New(settings *config.GrouperSettings) *goanalysis.Linter {
 			"var-require-grouping":         settings.VarRequireGrouping,
 		}
 	}
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"Analyze expression groups.",
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(grouper.New()).
+		WithDesc("Analyze expression groups.").
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/importas/importas.go
+++ b/pkg/golinters/importas/importas.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/julz/importas"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -16,55 +15,53 @@ import (
 func New(settings *config.ImportAsSettings) *goanalysis.Linter {
 	analyzer := importas.Analyzer
 
-	return goanalysis.NewLinter(
-		analyzer.Name,
-		analyzer.Doc,
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithContextSetter(func(lintCtx *linter.Context) {
-		if settings == nil {
-			return
-		}
-		if len(settings.Alias) == 0 {
-			lintCtx.Log.Infof("importas settings found, but no aliases listed. List aliases under alias: key.")
-		}
-
-		if err := analyzer.Flags.Set("no-unaliased", strconv.FormatBool(settings.NoUnaliased)); err != nil {
-			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
-		}
-
-		if err := analyzer.Flags.Set("no-extra-aliases", strconv.FormatBool(settings.NoExtraAliases)); err != nil {
-			lintCtx.Log.Errorf("failed to parse configuration: %v", err)
-		}
-
-		uniqPackages := make(map[string]config.ImportAsAlias)
-		uniqAliases := make(map[string]config.ImportAsAlias)
-		for _, a := range settings.Alias {
-			if a.Pkg == "" {
-				lintCtx.Log.Errorf("invalid configuration, empty package: pkg=%s alias=%s", a.Pkg, a.Alias)
-				continue
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer).
+		WithContextSetter(func(lintCtx *linter.Context) {
+			if settings == nil {
+				return
+			}
+			if len(settings.Alias) == 0 {
+				lintCtx.Log.Infof("importas settings found, but no aliases listed. List aliases under alias: key.")
 			}
 
-			if v, ok := uniqPackages[a.Pkg]; ok {
-				lintCtx.Log.Errorf("invalid configuration, multiple aliases for the same package: pkg=%s aliases=[%s,%s]", a.Pkg, a.Alias, v.Alias)
-			} else {
-				uniqPackages[a.Pkg] = a
-			}
-
-			// Skips the duplication check when:
-			// - the alias is empty.
-			// - the alias is a regular expression replacement pattern (ie. contains `$`).
-			v, ok := uniqAliases[a.Alias]
-			if ok && a.Alias != "" && !strings.Contains(a.Alias, "$") {
-				lintCtx.Log.Errorf("invalid configuration, multiple packages with the same alias: alias=%s packages=[%s,%s]", a.Alias, a.Pkg, v.Pkg)
-			} else {
-				uniqAliases[a.Alias] = a
-			}
-
-			err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", a.Pkg, a.Alias))
-			if err != nil {
+			if err := analyzer.Flags.Set("no-unaliased", strconv.FormatBool(settings.NoUnaliased)); err != nil {
 				lintCtx.Log.Errorf("failed to parse configuration: %v", err)
 			}
-		}
-	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
+
+			if err := analyzer.Flags.Set("no-extra-aliases", strconv.FormatBool(settings.NoExtraAliases)); err != nil {
+				lintCtx.Log.Errorf("failed to parse configuration: %v", err)
+			}
+
+			uniqPackages := make(map[string]config.ImportAsAlias)
+			uniqAliases := make(map[string]config.ImportAsAlias)
+			for _, a := range settings.Alias {
+				if a.Pkg == "" {
+					lintCtx.Log.Errorf("invalid configuration, empty package: pkg=%s alias=%s", a.Pkg, a.Alias)
+					continue
+				}
+
+				if v, ok := uniqPackages[a.Pkg]; ok {
+					lintCtx.Log.Errorf("invalid configuration, multiple aliases for the same package: pkg=%s aliases=[%s,%s]", a.Pkg, a.Alias, v.Alias)
+				} else {
+					uniqPackages[a.Pkg] = a
+				}
+
+				// Skips the duplication check when:
+				// - the alias is empty.
+				// - the alias is a regular expression replacement pattern (ie. contains `$`).
+				v, ok := uniqAliases[a.Alias]
+				if ok && a.Alias != "" && !strings.Contains(a.Alias, "$") {
+					lintCtx.Log.Errorf("invalid configuration, multiple packages with the same alias: alias=%s packages=[%s,%s]", a.Alias, a.Pkg, v.Pkg)
+				} else {
+					uniqAliases[a.Alias] = a
+				}
+
+				err := analyzer.Flags.Set("alias", fmt.Sprintf("%s:%s", a.Pkg, a.Alias))
+				if err != nil {
+					lintCtx.Log.Errorf("failed to parse configuration: %v", err)
+				}
+			}
+		}).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/inamedparam/inamedparam.go
+++ b/pkg/golinters/inamedparam/inamedparam.go
@@ -2,29 +2,22 @@ package inamedparam
 
 import (
 	"github.com/macabu/inamedparam"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.INamedParamSettings) *goanalysis.Linter {
-	a := inamedparam.Analyzer
-
-	var cfg map[string]map[string]any
+	var cfg map[string]any
 
 	if settings != nil {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				"skip-single-param": settings.SkipSingleParam,
-			},
+		cfg = map[string]any{
+			"skip-single-param": settings.SkipSingleParam,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(inamedparam.Analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/ineffassign/ineffassign.go
+++ b/pkg/golinters/ineffassign/ineffassign.go
@@ -2,18 +2,13 @@ package ineffassign
 
 import (
 	"github.com/gordonklaus/ineffassign/pkg/ineffassign"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := ineffassign.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"Detects when assignments to existing variables are not used",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(ineffassign.Analyzer).
+		WithDesc("Detects when assignments to existing variables are not used").
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/interfacebloat/interfacebloat.go
+++ b/pkg/golinters/interfacebloat/interfacebloat.go
@@ -2,28 +2,22 @@ package interfacebloat
 
 import (
 	"github.com/sashamelentyev/interfacebloat/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.InterfaceBloatSettings) *goanalysis.Linter {
-	a := analyzer.New()
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				analyzer.InterfaceMaxMethodsFlag: settings.Max,
-			},
+		cfg = map[string]any{
+			analyzer.InterfaceMaxMethodsFlag: settings.Max,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.New()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/intrange/intrange.go
+++ b/pkg/golinters/intrange/intrange.go
@@ -2,18 +2,12 @@ package intrange
 
 import (
 	"github.com/ckaznocha/intrange"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := intrange.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(intrange.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/ireturn/ireturn.go
+++ b/pkg/golinters/ireturn/ireturn.go
@@ -4,28 +4,24 @@ import (
 	"strings"
 
 	"github.com/butuzov/ireturn/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.IreturnSettings) *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
+	var cfg map[string]any
 
-	cfg := map[string]map[string]any{}
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"allow":    strings.Join(settings.Allow, ","),
 			"reject":   strings.Join(settings.Reject, ","),
 			"nonolint": true,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/lll/lll.go
+++ b/pkg/golinters/lll/lll.go
@@ -15,30 +15,23 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-const linterName = "lll"
-
 const goCommentDirectivePrefix = "//go:"
 
 func New(settings *config.LllSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			err := runLll(pass, settings)
-			if err != nil {
-				return nil, err
-			}
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "lll",
+			Doc:  "Reports long lines",
+			Run: func(pass *analysis.Pass) (any, error) {
+				err := runLll(pass, settings)
+				if err != nil {
+					return nil, err
+				}
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Reports long lines",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func runLll(pass *analysis.Pass, settings *config.LllSettings) error {

--- a/pkg/golinters/loggercheck/loggercheck.go
+++ b/pkg/golinters/loggercheck/loggercheck.go
@@ -2,7 +2,6 @@ package loggercheck
 
 import (
 	"github.com/timonwong/loggercheck"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -37,11 +36,7 @@ func New(settings *config.LoggerCheckSettings) *goanalysis.Linter {
 		}
 	}
 
-	analyzer := loggercheck.NewAnalyzer(opts...)
-	return goanalysis.NewLinter(
-		analyzer.Name,
-		analyzer.Doc,
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(loggercheck.NewAnalyzer(opts...)).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/maintidx/maintidx.go
+++ b/pkg/golinters/maintidx/maintidx.go
@@ -2,29 +2,22 @@ package maintidx
 
 import (
 	"github.com/yagipy/maintidx"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.MaintIdxSettings) *goanalysis.Linter {
-	analyzer := maintidx.Analyzer
-
-	cfg := map[string]map[string]any{
-		analyzer.Name: {"under": 20},
+	cfg := map[string]any{
+		"under": 20,
 	}
 
 	if settings != nil {
-		cfg[analyzer.Name] = map[string]any{
-			"under": settings.Under,
-		}
+		cfg["under"] = settings.Under
 	}
 
-	return goanalysis.NewLinter(
-		analyzer.Name,
-		analyzer.Doc,
-		[]*analysis.Analyzer{analyzer},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(maintidx.Analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/makezero/makezero.go
+++ b/pkg/golinters/makezero/makezero.go
@@ -10,28 +10,21 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-const linterName = "makezero"
-
 func New(settings *config.MakezeroSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			err := runMakeZero(pass, settings)
-			if err != nil {
-				return nil, err
-			}
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "makezero",
+			Doc:  "Find slice declarations with non-zero initial length",
+			Run: func(pass *analysis.Pass) (any, error) {
+				err := runMakeZero(pass, settings)
+				if err != nil {
+					return nil, err
+				}
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Finds slice declarations with non-zero initial length",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func runMakeZero(pass *analysis.Pass, settings *config.MakezeroSettings) error {

--- a/pkg/golinters/mirror/mirror.go
+++ b/pkg/golinters/mirror/mirror.go
@@ -2,29 +2,22 @@ package mirror
 
 import (
 	"github.com/butuzov/mirror"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := mirror.NewAnalyzer()
-
 	// mirror only lints test files if the `--with-tests` flag is passed,
 	// so we pass the `with-tests` flag as true to the analyzer before running it.
 	// This can be turned off by using the regular golangci-lint flags such as `--tests` or `--skip-files`
 	// or can be disabled per linter via exclude rules.
 	// (see https://github.com/golangci/golangci-lint/issues/2527#issuecomment-1023707262)
-	linterCfg := map[string]map[string]any{
-		a.Name: {
-			"with-tests": true,
-		},
+	cfg := map[string]any{
+		"with-tests": true,
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		linterCfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(mirror.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/misspell/misspell.go
+++ b/pkg/golinters/misspell/misspell.go
@@ -23,27 +23,22 @@ func New(settings *config.MisspellSettings) *goanalysis.Linter {
 		internal.LinterLogger.Fatalf("%s: %v", linterName, err)
 	}
 
-	a := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  "Finds commonly misspelled English words",
-		Run: func(pass *analysis.Pass) (any, error) {
-			for _, file := range pass.Files {
-				err := runMisspellOnFile(pass, file, replacer, settings.Mode)
-				if err != nil {
-					return nil, err
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: linterName,
+			Doc:  "Finds commonly misspelled English words",
+			Run: func(pass *analysis.Pass) (any, error) {
+				for _, file := range pass.Files {
+					err := runMisspellOnFile(pass, file, replacer, settings.Mode)
+					if err != nil {
+						return nil, err
+					}
 				}
-			}
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func createMisspellReplacer(settings *config.MisspellSettings) (*misspell.Replacer, error) {

--- a/pkg/golinters/mnd/mnd.go
+++ b/pkg/golinters/mnd/mnd.go
@@ -2,18 +2,15 @@ package mnd
 
 import (
 	mnd "github.com/tommy-muehle/go-mnd/v2"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.MndSettings) *goanalysis.Linter {
-	a := mnd.Analyzer
+	cfg := map[string]any{}
 
-	var linterCfg map[string]map[string]any
 	if settings != nil {
-		cfg := make(map[string]any)
 		if len(settings.Checks) > 0 {
 			cfg["checks"] = settings.Checks
 		}
@@ -26,16 +23,11 @@ func New(settings *config.MndSettings) *goanalysis.Linter {
 		if len(settings.IgnoredFunctions) > 0 {
 			cfg["ignored-functions"] = settings.IgnoredFunctions
 		}
-
-		linterCfg = map[string]map[string]any{
-			a.Name: cfg,
-		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		"An analyzer to detect magic numbers.",
-		[]*analysis.Analyzer{a},
-		linterCfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(mnd.Analyzer).
+		WithDesc("An analyzer to detect magic numbers.").
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/musttag/musttag.go
+++ b/pkg/golinters/musttag/musttag.go
@@ -2,7 +2,6 @@ package musttag
 
 import (
 	"go-simpler.org/musttag"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -21,9 +20,7 @@ func New(settings *config.MustTagSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := musttag.New(funcs...)
-
 	return goanalysis.
-		NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, nil).
+		NewLinterFromAnalyzer(musttag.New(funcs...)).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/nakedret/nakedret.go
+++ b/pkg/golinters/nakedret/nakedret.go
@@ -2,7 +2,6 @@ package nakedret
 
 import (
 	"github.com/alexkohler/nakedret/v2"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -16,12 +15,7 @@ func New(settings *config.NakedretSettings) *goanalysis.Linter {
 		cfg.MaxLength = settings.MaxFuncLines
 	}
 
-	a := nakedret.NakedReturnAnalyzer(cfg)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(nakedret.NakedReturnAnalyzer(cfg)).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/nestif/nestif.go
+++ b/pkg/golinters/nestif/nestif.go
@@ -8,25 +8,18 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-const linterName = "nestif"
-
 func New(settings *config.NestifSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			runNestIf(pass, settings)
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "nestif",
+			Doc:  "Reports deeply nested if statements",
+			Run: func(pass *analysis.Pass) (any, error) {
+				runNestIf(pass, settings)
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Reports deeply nested if statements",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func runNestIf(pass *analysis.Pass, settings *config.NestifSettings) {

--- a/pkg/golinters/nilerr/nilerr.go
+++ b/pkg/golinters/nilerr/nilerr.go
@@ -2,18 +2,13 @@ package nilerr
 
 import (
 	"github.com/gostaticanalysis/nilerr"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := nilerr.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"Finds the code that returns nil even if it checks that the error is not nil.",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(nilerr.Analyzer).
+		WithDesc("Find the code that returns nil even if it checks that the error is not nil.").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/nilnesserr/nilnesserr.go
+++ b/pkg/golinters/nilnesserr/nilnesserr.go
@@ -2,22 +2,18 @@ package nilnesserr
 
 import (
 	"github.com/alingse/nilnesserr"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
 func New() *goanalysis.Linter {
-	a, err := nilnesserr.NewAnalyzer(nilnesserr.LinterSetting{})
+	analyzer, err := nilnesserr.NewAnalyzer(nilnesserr.LinterSetting{})
 	if err != nil {
 		internal.LinterLogger.Fatalf("nilnesserr: create analyzer: %v", err)
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/nilnil/nilnil.go
+++ b/pkg/golinters/nilnil/nilnil.go
@@ -2,33 +2,28 @@ package nilnil
 
 import (
 	"github.com/Antonboom/nilnil/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.NilNilSettings) *goanalysis.Linter {
-	a := analyzer.New()
+	var cfg map[string]any
 
-	cfg := make(map[string]map[string]any)
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"detect-opposite": settings.DetectOpposite,
 		}
 		if b := settings.OnlyTwo; b != nil {
-			cfg[a.Name]["only-two"] = *b
+			cfg["only-two"] = *b
 		}
 		if len(settings.CheckedTypes) != 0 {
-			cfg[a.Name]["checked-types"] = settings.CheckedTypes
+			cfg["checked-types"] = settings.CheckedTypes
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.New()).
+		WithConfig(cfg).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/nlreturn/nlreturn.go
+++ b/pkg/golinters/nlreturn/nlreturn.go
@@ -2,26 +2,22 @@ package nlreturn
 
 import (
 	"github.com/ssgreg/nlreturn/v2/pkg/nlreturn"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.NlreturnSettings) *goanalysis.Linter {
-	a := nlreturn.NewAnalyzer()
+	var cfg map[string]any
 
-	cfg := map[string]map[string]any{}
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"block-size": settings.BlockSize,
 		}
 	}
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"nlreturn checks for a new line before return and branch statements to increase code clarity",
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(nlreturn.NewAnalyzer()).
+		WithDesc("Checks for a new line before return and branch statements to increase code clarity").
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/noctx/noctx.go
+++ b/pkg/golinters/noctx/noctx.go
@@ -2,18 +2,13 @@ package noctx
 
 import (
 	"github.com/sonatard/noctx"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := noctx.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"Detects function and method with missing usage of context.Context",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(noctx.Analyzer).
+		WithDesc("Detects function and method with missing usage of context.Context").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -35,33 +35,29 @@ func New(settings *config.NoLintLintSettings) *goanalysis.Linter {
 		internal.LinterLogger.Fatalf("%s: create analyzer: %v", nolintlint.LinterName, err)
 	}
 
-	analyzer := &analysis.Analyzer{
-		Name: nolintlint.LinterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			issues, err := lnt.Run(pass)
-			if err != nil {
-				return nil, fmt.Errorf("linter failed to run: %w", err)
-			}
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: nolintlint.LinterName,
+			Doc:  "Reports ill-formed or insufficient nolint directives",
+			Run: func(pass *analysis.Pass) (any, error) {
+				issues, err := lnt.Run(pass)
+				if err != nil {
+					return nil, fmt.Errorf("linter failed to run: %w", err)
+				}
 
-			if len(issues) == 0 {
+				if len(issues) == 0 {
+					return nil, nil
+				}
+
+				mu.Lock()
+				resIssues = append(resIssues, issues...)
+				mu.Unlock()
+
 				return nil, nil
-			}
-
-			mu.Lock()
-			resIssues = append(resIssues, issues...)
-			mu.Unlock()
-
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		nolintlint.LinterName,
-		"Reports ill-formed or insufficient nolint directives",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
-		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeSyntax)
+			},
+		}).
+		WithIssuesReporter(func(*linter.Context) []goanalysis.Issue {
+			return resIssues
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/nonamedreturns/nonamedreturns.go
+++ b/pkg/golinters/nonamedreturns/nonamedreturns.go
@@ -2,28 +2,22 @@ package nonamedreturns
 
 import (
 	"github.com/firefart/nonamedreturns/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.NoNamedReturnsSettings) *goanalysis.Linter {
-	a := analyzer.Analyzer
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				analyzer.FlagReportErrorInDefer: settings.ReportErrorInDefer,
-			},
+		cfg = map[string]any{
+			analyzer.FlagReportErrorInDefer: settings.ReportErrorInDefer,
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.Analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/nosprintfhostport/nosprintfhostport.go
+++ b/pkg/golinters/nosprintfhostport/nosprintfhostport.go
@@ -2,18 +2,12 @@ package nosprintfhostport
 
 import (
 	"github.com/stbenjam/no-sprintf-host-port/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := analyzer.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.Analyzer).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/paralleltest/paralleltest.go
+++ b/pkg/golinters/paralleltest/paralleltest.go
@@ -2,33 +2,28 @@ package paralleltest
 
 import (
 	"github.com/kunwardeep/paralleltest/pkg/paralleltest"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.ParallelTestSettings) *goanalysis.Linter {
-	a := paralleltest.NewAnalyzer()
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		d := map[string]any{
+		cfg = map[string]any{
 			"i":                     settings.IgnoreMissing,
 			"ignoremissingsubtests": settings.IgnoreMissingSubtests,
 		}
 
 		if config.IsGoGreaterThanOrEqual(settings.Go, "1.22") {
-			d["ignoreloopVar"] = true
+			cfg["ignoreloopVar"] = true
 		}
-
-		cfg = map[string]map[string]any{a.Name: d}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		"Detects missing usage of t.Parallel() method in your Go test",
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(paralleltest.NewAnalyzer()).
+		WithDesc("Detects missing usage of t.Parallel() method in your Go test").
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/perfsprint/perfsprint.go
+++ b/pkg/golinters/perfsprint/perfsprint.go
@@ -2,41 +2,36 @@ package perfsprint
 
 import (
 	"github.com/catenacyber/perfsprint/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.PerfSprintSettings) *goanalysis.Linter {
-	a := analyzer.New()
-
-	cfg := map[string]map[string]any{
-		a.Name: {"fiximports": false},
+	cfg := map[string]any{
+		"fiximports": false,
 	}
 
 	if settings != nil {
 		// NOTE: The option `ignore-tests` is not handled because it should be managed with `linters.exclusions.rules`
 
-		cfg[a.Name]["integer-format"] = settings.IntegerFormat
-		cfg[a.Name]["int-conversion"] = settings.IntConversion
+		cfg["integer-format"] = settings.IntegerFormat
+		cfg["int-conversion"] = settings.IntConversion
 
-		cfg[a.Name]["error-format"] = settings.ErrorFormat
-		cfg[a.Name]["err-error"] = settings.ErrError
-		cfg[a.Name]["errorf"] = settings.ErrorF
+		cfg["error-format"] = settings.ErrorFormat
+		cfg["err-error"] = settings.ErrError
+		cfg["errorf"] = settings.ErrorF
 
-		cfg[a.Name]["string-format"] = settings.StringFormat
-		cfg[a.Name]["sprintf1"] = settings.SprintF1
-		cfg[a.Name]["strconcat"] = settings.StrConcat
+		cfg["string-format"] = settings.StringFormat
+		cfg["sprintf1"] = settings.SprintF1
+		cfg["strconcat"] = settings.StrConcat
 
-		cfg[a.Name]["bool-format"] = settings.BoolFormat
-		cfg[a.Name]["hex-format"] = settings.HexFormat
+		cfg["bool-format"] = settings.BoolFormat
+		cfg["hex-format"] = settings.HexFormat
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.New()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/prealloc/prealloc.go
+++ b/pkg/golinters/prealloc/prealloc.go
@@ -11,25 +11,18 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
-const linterName = "prealloc"
-
 func New(settings *config.PreallocSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run: func(pass *analysis.Pass) (any, error) {
-			runPreAlloc(pass, settings)
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "prealloc",
+			Doc:  "Find slice declarations that could potentially be pre-allocated",
+			Run: func(pass *analysis.Pass) (any, error) {
+				runPreAlloc(pass, settings)
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Finds slice declarations that could potentially be pre-allocated",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 
 func runPreAlloc(pass *analysis.Pass, settings *config.PreallocSettings) {

--- a/pkg/golinters/predeclared/predeclared.go
+++ b/pkg/golinters/predeclared/predeclared.go
@@ -4,25 +4,23 @@ import (
 	"strings"
 
 	"github.com/nishanths/predeclared/passes/predeclared"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.PredeclaredSettings) *goanalysis.Linter {
-	a := predeclared.Analyzer
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				predeclared.IgnoreFlag:    strings.Join(settings.Ignore, ","),
-				predeclared.QualifiedFlag: settings.Qualified,
-			},
+		cfg = map[string]any{
+			predeclared.IgnoreFlag:    strings.Join(settings.Ignore, ","),
+			predeclared.QualifiedFlag: settings.Qualified,
 		}
 	}
 
-	return goanalysis.NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, cfg).
+	return goanalysis.
+		NewLinterFromAnalyzer(predeclared.Analyzer).
+		WithConfig(cfg).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/protogetter/protogetter.go
+++ b/pkg/golinters/protogetter/protogetter.go
@@ -2,7 +2,6 @@ package protogetter
 
 import (
 	"github.com/ghostiam/protogetter"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -10,6 +9,7 @@ import (
 
 func New(settings *config.ProtoGetterSettings) *goanalysis.Linter {
 	var cfg protogetter.Config
+
 	if settings != nil {
 		cfg = protogetter.Config{
 			SkipGeneratedBy:         settings.SkipGeneratedBy,
@@ -19,12 +19,7 @@ func New(settings *config.ProtoGetterSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := protogetter.NewAnalyzer(&cfg)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(protogetter.NewAnalyzer(&cfg)).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/reassign/reassign.go
+++ b/pkg/golinters/reassign/reassign.go
@@ -5,28 +5,22 @@ import (
 	"strings"
 
 	"github.com/curioswitch/go-reassign"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.ReassignSettings) *goanalysis.Linter {
-	a := reassign.NewAnalyzer()
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil && len(settings.Patterns) > 0 {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				reassign.FlagPattern: fmt.Sprintf("^(%s)$", strings.Join(settings.Patterns, "|")),
-			},
+		cfg = map[string]any{
+			reassign.FlagPattern: fmt.Sprintf("^(%s)$", strings.Join(settings.Patterns, "|")),
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(reassign.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/recvcheck/recvcheck.go
+++ b/pkg/golinters/recvcheck/recvcheck.go
@@ -2,7 +2,6 @@ package recvcheck
 
 import (
 	"github.com/raeperd/recvcheck"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -16,12 +15,7 @@ func New(settings *config.RecvcheckSettings) *goanalysis.Linter {
 		cfg.Exclusions = settings.Exclusions
 	}
 
-	a := recvcheck.NewAnalyzer(cfg)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(recvcheck.NewAnalyzer(cfg)).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/rowserrcheck/rowserrcheck.go
+++ b/pkg/golinters/rowserrcheck/rowserrcheck.go
@@ -2,7 +2,6 @@ package rowserrcheck
 
 import (
 	"github.com/jingyugao/rowserrcheck/passes/rowserr"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -10,16 +9,13 @@ import (
 
 func New(settings *config.RowsErrCheckSettings) *goanalysis.Linter {
 	var pkgs []string
+
 	if settings != nil {
 		pkgs = settings.Packages
 	}
 
-	a := rowserr.NewAnalyzer(pkgs...)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"checks whether Rows.Err of rows is checked successfully",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(rowserr.NewAnalyzer(pkgs...)).
+		WithDesc("checks whether Rows.Err of rows is checked successfully").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/sloglint/sloglint.go
+++ b/pkg/golinters/sloglint/sloglint.go
@@ -2,7 +2,6 @@ package sloglint
 
 import (
 	"go-simpler.org/sloglint"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -10,6 +9,7 @@ import (
 
 func New(settings *config.SlogLintSettings) *goanalysis.Linter {
 	var opts *sloglint.Options
+
 	if settings != nil {
 		opts = &sloglint.Options{
 			NoMixedArgs:    settings.NoMixedArgs,
@@ -26,9 +26,7 @@ func New(settings *config.SlogLintSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := sloglint.New(opts)
-
 	return goanalysis.
-		NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, nil).
+		NewLinterFromAnalyzer(sloglint.New(opts)).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/spancheck/spancheck.go
+++ b/pkg/golinters/spancheck/spancheck.go
@@ -2,7 +2,6 @@ package spancheck
 
 import (
 	"github.com/jjti/go-spancheck"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -25,9 +24,7 @@ func New(settings *config.SpancheckSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := spancheck.NewAnalyzerWithConfig(cfg)
-
 	return goanalysis.
-		NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, nil).
+		NewLinterFromAnalyzer(spancheck.NewAnalyzerWithConfig(cfg)).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/sqlclosecheck/sqlclosecheck.go
+++ b/pkg/golinters/sqlclosecheck/sqlclosecheck.go
@@ -2,18 +2,12 @@ package sqlclosecheck
 
 import (
 	"github.com/ryanrolds/sqlclosecheck/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/swaggo/swaggo.go
+++ b/pkg/golinters/swaggo/swaggo.go
@@ -1,23 +1,20 @@
 package swaggo
 
 import (
-	"golang.org/x/tools/go/analysis"
-
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
 	"github.com/golangci/golangci-lint/v2/pkg/goformatters/swaggo"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
-const linterName = "swaggo"
-
 func New() *goanalysis.Linter {
-	a := goformatters.NewAnalyzer(
-		internal.LinterLogger.Child(linterName),
-		"Check if swaggo comments are formatted",
-		swaggo.New(),
-	)
-
-	return goanalysis.NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, nil).
+	return goanalysis.
+		NewLinterFromAnalyzer(
+			goformatters.NewAnalyzer(
+				internal.LinterLogger.Child(swaggo.Name),
+				"Check if swaggo comments are formatted",
+				swaggo.New(),
+			),
+		).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/tagalign/tagalign.go
+++ b/pkg/golinters/tagalign/tagalign.go
@@ -2,7 +2,6 @@ package tagalign
 
 import (
 	"github.com/4meepo/tagalign"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -24,12 +23,7 @@ func New(settings *config.TagAlignSettings) *goanalysis.Linter {
 		}
 	}
 
-	analyzer := tagalign.NewAnalyzer(options...)
-
-	return goanalysis.NewLinter(
-		analyzer.Name,
-		analyzer.Doc,
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(tagalign.NewAnalyzer(options...)).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/tagliatelle/tagliatelle.go
+++ b/pkg/golinters/tagliatelle/tagliatelle.go
@@ -2,7 +2,6 @@ package tagliatelle
 
 import (
 	"github.com/ldez/tagliatelle"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -42,14 +41,9 @@ func New(settings *config.TagliatelleSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := tagliatelle.New(cfg)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(tagliatelle.New(cfg)).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func toExtendedRules(src map[string]config.TagliatelleExtendedRule) map[string]tagliatelle.ExtendedRule {

--- a/pkg/golinters/testableexamples/testableexamples.go
+++ b/pkg/golinters/testableexamples/testableexamples.go
@@ -2,18 +2,12 @@ package testableexamples
 
 import (
 	"github.com/maratori/testableexamples/pkg/testableexamples"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := testableexamples.NewAnalyzer()
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(testableexamples.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/testifylint/testifylint.go
+++ b/pkg/golinters/testifylint/testifylint.go
@@ -2,18 +2,16 @@ package testifylint
 
 import (
 	"github.com/Antonboom/testifylint/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.TestifylintSettings) *goanalysis.Linter {
-	a := analyzer.New()
+	var cfg map[string]any
 
-	cfg := make(map[string]map[string]any)
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"enable-all":  settings.EnableAll,
 			"disable-all": settings.DisableAll,
 
@@ -23,30 +21,28 @@ func New(settings *config.TestifylintSettings) *goanalysis.Linter {
 			"go-require.ignore-http-handlers":  settings.GoRequire.IgnoreHTTPHandlers,
 		}
 		if len(settings.EnabledCheckers) > 0 {
-			cfg[a.Name]["enable"] = settings.EnabledCheckers
+			cfg["enable"] = settings.EnabledCheckers
 		}
 		if len(settings.DisabledCheckers) > 0 {
-			cfg[a.Name]["disable"] = settings.DisabledCheckers
+			cfg["disable"] = settings.DisabledCheckers
 		}
 
 		if b := settings.Formatter.CheckFormatString; b != nil {
-			cfg[a.Name]["formatter.check-format-string"] = *b
+			cfg["formatter.check-format-string"] = *b
 		}
 		if p := settings.ExpectedActual.ExpVarPattern; p != "" {
-			cfg[a.Name]["expected-actual.pattern"] = p
+			cfg["expected-actual.pattern"] = p
 		}
 		if p := settings.RequireError.FnPattern; p != "" {
-			cfg[a.Name]["require-error.fn-pattern"] = p
+			cfg["require-error.fn-pattern"] = p
 		}
 		if m := settings.SuiteExtraAssertCall.Mode; m != "" {
-			cfg[a.Name]["suite-extra-assert-call.mode"] = m
+			cfg["suite-extra-assert-call.mode"] = m
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.New()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/testpackage/testpackage.go
+++ b/pkg/golinters/testpackage/testpackage.go
@@ -4,25 +4,23 @@ import (
 	"strings"
 
 	"github.com/maratori/testpackage/pkg/testpackage"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.TestpackageSettings) *goanalysis.Linter {
-	a := testpackage.NewAnalyzer()
+	var cfg map[string]any
 
-	var cfg map[string]map[string]any
 	if settings != nil {
-		cfg = map[string]map[string]any{
-			a.Name: {
-				testpackage.SkipRegexpFlagName:    settings.SkipRegexp,
-				testpackage.AllowPackagesFlagName: strings.Join(settings.AllowPackages, ","),
-			},
+		cfg = map[string]any{
+			testpackage.SkipRegexpFlagName:    settings.SkipRegexp,
+			testpackage.AllowPackagesFlagName: strings.Join(settings.AllowPackages, ","),
 		}
 	}
 
-	return goanalysis.NewLinter(a.Name, a.Doc, []*analysis.Analyzer{a}, cfg).
+	return goanalysis.
+		NewLinterFromAnalyzer(testpackage.NewAnalyzer()).
+		WithConfig(cfg).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/thelper/thelper.go
+++ b/pkg/golinters/thelper/thelper.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/kulti/thelper/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -14,8 +13,6 @@ import (
 )
 
 func New(settings *config.ThelperSettings) *goanalysis.Linter {
-	a := analyzer.NewAnalyzer()
-
 	opts := map[string]struct{}{
 		"t_name":  {},
 		"t_begin": {},
@@ -47,18 +44,14 @@ func New(settings *config.ThelperSettings) *goanalysis.Linter {
 
 	args := slices.Collect(maps.Keys(opts))
 
-	cfg := map[string]map[string]any{
-		a.Name: {
-			"checks": strings.Join(args, ","),
-		},
+	cfg := map[string]any{
+		"checks": strings.Join(args, ","),
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func applyTHelperOptions(o config.ThelperOptions, prefix string, opts map[string]struct{}) {

--- a/pkg/golinters/tparallel/tparallel.go
+++ b/pkg/golinters/tparallel/tparallel.go
@@ -2,17 +2,12 @@ package tparallel
 
 import (
 	"github.com/moricho/tparallel"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := tparallel.Analyzer
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(tparallel.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/typecheck.go
+++ b/pkg/golinters/typecheck.go
@@ -7,18 +7,11 @@ import (
 )
 
 func NewTypecheck() *goanalysis.Linter {
-	const linterName = "typecheck"
-
-	analyzer := &analysis.Analyzer{
-		Name: linterName,
-		Doc:  goanalysis.TheOnlyanalyzerDoc,
-		Run:  goanalysis.DummyRun,
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Like the front-end of a Go compiler, parses and type-checks Go code",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeNone)
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name: "typecheck",
+			Doc:  "Like the front-end of a Go compiler, parses and type-checks Go code",
+			Run:  goanalysis.DummyRun,
+		}).
+		WithLoadMode(goanalysis.LoadModeNone)
 }

--- a/pkg/golinters/unparam/unparam.go
+++ b/pkg/golinters/unparam/unparam.go
@@ -10,29 +10,22 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-const linterName = "unparam"
-
 func New(settings *config.UnparamSettings) *goanalysis.Linter {
-	analyzer := &analysis.Analyzer{
-		Name:     linterName,
-		Doc:      goanalysis.TheOnlyanalyzerDoc,
-		Requires: []*analysis.Analyzer{buildssa.Analyzer},
-		Run: func(pass *analysis.Pass) (any, error) {
-			err := runUnparam(pass, settings)
-			if err != nil {
-				return nil, err
-			}
+	return goanalysis.
+		NewLinterFromAnalyzer(&analysis.Analyzer{
+			Name:     "unparam",
+			Doc:      "Reports unused function parameters",
+			Requires: []*analysis.Analyzer{buildssa.Analyzer},
+			Run: func(pass *analysis.Pass) (any, error) {
+				err := runUnparam(pass, settings)
+				if err != nil {
+					return nil, err
+				}
 
-			return nil, nil
-		},
-	}
-
-	return goanalysis.NewLinter(
-		linterName,
-		"Reports unused function parameters",
-		[]*analysis.Analyzer{analyzer},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+				return nil, nil
+			},
+		}).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func runUnparam(pass *analysis.Pass, settings *config.UnparamSettings) error {

--- a/pkg/golinters/usestdlibvars/usestdlibvars.go
+++ b/pkg/golinters/usestdlibvars/usestdlibvars.go
@@ -2,18 +2,16 @@ package usestdlibvars
 
 import (
 	"github.com/sashamelentyev/usestdlibvars/pkg/analyzer"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.UseStdlibVarsSettings) *goanalysis.Linter {
-	a := analyzer.New()
+	var cfg map[string]any
 
-	cfg := make(map[string]map[string]any)
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			analyzer.ConstantKindFlag:       settings.ConstantKind,
 			analyzer.CryptoHashFlag:         settings.CryptoHash,
 			analyzer.HTTPMethodFlag:         settings.HTTPMethod,
@@ -29,10 +27,8 @@ func New(settings *config.UseStdlibVarsSettings) *goanalysis.Linter {
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.New()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/usetesting/usetesting.go
+++ b/pkg/golinters/usetesting/usetesting.go
@@ -2,18 +2,16 @@ package usetesting
 
 import (
 	"github.com/ldez/usetesting"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.UseTestingSettings) *goanalysis.Linter {
-	a := usetesting.NewAnalyzer()
+	var cfg map[string]any
 
-	cfg := make(map[string]map[string]any)
 	if settings != nil {
-		cfg[a.Name] = map[string]any{
+		cfg = map[string]any{
 			"contextbackground": settings.ContextBackground,
 			"contexttodo":       settings.ContextTodo,
 			"oschdir":           settings.OSChdir,
@@ -24,10 +22,8 @@ func New(settings *config.UseTestingSettings) *goanalysis.Linter {
 		}
 	}
 
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(usetesting.NewAnalyzer()).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/varnamelen/varnamelen.go
+++ b/pkg/golinters/varnamelen/varnamelen.go
@@ -5,15 +5,13 @@ import (
 	"strings"
 
 	"github.com/blizzy78/varnamelen"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New(settings *config.VarnamelenSettings) *goanalysis.Linter {
-	analyzer := varnamelen.NewAnalyzer()
-	cfg := map[string]map[string]any{}
+	var cfg map[string]any
 
 	if settings != nil {
 		vnlCfg := map[string]any{
@@ -30,17 +28,15 @@ func New(settings *config.VarnamelenSettings) *goanalysis.Linter {
 		if settings.MaxDistance > 0 {
 			vnlCfg["maxDistance"] = strconv.Itoa(settings.MaxDistance)
 		}
+
 		if settings.MinNameLength > 0 {
 			vnlCfg["minNameLength"] = strconv.Itoa(settings.MinNameLength)
 		}
-
-		cfg[analyzer.Name] = vnlCfg
 	}
 
-	return goanalysis.NewLinter(
-		analyzer.Name,
-		"checks that the length of a variable's name matches its scope",
-		[]*analysis.Analyzer{analyzer},
-		cfg,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(varnamelen.NewAnalyzer()).
+		WithDesc("checks that the length of a variable's name matches its scope").
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/wastedassign/wastedassign.go
+++ b/pkg/golinters/wastedassign/wastedassign.go
@@ -2,18 +2,13 @@ package wastedassign
 
 import (
 	"github.com/sanposhiho/wastedassign/v2"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := wastedassign.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		"Finds wasted assignment statements",
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(wastedassign.Analyzer).
+		WithDesc("Finds wasted assignment statements").
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/whitespace/whitespace.go
+++ b/pkg/golinters/whitespace/whitespace.go
@@ -2,7 +2,6 @@ package whitespace
 
 import (
 	"github.com/ultraware/whitespace"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -17,12 +16,7 @@ func New(settings *config.WhitespaceSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := whitespace.NewAnalyzer(&wsSettings)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(whitespace.NewAnalyzer(&wsSettings)).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/wrapcheck/wrapcheck.go
+++ b/pkg/golinters/wrapcheck/wrapcheck.go
@@ -2,7 +2,6 @@ package wrapcheck
 
 import (
 	"github.com/tomarrell/wrapcheck/v2/wrapcheck"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -29,12 +28,7 @@ func New(settings *config.WrapcheckSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := wrapcheck.NewAnalyzer(cfg)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(wrapcheck.NewAnalyzer(cfg)).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/wsl/wsl.go
+++ b/pkg/golinters/wsl/wsl.go
@@ -2,7 +2,6 @@ package wsl
 
 import (
 	"github.com/bombsimon/wsl/v4"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
@@ -10,6 +9,7 @@ import (
 
 func New(settings *config.WSLSettings) *goanalysis.Linter {
 	var conf *wsl.Configuration
+
 	if settings != nil {
 		conf = &wsl.Configuration{
 			StrictAppend:                     settings.StrictAppend,
@@ -30,12 +30,7 @@ func New(settings *config.WSLSettings) *goanalysis.Linter {
 		}
 	}
 
-	a := wsl.NewAnalyzer(conf)
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeSyntax)
+	return goanalysis.
+		NewLinterFromAnalyzer(wsl.NewAnalyzer(conf)).
+		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/zerologlint/zerologlint.go
+++ b/pkg/golinters/zerologlint/zerologlint.go
@@ -2,18 +2,12 @@ package zerologlint
 
 import (
 	"github.com/ykadowak/zerologlint"
-	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
 func New() *goanalysis.Linter {
-	a := zerologlint.Analyzer
-
-	return goanalysis.NewLinter(
-		a.Name,
-		a.Doc,
-		[]*analysis.Analyzer{a},
-		nil,
-	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	return goanalysis.
+		NewLinterFromAnalyzer(zerologlint.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }


### PR DESCRIPTION
90% of linters use only one analyzer, so a `Linter` constructor that takes only one analyzer can be used.

Also, the configuration map for those linters always uses the name of the analyzer as the first and only key, then, a method `WithConfig`, that handles this key, can be used.

This simplifies and removes a lot of code.