### PR TITLE
docs: fix revive defer rule configuration

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2299,13 +2299,7 @@ linters:
           severity: warning
           disabled: false
           exclude: [""]
-          arguments:
-            - "call-chain"
-            - "loop"
-            - "method-call"
-            - "recover"
-            - "immediate-recover"
-            - "return"
+          arguments: [["call-chain", "loop", "method-call", "recover", "return"]]
         # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#dot-imports
         - name: dot-imports
           severity: warning

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2299,7 +2299,12 @@ linters:
           severity: warning
           disabled: false
           exclude: [""]
-          arguments: [["call-chain", "loop", "method-call", "recover", "return"]]
+          arguments:
+            - - "call-chain"
+              - "loop"
+              - "method-call"
+              - "recover"
+              - "return"
         # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#dot-imports
         - name: dot-imports
           severity: warning


### PR DESCRIPTION
This is my first time creating a pull request.  
Please let me know if I made any mistakes in the process.

## Fix incorrect revive `defer` rule arguments format in docs

The current documentation lists the `defer` rule configuration for `revive` as follows:

```yaml
- name: defer
  severity: warning
  disabled: false
  exclude: [""]
  arguments:
    - "call-chain"
    - "loop"
    - "method-call"
    - "recover"
    - "immediate-recover"
    - "return"
```

However, this format is incorrect. According to the official `revive` rule descriptions ([source](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#defer)), the `arguments` field should be passed as a **nested list**:

```yaml
- name: defer
  severity: warning
  disabled: false
  exclude: [""]
  arguments: [["call-chain", "loop", "method-call", "recover", "return"]]
```

### Why is a nested list required?

In `revive`, the `Configure` method for the `defer` rule expects its first argument to be castable to a `[]any`. Since the top-level `arguments` are passed as a `[]interface{}`, the actual list must be nested as the first element. Otherwise, the cast fails at runtime.

In contrast, rules like `early-return` handle scalar arguments and use a simple `switch` structure. But the `defer` rule iterates over a list of options using `range`, making the nested structure essential for flexibility and correctness.

This commit updates the `golangci-lint` documentation to reflect the correct format.


<details>
  <summary>After</summary>

  <img width="1399" alt="スクリーンショット 2025-05-16 1 01 40" src="https://github.com/user-attachments/assets/2a4576c0-79b5-4f98-932f-fd6feb22a60b" />

</details>


