### PR TITLE
updated go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0


### PR DESCRIPTION
This PR updates the go version used in the go.mod file.
current version causes lint not to work when running it for projects that use go version 1.24.
When trying to run lint against a 1.24 project the following error is returned:
```
Error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
Failed executing command with error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
```

this minor change is fixing this issue.