### PR TITLE
Add noinlineerr linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -91,6 +91,7 @@ linters:
     - nilnil
     - nlreturn
     - noctx
+    - noinlineerr
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
@@ -200,6 +201,7 @@ linters:
     - nilnil
     - nlreturn
     - noctx
+    - noinlineerr
     - nolintlint
     - nonamedreturns
     - nosprintfhostport

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	4d63.com/gochecknoglobals v0.2.2
 	github.com/4meepo/tagalign v1.4.2
 	github.com/Abirdcfly/dupword v0.1.4
+	github.com/AlwxSin/noinlineerr v1.0.1
 	github.com/Antonboom/errname v1.1.0
 	github.com/Antonboom/nilnil v1.1.0
 	github.com/Antonboom/testifylint v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/4meepo/tagalign v1.4.2 h1:0hcLHPGMjDyM1gHG58cS73aQF8J4TdVR96TZViorO9E
 github.com/4meepo/tagalign v1.4.2/go.mod h1:+p4aMyFM+ra7nb41CnFG6aSDXqRxU/w1VQqScKqDARI=
 github.com/Abirdcfly/dupword v0.1.4 h1:jxqkdgO0L7FSwq4fMu3d+fAA1E3bBQAtl4utA3tcQZM=
 github.com/Abirdcfly/dupword v0.1.4/go.mod h1:s+BFMuL/I4YSiFv29snqyjwzDp4b65W2Kvy+PKzZ6cw=
+github.com/AlwxSin/noinlineerr v1.0.1 h1:xiNjgRwY1ExRJ8xy6NVfpxU5KyAssTH0h5cuoZipAd4=
+github.com/AlwxSin/noinlineerr v1.0.1/go.mod h1:FjvQoRSDujHgtQilUOsiFEp0Rh1J8qAVw53fxqSuI58=
 github.com/Antonboom/errname v1.1.0 h1:A+ucvdpMwlo/myWrkHEUEBWc/xuXdud23S8tmTb/oAE=
 github.com/Antonboom/errname v1.1.0/go.mod h1:O1NMrzgUcVBGIfi3xlVuvX8Q/VP/73sseCaAppfjqZw=
 github.com/Antonboom/nilnil v1.1.0 h1:jGxJxjgYS3VUUtOTNk8Z1icwT5ESpLH/426fjmQG+ng=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -791,6 +791,7 @@
             "nilnil",
             "nlreturn",
             "noctx",
+            "noinlineerr",
             "nolintlint",
             "nonamedreturns",
             "nosprintfhostport",

--- a/pkg/golinters/noinlineerr/noinlineerr.go
+++ b/pkg/golinters/noinlineerr/noinlineerr.go
@@ -1,0 +1,18 @@
+package noinlineerr
+
+import (
+	"github.com/AlwxSin/noinlineerr"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	analyzer := noinlineerr.NewAnalyzer()
+	return goanalysis.NewLinter(
+		analyzer.Name,
+		analyzer.Doc,
+		[]*analysis.Analyzer{analyzer},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/noinlineerr/noinlineerr_integration_test.go
+++ b/pkg/golinters/noinlineerr/noinlineerr_integration_test.go
@@ -1,0 +1,11 @@
+package noinlineerr
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/noinlineerr/testdata/noinlineerr.go
+++ b/pkg/golinters/noinlineerr/testdata/noinlineerr.go
@@ -1,0 +1,52 @@
+//golangcitest:args -Enoinlineerr
+package testdata
+
+func doSomething() error {
+	return nil
+}
+
+func doSmthManyArgs(a, b, c, d int) error {
+	return nil
+}
+
+func doSmthMultipleReturn() (bool, error) {
+	return false, nil
+}
+
+func valid() error {
+	err := doSomething() // ok
+	if err != nil {
+		return err
+	}
+
+	err = doSmthManyArgs(0, 0, 0, 0) // ok
+	if err != nil {
+		return err
+	}
+
+	_, err = doSmthMultipleReturn() // ok
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func invalid() error {
+	if err := doSomething(); err != nil { // want "avoid inline error handling using `if err := ...; err != nil; use plain assignment `err := ..."
+		return err
+	}
+
+	if err := doSmthManyArgs(0, // want "avoid inline error handling using `if err := ...; err != nil; use plain assignment `err := ..."
+		0,
+		0,
+		0,
+	); err != nil {
+		return err
+	}
+
+	if _, err := doSmthMultipleReturn(); err != nil { // want "avoid inline error handling using `if err := ...; err != nil; use plain assignment `err := ..."
+		_ = false
+		return err
+	}
+	return nil
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -79,6 +79,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nilnil"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nlreturn"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/noctx"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/noinlineerr"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nolintlint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nonamedreturns"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nosprintfhostport"
@@ -510,6 +511,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.28.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/sonatard/noctx"),
+
+		linter.NewConfig(noinlineerr.New()).
+			WithSince("v2.2.80").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/AlwxSin/noinlineerr"),
 
 		linter.NewConfig(nonamedreturns.New(&cfg.Linters.Settings.NoNamedReturns)).
 			WithSince("v1.46.0").


### PR DESCRIPTION
Adding [noinlineerr](https://github.com/AlwxSin/noinlineerr) linter.

Purpose - allow only one style of error handling.
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->
