### PR TITLE
fix: write the input to stdout when using stdin and there are no changes

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -4088,6 +4088,7 @@ formatters:
     # Default: lax
     generated: strict
     # Which file paths to exclude.
+    # This option is ignored when using `--stdin` as the path is unknown.
     # Default: []
     paths:
       - ".*\\.my\\.go$"

--- a/pkg/goformat/runner.go
+++ b/pkg/goformat/runner.go
@@ -57,7 +57,7 @@ func (c *Runner) Run(paths []string) error {
 	}
 
 	if c.opts.stdin {
-		return c.process("<standard input>", savedStdout, os.Stdin)
+		return c.formatStdIn("<standard input>", savedStdout, os.Stdin)
 	}
 
 	for _, path := range paths {
@@ -121,15 +121,6 @@ func (c *Runner) process(path string, stdout io.Writer, in io.Reader) error {
 
 	output := c.metaFormatter.Format(path, input)
 
-	if c.opts.stdin {
-		_, err = stdout.Write(output)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
 	if bytes.Equal(input, output) {
 		return nil
 	}
@@ -166,6 +157,36 @@ func (c *Runner) process(path string, stdout io.Writer, in io.Reader) error {
 	}
 
 	return os.WriteFile(path, output, perms)
+}
+
+func (c *Runner) formatStdIn(path string, stdout io.Writer, in io.Reader) error {
+	input, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+
+	match, err := c.matcher.IsGeneratedFile(path, input)
+	if err != nil {
+		return err
+	}
+
+	if match {
+		_, err = stdout.Write(input)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	output := c.metaFormatter.Format(path, input)
+
+	_, err = stdout.Write(output)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Runner) setOutputToDevNull() {

--- a/pkg/goformat/runner.go
+++ b/pkg/goformat/runner.go
@@ -171,6 +171,8 @@ func (c *Runner) formatStdIn(path string, stdout io.Writer, in io.Reader) error 
 	}
 
 	if match {
+		// If the file is generated,
+		// the input should be written to the stdout to avoid emptied the file.
 		_, err = stdout.Write(input)
 		if err != nil {
 			return err


### PR DESCRIPTION
Related to https://gophers.slack.com/archives/CS0TBRKPC/p1748028690710039

Currently, when using `--stdin` and a generated file modified by hand (yes, I know, it should not happen, but :shrug:) the file is emptied.


