### PR TITLE
add enonly linter: a linter to strict use of non-english chars in strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/alecthomas/go-check-sumtype v0.3.1
 	github.com/alexkohler/nakedret/v2 v2.0.6
 	github.com/alexkohler/prealloc v1.0.0
+	github.com/aliashahi/enonly v1.0.0
 	github.com/alingse/asasalint v0.0.11
 	github.com/alingse/nilnesserr v0.2.0
 	github.com/ashanbrown/forbidigo/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/alexkohler/nakedret/v2 v2.0.6 h1:ME3Qef1/KIKr3kWX3nti3hhgNxw6aqN5pZmQ
 github.com/alexkohler/nakedret/v2 v2.0.6/go.mod h1:l3RKju/IzOMQHmsEvXwkqMDzHHvurNQfAgE1eVmT40Q=
 github.com/alexkohler/prealloc v1.0.0 h1:Hbq0/3fJPQhNkN0dR95AVrr6R7tou91y0uHG5pOcUuw=
 github.com/alexkohler/prealloc v1.0.0/go.mod h1:VetnK3dIgFBBKmg0YnD9F9x6Icjd+9cvfHR56wJVlKE=
+github.com/aliashahi/enonly v1.0.0 h1:Po+uDWfMqUYgSjzhPaW+vFGjnnltBRo05TyGOdyNLeY=
+github.com/aliashahi/enonly v1.0.0/go.mod h1:RiIgRDk8ur1NaoOEyH9CJNCS7oHqC4gwujJ2IBoDwKU=
 github.com/alingse/asasalint v0.0.11 h1:SFwnQXJ49Kx/1GghOFz1XGqHYKp21Kq1nHad/0WQRnw=
 github.com/alingse/asasalint v0.0.11/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/alingse/nilnesserr v0.2.0 h1:raLem5KG7EFVb4UIDAXgrv3N2JIaffeKNtcEXkEWd/w=

--- a/pkg/golinters/enonly/enonly.go
+++ b/pkg/golinters/enonly/enonly.go
@@ -1,0 +1,14 @@
+package enonly
+
+import (
+	"github.com/aliashahi/enonly"
+
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New(settings any) *goanalysis.Linter {
+	return goanalysis.
+		NewLinterFromAnalyzer(enonly.NewEnOnlyAnalyzer()).
+		WithDesc("strict use of non-english language typography").
+		WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/enonly/enonly_integration_test.go
+++ b/pkg/golinters/enonly/enonly_integration_test.go
@@ -1,0 +1,11 @@
+package enonly
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/enonly/testdata/enony.go
+++ b/pkg/golinters/enonly/testdata/enony.go
@@ -1,0 +1,28 @@
+//golangcitest:args -Eenonly
+package testdata
+
+import (
+	"fmt"
+)
+
+var v = "فارسی" // want "contains non-english characters: \"فارسی\""
+
+const v2 = "فارسی" // want "contains non-english characters: \"فارسی\""
+
+func example() {
+	var test1 = "فارسی" // want "contains non-english characters: \"فارسی\""
+	_ = test1
+
+	test2 := "فارسی" // want "contains non-english characters: \"فارسی\""
+	_ = test2
+
+	var test3 string
+	test3 = "فارسی" // want "contains non-english characters: \"فارسی\""
+	_ = test3
+
+	example2("فارسی") // want "contains non-english characters: \"فارسی\""
+}
+
+func example2(s string) {
+	fmt.Println(s)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/dupword"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/durationcheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/embeddedstructfieldcheck"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/enonly"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/err113"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/errcheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/errchkjson"
@@ -216,6 +217,10 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		linter.NewConfig(embeddedstructfieldcheck.New(&cfg.Linters.Settings.EmbeddedStructFieldCheck)).
 			WithSince("v2.2.0").
 			WithURL("https://github.com/manuelarte/embeddedstructfieldcheck"),
+
+		linter.NewConfig(enonly.New(nil)).
+			WithSince("v1.0.0").
+			WithURL("https://github.com/aliashahi/enonly"),
 
 		linter.NewConfig(errcheck.New(&cfg.Linters.Settings.Errcheck)).
 			WithGroups(config.GroupStandard).


### PR DESCRIPTION
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->
