### PR TITLE
fix: formatters CLI flags help message

### DIFF
--- a/pkg/commands/formatters.go
+++ b/pkg/commands/formatters.go
@@ -59,7 +59,7 @@ func newFormattersCommand(logger logutils.Log) *formattersCommand {
 	fs.SortFlags = false // sort them as they are defined here
 
 	setupConfigFileFlagSet(fs, &c.opts.LoaderOptions)
-	setupLintersFlagSet(c.viper, fs)
+	setupFormattersFlagSet(c.viper, fs)
 
 	fs.BoolVar(&c.opts.JSON, "json", false, color.GreenString("Display as JSON"))
 

--- a/pkg/commands/formatters.go
+++ b/pkg/commands/formatters.go
@@ -59,6 +59,7 @@ func newFormattersCommand(logger logutils.Log) *formattersCommand {
 	fs.SortFlags = false // sort them as they are defined here
 
 	setupConfigFileFlagSet(fs, &c.opts.LoaderOptions)
+
 	setupFormattersFlagSet(c.viper, fs)
 
 	fs.BoolVar(&c.opts.JSON, "json", false, color.GreenString("Display as JSON"))


### PR DESCRIPTION
The flags were the ones of the linters commands.

The help text was displaying the linters help text.
And the completions was allowing to use `--disable`, `--fast-only`, `--enable-only`, and others that
are not supported by the formatters commands.

<details><summary>Before</summary>

```console
$ golangci-lint formatters --help
List current formatters configuration

Usage:
  golangci-lint formatters [flags]

Flags:
  -c, --config PATH           Read config from file path PATH
      --no-config             Don't read config file
      --default string        Default set of linters to enable (default "standard")
  -D, --disable strings       Disable specific linter
  -E, --enable strings        Enable specific linter
      --enable-only strings   Override linters configuration section to only run the specific linter(s)
      --fast-only             Filter enabled linters to run only fast linters
      --json                  Display as JSON

Global Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -h, --help           Help for a command
  -v, --verbose        Verbose output
```

</details> 

<details><summary>After</summary>

```console
$ golangci-lint formatters --help
List current formatters configuration

Usage:
  golangci-lint formatters [flags]

Flags:
  -c, --config PATH      Read config from file path PATH
      --no-config        Don't read config file
  -E, --enable strings   Enable specific formatter
      --json             Display as JSON

Global Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -h, --help           Help for a command
  -v, --verbose        Verbose output
```

</details> 