### PR TITLE
fix: error message when trying to migrate a migrated config

### DIFF
--- a/pkg/commands/migrate.go
+++ b/pkg/commands/migrate.go
@@ -81,10 +81,6 @@ func newMigrateCommand(log logutils.Log, info BuildInfo) *migrateCommand {
 }
 
 func (c *migrateCommand) execute(_ *cobra.Command, _ []string) error {
-	if c.cfg.Version != "" {
-		return fmt.Errorf("configuration version is already set: %s", c.cfg.Version)
-	}
-
 	srcPath := c.viper.ConfigFileUsed()
 	if srcPath == "" {
 		c.log.Warnf("No config file detected")
@@ -149,6 +145,10 @@ func (c *migrateCommand) preRunE(cmd *cobra.Command, _ []string) error {
 	if usedConfigFile == "" {
 		c.log.Warnf("No config file detected")
 		os.Exit(exitcodes.NoConfigFileDetected)
+	}
+
+	if c.cfg.Version != "" {
+		return fmt.Errorf("configuration version is already set: %s", c.cfg.Version)
 	}
 
 	c.log.Infof("Validating v1 configuration file: %s", usedConfigFile)

--- a/pkg/commands/migrate.go
+++ b/pkg/commands/migrate.go
@@ -137,6 +137,10 @@ func (c *migrateCommand) preRunE(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unsupported format: %s", c.opts.format)
 	}
 
+	if c.cfg.Version != "" {
+		return fmt.Errorf("configuration version is already set: %s", c.cfg.Version)
+	}
+
 	if c.opts.skipValidation {
 		return nil
 	}
@@ -145,10 +149,6 @@ func (c *migrateCommand) preRunE(cmd *cobra.Command, _ []string) error {
 	if usedConfigFile == "" {
 		c.log.Warnf("No config file detected")
 		os.Exit(exitcodes.NoConfigFileDetected)
-	}
-
-	if c.cfg.Version != "" {
-		return fmt.Errorf("configuration version is already set: %s", c.cfg.Version)
 	}
 
 	c.log.Infof("Validating v1 configuration file: %s", usedConfigFile)


### PR DESCRIPTION
The check was done in the wrong place, so it was not triggered
when the config was already migrated.

Another error message was reported about jsonschema validation issues.
Because a v2 config file does not validate against the v1 schema.

That was misleading.


<details><summary>Before</summary>

```console
$ golangci-lint migrate 
jsonschema: "linters.exclusions" does not validate with "/properties/linters/properties/exclusions/additionalProperties": additional properties 'presets' not allowed
jsonschema: "linters" does not validate with "/properties/linters/additionalProperties": additional properties 'default', 'settings' not allowed
jsonschema: "" does not validate with "/additionalProperties": additional properties 'version', 'formatters' not allowed
Failed executing command with error: the configuration contains invalid elements
```

</details> 

<details><summary>After</summary>

```console
$ golangci-lint migrate
The command is terminated due to an error: configuration version is already set: 2
exit status 3
```

</details> 