### PR TITLE
dev: handle linter major versions

### DIFF
--- a/pkg/goanalysis/linter.go
+++ b/pkg/goanalysis/linter.go
@@ -76,6 +76,25 @@ func (lnt *Linter) WithDesc(desc string) *Linter {
 	return lnt
 }
 
+func (lnt *Linter) WithVersion(v int) *Linter {
+	if v == 0 {
+		return lnt
+	}
+
+	for _, analyzer := range lnt.analyzers {
+		if lnt.name != analyzer.Name {
+			continue
+		}
+
+		// The analyzer name should be the same as the linter name to avoid displaying the name inside the reports.
+		analyzer.Name = fmt.Sprintf("%s_v%d", analyzer.Name, v)
+	}
+
+	lnt.name = fmt.Sprintf("%s_v%d", lnt.name, v)
+
+	return lnt
+}
+
 func (lnt *Linter) WithConfig(cfg map[string]any) *Linter {
 	if len(cfg) == 0 {
 		return lnt


### PR DESCRIPTION
I tried several approaches, this one is the only one that provides something that works: the previous linter version will be deprecated, and the new one will have a suffix.

```yml
linters:
  enable:
    - foo # deprecated
    - foo_v2
  settings:
    foo: # deprecated
      a: 1
      b: 2
    foo_v2:
      a: 1
      d: 2
```

It will not be usable in every case of breaking changes, but it will work for all linters that create a major version of the module.

usage example:
```go
	return goanalysis.
		NewLinterFromAnalyzer(analyzer).
		WithVersion(2).
		WithLoadMode(goanalysis.LoadModeTypesInfo)
```

A configuration migration suggestion can be added as a log.
