### PR TITLE
dev: correct debug log for default rules in revive

### DIFF
--- a/pkg/golinters/revive/revive.go
+++ b/pkg/golinters/revive/revive.go
@@ -436,7 +436,7 @@ func displayRules(conf *lint.Config) {
 	slices.Sort(enabledRules)
 
 	debugf("All available rules (%d): %s.", len(allRules), strings.Join(extractRulesName(allRules), ", "))
-	debugf("Default rules (%d): %s.", len(allRules), strings.Join(extractRulesName(allRules), ", "))
+	debugf("Default rules (%d): %s.", len(defaultRules), strings.Join(extractRulesName(defaultRules), ", "))
 	debugf("Enabled by config rules (%d): %s.", len(enabledRules), strings.Join(enabledRules, ", "))
 
 	debugf("revive configuration: %#v", conf)


### PR DESCRIPTION
Before:

```shellsession
$ make build && GL_DEBUG=revive ./golangci-lint run
go build -o golangci-lint ./cmd/golangci-lint
...
DEBU [revive] Default rules (87): add-constant, argument-limit, atomic, banned-characters, bare-return, blank-imports, bool-literal-in-expr, call-to-gc, cognitive-complexity, comment-spacings, comments-density, confusing-naming, confusing-results, constant-logical-expr, context-as-argument, context-keys-type, cyclomatic, datarace, deep-exit, defer, dot-imports, duplicated-imports, early-return, empty-block, empty-lines, enforce-map-style, enforce-repeated-arg-type-style, enforce-slice-style, error-naming, error-return, error-strings, errorf, exported, file-header, file-length-limit, filename-format, flag-parameter, function-length, function-result-limit, get-return, identical-branches, if-return, import-alias-naming, import-shadowing, imports-blocklist, increment-decrement, indent-error-flow, line-length-limit, max-control-nesting, max-public-structs, modifies-parameter, modifies-value-receiver, nested-structs, optimize-operands-order, package-comments, range, range-val-address, range-val-in-closure, receiver-naming, redefines-builtin-id, redundant-build-tag, redundant-import-alias, redundant-test-main-exit, string-format, string-of-int, struct-tag, superfluous-else, time-date, time-equal, time-naming, unchecked-type-assertion, unconditional-recursion, unexported-naming, unexported-return, unhandled-error, unnecessary-format, unnecessary-stmt, unreachable-code, unused-parameter, unused-receiver, use-any, use-errors-new, use-fmt-print, useless-break, var-declaration, var-naming, waitgroup-by-value. 
...
```

After:

```shellsession
$ make build && GL_DEBUG=revive ./golangci-lint run
go build -o golangci-lint ./cmd/golangci-lint
...
DEBU [revive] Default rules (23): blank-imports, context-as-argument, context-keys-type, dot-imports, empty-block, error-naming, error-return, error-strings, errorf, exported, increment-decrement, indent-error-flow, package-comments, range, receiver-naming, redefines-builtin-id, superfluous-else, time-naming, unexported-return, unreachable-code, unused-parameter, var-declaration, var-naming. 
...
```