### PR TITLE
dev: display list of staticcheck checks in debug

### DIFF
--- a/pkg/golinters/staticcheck/staticcheck.go
+++ b/pkg/golinters/staticcheck/staticcheck.go
@@ -15,6 +15,12 @@ import (
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/v2/pkg/logutils"
+)
+
+var (
+	debugf  = logutils.Debug(logutils.DebugKeyStaticcheck)
+	isDebug = logutils.HaveDebugTag(logutils.DebugKeyStaticcheck)
 )
 
 func New(settings *config.StaticCheckSettings) *goanalysis.Linter {
@@ -28,6 +34,21 @@ func New(settings *config.StaticCheckSettings) *goanalysis.Linter {
 	allAnalyzers := slices.Concat(staticcheck.Analyzers, stylecheck.Analyzers, simple.Analyzers, quickfix.Analyzers)
 
 	analyzers := setupAnalyzers(allAnalyzers, cfg.Checks)
+
+	if isDebug {
+		allAnalyzerNames := extractAnalyzerNames(allAnalyzers)
+		slices.Sort(allAnalyzerNames)
+		debugf("All available checks (%d): %s", len(allAnalyzers), strings.Join(allAnalyzerNames, ","))
+
+		var cfgAnalyzerNames []string
+		for _, a := range analyzers {
+			cfgAnalyzerNames = append(cfgAnalyzerNames, a.Name)
+		}
+		slices.Sort(cfgAnalyzerNames)
+		debugf("Enabled by config checks (%d): %s", len(analyzers), strings.Join(cfgAnalyzerNames, ","))
+
+		debugf("staticcheck configuration: %#v", cfg)
+	}
 
 	return goanalysis.NewLinter(
 		"staticcheck",
@@ -107,12 +128,7 @@ func normalizeList(list []string) []string {
 }
 
 func setupAnalyzers(src []*lint.Analyzer, checks []string) []*analysis.Analyzer {
-	var names []string
-	for _, a := range src {
-		names = append(names, a.Analyzer.Name)
-	}
-
-	filter := filterAnalyzerNames(names, checks)
+	filter := filterAnalyzerNames(extractAnalyzerNames(src), checks)
 
 	var ret []*analysis.Analyzer
 	for _, a := range src {
@@ -122,6 +138,14 @@ func setupAnalyzers(src []*lint.Analyzer, checks []string) []*analysis.Analyzer 
 	}
 
 	return ret
+}
+
+func extractAnalyzerNames(analyzers []*lint.Analyzer) []string {
+	var names []string
+	for _, a := range analyzers {
+		names = append(names, a.Analyzer.Name)
+	}
+	return names
 }
 
 // https://github.com/dominikh/go-tools/blob/9bf17c0388a65710524ba04c2d821469e639fdc2/lintcmd/lint.go#L437-L477

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -79,11 +79,12 @@ const (
 
 // Linters.
 const (
-	DebugKeyForbidigo = "forbidigo" // Debugs `forbidigo` linter.
-	DebugKeyGoCritic  = "gocritic"  // Debugs `gocritic` linter.
-	DebugKeyGovet     = "govet"     // Debugs `govet` linter.
-	DebugKeyLinter    = "linter"
-	DebugKeyRevive    = "revive" // Debugs `revive` linter.
+	DebugKeyForbidigo   = "forbidigo" // Debugs `forbidigo` linter.
+	DebugKeyGoCritic    = "gocritic"  // Debugs `gocritic` linter.
+	DebugKeyGovet       = "govet"     // Debugs `govet` linter.
+	DebugKeyLinter      = "linter"
+	DebugKeyRevive      = "revive"      // Debugs `revive` linter.
+	DebugKeyStaticcheck = "staticcheck" // Debugs `staticcheck` linter.
 )
 
 func getEnabledDebugs() map[string]bool {


### PR DESCRIPTION
The PR adds a new option `staticcheck` for `GL_DEBUG` allowing to print staticcheck checks and configuration.

```shellsession
$ make build && GL_DEBUG=staticcheck ./golangci-lint linters -v
go build -o golangci-lint ./cmd/golangci-lint
INFO [config_reader] Config search paths: [./ /Users/alexandear/src/github.com/golangci/golangci-lint /Users/alexandear/src/github.com/golangci /Users/alexandear/src/github.com /Users/alexandear/src /Users/alexandear /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [config_reader] Module name "github.com/golangci/golangci-lint/v2" 
DEBU [staticcheck] All available checks (160): QF1001,QF1002,QF1003,QF1004,QF1005,QF1006,QF1007,QF1008,QF1009,QF1010,QF1011,QF1012,S1000,S1001,S1002,S1003,S1004,S1005,S1006,S1007,S1008,S1009,S1010,S1011,S1012,S1016,S1017,S1018,S1019,S1020,S1021,S1023,S1024,S1025,S1028,S1029,S1030,S1031,S1032,S1033,S1034,S1035,S1036,S1037,S1038,S1039,S1040,SA1000,SA1001,SA1002,SA1003,SA1004,SA1005,SA1006,SA1007,SA1008,SA1010,SA1011,SA1012,SA1013,SA1014,SA1015,SA1016,SA1017,SA1018,SA1019,SA1020,SA1021,SA1023,SA1024,SA1025,SA1026,SA1027,SA1028,SA1029,SA1030,SA1031,SA1032,SA2000,SA2001,SA2002,SA2003,SA3000,SA3001,SA4000,SA4001,SA4003,SA4004,SA4005,SA4006,SA4008,SA4009,SA4010,SA4011,SA4012,SA4013,SA4014,SA4015,SA4016,SA4017,SA4018,SA4019,SA4020,SA4021,SA4022,SA4023,SA4024,SA4025,SA4026,SA4027,SA4028,SA4029,SA4030,SA4031,SA4032,SA5000,SA5001,SA5002,SA5003,SA5004,SA5005,SA5007,SA5008,SA5009,SA5010,SA5011,SA5012,SA6000,SA6001,SA6002,SA6003,SA6005,SA6006,SA9001,SA9002,SA9003,SA9004,SA9005,SA9006,SA9007,SA9008,SA9009,ST1000,ST1001,ST1003,ST1005,ST1006,ST1008,ST1011,ST1012,ST1013,ST1015,ST1016,ST1017,ST1018,ST1019,ST1020,ST1021,ST1022,ST1023 
DEBU [staticcheck] Enabled by config checks (154): QF1001,QF1002,QF1003,QF1004,QF1005,QF1006,QF1007,QF1008,QF1009,QF1010,QF1011,QF1012,S1000,S1001,S1002,S1003,S1004,S1005,S1006,S1007,S1008,S1009,S1010,S1011,S1012,S1016,S1017,S1018,S1019,S1020,S1021,S1023,S1024,S1025,S1028,S1029,S1030,S1031,S1032,S1033,S1034,S1035,S1036,S1037,S1038,S1039,S1040,SA1000,SA1001,SA1002,SA1003,SA1004,SA1005,SA1006,SA1007,SA1008,SA1010,SA1011,SA1012,SA1013,SA1014,SA1015,SA1016,SA1017,SA1018,SA1019,SA1020,SA1021,SA1023,SA1024,SA1025,SA1026,SA1027,SA1028,SA1029,SA1030,SA1031,SA1032,SA2000,SA2001,SA2002,SA2003,SA3000,SA3001,SA4000,SA4001,SA4003,SA4004,SA4005,SA4006,SA4008,SA4009,SA4010,SA4011,SA4012,SA4013,SA4014,SA4015,SA4016,SA4017,SA4018,SA4019,SA4020,SA4021,SA4022,SA4023,SA4024,SA4025,SA4026,SA4027,SA4028,SA4029,SA4030,SA4031,SA4032,SA5000,SA5001,SA5002,SA5003,SA5004,SA5005,SA5007,SA5008,SA5009,SA5010,SA5011,SA5012,SA6000,SA6001,SA6002,SA6003,SA6005,SA6006,SA9001,SA9002,SA9003,SA9004,SA9005,SA9006,SA9007,SA9008,SA9009,ST1001,ST1005,ST1006,ST1008,ST1011,ST1012,ST1013,ST1015,ST1017,ST1018,ST1019,ST1023 
DEBU [staticcheck] staticcheck configuration: &config.Config{Checks:[]string{"all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"}, Initialisms:[]string{"ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"}, DotImportWhitelist:[]string{"github.com/mmcloughlin/avo/build", "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg"}, HTTPStatusCodeWhitelist:[]string{"200", "400", "404", "500"}} 
```