### PR TITLE
Add zerolint linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -126,6 +126,7 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
+    - zerolint
     - zerologlint
 
   # Disable specific linters.
@@ -236,6 +237,7 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
+    - zerolint
     - zerologlint
 
   # All available settings of specific linters.
@@ -3907,6 +3909,19 @@ linters:
       # https://github.com/bombsimon/wsl/blob/HEAD/doc/configuration.md#force-short-decl-cuddling
       # Default: false
       force-short-decl-cuddling: true
+
+    zerolint:
+      # Analysis depth. Anything other that "default" might need an exclusion list.
+      # Default: "default"
+      level: full
+
+      # Fully qualified type names excluded from analysis.
+      # Default: empty
+      excluded:
+        - "struct{}"
+
+      # Limit zero-sized type detection to types matching the regex.
+      match: "^.*$"
 
     # The custom section can be used to define linter plugins to be loaded at runtime.
     # See README documentation for more info.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0
 	4d63.com/gochecknoglobals v0.2.2
+	fillmore-labs.com/zerolint v0.0.10
 	github.com/4meepo/tagalign v1.4.2
 	github.com/Abirdcfly/dupword v0.1.6
 	github.com/AlwxSin/noinlineerr v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 codeberg.org/chavacava/garif v0.2.0 h1:F0tVjhYbuOCnvNcU3YSpO6b3Waw6Bimy4K0mM8y6MfY=
 codeberg.org/chavacava/garif v0.2.0/go.mod h1:P2BPbVbT4QcvLZrORc2T29szK3xEOlnl0GiPTJmEqBQ=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+fillmore-labs.com/zerolint v0.0.10 h1:WsYBz92x8OO2qXMRciBit0qTtzG2NDu6waKYw2jvJ18=
+fillmore-labs.com/zerolint v0.0.10/go.mod h1:0V0kIS+x40wjQjQJGcAK0V9/H1T6rAvoy5oQo9Ue+5A=
 github.com/4meepo/tagalign v1.4.2 h1:0hcLHPGMjDyM1gHG58cS73aQF8J4TdVR96TZViorO9E=
 github.com/4meepo/tagalign v1.4.2/go.mod h1:+p4aMyFM+ra7nb41CnFG6aSDXqRxU/w1VQqScKqDARI=
 github.com/Abirdcfly/dupword v0.1.6 h1:qeL6u0442RPRe3mcaLcbaCi2/Y/hOcdtw6DE9odjz9c=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -829,6 +829,7 @@
             "whitespace",
             "wrapcheck",
             "wsl",
+            "zerolint",
             "zerologlint"
           ]
         },
@@ -4085,6 +4086,30 @@
             }
           }
         },
+        "zerolintSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "level": {
+              "description": "Analysis depth.",
+              "type": "string",
+              "enum": ["default", "extended", "full"],
+              "default": "default"
+            },
+            "excluded": {
+              "description": "Fully qualified type names excluded from analysis.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "match": {
+              "description": "Limit zero-sized type detection to types matching the regex.",
+              "type": "string",
+              "default": false
+            }
+          }
+        },
         "copyloopvarSettings": {
           "type": "object",
           "additionalProperties": false,
@@ -4586,6 +4611,9 @@
             },
             "wsl": {
               "$ref": "#/definitions/settings/definitions/wslSettings"
+            },
+            "zerolint": {
+              "$ref": "#/definitions/settings/definitions/zerolintSettings"
             },
             "copyloopvar": {
               "$ref": "#/definitions/settings/definitions/copyloopvarSettings"

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -3,7 +3,10 @@ package config
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"runtime"
+
+	"fillmore-labs.com/zerolint/pkg/zerolint/level"
 )
 
 var defaultLintersSettings = LintersSettings{
@@ -200,6 +203,11 @@ var defaultLintersSettings = LintersSettings{
 		ErrorVariableNames:               []string{"err"},
 		ForceExclusiveShortDeclarations:  false,
 	},
+	Zerolint: ZerolintSettings{
+		Level:    level.Default,
+		Excluded: nil,
+		Match:    nil,
+	},
 }
 
 type LintersSettings struct {
@@ -284,6 +292,7 @@ type LintersSettings struct {
 	Whitespace               WhitespaceSettings               `mapstructure:"whitespace"`
 	Wrapcheck                WrapcheckSettings                `mapstructure:"wrapcheck"`
 	WSL                      WSLSettings                      `mapstructure:"wsl"`
+	Zerolint                 ZerolintSettings                 `mapstructure:"zerolint"`
 
 	Custom map[string]CustomLinterSettings `mapstructure:"custom"`
 }
@@ -1007,6 +1016,12 @@ type WSLSettings struct {
 	ForceCuddleErrCheckAndAssign     bool     `mapstructure:"force-err-cuddling"`
 	ErrorVariableNames               []string `mapstructure:"error-variable-names"`
 	ForceExclusiveShortDeclarations  bool     `mapstructure:"force-short-decl-cuddling"`
+}
+
+type ZerolintSettings struct {
+	Excluded []string        `mapstructure:"excluded"`
+	Level    level.LintLevel `mapstructure:"level"`
+	Match    *regexp.Regexp  `mapstructure:"match"`
 }
 
 // CustomLinterSettings encapsulates the meta-data of a private linter.

--- a/pkg/golinters/zerolint/testdata/fix/in/zerolint.go
+++ b/pkg/golinters/zerolint/testdata/fix/in/zerolint.go
@@ -1,0 +1,24 @@
+//golangcitest:args -Ezerolint
+//golangcitest:config_path testdata/zerolint-fix.yml
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+type MyError struct{}
+
+func (*MyError) Error() string {
+	return "my error"
+}
+
+func DoWork() error {
+	return &MyError{}
+}
+
+func main() {
+	if err := DoWork(); errors.Is(err, &MyError{}) {
+		fmt.Println(`Got "my error"`)
+	}
+}

--- a/pkg/golinters/zerolint/testdata/fix/out/zerolint.go
+++ b/pkg/golinters/zerolint/testdata/fix/out/zerolint.go
@@ -1,0 +1,24 @@
+//golangcitest:args -Ezerolint
+//golangcitest:config_path testdata/zerolint-fix.yml
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+type MyError struct{}
+
+func (MyError) Error() string {
+	return "my error"
+}
+
+func DoWork() error {
+	return MyError{}
+}
+
+func main() {
+	if err := DoWork(); errors.Is(err, MyError{}) {
+		fmt.Println(`Got "my error"`)
+	}
+}

--- a/pkg/golinters/zerolint/testdata/zerolint-fix.yml
+++ b/pkg/golinters/zerolint/testdata/zerolint-fix.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    zerolint:
+      level: full

--- a/pkg/golinters/zerolint/testdata/zerolint.go
+++ b/pkg/golinters/zerolint/testdata/zerolint.go
@@ -1,0 +1,28 @@
+//golangcitest:args -Ezerolint
+//golangcitest:config_path testdata/zerolint.yml
+package testdata
+
+import (
+	"errors"
+	"fmt"
+)
+
+type MyError struct{}
+
+func (*MyError) Error() string { // want "zl:err"
+	return "my error"
+}
+
+func DoWork() error {
+	return &MyError{}
+}
+
+type Excluded struct{}
+
+func main() {
+	if err := DoWork(); errors.Is(err, &MyError{}) { // want "zl:cme"
+		fmt.Println(`Got "my error"`)
+	}
+
+	_ = &Excluded{} == &Excluded{}
+}

--- a/pkg/golinters/zerolint/testdata/zerolint.yml
+++ b/pkg/golinters/zerolint/testdata/zerolint.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  settings:
+    zerolint:
+      level: default
+      excluded:
+        - "command-line-arguments.Excluded"
+      match: "^.*$"

--- a/pkg/golinters/zerolint/zerolint.go
+++ b/pkg/golinters/zerolint/zerolint.go
@@ -1,0 +1,21 @@
+package zerolint
+
+import (
+	zl "fillmore-labs.com/zerolint/pkg/zerolint"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New(settings *config.ZerolintSettings) *goanalysis.Linter {
+	a := zl.New(
+		zl.WithLevel(settings.Level),
+		zl.WithExcludes(settings.Excluded),
+		zl.WithRegex(settings.Match),
+		zl.WithGenerated(true), // handle globally
+	)
+
+	return goanalysis.
+		NewLinterFromAnalyzer(a).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/zerolint/zerolint_integration_test.go
+++ b/pkg/golinters/zerolint/zerolint_integration_test.go
@@ -1,0 +1,19 @@
+package zerolint
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}
+
+func TestFix(t *testing.T) {
+	integration.RunFix(t)
+}
+
+func TestFixPathPrefix(t *testing.T) {
+	integration.RunFixPathPrefix(t)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -115,6 +115,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/whitespace"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/wrapcheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/wsl"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/zerolint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/zerologlint"
 	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 )
@@ -695,6 +696,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.20.0").
 			WithAutoFix().
 			WithURL("https://github.com/bombsimon/wsl"),
+
+		linter.NewConfig(zerolint.New(&cfg.Linters.Settings.Zerolint)).
+			WithSince("v2.2.0").
+			WithLoadForGoAnalysis().
+			WithAutoFix().
+			WithURL("https://github.com/fillmore-labs/zerolint"),
 
 		linter.NewConfig(zerologlint.New()).
 			WithSince("v1.53.0").


### PR DESCRIPTION
This patch integrates the `zerolint` linter, which detects unnecessary or potentially incorrect usage of pointers to zero-sized types.

Source Repository: https://github.com/fillmore-labs/zerolint

In-depth blog entry: https://blog.fillmore-labs.com/posts/zerosized-1/

Example issues found in public repositories:

* [x/sync/singleflight](https://pkg.go.dev/golang.org/x/sync/singleflight): [https://cs.opensource.google/go/x/sync/+/refs/tags/v0.14.0:singleflight/singleflight\_test.go;l=78](https://cs.opensource.google/go/x/sync/+/refs/tags/v0.14.0:singleflight/singleflight_test.go;l=78)
* [Delve](https://github.com/go-delve/delve): [https://github.com/go-delve/delve/blob/v1.24.2/service/debugger/debugger.go#L387](https://github.com/go-delve/delve/blob/v1.24.2/service/debugger/debugger.go#L387)
* [Grafana](https://grafana.com): [https://github.com/grafana/grafana/blob/v12.0.1/pkg/services/serviceaccounts/extsvcaccounts/service.go#L353](https://github.com/grafana/grafana/blob/v12.0.1/pkg/services/serviceaccounts/extsvcaccounts/service.go#L353)
* [Skaffold](https://skaffold.dev): [https://github.com/GoogleContainerTools/skaffold/blob/v2.16.0/pkg/skaffold/hooks/render.go#L93](https://github.com/GoogleContainerTools/skaffold/blob/v2.16.0/pkg/skaffold/hooks/render.go#L93)
* [Coder](https://coder.com): [https://github.com/coder/coder/blob/v2.22.1/cli/ssh.go#L578](https://github.com/coder/coder/blob/v2.22.1/cli/ssh.go#L578)
* [quic-go](https://quic-go.net/): [https://github.com/quic-go/quic-go/blob/v0.52.0/connection\_test.go#L1008](https://github.com/quic-go/quic-go/blob/v0.52.0/connection_test.go#L1008)
* [SigStore Cosign](https://www.sigstore.dev):   [https://github.com/sigstore/cosign/blob/v2.5.0/cmd/cosign/cli/attest/attest\_blob\_test.go#L60](https://github.com/sigstore/cosign/blob/v2.5.0/cmd/cosign/cli/attest/attest_blob_test.go#L60)
