### PR TITLE
fix: deduplicate typecheck errors

### DIFF
--- a/pkg/goanalysis/pkgerrors/errors.go
+++ b/pkg/goanalysis/pkgerrors/errors.go
@@ -20,6 +20,7 @@ func (e *IllTypedError) Error() string {
 
 func BuildIssuesFromIllTypedError(errs []error, lintCtx *linter.Context) ([]*result.Issue, error) {
 	var issues []*result.Issue
+
 	uniqReportedIssues := map[string]bool{}
 
 	var other error
@@ -39,9 +40,17 @@ func BuildIssuesFromIllTypedError(errs []error, lintCtx *linter.Context) ([]*res
 				if uniqReportedIssues[err.Msg] {
 					continue
 				}
+
 				uniqReportedIssues[err.Msg] = true
 				lintCtx.Log.Errorf("typechecking error: %s", err.Msg)
 			} else {
+				key := fmt.Sprintf("%s.%d.%d.%s", issue.FilePath(), issue.Line(), issue.Column(), issue.Text)
+				if uniqReportedIssues[key] {
+					continue
+				}
+
+				uniqReportedIssues[key] = true
+
 				issue.Pkg = ill.Pkg // to save to cache later
 				issues = append(issues, issue)
 			}

--- a/pkg/lint/runner.go
+++ b/pkg/lint/runner.go
@@ -232,7 +232,7 @@ func (r *Runner) processIssues(issues []*result.Issue, sw *timeutils.Stopwatch, 
 		})
 
 		if err != nil {
-			r.Log.Warnf("Can't process result by %s processor: %s", p.Name(), err)
+			r.Log.Warnf("Can't process results by %s processor: %s", p.Name(), err)
 		} else {
 			stat := statPerProcessor[p.Name()]
 			stat.inCount += len(issues)


### PR DESCRIPTION
Fixes #5863


<details>
<summary>to reproduce</summary>

```yml
version: '2'

issues:
  max-issues-per-linter: 0
  max-same-issues: 0
  uniq-by-line: false
```

```go
package main

import (
	"context"
)

func main() {
	context.Background(1)
}
```

```console
$ golangci-lint run
main.go:1: : # github.com/golangci/sandbox
./main.go:8:21: too many arguments in call to context.Background
        have (number)
        want () (typecheck)
package main
...
main.go:1: : # github.com/golangci/sandbox
./main.go:8:21: too many arguments in call to context.Background
        have (number)
        want () (typecheck)
package main
201 issues:
* typecheck: 201
```

</details>