### PR TITLE
dev: log level colors

### DIFF
--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -115,6 +115,9 @@ func setupLogger(logger logutils.Log) error {
 		logger.Fatalf("invalid value %q for --color; must be 'always', 'auto', or 'never'", opts.Color)
 	}
 
+	// For log level colors (mainly for verbose output)
+	logutils.DisableColors(color.NoColor)
+
 	return nil
 }
 

--- a/pkg/logutils/stderr_log.go
+++ b/pkg/logutils/stderr_log.go
@@ -17,13 +17,13 @@ const (
 	envLogTimestamp = "LOG_TIMESTAMP"
 )
 
+var _ Log = NewStderrLog(DebugKeyEmpty)
+
 type StderrLog struct {
 	name   string
 	logger *logrus.Logger
 	level  LogLevel
 }
-
-var _ Log = NewStderrLog(DebugKeyEmpty)
 
 func NewStderrLog(name string) *StderrLog {
 	sl := &StderrLog{
@@ -44,16 +44,7 @@ func NewStderrLog(name string) *StderrLog {
 	}
 
 	sl.logger.Out = StdErr
-	formatter := &logrus.TextFormatter{
-		DisableTimestamp:          true, // `INFO[0007] msg` -> `INFO msg`
-		EnvironmentOverrideColors: true,
-	}
-	if os.Getenv(envLogTimestamp) == "1" {
-		formatter.DisableTimestamp = false
-		formatter.FullTimestamp = true
-		formatter.TimestampFormat = time.StampMilli
-	}
-	sl.logger.Formatter = formatter
+	sl.logger.Formatter = logFormatter
 
 	return sl
 }
@@ -126,4 +117,25 @@ func (sl StderrLog) Child(name string) Log {
 
 func (sl *StderrLog) SetLevel(level LogLevel) {
 	sl.level = level
+}
+
+var logFormatter = newLogFormatter()
+
+func DisableColors(disable bool) {
+	logFormatter.DisableColors = disable
+}
+
+func newLogFormatter() *logrus.TextFormatter {
+	formatter := &logrus.TextFormatter{
+		DisableTimestamp:          true, // `INFO[0007] msg` -> `INFO msg`
+		EnvironmentOverrideColors: true,
+	}
+
+	if os.Getenv(envLogTimestamp) == "1" {
+		formatter.DisableTimestamp = false
+		formatter.FullTimestamp = true
+		formatter.TimestampFormat = time.StampMilli
+	}
+
+	return formatter
 }


### PR DESCRIPTION
Propagate `github.com/fatih/color` state to the log formatter.

Note: Disabling the colors changes the log format (but it doesn't change the report format).


<details>
<summary>Color format</summary>

```
INFO golangci-lint has version (devel) built with go1.24.3 from (unknown, modified: ?, mod sum: "") on (unknown)
```

</details>

<details>
<summary>No color format</summary>

```
level=info msg="golangci-lint has version (devel) built with go1.24.3 from (unknown, modified: ?, mod sum: \"\") on (unknown)"
```

</details>


Fixes #5865
