### PR TITLE
feat: add correcterr linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -28,6 +28,7 @@ linters:
     - containedctx
     - contextcheck
     - copyloopvar
+    - correcterr
     - cyclop
     - decorder
     - depguard
@@ -135,6 +136,7 @@ linters:
     - containedctx
     - contextcheck
     - copyloopvar
+    - correcterr
     - cyclop
     - decorder
     - depguard

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/golangci/golangci-lint/v2
 
-go 1.23.0
+go 1.23.9
+
+toolchain go1.24.4
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0
@@ -74,6 +76,7 @@ require (
 	github.com/ldez/tagliatelle v0.7.1
 	github.com/ldez/usetesting v0.4.3
 	github.com/leonklingele/grouper v1.1.2
+	github.com/m-ocean-it/correcterr v0.5.0
 	github.com/macabu/inamedparam v0.2.0
 	github.com/manuelarte/embeddedstructfieldcheck v0.3.0
 	github.com/manuelarte/funcorder v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -389,6 +389,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
+github.com/m-ocean-it/correcterr v0.5.0 h1:qGGJFmM/3jcZX6JhA1pul8fMHjD2uYW2dhMguHGlFvY=
+github.com/m-ocean-it/correcterr v0.5.0/go.mod h1:SYI+7Svgog53u7YoSbikyAli/5FQipL3M1LcVlIG/OU=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
 github.com/macabu/inamedparam v0.2.0/go.mod h1:+Pee9/YfGe5LJ62pYXqB89lJ+0k5bsR8Wgz/C0Zlq3U=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=

--- a/pkg/golinters/correcterr/correcterr.go
+++ b/pkg/golinters/correcterr/correcterr.go
@@ -1,0 +1,13 @@
+package correcterr
+
+import (
+	"github.com/m-ocean-it/correcterr"
+
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	return goanalysis.
+		NewLinterFromAnalyzer(correcterr.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/correcterr/correcterr_integration_test.go
+++ b/pkg/golinters/correcterr/correcterr_integration_test.go
@@ -1,0 +1,11 @@
+package correcterr
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/correcterr/testdata/correcterr.go
+++ b/pkg/golinters/correcterr/testdata/correcterr.go
@@ -1,0 +1,576 @@
+//golangcitest:args -Ecorrecterr
+package testdata
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ----------------------------------------------------
+// Triggers
+
+func CheckingAndReturningDifferentErrors() error {
+	var err1 = errors.New("1")
+	var err2 = errors.New("2")
+
+	if err1 != nil {
+		return err2 // want "returning not the error that was checked"
+	}
+
+	return nil
+}
+
+func CheckingAndReturningDifferentErrors2() error {
+	var err1 = errors.New("1")
+	if err2 := errors.New("2"); err2 != nil {
+		return err1 // want "returning not the error that was checked"
+	}
+
+	return nil
+}
+
+func ErrorfWrap() error {
+	err1 := errors.New("1")
+	err2 := errors.New("2")
+
+	if err1 != nil {
+		return fmt.Errorf("error: %w", err2) // want "returning not the error that was checked"
+	}
+
+	return nil
+}
+
+func ErrorfWrap2() error {
+	err1 := errors.New("1")
+	err2 := errors.New("2")
+
+	if err1 != nil {
+		return fmt.Errorf("errors: %w, %w", err1, err2) // want "returning not the error that was checked"
+	}
+
+	return nil
+}
+
+func FuncLit() {
+	var err error
+
+	func() error {
+		if innerErr := errors.New("inner"); innerErr != nil {
+			return err // want "returning not the error that was checked"
+		}
+
+		return nil
+	}()
+}
+
+func AssignFuncLit() error {
+	var err error
+
+	funcLitErr := func() error {
+		if innerErr := errors.New("inner"); innerErr != nil {
+			return err // want "returning not the error that was checked"
+		}
+
+		return nil
+	}()
+
+	return funcLitErr
+}
+
+func Switch() error {
+	var err error
+
+	switch {
+	case false:
+	case true:
+		if innerErr := errors.New("inner"); innerErr != nil {
+			return err // want "returning not the error that was checked"
+		}
+	}
+
+	return nil
+}
+
+func RangeStmt() error {
+	var err error
+
+	for range 5 {
+		if innerErr := errors.New("inner"); innerErr != nil {
+			return err // want "returning not the error that was checked"
+		}
+	}
+
+	return nil
+}
+
+func ForStmt() error {
+	err := errors.New("error")
+
+	for i := 0; i < 5; i++ {
+		_ = i
+
+		if innerErr := errors.New("inner"); innerErr != nil {
+			return err // want "returning not the error that was checked"
+		}
+	}
+
+	return nil
+}
+
+func NestedIfStatements() error {
+	err := errors.New("error")
+	anotherErr := errors.New("another")
+
+	if true {
+		if err != nil {
+			return anotherErr // want "returning not the error that was checked"
+		}
+	}
+
+	return nil
+}
+
+func TripleFooWrapOfWrongError() error {
+	err := errors.New("error")
+	anotherError := errors.New("another")
+
+	if err != nil {
+		return fooWrap(1, fooWrap(2, fooWrap(3, anotherError, "c"), "b"), "a") // want "returning not the error that was checked"
+	}
+
+	return nil
+}
+
+func ReturningMessage() (error, string) {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if err != nil {
+		return anotherErr, err.Error() // want "returning not the error that was checked"
+	}
+
+	return nil, "foo"
+}
+
+func ClosureErrors() error {
+	err := closureWrapper(func() error {
+		_, err := doSmth()
+		if err != nil {
+			return fooWrap(1, err, "a")
+		}
+
+		if _, innerErr := doSmth(); innerErr != nil {
+			return fooWrap(1, err, "a") // want "returning not the error that was checked"
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func ClosureReturnsErrorAssignedOutside() error {
+	funcErr := errors.New("func error")
+	anotherFuncErr := errors.New("another func error")
+
+	err := closureWrapper(func() error {
+		if funcErr != nil {
+			return anotherFuncErr // want "returning not the error that was checked"
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func ClosureReturnsErrorAssignedInside() error {
+	err := closureWrapper(func() error {
+		innerErr := errors.New("inner")
+		anotherInnerErr := errors.New("another inner")
+
+		if innerErr != nil {
+			return anotherInnerErr // want "returning not the error that was checked"
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func ClosureReturnsErrorDeclaredOutside() error {
+	var (
+		innerErr        = errors.New("inner")
+		anotherInnerErr = errors.New("another inner")
+	)
+
+	err := closureWrapper(func() error {
+		if innerErr != nil {
+			return anotherInnerErr // want "returning not the error that was checked"
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func ClosureReturnsErrorDeclaredInside() error {
+	err := closureWrapper(func() error {
+		var (
+			innerErr        = errors.New("inner")
+			anotherInnerErr = errors.New("another inner")
+		)
+
+		if innerErr != nil {
+			return anotherInnerErr // want "returning not the error that was checked"
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func ClosureInDeclaration() error {
+	var err = closureWrapper(func() error {
+		innerErr := errors.New("inner")
+		anotherInnerErr := errors.New("another")
+
+		if innerErr != nil {
+			return anotherInnerErr // want "returning not the error that was checked"
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func NoInitialLocalErrNames() {
+	closureWrapper(func() error {
+		innerErr := errors.New("inner")
+		anotherInnerErr := errors.New("another")
+
+		if innerErr != nil {
+			return anotherInnerErr // want "returning not the error that was checked"
+		}
+
+		return nil
+	})
+}
+
+func WrapCycle() error {
+	err := errors.New("error")
+	if err != nil {
+		var wrappedB error
+		wrappedA := fmt.Errorf("wrapped: %w", wrappedB)
+		wrappedB = fmt.Errorf("wrapped: %w", wrappedA)
+		wrappedB = fmt.Errorf("wrapped: %w", wrappedA)
+		wrappedA = fmt.Errorf("wrapped: %w", wrappedB)
+
+		return wrappedB // want "returning not the error that was checked"
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------
+// Non-triggers
+
+func Correct() error {
+	var err1 = errors.New("1")
+	var err2 = errors.New("2")
+
+	if err1 != nil {
+		return err1
+	}
+
+	if err2 != nil {
+		return err2
+	}
+
+	return nil
+}
+
+func NilError() error {
+	var someError error
+	var anotherError error
+
+	if someError == nil {
+		return anotherError
+	}
+
+	return nil
+}
+
+func LengthOfSlice() error {
+	var slice []int
+	err := errors.New("empty")
+	if len(slice) == 0 {
+		return err
+	}
+
+	return nil
+}
+
+func NewErrorAfterCheck() error {
+	var err error
+	if err != nil {
+		return errors.New("some new error")
+	}
+
+	return nil
+}
+
+func IfTrue() error {
+	var err error
+	if true {
+		return err
+	}
+
+	return nil
+}
+
+func CompareNumbers() error {
+	a := 2
+	b := 3
+	var err error
+
+	if a != b {
+		return err
+	}
+
+	return nil
+}
+
+func DoubleWrap() error {
+	var err error
+	if err != nil {
+		return fmt.Errorf("error: %w", fmt.Errorf("error: %w", err))
+	}
+
+	return nil
+}
+
+func TripleFooWrap() error {
+	var err error
+	if err != nil {
+		return fooWrap(1, fooWrap(2, fooWrap(3, err, "c"), "b"), "a")
+	}
+
+	return nil
+}
+
+func ReturningWrappedMessage() error {
+	err := errors.New("some error")
+	if err != nil {
+		return fooWrap(1, errors.New("new error"), err.Error())
+	}
+
+	return nil
+}
+
+func ReturningWrappedMessage2() error {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if err != nil {
+		return fooWrap(1, errors.New("new error"), anotherErr.Error())
+	}
+
+	return nil
+}
+
+func ErrorsIsCorrect() error {
+	err := errors.New("original")
+	wrappedErr := fmt.Errorf("wrapped: %w", err)
+	if errors.Is(wrappedErr, err) {
+		return wrappedErr
+	}
+
+	return nil
+}
+
+func ErrorsIsWrong() error {
+	err := errors.New("original")
+	anotherErr := errors.New("another")
+
+	wrappedErr := fmt.Errorf("wrapped: %w", err)
+	if errors.Is(wrappedErr, err) {
+		return anotherErr
+	}
+
+	return nil
+}
+
+func FooCheckCorrect() error {
+	err := errors.New("some error")
+
+	if fooCheck(1, err, "a") {
+		return err
+	}
+
+	return nil
+}
+
+func FooCheckWrappedCorrect() error {
+	err := errors.New("some error")
+
+	if fooCheck(1, err, "a") {
+		return fmt.Errorf("error: %w", err)
+	}
+
+	return nil
+}
+
+func FooCheckReturnMessageCorrect() error {
+	err := errors.New("some error")
+
+	if fooCheck(1, err, "a") {
+		return errors.New(err.Error())
+	}
+
+	return nil
+}
+
+func FooCheckReturnMessageCorrectWrapped() error {
+	err := errors.New("some error")
+
+	if fooCheck(1, err, "a") {
+		return fmt.Errorf("error: %s", err.Error())
+	}
+
+	return nil
+}
+
+func FooCheckWrong() error {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if fooCheck(1, err, "a") {
+		return anotherErr
+	}
+
+	return nil
+}
+
+func FooCheckWrappedWrong() error {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if fooCheck(1, err, "a") {
+		return fmt.Errorf("error: %w", anotherErr)
+	}
+
+	return nil
+}
+
+func FooCheckReturnMessageWrong() error {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if fooCheck(1, err, "a") {
+		return fmt.Errorf("error: %s", anotherErr.Error())
+	}
+
+	return nil
+}
+
+func FooCheckCorrect2() (error, error) {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if fooCheck(1, err, "a") {
+		return err, anotherErr
+	}
+
+	return nil, nil
+}
+
+func CheckTwoErrorsCorrect() error {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if err != nil && anotherErr != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ReturnWrappedErrorMessage() error {
+	err := errors.New("some error")
+
+	if err != nil {
+		return errors.New(fooWrap(1, err, "a").Error())
+	}
+
+	return nil
+}
+
+func ReturnWrappedErrorMessage2() error {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if err != nil {
+		return errors.New(fooWrap(1, anotherErr, "a").Error())
+	}
+
+	return nil
+}
+
+func ErrorCheckedInOuterIfStatement() error {
+	err := errors.New("some error")
+	anotherErr := errors.New("another error")
+
+	if err != nil {
+		if anotherErr != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func WrappingWithAssignmentBeforeReturning() error {
+	err := errors.New("error")
+	if err != nil {
+		wrappedErr := fmt.Errorf("wrapped: %w", err)
+
+		return wrappedErr
+	}
+
+	return nil
+}
+
+func WrappingWithDeclarationBeforeReturning() error {
+	err := errors.New("error")
+	if err != nil {
+		var wrappedErr error = fmt.Errorf("wrapped: %w", err)
+
+		return wrappedErr
+	}
+
+	return nil
+}
+
+// ----------------------------------------------------
+// Helpers
+
+func closureWrapper(fn func() error) error {
+	return fn()
+}
+
+func fooWrap(_ int, err error, _ string) error {
+	return err
+}
+
+func fooCheck(_ int, err error, _ string) bool {
+	return err != nil
+}
+
+func doSmth() (int, error) {
+	return 0, errors.New("doSmth failed")
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/containedctx"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/contextcheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/copyloopvar"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/correcterr"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/cyclop"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/decorder"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/depguard"
@@ -700,6 +701,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.53.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/ykadowak/zerologlint"),
+
+		linter.NewConfig(correcterr.New()).
+			WithSince("v2.2.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/m-ocean-it/correcterr"),
 
 		// nolintlint must be last because it looks at the results of all the previous linters for unused nolint directives
 		linter.NewConfig(nolintlint.New(&cfg.Linters.Settings.NoLintLint)).


### PR DESCRIPTION
https://github.com/m-ocean-it/correcterr

## About

It's a linter that checks whether the returned error is the same one that was checked in the condition.

### Examples

For more examples, see the `err_mistakes.go` file which is used in automated testing.

#### Will trigger

```go
if txErr != nil {
    return err // will be reported
}
```

```go
if txErr := doSmth(); txErr != nil {
    return err // will be reported
}
```

```go
if err != nil {
    return fmt.Errorf("error: %w", anotherErr) // will be reported
}
```

```go
if err != nil {
    return someCustomWrapper(someCustomError(anotherErr)) // will be reported
}
```

#### Will NOT trigger

```go
if err != nil {
    return errors.New("another") // creating an error on the spot is fine
}
```

```go
import "custom_errors"

if err != nil {
    return custom_errors.SomeError // returning an error defined outside of the function's scope is fine
}
```