### PR TITLE
fix: stop the analysis after the first package analysis error

### DIFF
--- a/pkg/goanalysis/runner_action.go
+++ b/pkg/goanalysis/runner_action.go
@@ -28,10 +28,14 @@ func (actAlloc *actionAllocator) alloc() *action {
 	return act
 }
 
-func (act *action) waitUntilDependingAnalyzersWorked() {
+func (act *action) waitUntilDependingAnalyzersWorked(stopChan chan struct{}) {
 	for _, dep := range act.Deps {
 		if dep.Package == act.Package {
-			<-dep.analysisDoneCh
+			select {
+			case <-stopChan:
+				return
+			case <-dep.analysisDoneCh:
+			}
 		}
 	}
 }

--- a/pkg/goanalysis/runner_checker.go
+++ b/pkg/goanalysis/runner_checker.go
@@ -95,7 +95,7 @@ func (act *action) analyze() {
 		}
 	}
 	if depErrors != nil {
-		act.Err = errors.Join(depErrors, errors.New("failed prerequisites"))
+		act.Err = fmt.Errorf("failed prerequisites: %w", depErrors)
 		return
 	}
 


### PR DESCRIPTION
Stops the analysis after the first package analysis error.

- Improve the speed when there are errors (about three times faster based on my test cases)
- Improve error reports
- Revert #5884 (because there is no accumulation of errors with this PR)


<details><summary>before</summary>

```console
$ ./golangci-lint run -v
INFO golangci-lint has version (devel) built with go1.24.3 from (751b9ca1972cd9a2b6de4de20a74dd281f970f5a, modified: false, mod sum: "") on 2025-06-19T12:16:25Z 
INFO [config_reader] Config search paths: [./ /home/ldez/sources/experimental/alingse-kubernetes /home/ldez/sources/experimental /home/ldez/sources /home/ldez /home /] 
INFO [config_reader] Used config file .golangci.yaml 
INFO [config_reader] Module name "k8s.io/kubernetes" 
INFO maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined 
INFO [goenv] Read go env for 1.642255ms: map[string]string{"GOCACHE":"/home/ldez/.cache/go-build", "GOROOT":"/home/ldez/.gvm/gos/go1.24.4"} 
INFO [lintersdb] Active 56 linters: [arangolint asasalint asciicheck bidichk bodyclose canonicalheader decorder depguard dupword durationcheck embeddedstructfieldcheck errcheck exptostd forbidigo ginkgolinter gocheckcompilerdirectives gochecksumtype gocyclo gofmt goheader gomodguard goprintffuncname govet grouper iface importas inamedparam ineffassign loggercheck makezero mirror misspell nilnesserr noinlineerr nosprintfhostport prealloc predeclared promlinter protogetter reassign revive sloglint spancheck sqlclosecheck staticcheck testableexamples testifylint thelper tparallel unconvert unparam usestdlibvars usetesting wastedassign whitespace zerologlint] 
INFO [loader] Go packages loading at mode 8767 (deps|files|imports|name|compiled_files|exports_file|types_sizes) took 1.161166663s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 167.656178ms 
INFO [linters_context] importas settings found, but no aliases listed. List aliases under alias: key. 
INFO [linters_context/goanalysis] analyzers took 25m27.357145051s with top 10 stages: buildir: 6m1.600535206s, revive: 58.606380067s, wastedassign: 58.370943925s, unparam: 33.489067736s, unconvert: 33.425121852s, misspell: 16.225627831s, nilness: 14.821658805s, ctrlflow: 14.765385101s, printf: 14.401039151s, SA1004: 13.350670354s 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gofmt"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gofmt"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gofmt"] 
INFO [runner] Issues before processing: 13057, after processing: 103 
INFO [runner] Processors filtering stat (in/out): filename_unadjuster: 13057/13057, diff: 115/115, uniq_by_line: 115/103, max_per_file_from_linter: 103/103, max_same_issues: 103/103, path_prettifier: 103/103, path_absoluter: 13057/13057, cgo: 13057/13057, invalid_issue: 13057/115, path_relativity: 115/115, exclusion_paths: 115/115, path_shortener: 103/103, severity-rules: 103/103, sort_results: 103/103, exclusion_rules: 115/115, fixer: 115/115, max_from_linter: 103/103, generated_file_filter: 115/115, nolint_filter: 115/115, source_code: 103/103 
INFO [runner] processing took 7.959429ms with stages: source_code: 7.133995ms, cgo: 332.087µs, path_absoluter: 161.06µs, path_relativity: 86.657µs, filename_unadjuster: 82.708µs, invalid_issue: 39.624µs, exclusion_rules: 25.632µs, max_same_issues: 24.179µs, uniq_by_line: 18.351µs, max_from_linter: 17.072µs, sort_results: 16.521µs, path_shortener: 15.251µs, nolint_filter: 2.196µs, max_per_file_from_linter: 1.221µs, path_prettifier: 949ns, generated_file_filter: 619ns, exclusion_paths: 604ns, fixer: 323ns, diff: 304ns, severity-rules: 76ns 
INFO [runner] linters took 40.261214295s with stages: goanalysis_metalinter: 40.253183333s 
cmd/kube-apiserver/app/options/completion.go:73:15: completed.Etcd undefined (type completedOptions has no field or method Etcd) (typecheck)
        if completed.Etcd != nil && completed.Etcd.EnableWatchCache {
                     ^
cmd/kube-apiserver/app/options/completion.go:76:73: completed.Etcd undefined (type completedOptions has no field or method Etcd) (typecheck)
                userSpecified, err := apiserveroptions.ParseWatchCacheSizes(completed.Etcd.WatchCacheSizes)
                                                                                      ^
cmd/kube-apiserver/app/options/completion.go:83:13: completed.Etcd undefined (type completedOptions has no field or method Etcd) (typecheck)
                completed.Etcd.WatchCacheSizes, err = apiserveroptions.WriteWatchCacheSizes(sizes)
                          ^
cmd/kube-apiserver/app/options/validation.go:137:82: s.GenericServerRunOptions undefined (type CompletedOptions has no field or method GenericServerRunOptions) (typecheck)
        errs = append(errs, validatePublicIPServiceClusterIPRangeIPFamilies(s.Extra, *s.GenericServerRunOptions)...)
                                                                                        ^
cmd/kube-apiserver/app/server.go:45:2: "k8s.io/component-base/featuregate" imported and not used (typecheck)
        "k8s.io/component-base/featuregate"
        ^
cmd/kube-scheduler/app/server.go:52:2: "k8s.io/component-base/featuregate" imported and not used (typecheck)
        "k8s.io/component-base/featuregate"
        ^
pkg/features/kube_features_test.go:19:1: expected 'package', found 'import' (typecheck)
import (
^
pkg/kubelet/kubelet.go:992:7: klet.AddPodSyncLoopHandler undefined (type *Kubelet has no field or method AddPodSyncLoopHandler) (typecheck)
        klet.AddPodSyncLoopHandler(activeDeadlineHandler)
             ^
pkg/kubelet/kubelet.go:993:7: klet.AddPodSyncHandler undefined (type *Kubelet has no field or method AddPodSyncHandler) (typecheck)
        klet.AddPodSyncHandler(activeDeadlineHandler)
             ^
pkg/kubelet/lifecycle/handlers.go:223:11: a.Validate undefined (type *appArmorAdmitHandler has no field or method Validate) (typecheck)
        err := a.Validate(attrs.Pod)
                 ^
pkg/kubelet/server/server.go:776:20: s.host.GetPodByName undefined (type HostInterface has no field or method GetPodByName) (typecheck)
        pod, ok := s.host.GetPodByName(podNamespace, podID)
                          ^
pkg/kubelet/server/server.go:846:17: s.host.GetPods undefined (type HostInterface has no field or method GetPods) (typecheck)
        pods := s.host.GetPods()
                       ^
pkg/kubelet/server/server.go:933:20: s.host.GetPodByName undefined (type HostInterface has no field or method GetPodByName) (typecheck)
        pod, ok := s.host.GetPodByName(params.podNamespace, params.podName)
                          ^
pkg/kubelet/server/server.go:958:20: s.host.GetPodByName undefined (type HostInterface has no field or method GetPodByName) (typecheck)
        pod, ok := s.host.GetPodByName(params.podNamespace, params.podName)
                          ^
pkg/kubelet/server/server.go:976:20: s.host.GetPodByName undefined (type HostInterface has no field or method GetPodByName) (typecheck)
        pod, ok := s.host.GetPodByName(params.podNamespace, params.podName)
                          ^
pkg/kubelet/server/server.go:1017:20: s.host.GetPodByName undefined (type HostInterface has no field or method GetPodByName) (typecheck)
        pod, ok := s.host.GetPodByName(params.podNamespace, params.podName)
                          ^
pkg/kubelet/server/server.go:1040:20: s.host.GetPodByName undefined (type HostInterface has no field or method GetPodByName) (typecheck)
        pod, ok := s.host.GetPodByName(request.PathParameter("podNamespace"), request.PathParameter("podID"))
                          ^
pkg/kubelet/server/server.go:1189:16: a.host.GetRequestedContainersInfo undefined (type HostInterface has no field or method GetRequestedContainersInfo) (typecheck)
        return a.host.GetRequestedContainersInfo(containerName, options)
                      ^
pkg/kubelet/volumemanager/cache/desired_state_of_world.go:585:9: vmt.DesiredPersistentVolumeSize undefined (type VolumeToMount has no field or method DesiredPersistentVolumeSize) (typecheck)
                                vmt.DesiredPersistentVolumeSize = volumeObj.persistentVolumeSize.DeepCopy()
                                    ^
pkg/proxy/iptables/proxier.go:347:45: svcPort.Protocol undefined (type *servicePortInfo has no field or method Protocol) (typecheck)
        protocol := strings.ToLower(string(svcPort.Protocol()))
                                                   ^
pkg/proxy/nftables/proxier.go:350:89: svcPort.Protocol undefined (type *servicePortInfo has no field or method Protocol) (typecheck)
        chainNameBase := servicePortChainNameBase(&svcPortName, strings.ToLower(string(svcPort.Protocol())))
                                                                                               ^
pkg/proxy/nftables/proxier.go:1913:29: svcInfo.SessionAffinityType undefined (type *servicePortInfo has no field or method SessionAffinityType) (typecheck)
        wantAffinitySet := svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP
                                   ^
pkg/proxy/nftables/proxier.go:1919:13: svcInfo.SessionAffinityType undefined (type *servicePortInfo has no field or method SessionAffinityType) (typecheck)
        if svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP {
                   ^
pkg/scheduler/framework/plugins/noderesources/fit.go:225:9: result.SetMaxResource undefined (type *preFilterState has no field or method SetMaxResource) (typecheck)
        result.SetMaxResource(reqs)
               ^
pkg/scheduler/framework/plugins/noderesources/fit.go:415:16: podRequest.MilliCPU undefined (type *preFilterState has no field or method MilliCPU) (typecheck)
        if podRequest.MilliCPU == 0 &&
                      ^
pkg/scheduler/framework/plugins/noderesources/fit.go:416:14: podRequest.Memory undefined (type *preFilterState has no field or method Memory) (typecheck)
                podRequest.Memory == 0 &&
                           ^
pkg/scheduler/framework/plugins/noderesources/fit.go:417:14: podRequest.EphemeralStorage undefined (type *preFilterState has no field or method EphemeralStorage) (typecheck)
                podRequest.EphemeralStorage == 0 &&
                           ^
pkg/scheduler/framework/plugins/noderesources/fit.go:418:18: podRequest.ScalarResources undefined (type *preFilterState has no field or method ScalarResources) (typecheck)
                len(podRequest.ScalarResources) == 0 {
                               ^
pkg/scheduler/framework/plugins/noderesources/fit.go:422:17: podRequest.MilliCPU undefined (type *preFilterState has no field or method MilliCPU) (typecheck)
        if (podRequest.MilliCPU > 0 && modifiedNodeInfo.Allocatable.MilliCPU > originalNodeInfo.Allocatable.MilliCPU) ||
                       ^
pkg/scheduler/framework/plugins/noderesources/fit.go:423:15: podRequest.Memory undefined (type *preFilterState has no field or method Memory) (typecheck)
                (podRequest.Memory > 0 && modifiedNodeInfo.Allocatable.Memory > originalNodeInfo.Allocatable.Memory) ||
                            ^
pkg/scheduler/framework/plugins/noderesources/fit.go:424:15: podRequest.EphemeralStorage undefined (type *preFilterState has no field or method EphemeralStorage) (typecheck)
                (podRequest.EphemeralStorage > 0 && modifiedNodeInfo.Allocatable.EphemeralStorage > originalNodeInfo.Allocatable.EphemeralStorage) {
                            ^
pkg/scheduler/framework/plugins/noderesources/fit.go:428:40: podRequest.ScalarResources undefined (type *preFilterState has no field or method ScalarResources) (typecheck)
        for rName, rQuant := range podRequest.ScalarResources {
                                              ^
pkg/scheduler/framework/plugins/noderesources/fit.go:522:16: podRequest.MilliCPU undefined (type *preFilterState has no field or method MilliCPU) (typecheck)
        if podRequest.MilliCPU == 0 &&
                      ^
pkg/scheduler/framework/plugins/noderesources/fit.go:523:14: podRequest.Memory undefined (type *preFilterState has no field or method Memory) (typecheck)
                podRequest.Memory == 0 &&
                           ^
pkg/scheduler/framework/plugins/noderesources/fit.go:524:14: podRequest.EphemeralStorage undefined (type *preFilterState has no field or method EphemeralStorage) (typecheck)
                podRequest.EphemeralStorage == 0 &&
                           ^
pkg/scheduler/framework/plugins/noderesources/fit.go:525:18: podRequest.ScalarResources undefined (type *preFilterState has no field or method ScalarResources) (typecheck)
                len(podRequest.ScalarResources) == 0 {
                               ^
pkg/scheduler/framework/plugins/noderesources/fit.go:529:16: podRequest.MilliCPU undefined (type *preFilterState has no field or method MilliCPU) (typecheck)
        if podRequest.MilliCPU > 0 && podRequest.MilliCPU > (nodeInfo.Allocatable.MilliCPU-nodeInfo.Requested.MilliCPU) {
                      ^
pkg/scheduler/framework/plugins/noderesources/fit.go:533:29: podRequest.MilliCPU undefined (type *preFilterState has no field or method MilliCPU) (typecheck)
                        Requested:    podRequest.MilliCPU,
                                                 ^
pkg/scheduler/framework/plugins/noderesources/fit.go:536:29: podRequest.MilliCPU undefined (type *preFilterState has no field or method MilliCPU) (typecheck)
                        Unresolvable: podRequest.MilliCPU > nodeInfo.Allocatable.MilliCPU,
                                                 ^
pkg/scheduler/framework/plugins/noderesources/fit.go:539:16: podRequest.Memory undefined (type *preFilterState has no field or method Memory) (typecheck)
        if podRequest.Memory > 0 && podRequest.Memory > (nodeInfo.Allocatable.Memory-nodeInfo.Requested.Memory) {
                      ^
pkg/scheduler/framework/plugins/noderesources/fit.go:543:29: podRequest.Memory undefined (type *preFilterState has no field or method Memory) (typecheck)
                        Requested:    podRequest.Memory,
                                                 ^
pkg/scheduler/framework/plugins/noderesources/fit.go:546:29: podRequest.Memory undefined (type *preFilterState has no field or method Memory) (typecheck)
                        Unresolvable: podRequest.Memory > nodeInfo.Allocatable.Memory,
                                                 ^
pkg/scheduler/framework/plugins/noderesources/fit.go:549:16: podRequest.EphemeralStorage undefined (type *preFilterState has no field or method EphemeralStorage) (typecheck)
        if podRequest.EphemeralStorage > 0 &&
                      ^
pkg/scheduler/framework/plugins/noderesources/fit.go:550:14: podRequest.EphemeralStorage undefined (type *preFilterState has no field or method EphemeralStorage) (typecheck)
                podRequest.EphemeralStorage > (nodeInfo.Allocatable.EphemeralStorage-nodeInfo.Requested.EphemeralStorage) {
                           ^
pkg/scheduler/framework/plugins/noderesources/fit.go:554:29: podRequest.EphemeralStorage undefined (type *preFilterState has no field or method EphemeralStorage) (typecheck)
                        Requested:    podRequest.EphemeralStorage,
                                                 ^
pkg/scheduler/framework/plugins/noderesources/fit.go:557:29: podRequest.EphemeralStorage undefined (type *preFilterState has no field or method EphemeralStorage) (typecheck)
                        Unresolvable: podRequest.EphemeralStorage > nodeInfo.Allocatable.EphemeralStorage,
                                                 ^
pkg/scheduler/framework/plugins/noderesources/fit.go:561:40: podRequest.ScalarResources undefined (type *preFilterState has no field or method ScalarResources) (typecheck)
        for rName, rQuant := range podRequest.ScalarResources {
                                              ^
pkg/scheduler/framework/plugins/noderesources/fit.go:583:30: podRequest.ScalarResources undefined (type *preFilterState has no field or method ScalarResources) (typecheck)
                                Requested:    podRequest.ScalarResources[rName],
                                                         ^
pkg/scheduler/framework/runtime/framework.go:23:2: "io" imported and not used (typecheck)
        "io"
        ^
pkg/volume/testing/volume_host.go:53:2: undefined: VolumeHost (typecheck)
        VolumeHost
        ^
pkg/volume/testing/volume_host.go:55:18: undefined: VolumePluginMgr (typecheck)
        GetPluginMgr() *VolumePluginMgr
                        ^
pkg/volume/testing/volume_host.go:63:26: undefined: VolumePluginMgr (typecheck)
        pluginMgr              *VolumePluginMgr
                                ^
pkg/volume/testing/volume_host.go:78:7: undefined: VolumeHost (typecheck)
var _ VolumeHost = &fakeVolumeHost{}
      ^
pkg/volume/testing/volume_host.go:81:96: undefined: VolumePlugin (typecheck)
func NewFakeVolumeHost(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin) FakeVolumeHost {
                                                                                               ^
pkg/volume/testing/volume_host.go:85:113: undefined: VolumePlugin (typecheck)
func NewFakeVolumeHostWithCloudProvider(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin) FakeVolumeHost {
                                                                                                                ^
pkg/volume/testing/volume_host.go:89:111: undefined: VolumePlugin (typecheck)
func NewFakeVolumeHostWithCSINodeName(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) FakeVolumeHost {
                                                                                                              ^
pkg/volume/testing/volume_host.go:93:96: undefined: VolumePlugin (typecheck)
func newFakeVolumeHost(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, pathToTypeMap map[string]hostutil.FileType, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) FakeVolumeHost {
                                                                                               ^
pkg/volume/testing/volume_host.go:98:20: undefined: VolumePluginMgr (typecheck)
        host.pluginMgr = &VolumePluginMgr{}
                          ^
pkg/volume/testing/volume_host.go:147:42: undefined: VolumePluginMgr (typecheck)
func (f *fakeVolumeHost) GetPluginMgr() *VolumePluginMgr {
                                         ^
pkg/volume/testing/volume_host.go:155:65: undefined: Spec (typecheck)
func (f *fakeVolumeHost) NewWrapperMounter(volName string, spec Spec, pod *v1.Pod) (Mounter, error) {
                                                                ^
pkg/volume/testing/volume_host.go:168:67: undefined: Spec (typecheck)
func (f *fakeVolumeHost) NewWrapperUnmounter(volName string, spec Spec, podUID types.UID) (Unmounter, error) {
                                                                  ^
pkg/volume/testing/volume_host.go:252:7: undefined: AttachDetachVolumeHost (typecheck)
var _ AttachDetachVolumeHost = &fakeAttachDetachVolumeHost{}
      ^
pkg/volume/testing/volume_host.go:255:123: undefined: VolumePlugin (typecheck)
func NewFakeAttachDetachVolumeHostWithCSINodeName(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) FakeVolumeHost {
                                                                                                                          ^
pkg/volume/testing/volume_host.go:259:108: undefined: VolumePlugin (typecheck)
func newFakeAttachDetachVolumeHost(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, pathToTypeMap map[string]hostutil.FileType, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) FakeVolumeHost {
                                                                                                           ^
pkg/volume/testing/volume_host.go:269:20: undefined: VolumePluginMgr (typecheck)
        host.pluginMgr = &VolumePluginMgr{}
                          ^
pkg/volume/testing/volume_host.go:323:7: undefined: KubeletVolumeHost (typecheck)
var _ KubeletVolumeHost = &fakeKubeletVolumeHost{}
      ^
pkg/volume/testing/volume_host.go:326:103: undefined: VolumePlugin (typecheck)
func NewFakeKubeletVolumeHost(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin) *fakeKubeletVolumeHost {
                                                                                                      ^
pkg/volume/testing/volume_host.go:330:118: undefined: VolumePlugin (typecheck)
func NewFakeKubeletVolumeHostWithCSINodeName(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) *fakeKubeletVolumeHost {
                                                                                                                     ^
pkg/volume/testing/volume_host.go:334:120: undefined: VolumePlugin (typecheck)
func NewFakeKubeletVolumeHostWithMounterFSType(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, pathToTypeMap map[string]hostutil.FileType) *fakeKubeletVolumeHost {
                                                                                                                       ^
pkg/volume/testing/volume_host.go:338:103: undefined: VolumePlugin (typecheck)
func newFakeKubeletVolumeHost(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, pathToTypeMap map[string]hostutil.FileType, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) *fakeKubeletVolumeHost {
                                                                                                      ^
pkg/volume/testing/volume_host.go:348:20: undefined: VolumePluginMgr (typecheck)
        host.pluginMgr = &VolumePluginMgr{}
                          ^
pkg/volume/util/operationexecutor/operation_generator.go:37:2: "k8s.io/cloud-provider/volume/errors" imported as volerr and not used (typecheck)
        volerr "k8s.io/cloud-provider/volume/errors"
        ^
test/e2e/kubectl/kubectl.go:86:2: "k8s.io/utils/exec" imported as uexec and not used (typecheck)
        uexec "k8s.io/utils/exec"
        ^
test/e2e/node/apparmor.go:68:4: declared and not used: profile (typecheck)
                        profile := pod.Spec.SecurityContext.AppArmorProfile
                        ^
test/e2e/node/kubelet_perf.go:28:2: "k8s.io/kubelet/pkg/apis/stats/v1alpha1" imported as kubeletstatsv1alpha1 and not used (typecheck)
        kubeletstatsv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
        ^
test/e2e/node/kubelet_perf.go:244:51: missing type in composite literal (typecheck)
                                        kubeletstatsv1alpha1.SystemContainerKubelet: {0.50: 0.10, 0.95: 0.20},
                                                                                     ^
test/e2e/node/kubelet_perf.go:245:51: missing type in composite literal (typecheck)
                                        kubeletstatsv1alpha1.SystemContainerRuntime: {0.50: 0.10, 0.95: 0.20},
                                                                                     ^
test/e2e/node/kubelet_perf.go:255:51: missing type in composite literal (typecheck)
                                        kubeletstatsv1alpha1.SystemContainerKubelet: {0.50: 0.35, 0.95: 0.50},
                                                                                     ^
test/e2e/node/kubelet_perf.go:256:51: missing type in composite literal (typecheck)
                                        kubeletstatsv1alpha1.SystemContainerRuntime: {0.50: 0.10, 0.95: 0.50},
                                                                                     ^
test/e2e/storage/testsuites/volumemode.go:142:5: l.Volume undefined (type local has no field or method Volume) (typecheck)
                l.Volume = storageframework.CreateVolume(ctx, driver, l.config, pattern.VolType)
                  ^
test/e2e/storage/testsuites/volumemode.go:152:87: l.Volume undefined (type local has no field or method Volume) (typecheck)
                                pvSource, volumeNodeAffinity = pDriver.GetPersistentVolumeSource(false, fsType, l.Volume)
                                                                                                                  ^
test/e2e/storage/testsuites/volumemode.go:158:7: l.Sc undefined (type local has no field or method Sc) (typecheck)
                                l.Sc = storageClass
                                  ^
test/e2e/storage/testsuites/volumemode.go:159:7: l.Pv undefined (type local has no field or method Pv) (typecheck)
                                l.Pv = e2epv.MakePersistentVolume(pvConfig)
                                  ^
test/e2e/storage/testsuites/volumemode.go:160:7: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                l.Pvc = e2epv.MakePersistentVolumeClaim(pvcConfig, l.ns.Name)
                                  ^
test/e2e/storage/testsuites/volumemode.go:164:7: l.Sc undefined (type local has no field or method Sc) (typecheck)
                                l.Sc = dDriver.GetDynamicProvisionStorageClass(ctx, l.config, fsType)
                                  ^
test/e2e/storage/testsuites/volumemode.go:165:10: l.Sc undefined (type local has no field or method Sc) (typecheck)
                                if l.Sc == nil {
                                     ^
test/e2e/storage/testsuites/volumemode.go:168:7: l.Sc undefined (type local has no field or method Sc) (typecheck)
                                l.Sc.VolumeBindingMode = &volBindMode
                                  ^
test/e2e/storage/testsuites/volumemode.go:174:7: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                l.Pvc = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
                                  ^
test/e2e/storage/testsuites/volumemode.go:176:28: l.Sc undefined (type local has no field or method Sc) (typecheck)
                                        StorageClassName: &(l.Sc.Name),
                                                              ^
test/e2e/storage/testsuites/volumemode.go:187:25: l.CleanupResource undefined (type local has no field or method CleanupResource) (typecheck)
                errs = append(errs, l.CleanupResource(ctx))
                                      ^
test/e2e/storage/testsuites/volumemode.go:206:65: l.Sc undefined (type local has no field or method Sc) (typecheck)
                                l.Sc, err = l.cs.StorageV1().StorageClasses().Create(ctx, l.Sc, metav1.CreateOptions{})
                                                                                            ^
test/e2e/storage/testsuites/volumemode.go:210:65: l.Pv undefined (type local has no field or method Pv) (typecheck)
                                l.Pv, err = l.cs.CoreV1().PersistentVolumes().Create(ctx, l.Pv, metav1.CreateOptions{})
                                                                                            ^
test/e2e/storage/testsuites/volumemode.go:214:7: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                l.Pvc.Spec.VolumeName = l.Pv.Name
                                  ^
test/e2e/storage/testsuites/volumemode.go:215:80: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                l.Pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(ctx, l.Pvc, metav1.CreateOptions{})
                                                                                                           ^
test/e2e/storage/testsuites/volumemode.go:218:86: l.Pv undefined (type local has no field or method Pv) (typecheck)
                                framework.ExpectNoError(e2epv.WaitOnPVandPVC(ctx, l.cs, f.Timeouts, l.ns.Name, l.Pv, l.Pvc), "Failed to bind pv and pvc")
                                                                                                                 ^
test/e2e/storage/testsuites/volumemode.go:223:51: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                        PVCs:          []*v1.PersistentVolumeClaim{l.Pvc},
                                                                                     ^
test/e2e/storage/testsuites/volumemode.go:267:65: l.Sc undefined (type local has no field or method Sc) (typecheck)
                                l.Sc, err = l.cs.StorageV1().StorageClasses().Create(ctx, l.Sc, metav1.CreateOptions{})
                                                                                            ^
test/e2e/storage/testsuites/volumemode.go:271:80: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                l.Pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(ctx, l.Pvc, metav1.CreateOptions{})
                                                                                                           ^
test/e2e/storage/testsuites/volumemode.go:276:36: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                        "involvedObject.name":      l.Pvc.Name,
                                                                      ^
test/e2e/storage/testsuites/volumemode.go:290:76: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                                pvc, err := l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Get(ctx, l.Pvc.Name, metav1.GetOptions{})
                                                                                                       ^
test/e2e/storage/testsuites/volumemode.go:310:48: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                        PVCs:         []*v1.PersistentVolumeClaim{l.Pvc},
                                                                    ^
test/e2e/storage/testsuites/volumemode.go:367:48: l.Pvc undefined (type local has no field or method Pvc) (typecheck)
                        PVCs:         []*v1.PersistentVolumeClaim{l.Pvc},
                                                                    ^
test/e2e_node/checkpoint_container.go:32:2: "k8s.io/apimachinery/pkg/api/errors" imported as apierrors and not used (typecheck)
        apierrors "k8s.io/apimachinery/pkg/api/errors"
        ^
103 issues:
* typecheck: 103
INFO File cache stats: 20 entries of total size 733.4KiB 
INFO Memory: 374 samples, avg is 4527.6MB, max is 7420.5MB 
INFO Execution took 41.5951737s    
```

</details>

<details><summary>after</summary>


```console
$ ./golangci-lint run -v
INFO golangci-lint has version (devel) built with go1.24.3 from (751b9ca1972cd9a2b6de4de20a74dd281f970f5a, modified: true, mod sum: "") on 2025-06-19T12:16:25Z 
INFO [config_reader] Config search paths: [./ /home/ldez/sources/experimental/alingse-kubernetes /home/ldez/sources/experimental /home/ldez/sources /home/ldez /home /] 
INFO [config_reader] Used config file .golangci.yaml 
INFO [config_reader] Module name "k8s.io/kubernetes" 
INFO maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined 
INFO [goenv] Read go env for 2.092671ms: map[string]string{"GOCACHE":"/home/ldez/.cache/go-build", "GOROOT":"/home/ldez/.gvm/gos/go1.24.4"} 
INFO [lintersdb] Active 56 linters: [arangolint asasalint asciicheck bidichk bodyclose canonicalheader decorder depguard dupword durationcheck embeddedstructfieldcheck errcheck exptostd forbidigo ginkgolinter gocheckcompilerdirectives gochecksumtype gocyclo gofmt goheader gomodguard goprintffuncname govet grouper iface importas inamedparam ineffassign loggercheck makezero mirror misspell nilnesserr noinlineerr nosprintfhostport prealloc predeclared promlinter protogetter reassign revive sloglint spancheck sqlclosecheck staticcheck testableexamples testifylint thelper tparallel unconvert unparam usestdlibvars usetesting wastedassign whitespace zerologlint] 
INFO [loader] Go packages loading at mode 8767 (files|imports|types_sizes|compiled_files|deps|exports_file|name) took 1.229635705s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 164.095471ms 
INFO [linters_context] importas settings found, but no aliases listed. List aliases under alias: key. 
INFO [linters_context/goanalysis] analyzers took 6m38.105029559s with top 10 stages: buildir: 1m38.253806175s, revive: 22.913114595s, wastedassign: 11.192506979s, unconvert: 8.242703345s, inspect: 4.707992876s, ctrlflow: 4.573144635s, printf: 4.432678592s, unparam: 3.944422078s, buildssa: 3.759399962s, misspell: 3.685383046s 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gofmt"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gofmt"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gofmt"] 
INFO [runner] Issues before processing: 3918, after processing: 1 
INFO [runner] Processors filtering stat (in/out): cgo: 3918/3918, filename_unadjuster: 3918/3918, invalid_issue: 3918/1, max_per_file_from_linter: 1/1, source_code: 1/1, path_shortener: 1/1, sort_results: 1/1, path_relativity: 1/1, exclusion_rules: 1/1, path_prettifier: 1/1, path_absoluter: 3918/3918, exclusion_paths: 1/1, fixer: 1/1, max_from_linter: 1/1, generated_file_filter: 1/1, nolint_filter: 1/1, diff: 1/1, uniq_by_line: 1/1, max_same_issues: 1/1, severity-rules: 1/1 
INFO [runner] processing took 267.829µs with stages: cgo: 102.773µs, path_absoluter: 54.798µs, exclusion_rules: 37.561µs, source_code: 32.921µs, filename_unadjuster: 18.954µs, invalid_issue: 11.307µs, path_relativity: 1.873µs, sort_results: 1.442µs, uniq_by_line: 1.409µs, path_shortener: 971ns, max_same_issues: 883ns, nolint_filter: 766ns, max_from_linter: 560ns, exclusion_paths: 312ns, generated_file_filter: 285ns, fixer: 268ns, diff: 266ns, path_prettifier: 211ns, max_per_file_from_linter: 202ns, severity-rules: 67ns 
INFO [runner] linters took 12.550995603s with stages: goanalysis_metalinter: 12.550677273s 
pkg/features/kube_features_test.go:19:1: expected 'package', found 'import' (typecheck)
import (
^
1 issues:
* typecheck: 1
INFO File cache stats: 1 entries of total size 3.3KiB 
INFO Memory: 141 samples, avg is 2003.9MB, max is 4186.0MB 
INFO Execution took 13.949797867s   
```

</details>
