### PR TITLE
assets/formatters: update the GCI documentation

### DIFF
--- a/assets/formatters-info.json
+++ b/assets/formatters-info.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "gci",
-    "desc": "Checks if code and import statements are formatted, with additional rules.",
+    "desc": "Checks if import statements are deterministically sorted.",
     "Groups": null,
     "loadMode": 8199,
     "originalURL": "https://github.com/daixiang0/gci",


### PR DESCRIPTION
The `gci` tool does not format code - it only ensures that import blocks are formatted deterministically, according to the configuration. The previous documentation blurb looks like it may have been copy-pasted from some of the other formatter docs, and was misleading at best.
