### PR TITLE
assets/formatters: update the GCI documentation

### DIFF
--- a/assets/formatters-info.json
+++ b/assets/formatters-info.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "gci",
-    "desc": "Checks if code and import statements are formatted, with additional rules.",
+    "desc": "Checks if import statements are deterministically sorted.",
     "Groups": null,
     "loadMode": 8199,
     "originalURL": "https://github.com/daixiang0/gci",


### PR DESCRIPTION
The `gci` tool does not format code - it only ensures that import blocks are formatted deterministically, according to the configuration. The previous documentation blurb looks like it may have been copy-pasted from some of the other formatter docs, and was misleading at best.

@ldez  please do not close this ... see the proof:

Just using `gci` does NOT format Go source files:

```
$ cat .golangci.yaml 
version: "2"
formatters:
  enable:
    - gci
  settings:
    gci:
      custom-order: true
      sections:
        - standard
        - default
        - prefix(k8s.io)
        - prefix(sigs.k8s.io)
        - prefix(github.com/Azure)
        - blank
        - dot
$ go tool golangci-lint fmt
$ git diff
$ go fmt ./...
pkg/config/ev2config/sanitizer/sanitizedconfig.go
pkg/types/resourcegroup.go
pkg/types/shell.go
```

Adding `gofmt` DOES:

```
$ cat .golangci.yaml 
version: "2"
formatters:
  enable:
    - gci
    - gofmt
  settings:
    gci:
      custom-order: true
      sections:
        - standard
        - default
        - prefix(k8s.io)
        - prefix(sigs.k8s.io)
        - prefix(github.com/Azure)
        - blank
        - dot
$ go tool golangci-lint fmt
$ git diff
diff --git a/.golangci.yaml b/.golangci.yaml
index fef60b0..6878cbb 100644
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@ version: "2"
 formatters:
   enable:
     - gci
+    - gofmt
   settings:
     gci:
       custom-order: true
diff --git a/pkg/config/ev2config/sanitizer/sanitizedconfig.go b/pkg/config/ev2config/sanitizer/sanitizedconfig.go
index 110a582..b479265 100644
--- a/pkg/config/ev2config/sanitizer/sanitizedconfig.go
+++ b/pkg/config/ev2config/sanitizer/sanitizedconfig.go
@@ -10,8 +10,8 @@ type SanitizedCloudConfig struct {
 }
 
 type SanitizedCloudConfigValues struct {
-       CloudName string `json:"cloudName"`
-       KeyVault KeyVaultValues `json:"keyVault"`
+       CloudName string         `json:"cloudName"`
+       KeyVault  KeyVaultValues `json:"keyVault"`
 }
 
 type KeyVaultValues struct {
diff --git a/pkg/types/resourcegroup.go b/pkg/types/resourcegroup.go
index 4076e95..dc83dc6 100644
--- a/pkg/types/resourcegroup.go
+++ b/pkg/types/resourcegroup.go
@@ -18,8 +18,8 @@ import "fmt"
 
 // ResourceGroup represents the resourcegroup containing all steps
 type ResourceGroup struct {
-       Name         string               `json:"name"`
-       Subscription string `json:"subscription"`
+       Name                     string                    `json:"name"`
+       Subscription             string                    `json:"subscription"`
        SubscriptionProvisioning *SubscriptionProvisioning `json:"subscriptionProvisioning,omitempty"`
        // Deprecated: AKSCluster to be removed
        AKSCluster string `json:"aksCluster,omitempty"`
diff --git a/pkg/types/shell.go b/pkg/types/shell.go
index c061617..baec86d 100644
--- a/pkg/types/shell.go
+++ b/pkg/types/shell.go
@@ -26,7 +26,7 @@ type ShellStep struct {
        DryRun        DryRun      `json:"dryRun,omitempty"`
        References    []Reference `json:"references,omitempty"`
        SubnetId      string      `json:"subnetId,omitempty"`
-       ShellIdentity Value    `json:"shellIdentity,omitempty"`
+       ShellIdentity Value       `json:"shellIdentity,omitempty"`
 }
 
 // Reference represents a configurable reference
```