### PR TITLE
fix: formats consistently the code with gci

### DIFF
--- a/pkg/goformatters/gci/gci.go
+++ b/pkg/goformatters/gci/gci.go
@@ -2,6 +2,7 @@ package gci
 
 import (
 	"context"
+	"go/format"
 
 	gcicfg "github.com/daixiang0/gci/pkg/config"
 	"github.com/daixiang0/gci/pkg/gci"
@@ -60,5 +61,14 @@ func (*Formatter) Name() string {
 
 func (f *Formatter) Format(filename string, src []byte) ([]byte, error) {
 	_, formatted, err := gci.LoadFormat(src, filename, *f.config)
-	return formatted, err
+	if err != nil {
+		return nil, err
+	}
+
+	// gci format the code only when the imports are modified,
+	// this produced inconsistencies.
+	// To be always consistent, the code should always be formatted.
+	// https://github.com/daixiang0/gci/blob/c4f689991095c0e54843dca76fb9c3bad58ec5c7/pkg/gci/gci.go#L148-L151
+	// https://github.com/daixiang0/gci/blob/c4f689991095c0e54843dca76fb9c3bad58ec5c7/pkg/gci/gci.go#L215
+	return format.Source(formatted)
 }


### PR DESCRIPTION

<details><summary>This code will be formatted</summary>

```go
package main

import (
	"fmt"

	"os"
)

type Foo struct {
Value string
}
```

</details>


<details><summary>This code will NOT be formatted</summary>

```go
package main

type Foo struct {
Value string
}
```

</details>

The code is formatted only if the imports are updated by `gci`.

This is not consistent.
