### PR TITLE
feat: Clear analysis cache when running custom command

### DIFF
--- a/pkg/commands/custom.go
+++ b/pkg/commands/custom.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/golangci/golangci-lint/v2/internal/cache"
 	"github.com/golangci/golangci-lint/v2/pkg/commands/internal"
 	"github.com/golangci/golangci-lint/v2/pkg/logutils"
 )
@@ -55,6 +56,14 @@ func (c *customCommand) preRunE(_ *cobra.Command, _ []string) error {
 }
 
 func (c *customCommand) runE(cmd *cobra.Command, _ []string) error {
+	// Clear cache before building custom version
+	cacheDir := cache.DefaultDir()
+	if err := os.RemoveAll(cacheDir); err != nil {
+		c.log.Warnf("Failed to clear cache: %v", err)
+	} else {
+		c.log.Infof("Cache cleared: %s", cacheDir)
+	}
+
 	tmp, err := os.MkdirTemp(os.TempDir(), "custom-gcl")
 	if err != nil {
 		return fmt.Errorf("create temporary directory: %w", err)


### PR DESCRIPTION
## Overview
This PR adds automatic cache clearing when running the custom command to prevent outdated cache results from affecting the behavior.

## Changes
- Added cache directory removal in the runE method of custom.go
- Added appropriate log messages for successful/failed cache clearing

## Reason
When using the custom command, the linter itself is being modified with custom plugins or configurations. In this scenario, previously cached analysis results become invalid and can lead to incorrect linting results or unexpected behavior. 

By ensuring a fresh start with a clean cache directory for each custom build, we guarantee that the analysis results accurately reflect the current state of the modified linter, providing more consistent and reliable results.
