### PR TITLE
docs: point towards goimports when autofixing perfsprint

### DIFF
--- a/assets/linters-info.json
+++ b/assets/linters-info.json
@@ -744,7 +744,7 @@
   },
   {
     "name": "perfsprint",
-    "desc": "Checks that fmt.Sprintf can be replaced with a faster alternative.",
+    "desc": "Checks if fmt.Sprintf and the like can be replaced with a faster alternative.\nSome autofixes made by this linter may need followup import fixups, see the goimports formatter.",
     "Groups": null,
     "loadMode": 8767,
     "originalURL": "https://github.com/catenacyber/perfsprint",


### PR DESCRIPTION
I recently found out that perfsprint autofixes can break code because it does not fix imports, and that not fixing them is actually a request from here: https://github.com/catenacyber/perfsprint/issues/19

I think it would be good to mention this in docs. Not sure what's the best way, but here's one.