### PR TITLE
Add pkgname linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -97,6 +97,7 @@ linters:
     - nosprintfhostport
     - paralleltest
     - perfsprint
+    - pkgname
     - prealloc
     - predeclared
     - promlinter
@@ -207,6 +208,7 @@ linters:
     - nosprintfhostport
     - paralleltest
     - perfsprint
+    - pkgname
     - prealloc
     - predeclared
     - promlinter
@@ -2091,6 +2093,11 @@ linters:
       # Enable/disable optimization of hex formatting.
       # Default: true
       hex-format: false
+
+    pkgname:
+      # Include import alias in checks.
+      # Default: false
+      import-alias: true
 
     prealloc:
       # IMPORTANT: we don't recommend using this linter before doing performance profiling.

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	github.com/ultraware/whitespace v0.2.0
 	github.com/uudashr/gocognit v1.2.0
 	github.com/uudashr/iface v1.4.0
+	github.com/uudashr/pkgname v1.0.0
 	github.com/valyala/quicktemplate v1.8.0
 	github.com/xen0n/gosmopolitan v1.3.0
 	github.com/yagipy/maintidx v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,8 @@ github.com/uudashr/gocognit v1.2.0 h1:3BU9aMr1xbhPlvJLSydKwdLN3tEUUrzPSSM8S4hDYR
 github.com/uudashr/gocognit v1.2.0/go.mod h1:k/DdKPI6XBZO1q7HgoV2juESI2/Ofj9AcHPZhBBdrTU=
 github.com/uudashr/iface v1.4.0 h1:ImZ+1oEJPXvjap7nK0md7gA9RRH7PMp4vliaLkJ2+cg=
 github.com/uudashr/iface v1.4.0/go.mod h1:i/H4cfRMPe0izticV8Yz0g6/zcsh5xXlvthrdh1kqcY=
+github.com/uudashr/pkgname v1.0.0 h1:SupGD3U97Jr/TDGhXBOmNV7o4R/f/U0L3d2LLPfuqGQ=
+github.com/uudashr/pkgname v1.0.0/go.mod h1:n74Zn6wf+7TkLnErNsB9Yeq18zhn84rtBzFR0xRbJoQ=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/quicktemplate v1.8.0 h1:zU0tjbIqTRgKQzFY1L42zq0qR3eh4WoQQdIdqCysW5k=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1512,6 +1512,17 @@
             }
           }
         },
+        "pkgnameSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "import-alias": {
+              "description": "Include import alias in the checks.",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
         "goconstSettings": {
           "type": "object",
           "additionalProperties": false,
@@ -4522,6 +4533,9 @@
             },
             "perfsprint": {
               "$ref": "#/definitions/settings/definitions/perfsprintSettings"
+            },
+            "pkgname": {
+              "$ref": "#/definitions/settings/definitions/pkgnameSettings"
             },
             "prealloc": {
               "$ref": "#/definitions/settings/definitions/preallocSettings"

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -259,6 +259,7 @@ type LintersSettings struct {
 	NoNamedReturns           NoNamedReturnsSettings           `mapstructure:"nonamedreturns"`
 	ParallelTest             ParallelTestSettings             `mapstructure:"paralleltest"`
 	PerfSprint               PerfSprintSettings               `mapstructure:"perfsprint"`
+	Pkgname                  PkgnameSettings                  `mapstructure:"pkgname"`
 	Prealloc                 PreallocSettings                 `mapstructure:"prealloc"`
 	Predeclared              PredeclaredSettings              `mapstructure:"predeclared"`
 	Promlinter               PromlinterSettings               `mapstructure:"promlinter"`
@@ -736,6 +737,10 @@ type PerfSprintSettings struct {
 
 	BoolFormat bool `mapstructure:"bool-format"`
 	HexFormat  bool `mapstructure:"hex-format"`
+}
+
+type PkgnameSettings struct {
+	ImportAlias bool `mapstructure:"import-alias"`
 }
 
 type PreallocSettings struct {

--- a/pkg/golinters/pkgname/pkgname.go
+++ b/pkg/golinters/pkgname/pkgname.go
@@ -1,0 +1,22 @@
+package pkgname
+
+import (
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+	"github.com/uudashr/pkgname"
+)
+
+func New(settings *config.PkgnameSettings) *goanalysis.Linter {
+	var cfg map[string]any
+
+	if settings != nil {
+		cfg = map[string]any{
+			"include-import-alias": settings.ImportAlias,
+		}
+	}
+
+	return goanalysis.
+		NewLinterFromAnalyzer(pkgname.Analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/pkgname/pkgname_integration_test.go
+++ b/pkg/golinters/pkgname/pkgname_integration_test.go
@@ -1,0 +1,11 @@
+package pkgname
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/pkgname/testdata/importalias.go
+++ b/pkg/golinters/pkgname/testdata/importalias.go
@@ -1,0 +1,15 @@
+//golangcitest:args -Epkgname
+//golangcitest:config_path importalias.yml
+package hello
+
+import (
+	go_format "fmt" // want "found import 'fmt' with alias 'go_format', should not use under_score in package alias name"
+	"log"
+	structLog "log/slog" // want "found import 'log/slog' with alias 'structLog', should not use mixedCaps in package alias name"
+)
+
+func Hello() {
+	go_format.Println("Hello, World!")
+	structLog.Info("Hello, World!")
+	log.Println("Hello, World!")
+}

--- a/pkg/golinters/pkgname/testdata/importalias.yml
+++ b/pkg/golinters/pkgname/testdata/importalias.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    pkgname:
+      import-alias: true

--- a/pkg/golinters/pkgname/testdata/mixedcaps.go
+++ b/pkg/golinters/pkgname/testdata/mixedcaps.go
@@ -1,0 +1,3 @@
+//golangcitest:args -Epkgname
+
+package helloWorld // want "found package 'helloWorld', should not use mixedCaps in package name"

--- a/pkg/golinters/pkgname/testdata/underscore.go
+++ b/pkg/golinters/pkgname/testdata/underscore.go
@@ -1,0 +1,2 @@
+//golangcitest:args -Epkgname
+package hello_world // want "found package 'hello_world', should not use under_score in package name"

--- a/pkg/golinters/pkgname/testdata/underscore_cgo.go
+++ b/pkg/golinters/pkgname/testdata/underscore_cgo.go
@@ -1,0 +1,22 @@
+//golangcitest:args -Epkgname
+package hello_world // want "found package 'hello_world', should not use under_score in package name"
+
+/*
+ #include <stdio.h>
+ #include <stdlib.h>
+
+ void myprint(char* s) {
+ 	printf("%d\n", s);
+ }
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+func _() {
+	cs := C.CString("Hello from stdio\n")
+	C.myprint(cs)
+	C.free(unsafe.Pointer(cs))
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -85,6 +85,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nosprintfhostport"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/paralleltest"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/perfsprint"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/pkgname"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/prealloc"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/predeclared"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/promlinter"
@@ -536,6 +537,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithAutoFix().
 			WithURL("https://github.com/catenacyber/perfsprint"),
+
+		linter.NewConfig(pkgname.New(&cfg.Linters.Settings.Pkgname)).
+			WithSince("v2.2.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/uudashr/pkgname"),
 
 		linter.NewConfig(prealloc.New(&cfg.Linters.Settings.Prealloc)).
 			WithSince("v1.19.0").


### PR DESCRIPTION
Add [pkgname](https://github.com/uudashr/pkgname) linter.

This linter encourage us to follow Go idiomatic package name.

[The Go Blog: Package names](https://go.dev/blog/package-names#package-names)
> Good package names are short and clear. They are lower case, with no under_scores or mixedCaps. ...

[The Go Blog: Package names](https://go.dev/blog/package-names#package-names)
> The style of names typical of another language might not be idiomatic in a Go program. Here are two examples of names that might be good style in other languages but do not fit well in Go:
> 
> - `computeServiceClient`
> - `priority_queue`

[Effective Go - Package names](https://go.dev/doc/effective_go#package-names)

> By convention, packages are given lower case, single-word names; there should be no need for underscores or mixedCaps. ...
