### PR TITLE
dev: add suggested migration for linter configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -191,7 +191,11 @@ linters:
       - path: pkg/lint/lintersdb/builder_linter.go
         text: "SA1019: wsl.NewV4 is deprecated: use NewV5 instead."
         linters:
-        - staticcheck
+          - staticcheck
+      - path: pkg/golinters/wsl/wsl.go
+        text: "SA1019: config.WSLv4Settings is deprecated: use WSLv5Settings instead."
+        linters:
+          - staticcheck
 
 formatters:
   enable:

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -430,6 +430,17 @@ func (c *runCommand) printDeprecatedLinterMessages(enabledLinters map[string]*li
 		}
 
 		c.log.Warnf("The linter '%s' is deprecated (since %s) due to: %s %s", name, lc.Deprecation.Since, lc.Deprecation.Message, extra)
+
+		if lc.Deprecation.ConfigSuggestion != nil {
+			suggestion, err := lc.Deprecation.ConfigSuggestion()
+			if err != nil {
+				c.log.Errorf("New configuration suggestion error: %v", err)
+			}
+
+			if suggestion != "" {
+				c.log.Warnf("Suggested new configuration:\n%s", suggestion)
+			}
+		}
 	}
 }
 

--- a/pkg/golinters/wsl/wsl.go
+++ b/pkg/golinters/wsl/wsl.go
@@ -1,10 +1,14 @@
 package wsl
 
 import (
+	"slices"
+
 	wslv4 "github.com/bombsimon/wsl/v4"
+	wslv5 "github.com/bombsimon/wsl/v5"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 )
 
 // Deprecated: use NewV5 instead.
@@ -34,4 +38,68 @@ func NewV4(settings *config.WSLv4Settings) *goanalysis.Linter {
 	return goanalysis.
 		NewLinterFromAnalyzer(wslv4.NewAnalyzer(conf)).
 		WithLoadMode(goanalysis.LoadModeSyntax)
+}
+
+// Only used the set YAML struct tags.
+type v5YAML struct {
+	AllowFirstInBlock bool     `yaml:"allow-first-in-block"`
+	AllowWholeBlock   bool     `yaml:"allow-whole-block"`
+	BranchMaxLines    int      `yaml:"branch-max-lines,omitempty"`
+	CaseMaxLines      int      `yaml:"case-max-lines,omitempty"`
+	Enable            []string `yaml:"enable,omitempty"`
+	Disable           []string `yaml:"disable,omitempty"`
+}
+
+func Migration(old *config.WSLv4Settings) any {
+	if old == nil {
+		return nil
+	}
+
+	cfg := v5YAML{
+		AllowFirstInBlock: true,
+		AllowWholeBlock:   false,
+		BranchMaxLines:    2,
+		CaseMaxLines:      old.ForceCaseTrailingWhitespaceLimit,
+	}
+
+	if !old.StrictAppend {
+		cfg.Disable = append(cfg.Disable, wslv5.CheckAppend.String())
+	}
+
+	if old.AllowAssignAndAnythingCuddle {
+		cfg.Disable = append(cfg.Disable, wslv5.CheckAssign.String())
+	}
+
+	if old.AllowMultiLineAssignCuddle {
+		internal.LinterLogger.Warnf("`allow-multiline-assign` is deprecated and always allowed in wsl >= v5")
+	}
+
+	if old.AllowTrailingComment {
+		internal.LinterLogger.Warnf("`allow-trailing-comment` is deprecated and always allowed in wsl >= v5")
+	}
+
+	if old.AllowSeparatedLeadingComment {
+		internal.LinterLogger.Warnf("`allow-separated-leading-comment` is deprecated and always allowed in wsl >= v5")
+	}
+
+	if old.AllowCuddleDeclaration {
+		cfg.Disable = append(cfg.Disable, wslv5.CheckDecl.String())
+	}
+
+	if old.ForceCuddleErrCheckAndAssign {
+		cfg.Enable = append(cfg.Enable, wslv5.CheckErr.String())
+	}
+
+	if old.ForceExclusiveShortDeclarations {
+		cfg.Enable = append(cfg.Enable, wslv5.CheckAssignExclusive.String())
+	}
+
+	if !old.AllowAssignAndCallCuddle {
+		cfg.Enable = append(cfg.Enable, wslv5.CheckAssignExpr.String())
+	}
+
+	slices.Sort(cfg.Enable)
+	slices.Sort(cfg.Disable)
+
+	return cfg
 }

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -692,7 +692,8 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithURL("https://github.com/tomarrell/wrapcheck"),
 
 		linter.NewConfig(wsl.NewV4(&cfg.Linters.Settings.WSL)).
-			DeprecatedWarning("new major version.", "v2.2.0", "wsl_v5").
+			DeprecatedWarning("new major version.", "v2.2.0",
+				linter.Replacement("wsl_v5", wsl.Migration, &cfg.Linters.Settings.WSL)).
 			WithSince("v1.20.0").
 			WithAutoFix().
 			WithURL("https://github.com/bombsimon/wsl"),


### PR DESCRIPTION
The goal is to display a suggested migration configuration when running golangci-lint.

~~The code related to the command `migrate` is ambiguous due to the difference between the default values of v4 and v5.~~
Edit: I removed the part related to the `migrate` command because I'm not fully happy with the approach.