### PR TITLE
dev: fix GitHub Action assets generation

### DIFF
--- a/assets/github-action-config-v1.json
+++ b/assets/github-action-config-v1.json
@@ -196,7 +196,7 @@
       "Error": "golangci-lint version 'v2.1' isn't supported: only v1 versions are supported"
     },
     "v2.2": {
-      "Error": "golangci-lint version 'v2.1' isn't supported: only v1 versions are supported"
+      "Error": "golangci-lint version 'v2.2' isn't supported: only v1 versions are supported"
     }
   }
 }

--- a/assets/github-action-config.json
+++ b/assets/github-action-config.json
@@ -196,7 +196,7 @@
       "Error": "golangci-lint version 'v2.1' isn't supported: only v1 versions are supported"
     },
     "v2.2": {
-      "Error": "golangci-lint version 'v2.1' isn't supported: only v1 versions are supported"
+      "Error": "golangci-lint version 'v2.2' isn't supported: only v1 versions are supported"
     }
   }
 }

--- a/scripts/gen_github_action_config/main.go
+++ b/scripts/gen_github_action_config/main.go
@@ -103,7 +103,7 @@ func fetchAllReleases(ctx context.Context) ([]release, error) {
 					EndCursor   githubv4.String
 					HasNextPage bool
 				}
-			} `graphql:"releases(first: 100, orderBy: { field: CREATED_AT, direction: DESC }, after: $releasesCursor)"`
+			} `graphql:"releases(first: 80, orderBy: { field: CREATED_AT, direction: DESC }, after: $releasesCursor)"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 


### PR DESCRIPTION
The current releases size used inside the query creates a 504 (and I don't know why).

It was failing during the 3 latest releases (so I updated the files manually).
https://github.com/golangci/golangci-lint/actions/workflows/post-release.yml

Reducing this size fixes the 504 problem, and doesn't change the result as we iterate over the cursor.