### PR TITLE
docs: add the command to check the Go version used to build

### DIFF
--- a/docs/src/docs/welcome/faq.mdx
+++ b/docs/src/docs/welcome/faq.mdx
@@ -44,7 +44,7 @@ If there are `typecheck` errors, golangci-lint will not be able to produce other
 
 How to troubleshoot:
 
-- [ ] Ensure the version of golangci-lint is built with a compatible version of Go.
+- [ ] Ensure the version of golangci-lint is built with a compatible version of Go (`golangci-lint version`).
 - [ ] Ensure dependencies are up to date with `go mod tidy`.
 - [ ] Ensure building works with `go run ./...`/`go build ./...` - whole package.
 - [ ] Ensure you are not running an analysis on code that depends on files/packages outside the scope of the analyzed elements.


### PR DESCRIPTION
Adds the command line to check the Go version used to build golangci-lint. 