### PR TITLE
fix: skip type check in ExclusionPaths Processor

### DIFF
--- a/pkg/result/processors/exclusion_paths.go
+++ b/pkg/result/processors/exclusion_paths.go
@@ -73,7 +73,7 @@ func (p *ExclusionPaths) Process(issues []*result.Issue) ([]*result.Issue, error
 		return issues, nil
 	}
 
-	return filterIssues(issues, p.shouldPassIssue), nil
+	return filterIssuesUnsafe(issues, p.shouldPassIssue), nil
 }
 
 func (p *ExclusionPaths) Finish() {


### PR DESCRIPTION
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
In the scenario of exclusion.paths, we should skip all checks, including typecheck. For example, some legacy code.