### PR TITLE
docs: fix tutorial URL

### DIFF
--- a/docs/src/docs/contributing/new-linters.mdx
+++ b/docs/src/docs/contributing/new-linters.mdx
@@ -4,7 +4,7 @@ title: New linters
 
 ## How to write a linter
 
-Use `go/analysis` and take a look at [this tutorial](https://disaev.me/p/writing-useful-go-analysis-linter/):
+Use `go/analysis` and take a look at [this tutorial](https://web.archive.org/web/20250527152107/https://disaev.me/p/writing-useful-go-analysis-linter/):
 it shows how to write `go/analysis` linter from scratch and integrate it into `golangci-lint`.
 
 ## How to add a public linter to `golangci-lint`


### PR DESCRIPTION
Fixes #5924

Uses the Wayback Machine for now.
In the future, I think I will write a new tutorial.