### PR TITLE
fix: panic: close of closed channel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,7 @@ require (
 	go.augendre.info/fatcontext v0.8.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/mod v0.26.0
+	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.34.0
 	golang.org/x/tools v0.34.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -213,7 +214,6 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
-	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/pkg/goanalysis/runner_action.go
+++ b/pkg/goanalysis/runner_action.go
@@ -34,6 +34,7 @@ func (act *action) waitUntilDependingAnalyzersWorked(ctx context.Context, stopCh
 		if dep.Package == act.Package {
 			select {
 			case <-stopChan:
+				return
 			case <-ctx.Done():
 				return
 			case <-dep.analysisDoneCh:

--- a/pkg/goanalysis/runner_action.go
+++ b/pkg/goanalysis/runner_action.go
@@ -1,6 +1,7 @@
 package goanalysis
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 
@@ -28,11 +29,12 @@ func (actAlloc *actionAllocator) alloc() *action {
 	return act
 }
 
-func (act *action) waitUntilDependingAnalyzersWorked(stopChan chan struct{}) {
+func (act *action) waitUntilDependingAnalyzersWorked(ctx context.Context, stopChan chan struct{}) {
 	for _, dep := range act.Deps {
 		if dep.Package == act.Package {
 			select {
 			case <-stopChan:
+			case <-ctx.Done():
 				return
 			case <-dep.analysisDoneCh:
 			}

--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -1,6 +1,7 @@
 package goanalysis
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -84,14 +85,16 @@ func (lp *loadingPackage) analyze(stopChan chan struct{}, loadMode LoadMode, loa
 		return
 	}
 
-	var actsWg errgroup.Group
+	actsWg, ctx := errgroup.WithContext(context.Background())
 
 	for _, act := range lp.actions {
 		actsWg.Go(func() error {
-			act.waitUntilDependingAnalyzersWorked(stopChan)
+			act.waitUntilDependingAnalyzersWorked(ctx, stopChan)
 
 			select {
 			case <-stopChan:
+				return nil
+			case <-ctx.Done():
 				return nil
 			default:
 			}


### PR DESCRIPTION
I tested the PR with a huge cycle of thousands of runs with typecheck error on 3 projects.

This neither changes the report from the previous PR nor the performance from the previous PR.
It closes the channel after the actions analysis instead of during the actions analysis.

Fixes #5923
