### PR TITLE
Add clearslice linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -137,6 +137,7 @@ linters:
     - bidichk
     - bodyclose
     - canonicalheader
+    - clearslice
     - containedctx
     - contextcheck
     - copyloopvar

--- a/go.mod
+++ b/go.mod
@@ -127,6 +127,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0
 	github.com/yeya24/promlinter v0.3.0
 	github.com/ykadowak/zerologlint v0.1.5
+	github.com/zcross/clearslice v0.1.0
 	gitlab.com/bosi/decorder v0.4.2
 	go-simpler.org/musttag v0.13.1
 	go-simpler.org/sloglint v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -619,6 +619,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zcross/clearslice v0.1.0 h1:EYEvp637q7Gixj69NC7g5WEL14cDjQSqI0/t0D/k6i8=
+github.com/zcross/clearslice v0.1.0/go.mod h1:xt3Wddpt03BV1Ins+sVRUx4LhqiEYX8eja0CXK6GFpc=
 gitlab.com/bosi/decorder v0.4.2 h1:qbQaV3zgwnBZ4zPMhGLW4KZe7A7NwxEhJx39R3shffo=
 gitlab.com/bosi/decorder v0.4.2/go.mod h1:muuhHoaJkA9QLcYHq4Mj8FJUwDZ+EirSHRiaTcTf6T8=
 go-simpler.org/assert v0.9.0 h1:PfpmcSvL7yAnWyChSjOz6Sp6m9j5lyK8Ok9pEL31YkQ=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -755,6 +755,7 @@
             "bidichk",
             "bodyclose",
             "canonicalheader",
+            "clearslice",
             "containedctx",
             "contextcheck",
             "copyloopvar",

--- a/pkg/golinters/clearslice/clearslice.go
+++ b/pkg/golinters/clearslice/clearslice.go
@@ -1,0 +1,18 @@
+package clearslice
+
+import (
+	clearslice "github.com/zcross/clearslice/analyzer"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	a := clearslice.NewAnalyzer()
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*analysis.Analyzer{a},
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/clearslice/clearslice_integration_test.go
+++ b/pkg/golinters/clearslice/clearslice_integration_test.go
@@ -1,0 +1,19 @@
+package clearslice
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}
+
+func TestFix(t *testing.T) {
+	integration.RunFix(t)
+}
+
+func TestFixPathPrefix(t *testing.T) {
+	integration.RunFixPathPrefix(t)
+}

--- a/pkg/golinters/clearslice/testdata/clearslice.go
+++ b/pkg/golinters/clearslice/testdata/clearslice.go
@@ -1,0 +1,181 @@
+//golangcitest:args -Eclearslice
+package simple
+
+import (
+	"fmt"
+	"slices"
+)
+
+type ReferenceAliasTypeA string
+type ReferenceAliasTypeB *int
+type PrimitiveAliasType float64
+
+type FlatStruct struct {
+	Field1 int
+	Field2 float64
+	Field3 bool
+}
+
+type NestedFlatStruct struct {
+	ThingOne FlatStruct
+	ThingTwo FlatStruct
+}
+
+type FlatLookingStructWithSlice struct {
+	Flats []FlatStruct
+}
+
+type ReferenceHoldingStruct struct {
+	Field1 *FlatStruct
+}
+
+type ReferenceHoldingStructUnexported struct {
+	field1 *FlatStruct
+}
+
+type NestedRefStruct struct {
+	Refs []ReferenceHoldingStruct
+}
+
+type NestedRefStructUnexported struct {
+	refs []ReferenceHoldingStruct
+}
+
+type SomeThingWithFlatSliceMember struct {
+	Flats []FlatStruct
+}
+
+func _() {
+	// Safe: slice of primitive types (int)
+	s := []int{1, 2, 3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of primitive types (float)
+	s := []float64{1.1, 2.2, 3.3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of struct free of reference types
+	s := []FlatStruct{{1, 1.1, true}, {2, 2.2, false}}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of struct free of reference types
+	s := []NestedFlatStruct{
+		{ThingOne: FlatStruct{1, 1.1, true}, ThingTwo: FlatStruct{2, 2.2, false}},
+	}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct that has a slice field (even if slice elements do not contain references)
+	s := []FlatLookingStructWithSlice{
+		{Flats: []FlatStruct{{1, 1.1, true}, {2, 2.2, false}}},
+	}
+	s = s[:0] // want `slice s of type .*\.FlatLookingStructWithSlice is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of alias types that are not reference types
+	s := []PrimitiveAliasType{1.1, 2.2, 3.3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of alias types that are reference types
+	s := []ReferenceAliasTypeA{"a", "b", "c"}
+	s = s[:0] // want `slice s of type .*\.ReferenceAliasTypeA is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of alias types that are reference types
+	s := []ReferenceAliasTypeB{new(int), new(int)}
+	s = s[:0] // want `slice s of type .*\.ReferenceAliasTypeB is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having top level exported fields of reference types
+	s := []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}
+	s = s[:0] // want `slice s of type .*\.ReferenceHoldingStruct is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having unexported fields of reference types
+	s := []ReferenceHoldingStructUnexported{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}
+	s = s[:0] // want `slice s of type .*\.ReferenceHoldingStructUnexported is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having nested slices of structs with reference types
+	s := []NestedRefStruct{{Refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}}}
+	s = s[:0] // want `slice s of type .*\.NestedRefStruct is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having nested slices of structs with unexported reference types
+	s := []NestedRefStructUnexported{{refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}}}
+	s = s[:0] // want `slice s of type .*\.NestedRefStructUnexported is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of strings
+	s := []string{"a", "b", "c"}
+	s = s[:0] // want `slice s of type string is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of pointers to primitive types
+	s := make([]*int, 0, 5)
+	s = s[:0] // want `slice s of type \*int is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: the slice is a member of a struct, but its own elements do not contain references
+	o := &SomeThingWithFlatSliceMember{
+		Flats: []FlatStruct{{1, 1.1, true}},
+	}
+	o.Flats = o.Flats[:0]
+	fmt.Printf("%+v\n", o)
+}
+
+func _() {
+	// Unsafe: the slice is a member of a struct, and its own elements do contain references
+	o := &NestedRefStructUnexported{
+		refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}},
+	}
+	o.refs = o.refs[:0] // want `slice o.refs of type .*\.ReferenceHoldingStruct is resized to zero length without clearing elements`
+	fmt.Printf("%+v\n", o)
+}
+
+func _() {
+	// Safe pattern that may be prevalent in existing code: clear() directly preceding length adjustment
+	s := []*int{new(int), new(int)}
+	clear(s)
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Recommended pattern: use slices.Delete(s, 0, len(s)) to clear elements up to length
+	s := []*int{new(int), new(int)}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}

--- a/pkg/golinters/clearslice/testdata/fix/in/simple.go
+++ b/pkg/golinters/clearslice/testdata/fix/in/simple.go
@@ -1,0 +1,182 @@
+//golangcitest:args -Eclearslice
+//golangcitest:expected_exitcode 0
+package simple
+
+import (
+	"fmt"
+	"slices"
+)
+
+type ReferenceAliasTypeA string
+type ReferenceAliasTypeB *int
+type PrimitiveAliasType float64
+
+type FlatStruct struct {
+	Field1 int
+	Field2 float64
+	Field3 bool
+}
+
+type NestedFlatStruct struct {
+	ThingOne FlatStruct
+	ThingTwo FlatStruct
+}
+
+type FlatLookingStructWithSlice struct {
+	Flats []FlatStruct
+}
+
+type ReferenceHoldingStruct struct {
+	Field1 *FlatStruct
+}
+
+type ReferenceHoldingStructUnexported struct {
+	field1 *FlatStruct
+}
+
+type NestedRefStruct struct {
+	Refs []ReferenceHoldingStruct
+}
+
+type NestedRefStructUnexported struct {
+	refs []ReferenceHoldingStruct
+}
+
+type SomeThingWithFlatSliceMember struct {
+	Flats []FlatStruct
+}
+
+func _() {
+	// Safe: slice of primitive types (int)
+	s := []int{1, 2, 3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of primitive types (float)
+	s := []float64{1.1, 2.2, 3.3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of struct free of reference types
+	s := []FlatStruct{{1, 1.1, true}, {2, 2.2, false}}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of struct free of reference types
+	s := []NestedFlatStruct{
+		{ThingOne: FlatStruct{1, 1.1, true}, ThingTwo: FlatStruct{2, 2.2, false}},
+	}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct that has a slice field (even if slice elements do not contain references)
+	s := []FlatLookingStructWithSlice{
+		{Flats: []FlatStruct{{1, 1.1, true}, {2, 2.2, false}}},
+	}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of alias types that are not reference types
+	s := []PrimitiveAliasType{1.1, 2.2, 3.3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of alias types that are reference types
+	s := []ReferenceAliasTypeA{"a", "b", "c"}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of alias types that are reference types
+	s := []ReferenceAliasTypeB{new(int), new(int)}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having top level exported fields of reference types
+	s := []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having unexported fields of reference types
+	s := []ReferenceHoldingStructUnexported{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having nested slices of structs with reference types
+	s := []NestedRefStruct{{Refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}}}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having nested slices of structs with unexported reference types
+	s := []NestedRefStructUnexported{{refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}}}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of strings
+	s := []string{"a", "b", "c"}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of pointers to primitive types
+	s := make([]*int, 0, 5)
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: the slice is a member of a struct, but its own elements do not contain references
+	o := &SomeThingWithFlatSliceMember{
+		Flats: []FlatStruct{{1, 1.1, true}},
+	}
+	o.Flats = o.Flats[:0]
+	fmt.Printf("%+v\n", o)
+}
+
+func _() {
+	// Unsafe: the slice is a member of a struct, and its own elements do contain references
+	o := &NestedRefStructUnexported{
+		refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}},
+	}
+	o.refs = o.refs[:0]
+	fmt.Printf("%+v\n", o)
+}
+
+func _() {
+	// Safe pattern that may be prevalent in existing code: clear() directly preceding length adjustment
+	s := []*int{new(int), new(int)}
+	clear(s)
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Recommended pattern: use slices.Delete(s, 0, len(s)) to clear elements up to length
+	s := []*int{new(int), new(int)}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}

--- a/pkg/golinters/clearslice/testdata/fix/out/simple.go
+++ b/pkg/golinters/clearslice/testdata/fix/out/simple.go
@@ -1,0 +1,182 @@
+//golangcitest:args -Eclearslice
+//golangcitest:expected_exitcode 0
+package simple
+
+import (
+	"fmt"
+	"slices"
+)
+
+type ReferenceAliasTypeA string
+type ReferenceAliasTypeB *int
+type PrimitiveAliasType float64
+
+type FlatStruct struct {
+	Field1 int
+	Field2 float64
+	Field3 bool
+}
+
+type NestedFlatStruct struct {
+	ThingOne FlatStruct
+	ThingTwo FlatStruct
+}
+
+type FlatLookingStructWithSlice struct {
+	Flats []FlatStruct
+}
+
+type ReferenceHoldingStruct struct {
+	Field1 *FlatStruct
+}
+
+type ReferenceHoldingStructUnexported struct {
+	field1 *FlatStruct
+}
+
+type NestedRefStruct struct {
+	Refs []ReferenceHoldingStruct
+}
+
+type NestedRefStructUnexported struct {
+	refs []ReferenceHoldingStruct
+}
+
+type SomeThingWithFlatSliceMember struct {
+	Flats []FlatStruct
+}
+
+func _() {
+	// Safe: slice of primitive types (int)
+	s := []int{1, 2, 3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of primitive types (float)
+	s := []float64{1.1, 2.2, 3.3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of struct free of reference types
+	s := []FlatStruct{{1, 1.1, true}, {2, 2.2, false}}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of struct free of reference types
+	s := []NestedFlatStruct{
+		{ThingOne: FlatStruct{1, 1.1, true}, ThingTwo: FlatStruct{2, 2.2, false}},
+	}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct that has a slice field (even if slice elements do not contain references)
+	s := []FlatLookingStructWithSlice{
+		{Flats: []FlatStruct{{1, 1.1, true}, {2, 2.2, false}}},
+	}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: slice of alias types that are not reference types
+	s := []PrimitiveAliasType{1.1, 2.2, 3.3}
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of alias types that are reference types
+	s := []ReferenceAliasTypeA{"a", "b", "c"}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of alias types that are reference types
+	s := []ReferenceAliasTypeB{new(int), new(int)}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having top level exported fields of reference types
+	s := []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having unexported fields of reference types
+	s := []ReferenceHoldingStructUnexported{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having nested slices of structs with reference types
+	s := []NestedRefStruct{{Refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}}}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of struct having nested slices of structs with unexported reference types
+	s := []NestedRefStructUnexported{{refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}}}}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of strings
+	s := []string{"a", "b", "c"}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Unsafe: slice of pointers to primitive types
+	s := make([]*int, 0, 5)
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Safe: the slice is a member of a struct, but its own elements do not contain references
+	o := &SomeThingWithFlatSliceMember{
+		Flats: []FlatStruct{{1, 1.1, true}},
+	}
+	o.Flats = o.Flats[:0]
+	fmt.Printf("%+v\n", o)
+}
+
+func _() {
+	// Unsafe: the slice is a member of a struct, and its own elements do contain references
+	o := &NestedRefStructUnexported{
+		refs: []ReferenceHoldingStruct{{&FlatStruct{1, 1.1, true}}, {&FlatStruct{2, 2.2, false}}},
+	}
+	o.refs = slices.Delete(o.refs, 0, len(o.refs))
+	fmt.Printf("%+v\n", o)
+}
+
+func _() {
+	// Safe pattern that may be prevalent in existing code: clear() directly preceding length adjustment
+	s := []*int{new(int), new(int)}
+	clear(s)
+	s = s[:0]
+	fmt.Printf("%+v\n", s)
+}
+
+func _() {
+	// Recommended pattern: use slices.Delete(s, 0, len(s)) to clear elements up to length
+	s := []*int{new(int), new(int)}
+	s = slices.Delete(s, 0, len(s))
+	fmt.Printf("%+v\n", s)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/bidichk"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/bodyclose"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/canonicalheader"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/clearslice"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/containedctx"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/contextcheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/copyloopvar"
@@ -172,6 +173,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.44.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/sivchari/containedctx"),
+
+		linter.NewConfig(clearslice.New()).
+			WithSince("v2.3.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/zcross/clearslice"),
 
 		linter.NewConfig(contextcheck.New()).
 			WithSince("v1.43.0").


### PR DESCRIPTION
Adding [clearslice](https://github.com/zcross/clearslice) linter.

Motivation: Naive detection of slice reuse patterns that might lead to longer object liveness, potentially contributing to unnecessary longer or indefinite object retention. For a better-written (and visualized) explanation, see [Robust generic functions on slices](https://go.dev/blog/generic-slice-functions) from The Go Blog

Example:
```
type someHotPathProcessor struct {
  itemsToProcess []string
}

func processTick() {
  doWork(itemsToProcess)
  itemsToProcess = itemsToProcess[:0]
}
```

Recommended replacement:
```
type someHotPathProcessor struct {
  itemsToProcess []string
}

func processTick() {
  doWork(itemsToProcess)
  itemsToProcess = slices.Delete(itemsToProcess, 0, len(itemsToProcess))
}
```

This is my first golangci-lint linter contribution, so here are my attempts to minimize annoyance for users (ei.e,. false positives)
* Recognize when `x = x[:0]` pattern is immediately preceded by a `clear(x)` and do not fail lint
* Recognize when slice elements are strictly primitive types (or structs of strictly primitive fields, recursively)
* PR this in disabled-by-default state, allowing people to opt-in if interested
* Provide working fix option that uses simple same-line one-liner replacement
    *  (`x = x[:0]` -> `x = slices.Delete(x, 0, len(x))`

And some potential discussion points:
* `slices.Delete(x, 0, N)` is indeed O(N) due to the iteration+zeroing work done, just like `clear()`. 
    * This fix can provide peace of mind but one can imagine consciously dropping `//nolint` ignores in code that is explicitly aware of the risk and/or is actually structurally safe (beyond what the naive linter can recognize).
* Given the linter's fix suggestion only holds for Go ≥ 1.22, is it reasonable to associate that minimum version with this linter rather than attempting to provide multiline fix suggestions (e.g., preceding `clear()` when on an older Go)
* I've not written many analyzers outside of very simple ones. Would it be feasible to do escape analysis or something like it to determine when a slice allocated in a given scope does not escape that scope, even if said slice is used repeatedly in said scope with the length-only resizing pattern? 