### PR TITLE
fix: panic: close of closed channel

### DIFF
--- a/pkg/goanalysis/runner_action.go
+++ b/pkg/goanalysis/runner_action.go
@@ -29,12 +29,10 @@ func (actAlloc *actionAllocator) alloc() *action {
 	return act
 }
 
-func (act *action) waitUntilDependingAnalyzersWorked(ctx context.Context, stopChan chan struct{}) {
+func (act *action) waitUntilDependingAnalyzersWorked(ctx context.Context) {
 	for _, dep := range act.Deps {
 		if dep.Package == act.Package {
 			select {
-			case <-stopChan:
-				return
 			case <-ctx.Done():
 				return
 			case <-dep.analysisDoneCh:


### PR DESCRIPTION
I used a global cancellable `context` because `cancel` is concurrency safe (and so can be called several times).

The background of the problem is the fact of having go routines inside go routines inside go routines.

I think I will rewrite this section at some point.

---

To reproduce, I replaced `Next` with a non-existent method `Foo`.

```bash
git clone https://github.com/NVIDIA/aistore.git
git checkout 7730e4290
```

```diff
diff --git i/cmd/cli/cli/lhotse.go w/cmd/cli/cli/lhotse.go
index 1a13987aa..c16e0b1a2 100644
--- i/cmd/cli/cli/lhotse.go
+++ w/cmd/cli/cli/lhotse.go
@@ -262,7 +262,7 @@ func lhotseMultiBatch(c *cli.Context, outCtx *mossReqParseCtx) error {
                // when batch is full
                if len(currentBatch) >= outCtx.batchSize {
                        // Get next filename from template
-                       shardName, hasNext := outCtx.pt.Next()
+                       shardName, hasNext := outCtx.pt.Foo()
                        if !hasNext {
                                return fmt.Errorf("template exhausted at batch %d (generated %d batches so far)", totalBatches+1, totalBatches)
                        }
```


---

Fixes #5938
Related to #5929, #5923
