### PR TITLE
Add safebigint linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -105,6 +105,7 @@ linters:
     - recvcheck
     - revive
     - rowserrcheck
+    - safebigint
     - sloglint
     - spancheck
     - sqlclosecheck
@@ -2770,6 +2771,14 @@ linters:
       # Default: []
       packages:
         - github.com/jmoiron/sqlx
+
+    safebigint:
+      # Check for calls to Uint64() and Int64() which have undefined behavior
+      # when the object contains a value that doesn't fit in those types.
+      disable-truncation-check: true
+      # Check for shared object mutation where the first argument is also the
+      # method receiver.
+      disable-mutation-check: true
 
     sloglint:
       # Enforce not mixing key-value pairs and attributes.

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/uudashr/gocognit v1.2.0
 	github.com/uudashr/iface v1.4.1
 	github.com/valyala/quicktemplate v1.8.0
+	github.com/winder/safebigint v0.1.0
 	github.com/xen0n/gosmopolitan v1.3.0
 	github.com/yagipy/maintidx v1.0.0
 	github.com/yeya24/promlinter v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/quicktemplate v1.8.0 h1:zU0tjbIqTRgKQzFY1L42zq0qR3eh4WoQQdIdqCysW5k=
 github.com/valyala/quicktemplate v1.8.0/go.mod h1:qIqW8/igXt8fdrUln5kOSb+KWMaJ4Y8QUsfd1k6L2jM=
+github.com/winder/safebigint v0.1.0 h1:41Div4Zq9rO2GqHZmZuNvvhjHbvAOQjQ0OBHTLmpkSk=
+github.com/winder/safebigint v0.1.0/go.mod h1:aadkBB9QeRX8qqomqwVfgkLC335aYmzwCOOWQ1oLu+8=
 github.com/xen0n/gosmopolitan v1.3.0 h1:zAZI1zefvo7gcpbCOrPSHJZJYA9ZgLfJqtKzZ5pHqQM=
 github.com/xen0n/gosmopolitan v1.3.0/go.mod h1:rckfr5T6o4lBtM1ga7mLGKZmLxswUoH1zxHgNXOsEt4=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -137,6 +137,10 @@ var defaultLintersSettings = LintersSettings{
 	Predeclared: PredeclaredSettings{
 		Qualified: false,
 	},
+	SafeBigInt: SafeBigIntSettings{
+		DisableTruncationCheck: true,
+		DisableMutationCheck:   true,
+	},
 	SlogLint: SlogLintSettings{
 		NoMixedArgs:    true,
 		KVOnly:         false,
@@ -276,6 +280,7 @@ type LintersSettings struct {
 	Recvcheck                RecvcheckSettings                `mapstructure:"recvcheck"`
 	Revive                   ReviveSettings                   `mapstructure:"revive"`
 	RowsErrCheck             RowsErrCheckSettings             `mapstructure:"rowserrcheck"`
+	SafeBigInt               SafeBigIntSettings               `mapstructure:"safebigint"`
 	SlogLint                 SlogLintSettings                 `mapstructure:"sloglint"`
 	Spancheck                SpancheckSettings                `mapstructure:"spancheck"`
 	Staticcheck              StaticCheckSettings              `mapstructure:"staticcheck"`
@@ -808,6 +813,11 @@ type ReviveDirective struct {
 
 type RowsErrCheckSettings struct {
 	Packages []string `mapstructure:"packages"`
+}
+
+type SafeBigIntSettings struct {
+	DisableTruncationCheck bool `mapstructure:"enable-truncation-check"`
+	DisableMutationCheck   bool `mapstructure:"enable-mutation-check"`
 }
 
 type SlogLintSettings struct {

--- a/pkg/golinters/safebigint/safebigint.go
+++ b/pkg/golinters/safebigint/safebigint.go
@@ -1,0 +1,26 @@
+package safebigint
+
+import (
+	"github.com/winder/safebigint"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
+)
+
+func New(settings *config.SafeBigIntSettings) *goanalysis.Linter {
+	cfg := safebigint.LinterSettings{}
+	if settings != nil {
+		cfg.EnableTruncationCheck = !settings.DisableTruncationCheck
+		cfg.EnableMutationCheck = !settings.DisableMutationCheck
+	}
+
+	analyzer, err := safebigint.NewAnalyzer(cfg)
+	if err != nil {
+		internal.LinterLogger.Fatalf("safebigint: new analyzer: %v", err)
+	}
+
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/safebigint/testdata/safebigint_helpers.go
+++ b/pkg/golinters/safebigint/testdata/safebigint_helpers.go
@@ -1,0 +1,38 @@
+package safebigint
+
+import (
+	"math/big"
+)
+
+func unsupportedExpr() {
+	// will be parsed but won't match selector expression unless it's in a call
+	_ = big.NewInt(1).Add(big.NewInt(1), big.NewInt(2))
+	_ = 123 // Still might not run unless passed to call
+}
+
+func literalArg(x *big.Int) {
+	x.Add(big.NewInt(1), nil) // nil → getReferencedObject(nil) → default case
+}
+
+func noUses() {
+	var x *big.Int
+	x.BitLen()     // x is declared, but `TypesInfo.Uses[x]` may be nil
+	_ = x.BitLen() // x used but not as selector.X — this may resolve to nil in TypesInfo.Uses
+}
+
+func callWithCompositeExpr() {
+	// This expression is a *big.Int but not an Ident or SelectorExpr
+	_ = []*big.Int{big.NewInt(1)}[0].Uint64()
+}
+
+type myInt int
+
+func checkLocalNamed() {
+	var x *myInt
+	_ = x
+}
+
+func notASelector() {
+	f := func() {}
+	f() // call.Fun is an Ident, not a SelectorExpr
+}

--- a/pkg/golinters/safebigint/testdata/safebigint_mutation_check.go
+++ b/pkg/golinters/safebigint/testdata/safebigint_mutation_check.go
@@ -1,0 +1,99 @@
+package safebigint
+
+import "math/big"
+
+func safeMutation() {
+	x := big.NewInt(1)
+	y := big.NewInt(2)
+	z := big.NewInt(3)
+
+	// Valid: receiver is different from args
+	x.Add(y, z)
+
+	// Unrelated method
+	x.BitLen()
+
+	// Struct selector field (should not match big.Int directly)
+	type wrapper struct{ b *big.Int }
+	var w wrapper
+	w.b = big.NewInt(5)
+	w.b.Add(y, z)
+}
+
+func mixedArgs() {
+	x := big.NewInt(1)
+	x.Add(nil, nil) // nil arg — getReferencedObject will return nil
+}
+
+func notAMutation() {
+	x := big.NewInt(1)
+	_ = x.BitLen() // triggers checkForMutation, skips early
+}
+
+type customBig struct{}
+
+func (c *customBig) Add(x, y *customBig) {} // shadowing method
+
+func sharedMutationCases() {
+	// Unsafe: receiver is same as first argument
+	a := big.NewInt(10)
+	b := big.NewInt(2)
+	a.Add(a, b) // want "shared-object mutation: calling Add with receiver also passed as argument"
+
+	// Unsafe: receiver is reused in both argument slots
+	c := big.NewInt(5)
+	c.Mul(c, c) // want "shared-object mutation: calling Mul with receiver also passed as argument"
+
+	// Unsafe: alias of receiver
+	x := big.NewInt(100)
+	y := x
+	x.Sub(x, y) // want "shared-object mutation: calling Sub with receiver also passed as argument"
+
+	// Unsafe: even with three args
+	e := big.NewInt(3)
+	e.Exp(e, e, nil) // want "shared-object mutation: calling Exp with receiver also passed as argument"
+
+	// Safe: all different
+	f := big.NewInt(2)
+	g := big.NewInt(3)
+	h := big.NewInt(4)
+	f.Add(g, h) // OK
+
+	// Safe: non-mutating method
+	result := new(big.Int)
+	xor := new(big.Int)
+	yor := new(big.Int)
+	result.Xor(xor, yor) // OK
+
+	// Safe: unrelated type with similar method name
+	var custom customBig
+	custom.Add(&custom, &custom) // OK
+
+	// Unsafe: reassigned variable
+	m := big.NewInt(10)
+	n := m
+	n.And(n, m) // want "shared-object mutation: calling And with receiver also passed as argument"
+
+	// Unsafe: all arguments are the same variable
+	q := big.NewInt(7)
+	q.Mod(q, q) // want "shared-object mutation: calling Mod with receiver also passed as argument"
+
+	// Safe: selector field on different variable
+	type S struct{ x *big.Int }
+	var s S
+	s.x = big.NewInt(20)
+	other := big.NewInt(5)
+	s.x.Add(other, other) // OK
+}
+
+func unsafeMutation() {
+	x := big.NewInt(1)
+	x.Add(x, big.NewInt(2)) // want "shared-object mutation: calling Add with receiver also passed as argument"
+	x.Mul(x, x)             // want "shared-object mutation: calling Mul with receiver also passed as argument"
+
+	y := x
+	x.Sub(x, y) // want "shared-object mutation: calling Sub with receiver also passed as argument"
+
+	z := big.NewInt(5)
+	z.Exp(z, z, nil) // want "shared-object mutation: calling Exp with receiver also passed as argument"
+}

--- a/pkg/golinters/safebigint/testdata/safebigint_truncation_check.go
+++ b/pkg/golinters/safebigint/testdata/safebigint_truncation_check.go
@@ -1,0 +1,38 @@
+package safebigint
+
+import (
+	"math/big"
+)
+
+type myBigInt struct{}
+
+func (m *myBigInt) Uint64() uint64 { return 42 } // Should NOT trigger
+
+func safeConversion(b *big.Int) uint64 {
+	if b.Cmp(big.NewInt(0)) < 0 {
+		return 0
+	}
+	return b.Uint64() // want "calling Uint64 on \\*big.Int may silently truncate or overflow"
+}
+
+func testMixed() {
+	x := big.NewInt(123)
+	_ = x.Uint64() // want "calling Uint64 on \\*big.Int may silently truncate or overflow"
+
+	_ = x.BitLen() // not a truncating method
+
+	y := new(myBigInt)
+	_ = y.Uint64() // OK: user-defined type
+}
+
+func testIgnore() {
+	var i int
+	_ = uint64(i) // OK: not big.Int
+}
+
+func otherTruncationExamples() {
+	b := big.NewInt(123456789)
+
+	_ = b.Uint64() // want "calling Uint64 on \\*big.Int may silently truncate or overflow"
+	_ = b.Int64()  // want "calling Int64 on \\*big.Int may silently truncate or overflow"
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -93,6 +93,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/recvcheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/revive"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/rowserrcheck"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/safebigint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/sloglint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/spancheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/sqlclosecheck"
@@ -575,6 +576,12 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.23.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/jingyugao/rowserrcheck"),
+
+		linter.NewConfig(safebigint.New(&cfg.Linters.Settings.SafeBigInt)).
+			WithSince("v2.3.0").
+			WithLoadForGoAnalysis().
+			WithAutoFix().
+			WithURL("https://github.com/winder/safebigint"),
 
 		linter.NewConfig(sloglint.New(&cfg.Linters.Settings.SlogLint)).
 			WithSince("v1.55.0").


### PR DESCRIPTION
[safebigint](https://github.com/winder/safebigint) checks for potential misuse of the `math/big` package, in particular the `Uint64()` and `Int64()` functions which silently truncate numbers which don't fit in the returned type.