### PR TITLE
feat: add `notag` linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -95,6 +95,7 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
+    - notag
     - paralleltest
     - perfsprint
     - prealloc
@@ -206,6 +207,7 @@ linters:
     - nolintlint
     - nonamedreturns
     - nosprintfhostport
+    - notag
     - paralleltest
     - perfsprint
     - prealloc
@@ -2056,6 +2058,9 @@ linters:
       # Report named error if it is assigned inside defer.
       # Default: false
       report-error-in-defer: true
+
+    notag:
+      denied: "json"
 
     paralleltest:
       # Ignore missing calls to `t.Parallel()` and only report incorrect uses of it.

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/gordonklaus/ineffassign v0.1.0
 	github.com/gostaticanalysis/forcetypeassert v0.2.0
 	github.com/gostaticanalysis/nilerr v0.1.1
+	github.com/guerinoni/notag v1.0.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/jgautheron/goconst v1.8.2
 	github.com/jingyugao/rowserrcheck v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,8 @@ github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.5.0 h1:Dq4wT1DdTwTGCQQv3rl3IvD5Ld0E6HiY+3Zh0sUGqw8=
 github.com/gostaticanalysis/testutil v0.5.0/go.mod h1:OLQSbuM6zw2EvCcXTz1lVq5unyoNft372msDY0nY5Hs=
+github.com/guerinoni/notag v1.0.0 h1:TtGYXYorgwZEI6iYUgqu58Hagk9KqFYNFCCNf9L7nIk=
+github.com/guerinoni/notag v1.0.0/go.mod h1:vTEwA6I/5gvT7EnsBQE9jXizj14ywiAxRxzXuzuy0Gw=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fUvGGCwJfdASSzbrfo=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0/go.mod h1:hgdqLXA4f6NIjRVisM1TJ9aOJVNRqKZj+xDGF6m7PBw=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -825,6 +825,7 @@
             "nolintlint",
             "nonamedreturns",
             "nosprintfhostport",
+            "notag",
             "paralleltest",
             "perfsprint",
             "prealloc",

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -266,6 +266,7 @@ type LintersSettings struct {
 	Nlreturn                 NlreturnSettings                 `mapstructure:"nlreturn"`
 	NoLintLint               NoLintLintSettings               `mapstructure:"nolintlint"`
 	NoNamedReturns           NoNamedReturnsSettings           `mapstructure:"nonamedreturns"`
+	NoTag                    NoTagSettings                    `mapstructure:"notag"`
 	ParallelTest             ParallelTestSettings             `mapstructure:"paralleltest"`
 	PerfSprint               PerfSprintSettings               `mapstructure:"perfsprint"`
 	Prealloc                 PreallocSettings                 `mapstructure:"prealloc"`
@@ -707,6 +708,12 @@ type NilNilSettings struct {
 
 type NlreturnSettings struct {
 	BlockSize int `mapstructure:"block-size"`
+}
+
+type NoTagSettings struct {
+	Denied        string            `mapstructure:"denied"`
+	DeniedPkg     map[string]string `mapstructure:"denied-pkg"`
+	DeniedPkgPath map[string]string `mapstructure:"denied-pkg-path"`
 }
 
 type MndSettings struct {

--- a/pkg/golinters/notag/notag.go
+++ b/pkg/golinters/notag/notag.go
@@ -1,0 +1,18 @@
+package notag
+
+import (
+	"github.com/guerinoni/notag/pkg/analyzer"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New(settings *config.NoTagSettings) *goanalysis.Linter {
+	c := analyzer.Setting{
+		GlobalTagsDenied: settings.Denied,
+		Pkg:              settings.DeniedPkg,
+		PkgPath:          settings.DeniedPkgPath,
+	}
+	a := analyzer.NewAnalyzerWithConfig(c)
+	return goanalysis.NewLinterFromAnalyzer(a)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -83,6 +83,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nolintlint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nonamedreturns"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nosprintfhostport"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/notag"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/paralleltest"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/perfsprint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/prealloc"
@@ -525,6 +526,10 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		linter.NewConfig(nosprintfhostport.New()).
 			WithSince("v1.46.0").
 			WithURL("https://github.com/stbenjam/no-sprintf-host-port"),
+
+		linter.NewConfig(notag.New(&cfg.Linters.Settings.NoTag)).
+			WithSince("next_version").
+			WithURL("https://github.com/guerinoni/notag"),
 
 		linter.NewConfig(paralleltest.New(&cfg.Linters.Settings.ParallelTest)).
 			WithSince("v1.33.0").


### PR DESCRIPTION
This add a new linter notag https://github.com/guerinoni/notag, which is able
to warn you about usage of tags in structs.
It can catches tags globally, by pkg name or by pkg path.

This is tested against this repo changing the config `.golangci.yml`
with this options
```
    notag:
      denied: "db"
      denied-pkg:
        - printers: xml
      denied-pkg-path:
        - github.com/golangci/golangci-lint/v2/pkg/config: validate
```

And the output looks ok.

Other tests are in the main repository.
