### PR TITLE
staticcheck: allow empty options

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -838,7 +838,7 @@ type StaticCheckSettings struct {
 }
 
 func (s *StaticCheckSettings) HasConfiguration() bool {
-	return len(s.Initialisms) > 0 || len(s.HTTPStatusCodeWhitelist) > 0 || len(s.DotImportWhitelist) > 0 || len(s.Checks) > 0
+	return s.Initialisms == nil || s.HTTPStatusCodeWhitelist == nil || s.DotImportWhitelist == nil || s.Checks == nil
 }
 
 type TagAlignSettings struct {

--- a/pkg/golinters/staticcheck/staticcheck.go
+++ b/pkg/golinters/staticcheck/staticcheck.go
@@ -79,19 +79,19 @@ func createConfig(settings *config.StaticCheckSettings) *scconfig.Config {
 		HTTPStatusCodeWhitelist: settings.HTTPStatusCodeWhitelist,
 	}
 
-	if len(cfg.Checks) == 0 {
+	if cfg.Checks == nil {
 		cfg.Checks = defaultChecks
 	}
 
-	if len(cfg.Initialisms) == 0 {
+	if cfg.Initialisms == nil {
 		cfg.Initialisms = append(cfg.Initialisms, scconfig.DefaultConfig.Initialisms...)
 	}
 
-	if len(cfg.DotImportWhitelist) == 0 {
+	if cfg.DotImportWhitelist == nil {
 		cfg.DotImportWhitelist = append(cfg.DotImportWhitelist, scconfig.DefaultConfig.DotImportWhitelist...)
 	}
 
-	if len(cfg.HTTPStatusCodeWhitelist) == 0 {
+	if cfg.HTTPStatusCodeWhitelist == nil {
 		cfg.HTTPStatusCodeWhitelist = append(cfg.HTTPStatusCodeWhitelist, scconfig.DefaultConfig.HTTPStatusCodeWhitelist...)
 	}
 

--- a/pkg/golinters/staticcheck/testdata/stylecheck_empty.go
+++ b/pkg/golinters/staticcheck/testdata/stylecheck_empty.go
@@ -1,0 +1,15 @@
+//golangcitest:args -Estaticcheck
+//golangcitest:config_path testdata/stylecheck_empty.yml
+package testdata
+
+import "net/http"
+
+func _() {
+	http.StatusText(200) // want "ST1013: should use constant http.StatusOK instead of numeric literal 200"
+	http.StatusText(400) // want "ST1013: should use constant http.StatusBadRequest instead of numeric literal 400"
+	http.StatusText(404) // want "ST1013: should use constant http.StatusNotFound instead of numeric literal 404"
+	http.StatusText(418) // want "ST1013: should use constant http.StatusTeapot instead of numeric literal 418"
+	http.StatusText(500) // want "ST1013: should use constant http.StatusInternalServerError instead of numeric literal 500"
+	http.StatusText(503) // want "ST1013: should use constant http.StatusServiceUnavailable instead of numeric literal 503"
+	http.StatusText(600)
+}

--- a/pkg/golinters/staticcheck/testdata/stylecheck_empty.yml
+++ b/pkg/golinters/staticcheck/testdata/stylecheck_empty.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      checks: ["ST1013"]
+      http-status-code-whitelist: [ ]

--- a/pkg/golinters/staticcheck/testdata/stylecheck_nil.go
+++ b/pkg/golinters/staticcheck/testdata/stylecheck_nil.go
@@ -1,0 +1,15 @@
+//golangcitest:args -Estaticcheck
+//golangcitest:config_path testdata/stylecheck_nil.yml
+package testdata
+
+import "net/http"
+
+func _() {
+	http.StatusText(200)
+	http.StatusText(400)
+	http.StatusText(404)
+	http.StatusText(418) // want "ST1013: should use constant http.StatusTeapot instead of numeric literal 418"
+	http.StatusText(500)
+	http.StatusText(503) // want "ST1013: should use constant http.StatusServiceUnavailable instead of numeric literal 503"
+	http.StatusText(600)
+}

--- a/pkg/golinters/staticcheck/testdata/stylecheck_nil.yml
+++ b/pkg/golinters/staticcheck/testdata/stylecheck_nil.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      checks: ["ST1013"]


### PR DESCRIPTION
With the staticcheck configuration, an option nil or empty should not produce the same behavior.
