### PR TITLE
dev: improve search index

### DIFF
--- a/docs/layouts/_partials/utils/extract-headings.html
+++ b/docs/layouts/_partials/utils/extract-headings.html
@@ -1,0 +1,31 @@
+{{/*
+Extracts all headings from a page and adds them to the scratchpad.
+
+The keys can be obtained from the scratchpad by using the "keys" key.
+The titles can be obtained from the scratchpad by using the "titles" key.
+
+The scratchpad must be initialized with empty slices before calling this function for the keys "keys" and "titles"
+
+@param {any} target The element to extract headings from.
+@param {any} scratch The scratchpad to add the keys and titles to.
+
+@example {{ partial "utils/extract-headings.html" (dict "target" $h1 "scratch" $s) }}
+*/}}
+
+{{ range $heading := index .target.Headings }}
+  {{ if and (eq $heading.Level 0) (not $heading.Title) }}
+    {{ $.scratch.Add "keys" (slice $heading.Title) }}
+  {{ else }}
+    {{ $key := (printf "%s#%s" $heading.ID $heading.Title) }}
+    {{ $.scratch.Add "keys" (slice $key) }}
+  {{ end }}
+
+  {{ $title := (printf "<h%d>%s" $heading.Level $heading.Title) }}
+  {{ $.scratch.Add "titles" (slice $title) }}
+
+  {{ partial "utils/extract-headings.html" (dict
+    "target" $heading
+    "scratch" $.scratch
+    )
+  }}
+{{ end }}

--- a/docs/layouts/_partials/utils/fragments.html
+++ b/docs/layouts/_partials/utils/fragments.html
@@ -3,22 +3,14 @@
 {{ $page := .context }}
 {{ $type := .type | default "content" }}
 
-{{ $headingKeys := slice }}
-{{ $headingTitles := slice }}
+{{ $s := newScratch }}
+{{ $s.Set "keys" slice }}
+{{ $s.Set "titles" slice }}
 
-{{ range $h1 := $page.Fragments.Headings }}
-  {{ if eq $h1.Title "" }}
-    {{ $headingKeys = $headingKeys | append $h1.Title }}
-  {{ else }}
-    {{ $headingKeys = $headingKeys | append (printf "%s#%s" $h1.ID $h1.Title) }}
-  {{ end }}
-  {{ $headingTitles = $headingTitles | append (printf "<h1>%s" $h1.Title) }}
+{{ partial "utils/extract-headings.html" (dict "target" $page.Fragments "scratch" $s) }}
 
-  {{ range $h2 := $h1.Headings }}
-    {{ $headingKeys = $headingKeys | append (printf "%s#%s" $h2.ID $h2.Title) }}
-    {{ $headingTitles = $headingTitles | append (printf "<h2>%s" $h2.Title) }}
-  {{ end }}
-{{ end }}
+{{ $headingKeys := $s.Get "keys" }}
+{{ $headingTitles := $s.Get "titles" }}
 
 {{ $content := $page.Content | htmlUnescape }}
 {{ $len := len $headingKeys }}


### PR DESCRIPTION
Parse all headings to retrieve the precise section, not the parent, when heading > h2.

I submitted the PR to the upstream with this approach https://github.com/imfing/hextra/pull/740