### PR TITLE
docs: fix filter bar items

### DIFF
--- a/docs/content/docs/formatters/_index.md
+++ b/docs/content/docs/formatters/_index.md
@@ -25,12 +25,11 @@ golangci-lint formatters
 
 ## All formatters
 
-<div class="hx-mt-6">
-    {{< icon "filter" >}}
-    {{< clickable-badge icon="fire" id="new-filter" content="New" class="gl-filter hx-cursor-pointer" type="warning" border=false >}}
-    {{< clickable-badge icon="emoji-sad" id="deprecated-filter" content="Deprecated" class="gl-filter hx-cursor-pointer" type="info" border=false >}}
-    {{< clickable-badge icon="trash" id="reset-filter" content="Reset" class="gl-filter-reset gl-hidden hx-cursor-pointer" type="error" border=true >}}
-</div>
+{{< filter-bar >}}
+    {{< clickable-badge class="gl-filter" id="new-filter" icon="fire" content="New" type="warning" >}}
+    {{< clickable-badge class="gl-filter" id="deprecated-filter" icon="emoji-sad" content="Deprecated" type="info" >}}
+    {{< clickable-badge class="gl-filter-reset gl-hidden" id="reset-filter" icon="trash" content="Reset" type="error" border=true >}}
+{{< /filter-bar >}}
 
 {{< cards >}}
     {{< item-cards path="formatters" data="formatters_info" >}}

--- a/docs/content/docs/linters/_index.md
+++ b/docs/content/docs/linters/_index.md
@@ -25,16 +25,15 @@ golangci-lint linters
 
 ## All Linters
 
-<div class="hx-mt-6">
-    {{< icon "filter" >}}
-    {{< clickable-badge icon="inbox" id="default-filter" content="Default" class="gl-filter hx-cursor-pointer" type="info" border=false >}}
-    {{< clickable-badge icon="fire" id="new-filter" content="New" class="gl-filter hx-cursor-pointer" type="warning" border=false >}}
-    {{< clickable-badge icon="sparkles" id="autofix-filter" content="Autofix" class="gl-filter hx-cursor-pointer" type="info" border=false >}}
-    {{< clickable-badge icon="fast-forward" id="fast-filter" content="Fast" class="gl-filter hx-cursor-pointer" border=false >}}
-    {{< clickable-badge icon="play" id="slow-filter" content="Slow" class="gl-filter hx-cursor-pointer" border=false >}}
-    {{< clickable-badge icon="emoji-sad" id="deprecated-filter" content="Deprecated" class="gl-filter hx-cursor-pointer" type="info" border=false >}}
-    {{< clickable-badge icon="trash" id="reset-filter" content="Reset" class="gl-filter-reset gl-hidden hx-cursor-pointer" type="error" border=true >}}
-</div>
+{{< filter-bar >}}
+    {{< clickable-badge class="gl-filter" id="default-filter" icon="inbox" content="Default" type="info" >}}
+    {{< clickable-badge class="gl-filter" id="new-filter" icon="fire" content="New" type="warning" >}}
+    {{< clickable-badge class="gl-filter" id="autofix-filter" icon="sparkles" content="Autofix" type="info" >}}
+    {{< clickable-badge class="gl-filter" id="fast-filter" icon="fast-forward" content="Fast" >}}
+    {{< clickable-badge class="gl-filter" id="slow-filter" icon="play" content="Slow" >}}
+    {{< clickable-badge class="gl-filter" id="deprecated-filter" icon="emoji-sad" content="Deprecated" type="info" >}}
+    {{< clickable-badge class="gl-filter-reset gl-hidden" icon="trash" id="reset-filter" content="Reset" type="error" border=true >}}
+{{< /filter-bar >}}
 
 {{< cards >}}
     {{< item-cards path="linters" data="linters_info" >}}

--- a/docs/layouts/_partials/clickable-badge.html
+++ b/docs/layouts/_partials/clickable-badge.html
@@ -30,8 +30,8 @@ Creates a badge with the given id and class.
 
 {{- $borderClass := cond (eq $border true) "hx-border" "" -}}
 {{- $badgeClass := or ($styleClass.Get $type) $defaultClass  -}}
-<div class="hextra-badge hx-mt-2">
-    <div id="{{ $id }}" class="hx-inline-flex hx-gap-1 hx-items-center hx-rounded-full hx-px-2.5 hx-leading-6 hx-text-[.65rem] {{ $borderClass }} {{ $badgeClass }} {{ $class }}">
+<div class="hextra-badge hx-mt-2 hx-mx-1">
+    <div id="{{ $id }}" class="hx-inline-flex hx-gap-1 hx-items-center hx-rounded-full hx-px-2.5 hx-leading-6 hx-text-[.65rem] hx-cursor-pointer {{ $borderClass }} {{ $badgeClass }} {{ $class }}">
         {{- with $icon -}}{{- partial "utils/icon" (dict "name" . "attributes" "height=12") -}}{{- end -}}
         {{- $content -}}
     </div>

--- a/docs/layouts/_shortcodes/filter-bar.html
+++ b/docs/layouts/_shortcodes/filter-bar.html
@@ -1,0 +1,12 @@
+{{- /*
+This shortcode is used to create a filter bar.
+
+@example {{< filter-bar >}}{{< clickable-badge content="Example">}}{{< filter-bar >}}
+*/ -}}
+
+<div class="hx-mt-6">
+  <span class="hx-inline-block hx-align-text-bottom icon" title="Filter">
+    {{- partial "utils/icon.html" (dict "name" "filter" "attributes" "height=1.2em") -}}
+  </span>
+  {{ .Inner }}
+</div>


### PR DESCRIPTION
Improve and simplify the filter bar.

The build uses `--minify` flag to minify the website, which removes whitespace between elements, and so the filter bar is compacted.

This flag cannot be used with the target `make serve` because this is very slow.

<details>
<summary>Before</summary>

<img width="1122" height="278" src="https://github.com/user-attachments/assets/9039c698-f5d8-4909-973c-4de390bbb4ad" />

</details>

<details>
<summary>After</summary>

<img width="1092" height="242" src="https://github.com/user-attachments/assets/d624e8e9-00f7-4592-ae1d-3d576a7d0e87" />

</details>
