### PR TITLE
dev: add website aliases

### DIFF
--- a/docs/content/docs/configuration/_index.md
+++ b/docs/content/docs/configuration/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Configuration
 weight: 2
+aliases:
+  - /usage/configuration/
 ---
 
 The config file has lower priority than command-line options.

--- a/docs/content/docs/contributing/_index.md
+++ b/docs/content/docs/contributing/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Contributing
 weight: 6
+aliases:
+  - /contributing/quick-start/
 ---
 
 {{< cards >}}

--- a/docs/content/docs/contributing/architecture.md
+++ b/docs/content/docs/contributing/architecture.md
@@ -1,6 +1,8 @@
 ---
 title: Architecture
 weight: 3
+aliases:
+  - /contributing/architecture/
 ---
 
 There are the following golangci-lint execution steps:

--- a/docs/content/docs/contributing/debug.md
+++ b/docs/content/docs/contributing/debug.md
@@ -1,6 +1,8 @@
 ---
 title: Debugging
 weight: 5
+aliases:
+  - /contributing/debug/
 ---
 
 You can see a verbose output of linter by using `-v` option.

--- a/docs/content/docs/contributing/faq.md
+++ b/docs/content/docs/contributing/faq.md
@@ -1,6 +1,8 @@
 ---
 title: FAQ
 weight: 6
+aliases:
+  - /contributing/faq/
 ---
 
 ## How to add a new open-source linter to `golangci-lint`

--- a/docs/content/docs/contributing/new-linters.md
+++ b/docs/content/docs/contributing/new-linters.md
@@ -1,6 +1,8 @@
 ---
 title: New linters
 weight: 4
+aliases:
+  - /contributing/new-linters/
 ---
 
 ## How to write a linter

--- a/docs/content/docs/contributing/website.md
+++ b/docs/content/docs/contributing/website.md
@@ -1,6 +1,8 @@
 ---
 title: This Website
 weight: 7
+aliases:
+  - /contributing/website/
 ---
 
 ## Technology

--- a/docs/content/docs/contributing/workflow.md
+++ b/docs/content/docs/contributing/workflow.md
@@ -1,6 +1,8 @@
 ---
 title: Workflow
 weight: 2
+aliases:
+  - /contributing/workflow/
 ---
 
 By participating in this project, you agree to abide our [code of conduct](https://github.com/golangci/golangci-lint?tab=coc-ov-file).

--- a/docs/content/docs/formatters/_index.md
+++ b/docs/content/docs/formatters/_index.md
@@ -2,6 +2,8 @@
 title: Formatters
 weight: 4
 excludeSearch: true
+aliases:
+  - /usage/formatters/
 ---
 
 To see a list of supported formatters and which formatters are enabled/disabled:

--- a/docs/content/docs/linters/_index.md
+++ b/docs/content/docs/linters/_index.md
@@ -2,6 +2,8 @@
 title: Linters
 weight: 3
 excludeSearch: true
+aliases:
+  - /usage/linters/
 ---
 
 To see a list of supported linters and which linters are enabled/disabled:

--- a/docs/content/docs/linters/false-positives.md
+++ b/docs/content/docs/linters/false-positives.md
@@ -1,6 +1,8 @@
 ---
 title: False Positives
 weight: 3
+aliases:
+  - /usage/false-positives/
 ---
 
 False positives are inevitable, but we did our best to reduce their count.

--- a/docs/content/docs/plugins/go-plugins.md
+++ b/docs/content/docs/plugins/go-plugins.md
@@ -1,6 +1,8 @@
 ---
 title: Go Plugin System
 weight: 2
+aliases:
+  - /plugins/go-plugins/
 ---
 
 {{< callout type="warning" >}}

--- a/docs/content/docs/plugins/module-plugins.md
+++ b/docs/content/docs/plugins/module-plugins.md
@@ -1,6 +1,8 @@
 ---
 title: Module Plugin System
 weight: 1
+aliases:
+  - /plugins/module-plugins/
 ---
 
 > [!TIP]

--- a/docs/content/docs/product/changelog.md
+++ b/docs/content/docs/product/changelog.md
@@ -2,6 +2,8 @@
 title: Changelog
 weight: 2
 excludeSearch: true
+aliases:
+  - /product/changelog/
 ---
 
 Follow the news and releases on [Mastodon](https://fosstodon.org/@golangcilint) and on [Bluesky](https://bsky.app/profile/golangci-lint.run).

--- a/docs/content/docs/product/migration-guide.md
+++ b/docs/content/docs/product/migration-guide.md
@@ -1,6 +1,8 @@
 ---
 title: Migration guide
 weight: 3
+aliases:
+  - /product/migration-guide/
 ---
 
 ## Command `migrate`

--- a/docs/content/docs/product/roadmap.md
+++ b/docs/content/docs/product/roadmap.md
@@ -1,6 +1,8 @@
 ---
 title: Roadmap
 weight: 4
+aliases:
+  - /product/roadmap/
 ---
 
 ## 💡 Feature Requests

--- a/docs/content/docs/product/thanks.md
+++ b/docs/content/docs/product/thanks.md
@@ -1,6 +1,8 @@
 ---
 title: Thanks
 weight: 1
+aliases:
+  - /product/thanks/
 ---
 
 ## ❤️

--- a/docs/content/docs/welcome/faq.md
+++ b/docs/content/docs/welcome/faq.md
@@ -2,6 +2,8 @@
 title: FAQ
 toc: false
 weight: 5
+aliases:
+  - /welcome/faq/
 ---
 
 ## Which Go versions are supported?

--- a/docs/content/docs/welcome/install.md
+++ b/docs/content/docs/welcome/install.md
@@ -1,6 +1,8 @@
 ---
 title: "Install"
 weight: 1
+aliases:
+  - /welcome/install/
 ---
 
 ## CI installation

--- a/docs/content/docs/welcome/integrations.md
+++ b/docs/content/docs/welcome/integrations.md
@@ -1,6 +1,8 @@
 ---
 title: Integrations
 weight: 3
+aliases:
+  - /welcome/integrations/
 ---
 
 ## Editor Integration

--- a/docs/content/docs/welcome/quick-start.md
+++ b/docs/content/docs/welcome/quick-start.md
@@ -1,6 +1,8 @@
 ---
 title: Quick Start
 weight: 2
+aliases:
+  - /welcome/quick-start/
 ---
 
 ## Linting


### PR DESCRIPTION
I discovered that we can create path [aliases](https://gohugo.io/content-management/urls/#aliases) to match the previous paths to the documentation.

<details>
<summary>mapping</summary>

| OLD                         | NEW                              |
|-----------------------------|----------------------------------|
| /welcome/install/           | /docs/welcome/install/           |
| /welcome/quick-start/       | /docs/welcome/quick-start/       |
| /welcome/integrations/      | /docs/welcome/integrations/      |
| /welcome/faq/               | /docs/welcome/faq/               |
| /usage/configuration/       | /docs/configuration/             |
| /usage/linters/             | /docs/linters/                   |
| /usage/false-positives/     | /docs/linters/false-positives/   |
| /usage/formatters/          | /docs/formatters/                |
| /product/thanks/            | /docs/product/thanks/            |
| /product/changelog/         | /docs/product/changelog/         |
| /product/migration-guide/   | /docs/product/migration-guide/   |
| /product/roadmap/           | /docs/product/roadmap/           |
| /contributing/quick-start/  | /docs/contributing/              |
| /contributing/workflow/     | /docs/contributing/workflow/     |
| /contributing/architecture/ | /docs/contributing/architecture/ |
| /contributing/new-linters/  | /docs/contributing/new-linters/  |
| /contributing/debug/        | /docs/contributing/debug/        |
| /contributing/faq/          | /docs/contributing/faq/          |
| /contributing/website/      | /docs/contributing/website/      |
| /plugins/module-plugins/    | /docs/plugins/module-plugins/    |
| /plugins/go-plugins/        | /docs/plugins/go-plugins/        |

</details>

Follows #5965
