### PR TITLE
dev: fix website search for items with quotes

### DIFF
--- a/docs/layouts/_partials/utils/extract-headings.html
+++ b/docs/layouts/_partials/utils/extract-headings.html
@@ -20,7 +20,7 @@ The scratchpad must be initialized with empty slices before calling this functio
     {{ $.scratch.Add "keys" (slice $key) }}
   {{ end }}
 
-  {{ $title := (printf "<h%d>%s" $heading.Level $heading.Title) }}
+  {{ $title := (printf "<h%d>%s" $heading.Level $heading.Title) | htmlUnescape }}
   {{ $.scratch.Add "titles" (slice $title) }}
 
   {{ partial "utils/extract-headings.html" (dict


### PR DESCRIPTION
Inside the search, the content is unescaped then the title must also be unescaped.

<details>
<summary>Before</summary>

<img width="2018" height="1208" src="https://github.com/user-attachments/assets/4d887d60-1ded-45b6-ac2c-522a77897543" />

</details>

<details>
<summary>After</summary>

<img width="1975" height="1231" src="https://github.com/user-attachments/assets/afa910c6-a808-4b9c-b8e3-149d17debfde" />

</details>

https://github.com/imfing/hextra/pull/741