### PR TITLE
docs: add links to changelog

### DIFF
--- a/docs/layouts/_partials/compare-versions.html
+++ b/docs/layouts/_partials/compare-versions.html
@@ -3,7 +3,7 @@ Compares two versions.
 
 @param {string} a Version A
 @param {string} b Version B
-@returns {boolean}
+@returns {int} -1 if a < b, 0 if a == b, 1 if a > b
 
 @example {{ partial "compare-versions.html" (dict "a" "v1.2.3" "b" "v1.2.4") }}
 */ -}}
@@ -11,4 +11,11 @@ Compares two versions.
 {{- $aVersion := path.Dir (replace .a "." "/") -}}
 {{- $bVersion := path.Dir (replace .b "." "/") -}}
 
-{{- return (eq $aVersion $bVersion) -}}
+{{- $result := 0 -}}
+{{- if (lt $aVersion $bVersion) -}}
+  {{- $result = -1 -}}
+{{- end -}}
+{{- if (gt $aVersion $bVersion) -}}
+  {{- $result = 1 -}}
+{{- end -}}
+{{- return $result -}}

--- a/docs/layouts/_partials/item-tag.html
+++ b/docs/layouts/_partials/item-tag.html
@@ -21,7 +21,7 @@ Creates tag information for an item (linter/formatter).
     {{- $tag.SetInMap "options" "subtitle" (print (strings.FirstUpper $item.deprecation.message) $replacement) -}}
     {{- $tag.SetInMap "options" "tag" (print "Deprecated since " $item.deprecation.since) -}}
     {{- $tag.SetInMap "options" "tagType" "error" -}}
-{{- else if (partial "compare-versions.html" (dict "a" $gcilVersion "b" $item.since)) -}}
+{{- else if eq (partial "compare-versions.html" (dict "a" $gcilVersion "b" $item.since)) 0 -}}
     {{- $tag.SetInMap "options" "tag" "New" -}}
     {{- $tag.SetInMap "options" "tagType" "warning" -}}
 {{- else if $item.canAutoFix -}}

--- a/docs/layouts/_shortcodes/item-cards.html
+++ b/docs/layouts/_shortcodes/item-cards.html
@@ -76,7 +76,7 @@ Creates a card for each item (linter/formatter) in a data file.
     {{- if in .groups "standard" -}}
         {{- $class = $class | append "gl-default" -}}
     {{- end -}}
-    {{- if (partial "compare-versions.html" (dict "a" $gcilVersion "b" .since)) -}}
+    {{- if eq (partial "compare-versions.html" (dict "a" $gcilVersion "b" .since)) 0 -}}
         {{- $class = $class | append "gl-new" -}}
     {{- end -}}
 

--- a/docs/layouts/_shortcodes/item-settings.html
+++ b/docs/layouts/_shortcodes/item-settings.html
@@ -34,22 +34,32 @@ Creates a section for each setting of a linter/formatter.
 
 {{/* Badges */}}
 <p>
+{{ $sinceLink := "/docs/product/changelog/" }}
+<!-- changelog entries are missing for versions less than v1.44.0 -->
+{{ if eq (partial "compare-versions.html" (dict "a" .since "b" "v1.43.0")) 1 }}
+  {{ $sinceLink = (print "/docs/product/changelog/#" (replace .since "." "")) }}
+{{ end }}
+<a href="{{ $sinceLink }}" title="Since golangci-lint {{ .since }}">
 {{ partial "shortcodes/badge.html" (dict
     "border" true
     "icon" "calendar"
     "content" (print "Since golangci-lint " .since)
     )
 }}
+</a>
 {{ if .deprecation -}}
+{{ $deprecatedSinceLink := (print "/docs/product/changelog/#" (replace .deprecation.since "." "")) }}
+<a href="{{ $deprecatedSinceLink }}" title="Deprecated since {{ .deprecation.since }}">
 {{ partial "shortcodes/badge.html" (dict
     "border" true
     "icon" "sparkles"
     "content" (print "Deprecated since " .deprecation.since)
     "type" "error"
     )
-    }}
+}}
+</a>
 {{ else }}
-    {{ if (partial "compare-versions.html" (dict "a" $gcilVersion "b" .since)) }}
+    {{ if eq (partial "compare-versions.html" (dict "a" $gcilVersion "b" .since)) 0 }}
 {{ partial "shortcodes/badge.html" (dict
     "border" true
     "icon" "sparkles"

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -241,7 +241,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithURL("https://github.com/polyfloyd/go-errorlint"),
 
 		linter.NewConfig(exhaustive.New(&cfg.Linters.Settings.Exhaustive)).
-			WithSince(" v1.28.0").
+			WithSince("v1.28.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/nishanths/exhaustive"),
 


### PR DESCRIPTION
This PR adds clickable links to "Since golangci-lint vX.X.0" and "Deprecated since vX.X.0" that point to the appropriate version in the [Changelog](https://golangci-lint.run/docs/product/changelog/#vXXX).

If the version is greater than or equal to `v1.44.0`, the link should be `https://golangci-lint.run/docs/product/changelog/#vXXX`. Otherwise, use `https://golangci-lint.run/docs/product/changelog/`. This is because changelog headings for these versions use the format `Month Year` instead of `vX.X.X`.

<details><summary>Screenshots</summary>
<p>

Since golangci-lint v1.46.0:

<img width="663" height="490" alt="image" src="https://github.com/user-attachments/assets/a222f981-0749-41b9-918a-a5c51492621f" />

Deprecated since v2.2.0:

<img width="663" height="490" alt="image" src="https://github.com/user-attachments/assets/d4aad36f-d362-4b5b-a471-99f2788819ea" />

</p>
</details> 