### PR TITLE
dev: minor doc style changes

### DIFF
--- a/docs/content/docs/product/migration-guide.md
+++ b/docs/content/docs/product/migration-guide.md
@@ -165,159 +165,22 @@ The `migrate` command automatically migrates `linters.presets` in individual lin
 {{< tab >}}
 Presets:
 
-- bugs:
-  - `asasalint`
-  - `asciicheck`
-  - `bidichk`
-  - `bodyclose`
-  - `contextcheck`
-  - `durationcheck`
-  - `errcheck`
-  - `errchkjson`
-  - `errorlint`
-  - `exhaustive`
-  - `gocheckcompilerdirectives`
-  - `gochecksumtype`
-  - `gosec`
-  - `gosmopolitan`
-  - `govet`
-  - `loggercheck`
-  - `makezero`
-  - `musttag`
-  - `nilerr`
-  - `nilnesserr`
-  - `noctx`
-  - `protogetter`
-  - `reassign`
-  - `recvcheck`
-  - `rowserrcheck`
-  - `spancheck`
-  - `sqlclosecheck`
-  - `staticcheck`
-  - `testifylint`
-  - `zerologlint`
-- comment:
-  - `dupword`
-  - `godot`
-  - `godox`
-  - `misspell`
-- complexity:
-  - `cyclop`
-  - `funlen`
-  - `gocognit`
-  - `gocyclo`
-  - `maintidx`
-  - `nestif`
-- error:
-  - `err113`
-  - `errcheck`
-  - `errorlint`
-  - `wrapcheck`
-- format:
-  - `gci`
-  - `gofmt`
-  - `gofumpt`
-  - `goimports`
-- import:
-  - `depguard`
-  - `gci`
-  - `goimports`
-  - `gomodguard`
-- metalinter:
-  - `gocritic`
-  - `govet`
-  - `revive`
-  - `staticcheck`
-- module:
-  - `depguard`
-  - `gomoddirectives`
-  - `gomodguard`
-- performance:
-  - `bodyclose`
-  - `fatcontext`
-  - `noctx`
-  - `perfsprint`
-  - `prealloc`
-- sql:
-  - `rowserrcheck`
-  - `sqlclosecheck`
-- style:
-  - `asciicheck`
-  - `canonicalheader`
-  - `containedctx`
-  - `copyloopvar`
-  - `decorder`
-  - `depguard`
-  - `dogsled`
-  - `dupl`
-  - `err113`
-  - `errname`
-  - `exhaustruct`
-  - `exptostd`
-  - `forbidigo`
-  - `forcetypeassert`
-  - `ginkgolinter`
-  - `gochecknoglobals`
-  - `gochecknoinits`
-  - `goconst`
-  - `gocritic`
-  - `godot`
-  - `godox`
-  - `goheader`
-  - `gomoddirectives`
-  - `gomodguard`
-  - `goprintffuncname`
-  - `gosimple`
-  - `grouper`
-  - `iface`
-  - `importas`
-  - `inamedparam`
-  - `interfacebloat`
-  - `intrange`
-  - `ireturn`
-  - `lll`
-  - `loggercheck`
-  - `makezero`
-  - `mirror`
-  - `misspell`
-  - `mnd`
-  - `musttag`
-  - `nakedret`
-  - `nilnil`
-  - `nlreturn`
-  - `nolintlint`
-  - `nonamedreturns`
-  - `nosprintfhostport`
-  - `paralleltest`
-  - `predeclared`
-  - `promlinter`
-  - `revive`
-  - `sloglint`
-  - `stylecheck`
-  - `tagalign`
-  - `tagliatelle`
-  - `testpackage`
-  - `tparallel`
-  - `unconvert`
-  - `usestdlibvars`
-  - `varnamelen`
-  - `wastedassign`
-  - `whitespace`
-  - `wrapcheck`
-  - `wsl`
-- test:
-  - `exhaustruct`
-  - `paralleltest`
-  - `testableexamples`
-  - `testifylint`
-  - `testpackage`
-  - `thelper`
-  - `tparallel`
-  - `usetesting`
-- unused:
-  - `ineffassign`
-  - `unparam`
-  - `unused`
+| name | linters |
+|------|---------|
+| bugs | `asasalint`, `asciicheck`, `bidichk`, `bodyclose`, `contextcheck`, `durationcheck`, `errcheck`, `errchkjson`, `errorlint`, `exhaustive`, `gocheckcompilerdirectives`, `gochecksumtype`, `gosec`, `gosmopolitan`, `govet`, `loggercheck`, `makezero`, `musttag`, `nilerr`, `nilnesserr`, `noctx`, `protogetter`, `reassign`, `recvcheck`, `rowserrcheck`, `spancheck`, `sqlclosecheck`, `staticcheck`, `testifylint`, `zerologlint` |
+| comment | `dupword`, `godot`, `godox`, `misspell` | 
+| complexity | `cyclop`, `funlen`, `gocognit`, `gocyclo`, `maintidx`, `nestif` |
+| error | `err113`, `errcheck`, `errorlint`, `wrapcheck` |
+| format | `gci`, `gofmt`, `gofumpt`, `goimports` |
+| import | `depguard`, `gci`, `goimports`, `gomodguard` |
+| metalinter | `gocritic`, `govet`, `revive`, `staticcheck` |
+| module | `depguard`, `gomoddirectives`, `gomodguard` |
+| performance | `bodyclose`, `fatcontext`, `noctx`, `perfsprint`, `prealloc` |
+| sql | `rowserrcheck`, `sqlclosecheck` |
+| style | `asciicheck`, `canonicalheader`, `containedctx`, `copyloopvar`, `decorder`, `depguard`, `dogsled`, `dupl`, `err113`, `errname`, `exhaustruct`, `exptostd`, `forbidigo`, `forcetypeassert`, `ginkgolinter`, `gochecknoglobals`, `gochecknoinits`, `goconst`, `gocritic`, `godot`, `godox`, `goheader`, `gomoddirectives`, `gomodguard`, `goprintffuncname`, `gosimple`, `grouper`, `iface`, `importas`, `inamedparam`, `interfacebloat`, `intrange`, `ireturn`, `lll`, `loggercheck`, `makezero`, `mirror`, `misspell`, `mnd`, `musttag`, `nakedret`, `nilnil`, `nlreturn`, `nolintlint`, `nonamedreturns`, `nosprintfhostport`, `paralleltest`, `predeclared`, `promlinter`, `revive`, `sloglint`, `stylecheck`, `tagalign`, `tagliatelle`, `testpackage`, `tparallel`, `unconvert`, `usestdlibvars`, `varnamelen`, `wastedassign`, `whitespace`, `wrapcheck`, `wsl` |
+| test | `exhaustruct`, `paralleltest`, `testableexamples`, `testifylint`, `testpackage`, `thelper`, `tparallel`, `usetesting` |
+| unused | `ineffassign`, `unparam`, `unused` |
+
 {{< /tab >}}
 {{< tab >}}
 ```yaml

--- a/docs/content/docs/welcome/install.md
+++ b/docs/content/docs/welcome/install.md
@@ -26,10 +26,9 @@ and it can be much faster than the simple binary installation.
 Also, the action creates GitHub annotations for found issues (you don't need to dig into build log to see found by golangci-lint issues).
 
 {{< cards cols=2 >}}
-    {{< card subtitle="Console Output" image="/images/colored-line-number.png" >}}
-    {{< card subtitle="Annotations" image="/images/annotations.png" >}}
+    {{< image-card src="/images/colored-line-number.png" title="Console Output" >}}
+    {{< image-card src="/images/annotations.png" title="Annotations" >}}
 {{< /cards >}}
-
 
 ### GitLab CI
 

--- a/docs/layouts/_shortcodes/details.html
+++ b/docs/layouts/_shortcodes/details.html
@@ -1,0 +1,12 @@
+{{- /* Modified version of https://github.com/imfing/hextra/blob/v0.9.7/layouts/shortcodes/details.html */ -}}
+{{- $title := .Get "title" | default "" -}}
+{{- $closed := eq (.Get "closed") "true" | default false -}}
+
+<details class="last-of-type:hx-mb-0 hx-rounded-lg hx-bg-neutral-50 dark:hx-bg-neutral-800 hx-p-2 hx-mt-4 hx-group" {{ if not $closed }}open{{ end }}>
+  <summary class="hx-flex hx-items-center hx-cursor-pointer hx-select-none hx-list-none hx-p-1 hx-rounded hx-transition-colors hover:hx-bg-gray-100 dark:hover:hx-bg-neutral-800 before:hx-mr-1 before:hx-inline-block before:hx-transition-transform before:hx-content-[''] dark:before:hx-invert rtl:before:hx-rotate-180 group-open:before:hx-rotate-90">
+    <span class="hx-text-lg">{{ $title | markdownify }}</span>
+  </summary>
+  <div class="hx-p-2 hx-overflow-hidden">
+    {{ .InnerDeindent | markdownify }}
+  </div>
+</details>

--- a/docs/layouts/_shortcodes/image-card.html
+++ b/docs/layouts/_shortcodes/image-card.html
@@ -1,0 +1,15 @@
+{{- /*
+Creates a card for an image.
+
+@param {string} src The path to the image.
+@param {string} title The title text for the image.
+
+@example {{< image-card src="path/to/image.png" title="Image description" >}}
+*/ -}}
+
+{{- $src := .Get "src" -}}
+{{- $title := .Get "title" -}}
+
+<div class="hextra-card hx-group hx-flex hx-flex-col hx-justify-start hx-overflow-hidden">
+  <img class="hextra-card-image" src="{{ $src }}" alt="{{ $title }}" title="{{ $title }}"/>
+</div>


### PR DESCRIPTION
- Uses a table instead of a list inside the migration guide for presets
- Replace `<strong>` by a simple `<div>` for detail titles
- Better style images (remove border, hover, etc.)