### PR TITLE
update upstream tags for golang dockerfile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -295,7 +295,7 @@ dockers:
       - '--label=org.opencontainers.image.created={{.Date}}'
       - '--label=org.opencontainers.image.revision={{.FullCommit}}'
       - '--label=org.opencontainers.image.version={{.Version}}'
-      - '--platform=linux/arm64'
+      - '--platform=linux/arm64v8'
 
   - use: buildx
     goos: linux
@@ -337,4 +337,4 @@ dockers:
       - '--label=org.opencontainers.image.created={{.Date}}'
       - '--label=org.opencontainers.image.revision={{.FullCommit}}'
       - '--label=org.opencontainers.image.version={{.Version}}'
-      - '--platform=linux/arm64'
+      - '--platform=linux/arm64v8'


### PR DESCRIPTION
I noticed the CI for goreleaser failed.

I think golang uses a slightly different architecture tag for arm64 now, calling it arm64v8.

Hopefully this is the fix!