### PR TITLE
dev: update Hextra to v0.10.1

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,5 +1,5 @@
 module github.com/golangci/docs
 
-go 1.23.0
+go 1.24.0
 
-require github.com/imfing/hextra v0.10.1-0.20250815010958-2033d50005ae // indirect
+require github.com/imfing/hextra v0.10.1 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.10.1-0.20250815010958-2033d50005ae h1:v54P0dueenb+fzIf+HWOu+HQ8KLzgH7oiAka6QVOUtA=
-github.com/imfing/hextra v0.10.1-0.20250815010958-2033d50005ae/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.10.1 h1:W2vI4Hot7z9lRcTmRFRQ1rzpnybp2tTuY6yHsRDUXq4=
+github.com/imfing/hextra v0.10.1/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=


### PR DESCRIPTION
https://github.com/imfing/hextra/compare/v0.10.0...v0.10.1


Note: the update of the dependencies cannot be done with dependabot as it's not a real module.

If you run `go mod tidy` locally, the module will be removed, and adding a fake Go file with a blank import will not work either.