### PR TITLE
dev: update Hextra to v0.10.2

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -32,3 +32,11 @@
 .hextra-nav-container a[title="Support us"]:hover  {
     transform: scale(1.3, 1.3);
 }
+
+.hextra-footer .social-media {
+    transition: ease-in-out 0.2s;
+}
+
+.hextra-footer .social-media :hover{
+    transform: translateY(-2px);
+}

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,4 @@ module github.com/golangci/docs
 
 go 1.24.0
 
-require github.com/imfing/hextra v0.10.1 // indirect
+require github.com/imfing/hextra v0.10.2 // indirect

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.10.1 h1:W2vI4Hot7z9lRcTmRFRQ1rzpnybp2tTuY6yHsRDUXq4=
-github.com/imfing/hextra v0.10.1/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.10.2 h1:etVtBSHH3V4xYZ2uqlh7HWZitdaZLWG+sCoGtFqyAEk=
+github.com/imfing/hextra v0.10.2/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -58,8 +58,12 @@ menu:
       weight: 5
       params:
         type: search
-    - name: GitHub
+    - name: Theme Toggle
       weight: 6
+      params:
+        type: theme-toggle
+    - name: GitHub
+      weight: 7
       url: "https://github.com/golangci/golangci-lint"
       params:
         icon: github

--- a/docs/layouts/_partials/footer.html
+++ b/docs/layouts/_partials/footer.html
@@ -35,7 +35,7 @@
 
       {{- range .Site.Params.footer.links -}}
       {{- $external := strings.HasPrefix .url "http" -}}
-      <a title="{{ .title }}" href="{{ .url }}" {{ if $external }}target="_blank"{{ end }} class="hx:text-sm hx:contrast-more:text-gray-700 hx:contrast-more:dark:text-gray-100 hx:relative -hx:ml-2 hx:whitespace-nowrap hx:p-1 hx:md:inline-block hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200">
+      <a title="{{ .title }}" href="{{ .url }}" {{ if $external }}target="_blank"{{ end }} class="social-media hx:text-sm hx:contrast-more:text-gray-700 hx:contrast-more:dark:text-gray-100 hx:relative -hx:ml-2 hx:whitespace-nowrap hx:p-1 hx:md:inline-block hx:text-gray-600 hx:hover:text-gray-800 hx:dark:text-gray-400 hx:dark:hover:text-gray-200">
         <span class="hx:text-center">
            {{- partial "utils/icon.html" (dict "name" .icon "attributes" "height=20") -}}
         </span>


### PR DESCRIPTION
Despite the version number, there are new features.

- https://github.com/imfing/hextra/compare/v0.10.1...v0.10.2
- https://github.com/imfing/hextra/releases/tag/v0.10.2


Note: the update of the dependencies cannot be done with dependabot as it's not a real module.

**This update is done by hand because dependabot is unable to update Hugo dependencies (they are not real modules.**