### PR TITLE
Update ineffassign and add new check-escaping-errors config option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/golangci/revgrep v0.8.0
 	github.com/golangci/swaggoswag v0.0.0-20250504205917-77f2aca3143e
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e
-	github.com/gordonklaus/ineffassign v0.1.0
+	github.com/gordonklaus/ineffassign v0.1.1-0.20250824073611-44548fda05c1
 	github.com/gostaticanalysis/forcetypeassert v0.2.0
 	github.com/gostaticanalysis/nilerr v0.1.1
 	github.com/hashicorp/go-version v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxV
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gordonklaus/ineffassign v0.1.0 h1:y2Gd/9I7MdY1oEIt+n+rowjBNDcLQq3RsH5hwJd0f9s=
-github.com/gordonklaus/ineffassign v0.1.0/go.mod h1:Qcp2HIAYhR7mNUVSIxZww3Guk4it82ghYcEXIAk+QT0=
+github.com/gordonklaus/ineffassign v0.1.1-0.20250824073611-44548fda05c1 h1:dmd4u/amDqbqYFPqUJ0sRbLUH1yrvF5JQwPQwbUWXO4=
+github.com/gordonklaus/ineffassign v0.1.1-0.20250824073611-44548fda05c1/go.mod h1:TIpymnagPSexySzs7F9FnO1XFTy8IT3a59vmZp5Y9Lw=
 github.com/gostaticanalysis/analysisutil v0.7.1 h1:ZMCjoue3DtDWQ5WyU16YbjbQEQ3VuzwxALrpYd+HeKk=
 github.com/gostaticanalysis/analysisutil v0.7.1/go.mod h1:v21E3hY37WKMGSnbsw2S/ojApNWb6C1//mXO48CXbVc=
 github.com/gostaticanalysis/comment v1.4.1/go.mod h1:ih6ZxzTHLdadaiSnF5WY3dxUoXfXAlTaRzuaNDlSado=
@@ -887,7 +887,6 @@ golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.1-0.20210205202024-ef80cdb6ec6d/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
 golang.org/x/tools v0.1.1-0.20210302220138-2ac05c832e1a/go.mod h1:9bzcO0MWcOuT0tm1iBGzDVPshzfwoVvREIui8C+MHqU=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -254,6 +254,7 @@ type LintersSettings struct {
 	Iface                    IfaceSettings                    `mapstructure:"iface"`
 	ImportAs                 ImportAsSettings                 `mapstructure:"importas"`
 	Inamedparam              INamedParamSettings              `mapstructure:"inamedparam"`
+	IneffAssign              IneffAssignSettings              `mapstructure:"ineffassign"`
 	InterfaceBloat           InterfaceBloatSettings           `mapstructure:"interfacebloat"`
 	Ireturn                  IreturnSettings                  `mapstructure:"ireturn"`
 	Lll                      LllSettings                      `mapstructure:"lll"`
@@ -642,6 +643,10 @@ type ImportAsAlias struct {
 
 type INamedParamSettings struct {
 	SkipSingleParam bool `mapstructure:"skip-single-param"`
+}
+
+type IneffAssignSettings struct {
+	CheckEscapingErrors bool `mapstructure:"check-escaping-errors"`
 }
 
 type InterfaceBloatSettings struct {

--- a/pkg/golinters/ineffassign/ineffassign.go
+++ b/pkg/golinters/ineffassign/ineffassign.go
@@ -1,14 +1,25 @@
 package ineffassign
 
 import (
+	"strconv"
+
 	"github.com/gordonklaus/ineffassign/pkg/ineffassign"
 
+	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 )
 
-func New() *goanalysis.Linter {
+func New(settings *config.IneffAssignSettings) *goanalysis.Linter {
+	analyzer := ineffassign.Analyzer
+
 	return goanalysis.
-		NewLinterFromAnalyzer(ineffassign.Analyzer).
+		NewLinterFromAnalyzer(analyzer).
+		WithContextSetter(func(lintCtx *linter.Context) {
+			if err := analyzer.Flags.Set("check-escaping-errors", strconv.FormatBool(settings.CheckEscapingErrors)); err != nil {
+				lintCtx.Log.Errorf("failed to parse configuration: %v", err)
+			}
+		}).
 		WithDesc("Detects when assignments to existing variables are not used").
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -424,7 +424,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.55.0").
 			WithURL("https://github.com/macabu/inamedparam"),
 
-		linter.NewConfig(ineffassign.New()).
+		linter.NewConfig(ineffassign.New(&cfg.Linters.Settings.IneffAssign)).
 			WithGroups(config.GroupStandard).
 			WithSince("v1.0.0").
 			WithURL("https://github.com/gordonklaus/ineffassign"),


### PR DESCRIPTION
This exposes the `check-escaping-errors` flag in the `ineffassign` linter.

Note the most recent tagged version of this linter is quite old with a few commits since then without a tagged release, so I don't think dependabot would pick up non-tagged versions.

If this is a showstopper I can raise an issue in the ineffassign repo asking for a new tag to be created but the other changes will still be needed to expose the new config flag.