### PR TITLE
dev: use repository link

### DIFF
--- a/docs/data/linters_info.json
+++ b/docs/data/linters_info.json
@@ -819,7 +819,7 @@
       "standard"
     ],
     "loadMode": 8767,
-    "originalURL": "https://staticcheck.dev/",
+    "originalURL": "https://github.com/dominikh/go-tools",
     "internal": false,
     "canAutoFix": true,
     "isSlow": true,

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -597,7 +597,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.0.0").
 			WithLoadForGoAnalysis().
 			WithAutoFix().
-			WithURL("https://staticcheck.dev/"),
+			WithURL("https://github.com/dominikh/go-tools"),
 
 		linter.NewConfig(swaggo.New()).
 			WithSince("v2.2.0").

--- a/scripts/website/dump_info/thanks.go
+++ b/scripts/website/dump_info/thanks.go
@@ -102,9 +102,6 @@ func extractInfo(lc *linter.Config) authorInfo {
 	exp := regexp.MustCompile(`https://(github|gitlab)\.com/([^/]+)/.*`)
 
 	switch lc.Name() {
-	case "staticcheck":
-		return authorInfo{Author: "dominikh", Host: hostGitHub}
-
 	case "exhaustruct":
 		return authorInfo{Author: "xobotyi", Host: hostGitHub}
 

--- a/scripts/website/dump_info/thanks_test.go
+++ b/scripts/website/dump_info/thanks_test.go
@@ -49,14 +49,6 @@ func Test_extractInfo(t *testing.T) {
 			expected: authorInfo{Author: "owner", Host: "gitlab"},
 		},
 		{
-			desc: "staticcheck",
-			lc: &linter.Config{
-				Linter:      &FakeLinter{name: "staticcheck"},
-				OriginalURL: "https://github.com/owner/linter",
-			},
-			expected: authorInfo{Author: "dominikh", Host: "github"},
-		},
-		{
 			desc: "gostaticanalysis",
 			lc: &linter.Config{
 				Linter:      &FakeLinter{name: "fake"},


### PR DESCRIPTION
Uses the repository URL instead of the website URL, like the other linters.