### PR TITLE
support running against other directories

### DIFF
--- a/pkg/config/base_loader.go
+++ b/pkg/config/base_loader.go
@@ -130,8 +130,9 @@ func (l *BaseLoader) getConfigSearchPaths() []string {
 	}
 
 	// find all dirs from it up to the root
-	searchPaths := []string{"./"}
+	searchPaths := []string{}
 
+	// Add the target directory and its parents first (highest priority)
 	for {
 		searchPaths = append(searchPaths, currentDir)
 
@@ -141,6 +142,15 @@ func (l *BaseLoader) getConfigSearchPaths() []string {
 		}
 
 		currentDir = parent
+	}
+
+	// Add current working directory if it's not already included and we haven't found a config yet
+	cwd, err := os.Getwd()
+	if err == nil {
+		absCwd, err := filepath.Abs(cwd)
+		if err == nil && !slices.Contains(searchPaths, absCwd) {
+			searchPaths = append(searchPaths, "./")
+		}
 	}
 
 	// find home directory for global config


### PR DESCRIPTION
I found it frustrating that you couldn't run:
```sh
golangci-lint run --fix ../mydir
```

This PR adds support for this, by checking if `../mydir` is part of a go module, finding the associated golangci config and running the configured linters.

For completeness, this PR also validates that all passed paths are part of the same module, and provides a nice error if not:

Example running against multiple modules:
```sh
$ golangci-lint run module1/subdir module2/subdir
ERRO Running error: context loading failed: failed to load packages: multiple Go modules detected: [/private/tmp/multi-subdir-test/module1 /private/tmp/multi-subdir-test/module2]

Multi-module analysis is not supported. Each module should be analyzed separately:
  golangci-lint run /private/tmp/multi-subdir-test/module1
  golangci-lint run /private/tmp/multi-subdir-test/module2
```

Example running against multiple packages in the same module: 
```sh
$ golangci-lint run ../module/bar ../module/baz
../../../private/tmp/sibling-test/module/bar/main.go:1: : # testmodule/bar
bar/main.go:5:3: "os" imported and not used (typecheck)
package bar
../../../private/tmp/sibling-test/module/baz/main.go:1: : # testmodule/baz
baz/main.go:5:3: "os" imported and not used (typecheck)
package baz
2 issues:
* typecheck: 2
```

This doesn't directly address https://github.com/golangci/golangci-lint/issues/828 but does make solving it a bit simpler (no need to change directories).
