### PR TITLE
pkg/goanalysis: add better error message for 'no export data' failure

### DIFF
--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -240,7 +240,8 @@ func (lp *loadingPackage) loadFromExportData() error {
 		}
 	}
 	if pkg.ExportFile == "" {
-		return fmt.Errorf("no export data for %q", pkg.ID)
+		// https://github.com/golangci/golangci-lint/issues/6056
+		return fmt.Errorf("no export data for %q. (typically this indicates a compilation failure in an imported package; ensure that 'go build' completes successfully)", pkg.ID)
 	}
 	f, err := os.Open(pkg.ExportFile)
 	if err != nil {


### PR DESCRIPTION
If compilation or building of a Go package fails, export data will not be available. Previously, we would mask the underlying failure and display only a message that "no export data" was available. This has led to lots of confusion among golangci-lint users (and users at my company, which is how I discovered this problem).

golangci#3996
golangci#4630
golangci#4912
golangci#4964
golangci#5037
golangci#5051
golangci#5184
golangci#5428
golangci#5437

In addition to numerous discussions. The only common thread between the responses to these discussions, is that the "no export data" error message is obscuring whatever the underlying problem is, and making it more difficult to troubleshoot.

golangci#2489
golangci#2191
golangci#2751
golangci#3363
golangci#4829
golangci#4880

This fix indicates to users what they should try next if they receive this error message from golangci-lint. Hopefully, this will help users solve their own problem, and reduce the amount of issues and discussions related to this issue that people post on the discussion boards.

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
