### PR TITLE
fix: no export data must always be handled as a typecheck error

### DIFF
--- a/pkg/goanalysis/pkgerrors/extract.go
+++ b/pkg/goanalysis/pkgerrors/extract.go
@@ -2,6 +2,7 @@ package pkgerrors
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"strings"
 
@@ -18,7 +19,9 @@ func extractErrors(pkg *packages.Package) []packages.Error {
 		return errors
 	}
 
+	skippedErrors := map[string]packages.Error{}
 	seenErrors := map[string]bool{}
+
 	var uniqErrors []packages.Error
 	for _, err := range errors {
 		msg := stackCrusher(err.Error())
@@ -26,13 +29,33 @@ func extractErrors(pkg *packages.Package) []packages.Error {
 			continue
 		}
 
+		// This `if` is important to avoid duplicate errors.
+		// The goal is to keep the most relevant error.
 		if msg != err.Error() {
+			prev, alreadySkip := skippedErrors[msg]
+			if !alreadySkip {
+				skippedErrors[msg] = err
+				continue
+			}
+
+			if len(err.Error()) < len(prev.Error()) {
+				skippedErrors[msg] = err
+			}
+
 			continue
 		}
+
+		delete(skippedErrors, msg)
 
 		seenErrors[msg] = true
 
 		uniqErrors = append(uniqErrors, err)
+	}
+
+	// In some cases, the error stack doesn't contain the tip error.
+	// We must keep at least one of the original errors that contain the specific message.
+	for skippedError := range maps.Values(skippedErrors) {
+		uniqErrors = append(uniqErrors, skippedError)
 	}
 
 	if len(pkg.GoFiles) != 0 {

--- a/pkg/goanalysis/pkgerrors/extract_test.go
+++ b/pkg/goanalysis/pkgerrors/extract_test.go
@@ -4,7 +4,129 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/tools/go/packages"
 )
+
+func Test_extractErrors(t *testing.T) {
+	testCases := []struct {
+		desc string
+		pkg  *packages.Package
+
+		expected []packages.Error
+	}{
+		{
+			desc: "package with errors",
+			pkg: &packages.Package{
+				IllTyped: true,
+				Errors: []packages.Error{
+					{Pos: "/home/ldez/sources/golangci/sandbox/main.go:6:11", Msg: "test"},
+				},
+			},
+			expected: []packages.Error{
+				{Pos: "/home/ldez/sources/golangci/sandbox/main.go:6:11", Msg: "test"},
+			},
+		},
+		{
+			desc: "full error stack deduplication",
+			pkg: &packages.Package{
+				IllTyped: true,
+				Imports: map[string]*packages.Package{
+					"test": {
+						IllTyped: true,
+						Errors: []packages.Error{
+							{
+								Pos:  "/home/ldez/sources/golangci/sandbox/main.go:6:11",
+								Msg:  `/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/result/processors/nolint.go:13:2: /home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/result/processors/nolint.go:13:2: could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/deadcode.go:21:9: undeclared name: linterName))`,
+								Kind: 3,
+							},
+							{
+								Pos:  "/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/result/processors/nolint.go:13:2",
+								Msg:  `could not import github.com/golangci/golangci-lint/pkg/lint/lintersdb (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/lint/lintersdb/manager.go:13:2: could not import github.com/golangci/golangci-lint/pkg/golinters (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/deadcode.go:21:9: undeclared name: linterName))`,
+								Kind: 3,
+							},
+							{
+								Pos:  "/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/lint/lintersdb/manager.go:13:2",
+								Msg:  `could not import github.com/golangci/golangci-lint/pkg/golinters (/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/deadcode.go:21:9: undeclared name: linterName)`,
+								Kind: 3,
+							},
+							{
+								Pos:  "/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/deadcode.go:21:9",
+								Msg:  `undeclared name: linterName`,
+								Kind: 3,
+							},
+						},
+					},
+				},
+			},
+			expected: []packages.Error{{
+				Pos:  "/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/golinters/deadcode.go:21:9",
+				Msg:  "undeclared name: linterName",
+				Kind: 3,
+			}},
+		},
+		{
+			desc: "package with import errors but with only one error and without tip error",
+			pkg: &packages.Package{
+				IllTyped: true,
+				Imports: map[string]*packages.Package{
+					"test": {
+						IllTyped: true,
+						Errors: []packages.Error{
+							{
+								Pos:  "/home/ldez/sources/golangci/sandbox/main.go:6:11",
+								Msg:  "could not import github.com/example/foo (main.go:6:2: missing go.sum entry for module providing package github.com/example/foo (imported by github.com/golangci/sandbox); to add:\n\tgo get github.com/golangci/sandbox)",
+								Kind: 3,
+							},
+						},
+					},
+				},
+			},
+			expected: []packages.Error{{
+				Pos:  "/home/ldez/sources/golangci/sandbox/main.go:6:11",
+				Msg:  "could not import github.com/example/foo (main.go:6:2: missing go.sum entry for module providing package github.com/example/foo (imported by github.com/golangci/sandbox); to add:\n\tgo get github.com/golangci/sandbox)",
+				Kind: 3,
+			}},
+		},
+		{
+			desc: "package with import errors but without tip error",
+			pkg: &packages.Package{
+				IllTyped: true,
+				Imports: map[string]*packages.Package{
+					"test": {
+						IllTyped: true,
+						Errors: []packages.Error{
+							{
+								Pos:  "/home/ldez/sources/golangci/sandbox/main.go:6:1",
+								Msg:  "foo (/home/ldez/sources/golangci/sandbox/main.go:6:11: could not import github.com/example/foo (main.go:6:2: missing go.sum entry for module providing package github.com/example/foo (imported by github.com/golangci/sandbox); to add:\n\tgo get github.com/golangci/sandbox))",
+								Kind: 3,
+							},
+							{
+								Pos:  "/home/ldez/sources/golangci/sandbox/main.go:6:11",
+								Msg:  "could not import github.com/example/foo (main.go:6:2: missing go.sum entry for module providing package github.com/example/foo (imported by github.com/golangci/sandbox); to add:\n\tgo get github.com/golangci/sandbox)",
+								Kind: 3,
+							},
+						},
+					},
+				},
+			},
+			expected: []packages.Error{{
+				Pos:  "/home/ldez/sources/golangci/sandbox/main.go:6:11",
+				Msg:  "could not import github.com/example/foo (main.go:6:2: missing go.sum entry for module providing package github.com/example/foo (imported by github.com/golangci/sandbox); to add:\n\tgo get github.com/golangci/sandbox)",
+				Kind: 3,
+			}},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			errors := extractErrors(test.pkg)
+
+			assert.Equal(t, test.expected, errors)
+		})
+	}
+}
 
 func Test_stackCrusher(t *testing.T) {
 	testCases := []struct {

--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -91,6 +91,10 @@ func (lp *loadingPackage) analyze(ctx context.Context, cancel context.CancelFunc
 			act.Err = werr
 		}
 
+		if len(lp.actions) == 0 {
+			lp.log.Warnf("no action but there is an error: %v", err)
+		}
+
 		return
 	}
 

--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -338,7 +338,8 @@ func (lp *loadingPackage) loadImportedPackageWithFacts(loadMode LoadMode) error 
 				Msg:  fmt.Sprintf("could not load export data: %s", err),
 				Kind: packages.ParseError,
 			})
-			return fmt.Errorf("could not load export data: %w", err)
+
+			return nil
 		}
 	}
 

--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -78,6 +78,9 @@ func (lp *loadingPackage) analyze(ctx context.Context, cancel context.CancelFunc
 	defer lp.decUse(loadMode < LoadModeWholeProgram)
 
 	if err := lp.loadWithFacts(loadMode); err != nil {
+		// Note: this error is ignored when there is no facts loading (e.g. with 98% of linters).
+		// But this is not a problem because the errors are added to the package.Errors.
+		// You through an error, try to add it to actions, but there is no action annnddd it's gone!
 		werr := fmt.Errorf("failed to load package %s: %w", lp.pkg.Name, err)
 
 		// Don't need to write error to errCh, it will be extracted and reported on another layer.
@@ -239,9 +242,11 @@ func (lp *loadingPackage) loadFromExportData() error {
 			return fmt.Errorf("dependency %q hasn't been loaded yet", path)
 		}
 	}
+
 	if pkg.ExportFile == "" {
 		return fmt.Errorf("no export data for %q", pkg.ID)
 	}
+
 	f, err := os.Open(pkg.ExportFile)
 	if err != nil {
 		return err
@@ -332,6 +337,7 @@ func (lp *loadingPackage) loadImportedPackageWithFacts(loadMode LoadMode) error 
 			if srcErr := lp.loadFromSource(loadMode); srcErr != nil {
 				return srcErr
 			}
+
 			// Make sure this package can't be imported successfully
 			pkg.Errors = append(pkg.Errors, packages.Error{
 				Pos:  "-",


### PR DESCRIPTION
This is not trivial to explain (even to reproduce the behavior), but in summary, golangci-lint should not return the error `fmt.Errorf("could not load export data: %w", err)` because it bypasses the `typecheck` report system.

When `typecheck` report system is bypassed, a log is printed instead of a report.

This is why there is:
```console
$ golangci-lint run 
WARN [runner] Can't run linter goanalysis_metalinter: buildir: failed to load package fake: could not load export data: no export data for "github.com/golangci/sandbox/fake" 
ERRO Running error: can't run linter goanalysis_metalinter
buildir: failed to load package fake: could not load export data: no export data for "github.com/golangci/sandbox/fake"
```
instead of
```console
$ ./golangci-lint run 
main.go:6:2: could not import github.com/golangci/sandbox/fake (-: # github.com/golangci/sandbox/fake
fake/tag.go:14:35: in call to slices.IsSortedFunc, type func(a Tag, b Tag) bool of tagCompare does not match inferred type func(a Tag, b Tag) int for func(a E, b E) int) (typecheck)                                                 
        "github.com/golangci/sandbox/fake"
        ^
1 issues:
* typecheck: 1
```

Behind this bug, there is another bug (I fixed it), it feels the same, but it's different internally:

<details>

Before:

```console
$ golangci-lint run        
WARN [runner] Can't run linter goanalysis_metalinter: buildir: failed to load package : could not load export data: no export data for "github.com/denis-tingaikin/go-header"
ERRO Running error: can't run linter goanalysis_metalinter
buildir: failed to load package : could not load export data: no export data for "github.com/denis-tingaikin/go-header" 
```
After:
```console
$ ./golangci-lint run
main.go:6:11: could not import github.com/denis-tingaikin/go-header (main.go:6:2: missing go.sum entry for module providing package github.com/denis-tingaikin/go-header (imported by github.com/golangci/sandbox); to add:
        go get github.com/golangci/sandbox) (typecheck)                                                                                                                                                                               
        goheader "github.com/denis-tingaikin/go-header"
                 ^
1 issues:
* typecheck: 1
```

</details>

Fixes #6056

Related to #3996, #4630, #4912, #4964, #5037, #5051, #5184, #5428, #5437
#2489, #2191, #2751, #3363, #4829