### PR TITLE
add namedreturns linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -192,6 +192,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/nikogura/namedreturns v0.1.2
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/go.sum
+++ b/go.sum
@@ -444,6 +444,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81U=
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
+github.com/nikogura/namedreturns v0.1.2 h1:fTkqUBScrXaNQ/6fi+3Xmh4TUcrlU4owABxlUmnVT2U=
+github.com/nikogura/namedreturns v0.1.2/go.mod h1:9ui2kQswms6rnmLoR5nhZk+fMR+Sk0iGGxpp/LJy4B8=
 github.com/nishanths/exhaustive v0.12.0 h1:vIY9sALmw6T/yxiASewa4TQcFsVYZQQRUQJhKRf3Swg=
 github.com/nishanths/exhaustive v0.12.0/go.mod h1:mEZ95wPIZW+x8kC4TgC+9YCUgiST7ecevsVDTgc2obs=
 github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm/w98Vk=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -271,6 +271,7 @@ type LintersSettings struct {
 	Mnd                      MndSettings                      `mapstructure:"mnd"`
 	MustTag                  MustTagSettings                  `mapstructure:"musttag"`
 	Nakedret                 NakedretSettings                 `mapstructure:"nakedret"`
+	NamedReturns             NamedReturnsSettings             `mapstructure:"namedreturns"`
 	Nestif                   NestifSettings                   `mapstructure:"nestif"`
 	NilNil                   NilNilSettings                   `mapstructure:"nilnil"`
 	Nlreturn                 NlreturnSettings                 `mapstructure:"nlreturn"`
@@ -735,6 +736,10 @@ type MustTagFunction struct {
 
 type NakedretSettings struct {
 	MaxFuncLines uint `mapstructure:"max-func-lines"`
+}
+
+type NamedReturnsSettings struct {
+	ReportErrorInDefer bool `mapstructure:"report-error-in-defer"`
 }
 
 type NestifSettings struct {

--- a/pkg/golinters/namedreturns/namedreturns.go
+++ b/pkg/golinters/namedreturns/namedreturns.go
@@ -1,0 +1,23 @@
+package namedreturns
+
+import (
+	"github.com/nikogura/namedreturns/analyzer"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New(settings *config.NamedReturnsSettings) *goanalysis.Linter {
+	var cfg map[string]any
+
+	if settings != nil {
+		cfg = map[string]any{
+			analyzer.FlagReportErrorInDefer: settings.ReportErrorInDefer,
+		}
+	}
+
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.Analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/namedreturns/testdata/namedreturns.go
+++ b/pkg/golinters/namedreturns/testdata/namedreturns.go
@@ -1,0 +1,138 @@
+package main
+
+import "errors"
+
+// =============================================================================
+// GOOD EXAMPLES - These should NOT trigger any reports
+// =============================================================================
+
+// Function with no return values - this is fine
+func noReturnValues() {
+	// No return values, so no reports needed
+}
+
+// Function with properly named returns - this is fine
+func goodNamedReturns() (result int, err error) {
+	result = 42
+	err = nil
+	return result, err
+}
+
+// Function with bare return using named returns - this is fine
+func bareReturnWithNamedReturns() (result int, err error) {
+	result = 42
+	err = nil
+	return // Uses the named return variables
+}
+
+// Method with properly named returns - this is fine
+type example struct{}
+
+func (e *example) goodMethod() (result int, err error) {
+	result = 42
+	err = nil
+	return result, err
+}
+
+// Function literal with properly named returns - this is fine
+var goodFuncLiteral = func() (result int, err error) {
+	result = 42
+	err = nil
+	return result, err
+}
+
+// Function with error return and defer assignment - this is fine (when flag is false)
+func errorWithDeferAssignment() (err error) {
+	defer func() {
+		err = errors.New("error occurred")
+	}()
+	return // Uses the named return variable
+}
+
+// =============================================================================
+// BAD EXAMPLES - These SHOULD trigger reports
+// =============================================================================
+
+// Unnamed returns - should report
+func unnamedReturns() (int, error) { // want `unnamed return with type "int" found - named returns are required` `unnamed return with type "error" found - named returns are required`
+	return 42, errors.New("error")
+}
+
+// Single unnamed return - should report
+func singleUnnamedReturn() int { // want `unnamed return with type "int" found - named returns are required`
+	return 42
+}
+
+// Underscore-named returns - should report
+func underscoreReturns() (_ int, _ string) { // want `underscore as a return variable name is unacceptable for type "int"` `underscore as a return variable name is unacceptable for type "string"`
+	return 42, "hello"
+}
+
+// Mixed underscore and proper names - should report on underscores
+func mixedUnderscoreReturns() (_ int, result string) { // want `underscore as a return variable name is unacceptable for type "int"`
+	return 42, result
+}
+
+// Named returns declared but not used in return statement - should report
+func namedReturnsNotUsed() (result int, err error) { // want `named return variable "result" is declared but not used in return statement` `named return variable "err" is declared but not used in return statement`
+	someValue := 42
+	someError := errors.New("error")
+	return someValue, someError
+}
+
+// Partial usage of named returns - should report on unused ones
+func partialNamedReturnUsage() (result int, err error) { // want `named return variable "result" is declared but not used in return statement`
+	err = errors.New("error")
+	return 42, err
+}
+
+// Named return shadowing - should report
+func shadowNamedReturn() (result int, err error) {
+	{
+		result := 42 // want `named return variable "result" is shadowed by local variable declaration`
+		// This shadows the named return variable
+		_ = result
+	}
+	err = errors.New("error")
+	return result, err
+}
+
+// Shadowing in loops - should report
+func shadowInLoop() (result int, err error) {
+	for result := 0; result < 10; result++ { // want `named return variable "result" is shadowed by for loop variable` `named return variable "result" is shadowed by local variable declaration`
+		// shadows named return via for-init
+		_ = result
+	}
+	err = errors.New("error")
+	return result, err
+}
+
+// Shadowing in range loops - should report
+func shadowInRange() (key string, value int) {
+	data := map[string]int{"a": 1, "b": 2}
+	for key, value := range data { // want `named return variable "key" is shadowed by range loop variable` `named return variable "value" is shadowed by range loop variable`
+		// shadows named returns via range variables
+		_ = key
+		_ = value
+	}
+	return key, value
+}
+
+// Shadowing with var declarations - should report
+func shadowWithVar() (result int, err error) {
+	{
+		var result int = 42 // want `named return variable "result" is shadowed by local variable declaration`
+		// This shadows the named return variable
+		_ = result
+	}
+	err = errors.New("error")
+	return result, err
+}
+
+// =============================================================================
+// HELPER FUNCTIONS - These are just for testing, not for analysis
+// =============================================================================
+
+func processError(err error)                         {}
+func doSomething() (num int, err error)              { num = 10; err = nil; return }
+func multierrAppendInto(_ *error, _ error) (ok bool) { ok = false; return }

--- a/pkg/golinters/namedreturns/testdata/report-error-in-defer.go
+++ b/pkg/golinters/namedreturns/testdata/report-error-in-defer.go
@@ -1,0 +1,75 @@
+package main
+
+import "fmt"
+
+// =============================================================================
+// TESTING THE report-error-in-defer FLAG
+// =============================================================================
+
+// When report-error-in-defer is FALSE (default), these should NOT report errors
+// because they use named returns with defer assignments
+
+func goodErrorWithDefer() (err error) {
+	defer func() {
+		err = fmt.Errorf("error occurred")
+	}()
+	return // Uses named return variable
+}
+
+func goodErrorWithDeferAndAssignment() (err error) {
+	defer func() {
+		err = fmt.Errorf("error occurred")
+	}()
+	return // Uses named return variable
+}
+
+// When report-error-in-defer is TRUE, these should report errors
+// because they use named returns but the flag is set to report them
+
+// With the flag enabled, we still allow bare returns with named errors
+func badErrorWithDefer() (err error) {
+	defer func() {
+		err = fmt.Errorf("error occurred")
+	}()
+	return // Uses named return variable, but flag is set to report
+}
+
+// =============================================================================
+// OTHER TEST CASES - These should always report regardless of flag
+// =============================================================================
+
+// Unnamed returns - should always report
+// This case must truly be unnamed to test that path. Keep body simple.
+func unnamedReturns() (int, error) { // want `unnamed return with type "int" found - named returns are required` `unnamed return with type "error" found - named returns are required`
+	return 0, nil
+}
+
+// Underscore returns - should always report
+func underscoreReturns() (_ int, _ error) { // want `underscore as a return variable name is unacceptable for type "int"` `underscore as a return variable name is unacceptable for type "error"`
+	return 0, nil
+}
+
+// Named returns not used - should always report
+func namedReturnsNotUsed() (result int, err error) { // want `named return variable "result" is declared but not used in return statement` `named return variable "err" is declared but not used in return statement`
+	someValue := 42
+	someError := fmt.Errorf("error")
+	return someValue, someError
+}
+
+// Shadowing - should always report
+func shadowNamedReturn() (result int, err error) {
+	{
+		result := 42 // want `named return variable "result" is shadowed by local variable declaration`
+		// This shadows the named return variable
+		_ = result
+	}
+	err = fmt.Errorf("error")
+	return result, err
+}
+
+// =============================================================================
+// HELPER FUNCTIONS - These are just for testing, not for analysis
+// =============================================================================
+
+func processError(err error)            {}
+func doSomething() (num int, err error) { num = 10; err = nil; return }

--- a/pkg/golinters/namedreturns/testdata/report-error-in-defer.yml
+++ b/pkg/golinters/namedreturns/testdata/report-error-in-defer.yml
@@ -1,0 +1,5 @@
+version: 2
+
+linters-settings:
+  namedreturns:
+    report-error-in-defer: true

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -82,6 +82,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nlreturn"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/noctx"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/noinlineerr"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/namedreturns"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nolintlint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nonamedreturns"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nosprintfhostport"
@@ -527,6 +528,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v2.2.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/AlwxSin/noinlineerr"),
+
+		linter.NewConfig(namedreturns.New(&cfg.Linters.Settings.NamedReturns)).
+			WithSince("v2.5.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/nikogura/namedreturns"),
 
 		linter.NewConfig(nonamedreturns.New(&cfg.Linters.Settings.NoNamedReturns)).
 			WithSince("v1.46.0").


### PR DESCRIPTION
This PR adds support for the [namedreturns](https://github.com/nikogura/namedreturns) linter, which detects and reports
 functions that use named returns but should return values explicitly for
better code clarity.


Addresses the need for detecting improper use of named returns in Go code,
following the same pattern as other linters in the codebase.
