### PR TITLE
docs: improve nolint section

### DIFF
--- a/docs/content/docs/linters/false-positives.md
+++ b/docs/content/docs/linters/false-positives.md
@@ -159,7 +159,7 @@ func someLegacyFunction() *string {
 }
 ```
 
-You can see more examples of using `nolint` directives direct in [our tests](https://github.com/golangci/golangci-lint/tree/HEAD/pkg/result/processors/testdata) for it.
+You can see more examples of using `nolint` directives in [our tests](https://github.com/golangci/golangci-lint/tree/HEAD/pkg/result/processors/testdata) for it.
 
 ### Syntax
 


### PR DESCRIPTION
The current documentation is not precise enough about the `nolint` syntax.