### PR TITLE
docs: gocritic enabled-checks and disabled-checks can be combined

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -717,8 +717,8 @@ linters:
       # Disable all checks.
       # Default: false
       disable-all: true
-      # Which checks should be enabled in addition to default checks; can't be combined with 'disabled-checks'.
-      # By default, list of stable checks is used (https://go-critic.com/overview#checks-overview):
+      # Which checks should be enabled in addition to default checks (or at all, if disable-all is true).
+      # The default checks are gocritic's stable checks (https://go-critic.com/overview#checks-overview):
       #   appendAssign, argOrder, assignOp, badCall, badCond, captLocal, caseOrder, codegenComment, commentFormatting,
       #   defaultCaseOrder, deprecatedComment, dupArg, dupBranchBody, dupCase, dupSubExpr, elseif, exitAfterDefer,
       #   flagDeref, flagName, ifElseChain, mapKey, newDeref, offBy1, regexpMust, singleCaseSwitch, sloppyLen,
@@ -1047,7 +1047,7 @@ linters:
       # Enable all checks.
       # Default: false
       enable-all: true
-      # Which checks should be disabled; can't be combined with 'enabled-checks'.
+      # Which checks should be disabled.
       # Default: []
       disabled-checks:
         - appendAssign

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -704,8 +704,8 @@ linters:
       # Disable all checks.
       # Default: false
       disable-all: true
-      # Which checks should be enabled in addition to default checks; can't be combined with 'disabled-checks'.
-      # By default, list of stable checks is used (https://go-critic.com/overview#checks-overview):
+      # Which checks should be enabled in addition to default checks (or at all, if disable-all is true).
+      # The default checks are gocritic's stable checks (https://go-critic.com/overview#checks-overview):
       #   appendAssign, argOrder, assignOp, badCall, badCond, captLocal, caseOrder, codegenComment, commentFormatting,
       #   defaultCaseOrder, deprecatedComment, dupArg, dupBranchBody, dupCase, dupSubExpr, elseif, exitAfterDefer,
       #   flagDeref, flagName, ifElseChain, mapKey, newDeref, offBy1, regexpMust, singleCaseSwitch, sloppyLen,
@@ -1034,7 +1034,7 @@ linters:
       # Enable all checks.
       # Default: false
       enable-all: true
-      # Which checks should be disabled; can't be combined with 'enabled-checks'.
+      # Which checks should be disabled.
       # Default: []
       disabled-checks:
         - appendAssign


### PR DESCRIPTION
The documentation currently indicates that enable-checks and disabled-checks can't be combined for gocritic. That is however not accurate: as per InferEnabledChecks in the gocritic wrapper,

* if enable-all is set, all available checks are added to the set of enabled checks
* otherwise, unless disable-all is set, the default checks are added to the set of enabled checks
* then the checks corresponding to each enabled tag are added
* then all enabled checks are added (with a warning if a check is enabled multiple times)
* then the checks corresponding to each disabled tag are removed
* finally, all disabled checks are removed (with a warning if a check wasn't enabled)

Using both enabled-checks and disabled-checks is useful when keeping the default set of checks as reference.

This adjusts the documentation to match the implementation.


related to #4458