### PR TITLE
feat: add  boolset linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -25,6 +25,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - boolset
     - canonicalheader
     - containedctx
     - contextcheck
@@ -139,6 +140,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - boolset
     - canonicalheader
     - containedctx
     - contextcheck

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/alexkohler/prealloc v1.0.0
 	github.com/alingse/asasalint v0.0.11
 	github.com/alingse/nilnesserr v0.2.0
+	github.com/arturmelanchyk/boolset v0.1.0
 	github.com/ashanbrown/forbidigo/v2 v2.1.0
 	github.com/ashanbrown/makezero/v2 v2.0.1
 	github.com/bkielbasa/cyclop v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/alingse/asasalint v0.0.11 h1:SFwnQXJ49Kx/1GghOFz1XGqHYKp21Kq1nHad/0WQ
 github.com/alingse/asasalint v0.0.11/go.mod h1:nCaoMhw7a9kSJObvQyVzNTPBDbNpdocqrSP7t/cW5+I=
 github.com/alingse/nilnesserr v0.2.0 h1:raLem5KG7EFVb4UIDAXgrv3N2JIaffeKNtcEXkEWd/w=
 github.com/alingse/nilnesserr v0.2.0/go.mod h1:1xJPrXonEtX7wyTq8Dytns5P2hNzoWymVUIaKm4HNFg=
+github.com/arturmelanchyk/boolset v0.1.0 h1:h2SsP7fRkQuMa+gehI8TMC8yeGmx3YVVKG7RPd41+ok=
+github.com/arturmelanchyk/boolset v0.1.0/go.mod h1:fbNSqEARCo6gKmn3cJoK/G6jaqmqBpeupHgIklA503o=
 github.com/ashanbrown/forbidigo/v2 v2.1.0 h1:NAxZrWqNUQiDz19FKScQ/xvwzmij6BiOw3S0+QUQ+Hs=
 github.com/ashanbrown/forbidigo/v2 v2.1.0/go.mod h1:0zZfdNAuZIL7rSComLGthgc/9/n2FqspBOH90xlCHdA=
 github.com/ashanbrown/makezero/v2 v2.0.1 h1:r8GtKetWOgoJ4sLyUx97UTwyt2dO7WkGFHizn/Lo8TY=

--- a/pkg/golinters/boolset/boolset.go
+++ b/pkg/golinters/boolset/boolset.go
@@ -1,0 +1,13 @@
+package boolset
+
+import (
+	"github.com/arturmelanchyk/boolset/boolset"
+
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	return goanalysis.
+		NewLinterFromAnalyzer(boolset.NewAnalyzer()).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/boolset/boolset_integration_test.go
+++ b/pkg/golinters/boolset/boolset_integration_test.go
@@ -1,0 +1,11 @@
+package boolset
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/boolset/testdata/boolset.go
+++ b/pkg/golinters/boolset/testdata/boolset.go
@@ -1,0 +1,23 @@
+//golangcitest:args -Eboolset
+package testdata
+
+import (
+	"log"
+)
+
+var allNames = []string{"a", "a", "b", "c", "c", "d"}
+
+func findDuplicates() []string {
+	var duplicates []string
+	uniqueNames := make(map[string]bool) // want "map\\[string\\]bool only stores \"true\" values; consider map\\[string\\]struct\\{\\}"
+	for _, name := range allNames {
+		if _, ok := uniqueNames[name]; ok {
+			duplicates = append(duplicates, name)
+			log.Println("Duplicate found: ", name)
+		} else {
+			uniqueNames[name] = true
+		}
+	}
+
+	return duplicates
+}

--- a/pkg/golinters/boolset/testdata/boolset_cgo.go
+++ b/pkg/golinters/boolset/testdata/boolset_cgo.go
@@ -1,0 +1,40 @@
+//golangcitest:args -Eboolset
+package testdata
+
+/*
+ #include <stdio.h>
+ #include <stdlib.h>
+
+ void myprint(char* s) {
+ 	printf("%d\n", s);
+ }
+*/
+import "C"
+
+import (
+	"log"
+	"unsafe"
+)
+
+func _() {
+	cs := C.CString("Hello from stdio\n")
+	C.myprint(cs)
+	C.free(unsafe.Pointer(cs))
+}
+
+var allNamesCgo = []string{"a", "a", "b", "c", "c", "d"}
+
+func findDuplicatesCgo() []string {
+	var duplicates []string
+	uniqueNames := make(map[string]bool) // want "map\\[string\\]bool only stores \"true\" values; consider map\\[string\\]struct\\{\\}"
+	for _, name := range allNamesCgo {
+		if _, ok := uniqueNames[name]; ok {
+			duplicates = append(duplicates, name)
+			log.Println("Duplicate found: ", name)
+		} else {
+			uniqueNames[name] = true
+		}
+	}
+
+	return duplicates
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/asciicheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/bidichk"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/bodyclose"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/boolset"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/canonicalheader"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/containedctx"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/contextcheck"
@@ -164,6 +165,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.18.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/timakin/bodyclose"),
+
+		linter.NewConfig(boolset.New()).
+			WithSince("v2.6.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/arturmelanchyk/boolset"),
 
 		linter.NewConfig(canonicalheader.New()).
 			WithSince("v1.58.0").


### PR DESCRIPTION
The PR adds support for [boolset](https://github.com/arturmelanchyk/boolset) linter

`boolset` is a Go linter that finds `map[T]bool` values which are effectively used as sets and recommends switching to
`map[T]struct{}`.
The replacement avoids storing redundant boolean payloads and can cut memory usage for large maps in half while keeping semantics identical.
