### PR TITLE
golangci-lint custom follows plugin's go.mod replace directives

### DIFF
--- a/pkg/commands/internal/builder.go
+++ b/pkg/commands/internal/builder.go
@@ -191,13 +191,17 @@ func (b Builder) mergeReplaceDirectives(ctx context.Context, pluginPath string) 
 	}
 
 	for _, r := range goMod.Replace {
-		abs := filepath.Join(pluginPath, r.New.Path)
+		abs, err := filepath.Abs(filepath.Join(pluginPath, r.New.Path))
+		if err != nil {
+			return fmt.Errorf("get absolute path: %w", err)
+		}
+
 		stat, err := os.Stat(abs)
 		if err != nil {
 			return fmt.Errorf("%s: %w", abs, err)
 		}
 		if stat.IsDir() {
-			r.New.Path = filepath.Join(pluginPath, r.New.Path)
+			r.New.Path = abs
 		}
 
 		replace := fmt.Sprintf("%s=%s", r.Old.Path, r.New.Path)

--- a/pkg/commands/internal/builder_test.go
+++ b/pkg/commands/internal/builder_test.go
@@ -1,9 +1,14 @@
 package internal
 
 import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_sanitizeVersion(t *testing.T) {
@@ -53,4 +58,40 @@ func Test_sanitizeVersion(t *testing.T) {
 			assert.Equal(t, test.expected, v)
 		})
 	}
+}
+
+func TestMergeReplaceDirectives(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary module structure:
+	// tmp/
+	//   go.mod
+	//   golangci-lint/
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(`
+module github.com/golangci/golangci-lint/v2
+go 1.24.0
+`), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(tmp, "golangci-lint"), 0o755))
+
+	b := NewBuilder(nil, &Configuration{Plugins: []*Plugin{
+		{Module: "example.com/plugin", Path: "testdata/plugin"},
+	}}, tmp)
+
+	err := b.mergeReplaceDirectives(t.Context(), filepath.Join("testdata", "plugin"))
+	require.NoError(t, err)
+
+	cmd := exec.Command("go", "mod", "edit", "-json")
+	cmd.Dir = b.repo
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+
+	var goMod struct {
+		Replace []struct{ New struct{ Path string } }
+	}
+	err = json.Unmarshal(output, &goMod)
+	require.NoError(t, err)
+
+	require.Len(t, goMod.Replace, 1)
+	assert.Contains(t, goMod.Replace[0].New.Path, "testdata/plugin/target")
 }

--- a/pkg/commands/internal/builder_test.go
+++ b/pkg/commands/internal/builder_test.go
@@ -71,8 +71,8 @@ func TestMergeReplaceDirectives(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(`
 module github.com/golangci/golangci-lint/v2
 go 1.24.0
-`), 0o644))
-	require.NoError(t, os.Mkdir(filepath.Join(tmp, "golangci-lint"), 0o755))
+`), 0o600))
+	require.NoError(t, os.Mkdir(filepath.Join(tmp, "golangci-lint"), 0o700))
 
 	b := NewBuilder(nil, &Configuration{Plugins: []*Plugin{
 		{Module: "example.com/plugin", Path: "testdata/plugin"},
@@ -84,7 +84,7 @@ go 1.24.0
 	err := b.mergeReplaceDirectives(t.Context(), filepath.Join("testdata", "plugin"))
 	require.NoError(t, err)
 
-	cmd := exec.Command("go", "mod", "edit", "-json")
+	cmd := exec.CommandContext(t.Context(), "go", "mod", "edit", "-json")
 	cmd.Dir = b.repo
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err)

--- a/pkg/commands/internal/testdata/plugin/go.mod
+++ b/pkg/commands/internal/testdata/plugin/go.mod
@@ -1,0 +1,7 @@
+module example.com/plugin
+
+go 1.24.0
+
+require example.com/target v0.0.0
+
+replace example.com/target => ./target

--- a/pkg/commands/internal/testdata/plugin/plugin.go
+++ b/pkg/commands/internal/testdata/plugin/plugin.go
@@ -1,0 +1,3 @@
+package plugin
+
+import _ "example.com/target"

--- a/pkg/commands/internal/testdata/plugin/target/go.mod
+++ b/pkg/commands/internal/testdata/plugin/target/go.mod
@@ -1,3 +1,7 @@
 module example.com/target
 
 go 1.24.0
+
+require example.com/other v0.0.0
+
+replace example.com/other => ./other

--- a/pkg/commands/internal/testdata/plugin/target/go.mod
+++ b/pkg/commands/internal/testdata/plugin/target/go.mod
@@ -1,0 +1,3 @@
+module example.com/target
+
+go 1.24.0

--- a/pkg/commands/internal/testdata/plugin/target/other/go.mod
+++ b/pkg/commands/internal/testdata/plugin/target/other/go.mod
@@ -1,0 +1,3 @@
+module example.com/other
+
+go 1.24.0

--- a/pkg/commands/internal/testdata/plugin/target/other/other.go
+++ b/pkg/commands/internal/testdata/plugin/target/other/other.go
@@ -1,0 +1,1 @@
+package other

--- a/pkg/commands/internal/testdata/plugin/target/target.go
+++ b/pkg/commands/internal/testdata/plugin/target/target.go
@@ -1,0 +1,1 @@
+package target

--- a/pkg/commands/internal/testdata/plugin/target/target.go
+++ b/pkg/commands/internal/testdata/plugin/target/target.go
@@ -1,1 +1,3 @@
 package target
+
+import _ "example.com/other"

--- a/pkg/commands/internal/testdata/plugin2/go.mod
+++ b/pkg/commands/internal/testdata/plugin2/go.mod
@@ -1,0 +1,7 @@
+module example.com/plugin2
+
+go 1.24.0
+
+require example.com/target v0.0.0
+
+replace example.com/target => ./target

--- a/pkg/commands/internal/testdata/plugin2/plugin.go
+++ b/pkg/commands/internal/testdata/plugin2/plugin.go
@@ -1,0 +1,3 @@
+package plugin
+
+import _ "example.com/target"

--- a/pkg/commands/internal/testdata/plugin2/target/go.mod
+++ b/pkg/commands/internal/testdata/plugin2/target/go.mod
@@ -1,0 +1,3 @@
+module example.com/target
+
+go 1.24.0

--- a/pkg/commands/internal/testdata/plugin2/target/target.go
+++ b/pkg/commands/internal/testdata/plugin2/target/target.go
@@ -1,0 +1,1 @@
+package target

--- a/pkg/commands/internal/testdata/plugin3/go.mod
+++ b/pkg/commands/internal/testdata/plugin3/go.mod
@@ -1,0 +1,7 @@
+module example.com/plugin2
+
+go 1.24.0
+
+require example.com/target v1.0.0
+
+replace example.com/target@v1.0.0 => ./target

--- a/pkg/commands/internal/testdata/plugin3/plugin.go
+++ b/pkg/commands/internal/testdata/plugin3/plugin.go
@@ -1,0 +1,3 @@
+package plugin
+
+import _ "example.com/target"

--- a/pkg/commands/internal/testdata/plugin3/target/go.mod
+++ b/pkg/commands/internal/testdata/plugin3/target/go.mod
@@ -1,0 +1,3 @@
+module example.com/target
+
+go 1.24.0

--- a/pkg/commands/internal/testdata/plugin3/target/target.go
+++ b/pkg/commands/internal/testdata/plugin3/target/target.go
@@ -1,0 +1,1 @@
+package target


### PR DESCRIPTION
When developing a golangci-lint plugin, it’s common to first implement the analyzer using the go/analysis interface and then wrap it with the golangci-lint plugin interface in a separate module. This separation is useful because the go/analysis interface is a generic abstraction that can be reused outside golangci-lint.

During development, a plugin may depend on an unreleased analyzer implementation and declare a replace directive in its `go.mod`. However, the current `golangci-lint custom` command ignores these directives. As a result, the custom build only succeeds if the plugin and the analyzer are bundled within the same `go.mod`.

This PR copies `replace` directives from the plugin's `go.mod` into the temporary `go.mod` used by `golangci-lint custom`. This ensures that the custom build correctly recognizes both the plugin and any modules it references via `replace`. As a result, plugins and analyzers can now be managed as separate modules.