### PR TITLE
-

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/v2
 
-go 1.24.0
+go 1.25.1
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0


### PR DESCRIPTION
Projects using Go 1.25+ are not compatible with the current `golangci-lint`. This PR aims at using a later version of Go to fix this dependency.