### PR TITLE
chore: freebsd/arm64 builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,8 +36,6 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
-      - goos: freebsd
-        goarch: arm64
 
 archives:
   - formats: [ 'tar.gz' ]

--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,7 @@ get_binaries() {
     darwin/s390x) BINARIES="golangci-lint" ;;
     freebsd/386) BINARIES="golangci-lint" ;;
     freebsd/amd64) BINARIES="golangci-lint" ;;
+    freebsd/arm64) BINARIES="golangci-lint" ;;
     freebsd/armv6) BINARIES="golangci-lint" ;;
     freebsd/armv7) BINARIES="golangci-lint" ;;
     freebsd/mips64) BINARIES="golangci-lint" ;;


### PR DESCRIPTION
This unblocks goreleaser from creating a freebsd/arm64 binary. I'm not sure why it has been blocked since golangci-lint is working fine on FreeBSD arm64/AArch64 when built manually.

Also, while here, adjust the `install.sh` script to support freebsd/arm64.

There is already a FreeBSD port of golangci-lint available at [devel/golangci-lint](https://www.freshports.org/devel/golangci-lint/) and the builds for arm64 seem to look fine.