### PR TITLE
dev: no semaphore if canceled

### DIFF
--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -67,7 +67,9 @@ func (lp *loadingPackage) analyze(ctx context.Context, cancel context.CancelFunc
 	case <-ctx.Done():
 		return
 	case loadSem <- struct{}{}:
-		defer func() { <-loadSem }()
+		defer func() {
+			<-loadSem
+		}()
 	}
 
 	// Save memory on unused more fields.


### PR DESCRIPTION
If context is canceled, we're still trying to acquire a semaphore but it's unnecessary so check context before blocking. This can improve cancelation speed by preventing starvation.