### PR TITLE
upgrade dupword v0.1.7 and add comments-only option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	4d63.com/gochecknoglobals v0.2.2
 	dev.gaijin.team/go/exhaustruct/v4 v4.0.0
 	github.com/4meepo/tagalign v1.4.3
-	github.com/Abirdcfly/dupword v0.1.6
+	github.com/Abirdcfly/dupword v0.1.7
 	github.com/AdminBenni/iota-mixing v1.0.0
 	github.com/AlwxSin/noinlineerr v1.0.5
 	github.com/Antonboom/errname v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ dev.gaijin.team/go/golib v0.6.0/go.mod h1:uY1mShx8Z/aNHWDyAkZTkX+uCi5PdX7KsG1eDQ
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/4meepo/tagalign v1.4.3 h1:Bnu7jGWwbfpAie2vyl63Zup5KuRv21olsPIha53BJr8=
 github.com/4meepo/tagalign v1.4.3/go.mod h1:00WwRjiuSbrRJnSVeGWPLp2epS5Q/l4UEy0apLLS37c=
-github.com/Abirdcfly/dupword v0.1.6 h1:qeL6u0442RPRe3mcaLcbaCi2/Y/hOcdtw6DE9odjz9c=
-github.com/Abirdcfly/dupword v0.1.6/go.mod h1:s+BFMuL/I4YSiFv29snqyjwzDp4b65W2Kvy+PKzZ6cw=
+github.com/Abirdcfly/dupword v0.1.7 h1:2j8sInznrje4I0CMisSL6ipEBkeJUJAmK1/lfoNGWrQ=
+github.com/Abirdcfly/dupword v0.1.7/go.mod h1:K0DkBeOebJ4VyOICFdppB23Q0YMOgVafM0zYW0n9lF4=
 github.com/AdminBenni/iota-mixing v1.0.0 h1:Os6lpjG2dp/AE5fYBPAA1zfa2qMdCAWwPMCgpwKq7wo=
 github.com/AdminBenni/iota-mixing v1.0.0/go.mod h1:i4+tpAaB+qMVIV9OK3m4/DAynOd5bQFaOu+2AhtBCNY=
 github.com/AlwxSin/noinlineerr v1.0.5 h1:RUjt63wk1AYWTXtVXbSqemlbVTb23JOSRiNsshj7TbY=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -386,8 +386,9 @@ type DuplSettings struct {
 }
 
 type DupWordSettings struct {
-	Keywords []string `mapstructure:"keywords"`
-	Ignore   []string `mapstructure:"ignore"`
+	Keywords     []string `mapstructure:"keywords"`
+	Ignore       []string `mapstructure:"ignore"`
+	CommentsOnly bool     `mapstructure:"comments-only"`
 }
 
 type EmbeddedStructFieldCheckSettings struct {

--- a/pkg/golinters/dupword/dupword.go
+++ b/pkg/golinters/dupword/dupword.go
@@ -14,8 +14,9 @@ func New(settings *config.DupWordSettings) *goanalysis.Linter {
 
 	if settings != nil {
 		cfg = map[string]any{
-			"keyword": strings.Join(settings.Keywords, ","),
-			"ignore":  strings.Join(settings.Ignore, ","),
+			"keyword":       strings.Join(settings.Keywords, ","),
+			"ignore":        strings.Join(settings.Ignore, ","),
+			"comments-only": settings.CommentsOnly,
 		}
 	}
 

--- a/pkg/golinters/dupword/testdata/dupword_comments_only.go
+++ b/pkg/golinters/dupword/testdata/dupword_comments_only.go
@@ -1,0 +1,24 @@
+//golangcitest:args -Edupword
+//golangcitest:config_path testdata/dupword_comments_only.yml
+package testdata
+
+import "fmt"
+
+func duplicateWordInComments() {
+	// this line include duplicated word the the // want `Duplicate words \(the\) found`
+	fmt.Println("hello")
+}
+
+func duplicateWordInStr() {
+	// When comments-only is enabled, duplicates in strings should NOT be flagged
+	a := "this line include duplicate word and and"
+	b := "print the\n the line, print the the \n\t the line. and and"
+	fmt.Println(a, b)
+}
+
+// Another comment with with duplicate words // want `Duplicate words \(with\) found`
+func anotherFunc() {
+	// Duplicate in in comment should be caught // want `Duplicate words \(in\) found`
+	s := "but but duplicate in string should be ignored"
+	fmt.Println(s)
+}

--- a/pkg/golinters/dupword/testdata/dupword_comments_only.yml
+++ b/pkg/golinters/dupword/testdata/dupword_comments_only.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    dupword:
+      comments-only: true


### PR DESCRIPTION
This updates dupword to v0.1.7 which includes a change from my PR Abirdcfly/dupword#63 to add a [-comments-only](https://github.com/Abirdcfly/dupword/pull/63) flag that only finds duplicate words in comments. This is presented as a configuration option `comments-only` to golangci-lint.

Test cases are added to ensure the flag is working.