### PR TITLE
add enable-default-rules: setting for revive

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -834,15 +834,16 @@ type RecvcheckSettings struct {
 }
 
 type ReviveSettings struct {
-	Go             string            `mapstructure:"-"`
-	MaxOpenFiles   int               `mapstructure:"max-open-files"`
-	Confidence     float64           `mapstructure:"confidence"`
-	Severity       string            `mapstructure:"severity"`
-	EnableAllRules bool              `mapstructure:"enable-all-rules"`
-	Rules          []ReviveRule      `mapstructure:"rules"`
-	ErrorCode      int               `mapstructure:"error-code"`
-	WarningCode    int               `mapstructure:"warning-code"`
-	Directives     []ReviveDirective `mapstructure:"directives"`
+	Go                 string            `mapstructure:"-"`
+	MaxOpenFiles       int               `mapstructure:"max-open-files"`
+	Confidence         float64           `mapstructure:"confidence"`
+	Severity           string            `mapstructure:"severity"`
+	EnableAllRules     bool              `mapstructure:"enable-all-rules"`
+	EnableDefaultRules bool              `mapstructure:"enable-default-rules"`
+	Rules              []ReviveRule      `mapstructure:"rules"`
+	ErrorCode          int               `mapstructure:"error-code"`
+	WarningCode        int               `mapstructure:"warning-code"`
+	Directives         []ReviveDirective `mapstructure:"directives"`
 }
 
 type ReviveRule struct {

--- a/pkg/golinters/revive/testdata/revive-enable-default.yml
+++ b/pkg/golinters/revive/testdata/revive-enable-default.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+linters:
+  settings:
+    revive:
+      enable-default-rules: true
+      rules:
+        # Disable one of the default rules
+        - name: exported
+          disabled: true
+        # Enable a non-default rule
+        - name: cyclomatic
+          arguments: [ 10 ]

--- a/pkg/golinters/revive/testdata/revive_enable_default.go
+++ b/pkg/golinters/revive/testdata/revive_enable_default.go
@@ -1,0 +1,36 @@
+//golangcitest:config_path testdata/revive-enable-default.yml
+//golangcitest:args -Erevive
+package testdata
+
+import (
+	"net/http"
+	"time"
+)
+
+// This function tests that default rules are still active (indent-error-flow is a default rule)
+func testEnableDefaultRules(t *time.Duration) error {
+	if t == nil {
+		return nil
+	} else { // want "indent-error-flow: if block ends with a return statement, .*"
+		return nil
+	}
+}
+
+// ExportedFunctionWithoutComment should not trigger because we disabled the exported rule
+func ExportedFunctionWithoutComment() {
+	// This is fine because 'exported' rule is disabled in the config
+}
+
+func testReviveComplexity(s string) { // want "cyclomatic: function testReviveComplexity has cyclomatic complexity 22"
+	if s == http.MethodGet || s == "2" || s == "3" || s == "4" || s == "5" || s == "6" || s == "7" {
+		return
+	}
+
+	if s == "1" || s == "2" || s == "3" || s == "4" || s == "5" || s == "6" || s == "7" {
+		return
+	}
+
+	if s == "1" || s == "2" || s == "3" || s == "4" || s == "5" || s == "6" || s == "7" {
+		return
+	}
+}


### PR DESCRIPTION
This adds an `enable-default-rules:` setting for revive. If set, the entries in the `rules:` list will be able to enable/disable individual rules assuming the default set has already been enabled. This makes it easier for users to exclude specific rules beyond the default configuration, and not have to check during upgrades if new rules have appeared in the default set.

Related: #1745, #5747