### PR TITLE
feat: add varasconst linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -125,6 +125,7 @@ linters:
     - unused
     - usestdlibvars
     - usetesting
+    - varasconst
     - varnamelen
     - wastedassign
     - whitespace
@@ -240,6 +241,7 @@ linters:
     - unused
     - usestdlibvars
     - usetesting
+    - varasconst
     - varnamelen
     - wastedassign
     - whitespace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/golangci/golangci-lint/v2
 
-go 1.24.0
+go 1.24.5
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0
@@ -15,6 +15,7 @@ require (
 	github.com/Antonboom/testifylint v1.6.4
 	github.com/BurntSushi/toml v1.5.0
 	github.com/Djarvur/go-err113 v0.1.1
+	github.com/MeenaAlfons/varasconst v0.1.2
 	github.com/MirrexOne/unqueryvet v1.2.1
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1
 	github.com/alecthomas/chroma/v2 v2.20.0
@@ -225,3 +226,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/meenaalfons/varasconst => github.com/meenaalfons/varasconst v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/Djarvur/go-err113 v0.1.1 h1:eHfopDqXRwAi+YmCUas75ZE0+hoBHJ2GQNLYRSxao
 github.com/Djarvur/go-err113 v0.1.1/go.mod h1:IaWJdYFLg76t2ihfflPZnM1LIQszWOsFDh2hhhAVF6k=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/MeenaAlfons/varasconst v0.1.2 h1:FjfTdiDucq18WpY2WMOTTQ52/7614pW9X/mE5GKo35Y=
+github.com/MeenaAlfons/varasconst v0.1.2/go.mod h1:HBUtQ4jxK6rcK38RrY6yupZPlTqMXyhZEFw5Cd3DDLU=
 github.com/MirrexOne/unqueryvet v1.2.1 h1:M+zdXMq84g+E1YOLa7g7ExN3dWfZQrdDSTCM7gC+m/A=
 github.com/MirrexOne/unqueryvet v1.2.1/go.mod h1:IWwCwMQlSWjAIteW0t+28Q5vouyktfujzYznSIWiuOg=
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1 h1:vckeWVESWp6Qog7UZSARNqfu/cZqvki8zsuj3piCMx4=

--- a/pkg/golinters/varasconst/testdata/varasconst.go
+++ b/pkg/golinters/varasconst/testdata/varasconst.go
@@ -1,0 +1,136 @@
+//golangcitest:args -Evarasconst
+package testdata
+
+var Global_1 = ""
+
+var (
+	Global_2 = ""
+	Global_3 = ""
+	global_4 = ""
+)
+
+// const
+var Global_Const_1 = ""
+
+// const
+var (
+	Global_Const_2 = ""
+	Global_Const_3 = ""
+	global_Const_4 = ""
+)
+
+var (
+
+	// const
+	Global_Const_5 = ""
+
+	Global_5 = ""
+
+	// const
+	Global_Const_6 = ""
+)
+
+func Direct_modification() {
+	Global_1 = "modified"
+	Global_2 = "modified"
+	Global_3 = "modified"
+	global_4 = "modified"
+	Global_5 = "modified"
+
+	Global_Const_1 = "modified" // want "assignment to global variable marked with const"
+	Global_Const_2 = "modified" // want "assignment to global variable marked with const"
+	Global_Const_3 = "modified" // want "assignment to global variable marked with const"
+	global_Const_4 = "modified" // want "assignment to global variable marked with const"
+	Global_Const_5 = "modified" // want "assignment to global variable marked with const"
+	Global_Const_6 = "modified" // want "assignment to global variable marked with const"
+
+	_ = global_4
+	_ = global_Const_4
+}
+
+func Hide_global_var_by_locally_defined_one() {
+	Global_1 := "defined"
+	Global_1 = "modified"
+
+	Global_Const_1 := "defined"
+	Global_Const_1 = "modified"
+
+	Global_2, Global_3 := "define multiple", "define multiple"
+	Global_2 = "modified"
+	Global_3 = "modified"
+
+	Global_Const_2, Global_Const_3 := "define multiple", "define multiple"
+	Global_Const_2 = "modified"
+	Global_Const_3 = "modified"
+
+	var global_4, global_Const_4 string
+	global_4 = "modified"
+	global_Const_4 = "modified"
+
+	_ = Global_1
+	_ = Global_2
+	_ = Global_3
+	_ = global_4
+	_ = Global_Const_1
+	_ = Global_Const_2
+	_ = Global_Const_3
+	_ = global_Const_4
+}
+
+func Assignment_in_if_stmt() {
+
+	if Global_1 = "assignment in if condition"; true {
+	}
+
+	if Global_Const_1 = "assignment in if condition"; true { // want "assignment to global variable marked with const"
+	}
+
+	if true {
+		Global_1 = "assignment in if body"
+		Global_Const_1 = "assignment in if body" // want "assignment to global variable marked with const"
+	}
+
+	_ = Global_1
+	_ = Global_Const_1
+}
+
+func Hidden_in_if_stmt_but_not_after() {
+	if Global_1 := "assignment in if condition"; true {
+		Global_1 = "modified"
+		_ = Global_1
+	}
+	Global_1 = "modified"
+
+	if Global_Const_1 := "assignment in if condition"; true {
+		Global_Const_1 = "modified"
+		_ = Global_Const_1
+	}
+	Global_Const_1 = "modified" // want "assignment to global variable marked with const"
+
+	if true {
+		Global_1 := "assignment in if body"
+		Global_Const_1 := "assignment in if body"
+
+		_ = Global_1
+		_ = Global_Const_1
+	}
+	Global_1 = "modified"
+	Global_Const_1 = "modified" // want "assignment to global variable marked with const"
+
+	_ = Global_1
+	_ = Global_Const_1
+}
+
+func Inside_func_literal() {
+
+	func() {
+		Global_1 = "modified"
+		Global_Const_1 = "modified" // want "assignment to global variable marked with const"
+	}()
+
+	func1 := func() {
+		Global_1 = "modified"
+		Global_Const_1 = "modified" // want "assignment to global variable marked with const"
+	}
+	func1()
+}

--- a/pkg/golinters/varasconst/varasconst.go
+++ b/pkg/golinters/varasconst/varasconst.go
@@ -1,0 +1,13 @@
+package varasconst
+
+import (
+	"github.com/MeenaAlfons/varasconst/pkg/analyzer"
+
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New() *goanalysis.Linter {
+	return goanalysis.
+		NewLinterFromAnalyzer(analyzer.Analyzer).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/varasconst/varasconst_integration_test.go
+++ b/pkg/golinters/varasconst/varasconst_integration_test.go
@@ -1,0 +1,11 @@
+package varasconst
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -114,6 +114,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/unused"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/usestdlibvars"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/usetesting"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/varasconst"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/varnamelen"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/wastedassign"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/whitespace"
@@ -691,6 +692,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithAutoFix().
 			WithURL("https://github.com/ldez/usetesting"),
+
+		linter.NewConfig(varasconst.New()).
+			WithSince("v2.5.1").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/MeenaAlfons/varasconst"),
 
 		linter.NewConfig(varnamelen.New(&cfg.Linters.Settings.Varnamelen)).
 			WithSince("v1.43.0").


### PR DESCRIPTION
This PR adds `varasconst` to available linters.

The Go linter [MeenaAlfons/varasconst](https://github.com/MeenaAlfons/varasconst) allows developer to mark global vars as constant using `// const`.

<details>

### General

I followed all the steps in this [docs](https://golangci-lint.run/docs/contributing/new-linters/) and from what I have seen in other PRs for adding a new linter.

The linter doesn't take any configurations (at least for now).

### Integration

Regarding testing, I copied most of the use cases from the test cases in the original repo. One case that cant be tested using golangci-lint test suite is changing a `var` marked as const that is imported from another package. I couldn't find a way to make the golangci-lint test suite run on multiple packages under `testdata`. See [tests for this case](https://github.com/MeenaAlfons/varasconst/blob/main/testdata/src/p2/p2.go) in the original repo.

</details>