### PR TITLE
feat!: warning when finding unknown linters

### DIFF
--- a/pkg/lint/lintersdb/validator.go
+++ b/pkg/lint/lintersdb/validator.go
@@ -1,7 +1,6 @@
 package lintersdb
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -61,7 +60,7 @@ func (v Validator) validateLintersNames(cfg *config.Linters) error {
 	}
 
 	if len(unknownNames) > 0 {
-		return fmt.Errorf("unknown linters: '%v', run 'golangci-lint help linters' to see the list of supported linters",
+		v.m.log.Warnf("unknown linters: '%v', run 'golangci-lint help linters' to see the list of supported linters",
 			strings.Join(unknownNames, ","))
 	}
 


### PR DESCRIPTION
Allow the program to continue running when unknown linters are found, and print a warning, so that it can be compatible with new versions of configuration files on old versions of golangci-lint. 

Before this, if a new version-specific linter was set, the old version would report an error and exit directly. This PR improves compatibility.

```
> ./golangci-lint run ./...
WARN [lintersdb] unknown linters: 'xxx', run 'golangci-lint help linters' to see the list of supported linters 
0 issues.
```