### PR TITLE
fix: use file depending on build configuration to invalidate cache

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -166,7 +166,7 @@ func (c *Cache) computePkgHash(pkg *packages.Package) (hashResults, error) {
 
 	fmt.Fprintf(key, "pkgpath %s\n", pkg.PkgPath)
 
-	for _, f := range pkg.CompiledGoFiles {
+	for _, f := range slices.Concat(pkg.CompiledGoFiles, pkg.IgnoredFiles) {
 		h, fErr := c.fileHash(f)
 		if fErr != nil {
 			return nil, fmt.Errorf("failed to calculate file %s hash: %w", f, fErr)


### PR DESCRIPTION
Adds `IgnoredFiles` to compute cache.

The name is confusing because this is Go files ignored during the build (build tags), and not related to `ignore` directive or non-Go files.

```go
// IgnoredFiles lists source files that are not part of the package
// using the current build configuration but that might be part of
// the package using other build configurations.
IgnoredFiles []string
```

Fixes #6178
