### PR TITLE
fix: follows symbolic links with formatter exclusion paths

### DIFF
--- a/pkg/goformat/runner.go
+++ b/pkg/goformat/runner.go
@@ -223,8 +223,13 @@ func NewRunnerOptions(cfg *config.Config, diff, diffColored, stdin bool) (Runner
 		return RunnerOptions{}, fmt.Errorf("get base path: %w", err)
 	}
 
+	evaluatedBasePath, err := fsutils.EvalSymlinks(basePath)
+	if err != nil {
+		return RunnerOptions{}, fmt.Errorf("evaluate base path: %w", err)
+	}
+
 	opts := RunnerOptions{
-		basePath:            basePath,
+		basePath:            evaluatedBasePath,
 		generated:           cfg.Formatters.Exclusions.Generated,
 		diff:                diff || diffColored,
 		colors:              diffColored,
@@ -251,7 +256,6 @@ func (o RunnerOptions) MatchAnyPattern(path string) (bool, error) {
 		return false, nil
 	}
 
-	// The basePath is already resolved via `fsutils.Getwd()` in `NewRunnerOptions`.
 	evaluatedPath, err := fsutils.EvalSymlinks(path)
 	if err != nil {
 		return false, err

--- a/pkg/goformat/runner_test.go
+++ b/pkg/goformat/runner_test.go
@@ -3,14 +3,12 @@ package goformat
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
-	"github.com/golangci/golangci-lint/v2/pkg/fsutils"
 )
 
 func TestRunnerOptions_MatchAnyPattern(t *testing.T) {
@@ -121,14 +119,6 @@ func TestRunnerOptions_MatchAnyPattern_withSymlinks(t *testing.T) {
 	}
 
 	cfg.SetConfigDir(realDir)
-
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		// IMPORTANT: On macOS, `tmpDir` might be` /var/..`. which is itself a symlink to `/private/var/...`
-		resolvedBasePath, errEval := fsutils.EvalSymlinks(realDir)
-		require.NoError(t, errEval)
-
-		cfg.SetConfigDir(resolvedBasePath)
-	}
 
 	opts, err := NewRunnerOptions(cfg, false, false, false)
 	require.NoError(t, err)


### PR DESCRIPTION
`ln -s worktree wt && cd wt && golangci-lint fmt` now works