### PR TITLE
fix: fmt command with symlinks

### DIFF
--- a/pkg/commands/fmt.go
+++ b/pkg/commands/fmt.go
@@ -113,14 +113,11 @@ func (c *fmtCommand) preRunE(_ *cobra.Command, _ []string) error {
 }
 
 func (c *fmtCommand) execute(_ *cobra.Command, args []string) error {
-	paths, err := cleanArgs(args)
-	if err != nil {
-		return fmt.Errorf("failed to clean arguments: %w", err)
-	}
+	paths := cleanArgs(args)
 
 	c.log.Infof("Formatting Go files...")
 
-	err = c.runner.Run(paths)
+	err := c.runner.Run(paths)
 	if err != nil {
 		return fmt.Errorf("failed to process files: %w", err)
 	}
@@ -134,25 +131,15 @@ func (c *fmtCommand) persistentPostRun(_ *cobra.Command, _ []string) {
 	}
 }
 
-func cleanArgs(args []string) ([]string, error) {
+func cleanArgs(args []string) []string {
 	if len(args) == 0 {
-		abs, err := filepath.Abs(".")
-		if err != nil {
-			return nil, err
-		}
-
-		return []string{abs}, nil
+		return []string{"."}
 	}
 
 	var expanded []string
 	for _, arg := range args {
-		abs, err := filepath.Abs(strings.ReplaceAll(arg, "...", ""))
-		if err != nil {
-			return nil, err
-		}
-
-		expanded = append(expanded, abs)
+		expanded = append(expanded, filepath.Clean(strings.ReplaceAll(arg, "...", "")))
 	}
 
-	return expanded, nil
+	return expanded
 }

--- a/pkg/goformat/runner_test.go
+++ b/pkg/goformat/runner_test.go
@@ -1,0 +1,140 @@
+package goformat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+)
+
+func TestRunnerOptions_MatchAnyPattern(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		cfg      *config.Config
+		filename string
+
+		assertMatch   assert.BoolAssertionFunc
+		expectedCount int
+	}{
+		{
+			desc: "match",
+			cfg: &config.Config{
+				Formatters: config.Formatters{
+					Exclusions: config.FormatterExclusions{
+						Paths: []string{`generated\.go`},
+					},
+				},
+			},
+			filename:      "generated.go",
+			assertMatch:   assert.True,
+			expectedCount: 1,
+		},
+		{
+			desc: "no match",
+			cfg: &config.Config{
+				Formatters: config.Formatters{
+					Exclusions: config.FormatterExclusions{
+						Paths: []string{`excluded\.go`},
+					},
+				},
+			},
+			filename:      "test.go",
+			assertMatch:   assert.False,
+			expectedCount: 0,
+		},
+		{
+			desc:        "no patterns",
+			cfg:         &config.Config{},
+			filename:    "test.go",
+			assertMatch: assert.False,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+
+			testFile := filepath.Join(tmpDir, test.filename)
+
+			err := os.WriteFile(testFile, []byte("package main"), 0o600)
+			require.NoError(t, err)
+
+			test.cfg.SetConfigDir(tmpDir)
+
+			opts, err := NewRunnerOptions(test.cfg, false, false, false)
+			require.NoError(t, err)
+
+			match, err := opts.MatchAnyPattern(testFile)
+			require.NoError(t, err)
+
+			test.assertMatch(t, match)
+
+			require.Len(t, opts.patterns, len(test.cfg.Formatters.Exclusions.Paths))
+
+			if len(opts.patterns) == 0 {
+				assert.Empty(t, opts.excludedPathCounter)
+			} else {
+				assert.Equal(t, test.expectedCount, opts.excludedPathCounter[opts.patterns[0]])
+			}
+		})
+	}
+}
+
+// File structure:
+//
+//	tmp
+//	├── project (`realDir`)
+//	│   ├── .golangci.yml
+//	│   └── test.go
+//	└── somewhere
+//	    └── symlink (to "project")
+func TestRunnerOptions_MatchAnyPattern_withSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testFile := filepath.Join(tmpDir, "project", "test.go")
+
+	realDir := filepath.Dir(testFile)
+
+	err := os.MkdirAll(realDir, 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(testFile, []byte("package main"), 0o600)
+	require.NoError(t, err)
+
+	symlink := filepath.Join(tmpDir, "somewhere", "symlink")
+
+	err = os.MkdirAll(filepath.Dir(symlink), 0o755)
+	require.NoError(t, err)
+
+	err = os.Symlink(realDir, symlink)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Formatters: config.Formatters{
+			Exclusions: config.FormatterExclusions{
+				Paths: []string{`^[^/\\]+\.go$`},
+			},
+		},
+	}
+
+	cfg.SetConfigDir(symlink)
+
+	opts, err := NewRunnerOptions(cfg, false, false, false)
+	require.NoError(t, err)
+
+	match, err := opts.MatchAnyPattern(filepath.Join(symlink, "test.go"))
+	require.NoError(t, err)
+
+	assert.True(t, match)
+
+	require.NotEmpty(t, opts.patterns)
+	require.Len(t, opts.patterns, len(cfg.Formatters.Exclusions.Paths))
+
+	assert.Equal(t, 1, opts.excludedPathCounter[opts.patterns[0]])
+}


### PR DESCRIPTION
The problem when running `golangci-lint fmt` inside a symlink is related to the `filepath.Walk` function.

> Walk does not follow symbolic links.
> https://pkg.go.dev/path/filepath#Walk

> WalkDir does not follow symbolic links.
> https://pkg.go.dev/path/filepath#WalkDir

Note: The `filepath.Walk/filepath.WalkDir` function is used by the `golangci-lint fmt` command but also by `gofmt`, `gofumpt`, etc.

The problem happens only with `golangci-lint fmt` because we use an absolute representation of paths.

But this absolute representation of paths is required by the exclusion paths system to evaluate the paths relatively to the base directory.

There are 2 ways to solve this problem:
- When the absolute representation is created, we could also evaluate the symlinks. But the output of the diff option will be impacted and will display the real path instead of the symlink path.
- Don't use an absolute representation of paths before the call to `Walk` function. But this will impact the exclusion paths system: the matching system needs the absolute representation.

I decided to go with the second option because it's closer to the `gofmt` and `gofumpt` behavior.

Note: this doesn't impact `golangci-lint run` because this is a different approach.

<details><summary>To reproduce</summary>

```bash
#!/bin/sh -e

GOLANGCI_LINT_BIN=golangci-lint

ROOT=$(mktemp -d)
mkdir -p $ROOT/project/

## Create module
cat > $ROOT/project/go.mod <<EOF
module github.com/golangci/sandbox

go1.24.0
EOF

# Create golangci-lint configuration file.
cat > $ROOT/project/.golangci.yaml <<EOF
version: "2"

formatters:
  enable:
    - gofmt
#  exclusions:
#    paths:
#      - ^[^/]+\\.go\$
EOF

## Create main.go file.
cat > $ROOT/project/main.go <<EOF
package main

import "fmt"

func main() {
fmt.Println("hello world") // Formatting problem.
}
EOF

## Create symlink to the project directory.
ln -s $ROOT/project/ $ROOT/workdir

## Run golangci-lint inside the real project directory.
cd $ROOT/project

echo
echo "--------------------------"
echo "Run on the real project directory ($(pwd)):"
echo

${GOLANGCI_LINT_BIN} fmt --diff || true

## Run golangci-lint inside the symlinked project directory.
cd $ROOT/workdir

echo
echo "--------------------------"
echo "Run on the symlinked project directory ($(pwd)):"
echo

${GOLANGCI_LINT_BIN} fmt --diff || true

rm -rf $ROOT
```

</details>


<details>
<summary>Before</summary>

```console
$ ./setup.sh

--------------------------
Run on the real project directory (/tmp/tmp.aRmyw8ndll/project):

diff /tmp/tmp.aRmyw8ndll/project/main.go.orig /tmp/tmp.aRmyw8ndll/project/main.go
--- /tmp/tmp.aRmyw8ndll/project/main.go.orig
+++ /tmp/tmp.aRmyw8ndll/project/main.go
@@ -3,5 +3,5 @@
 import "fmt"
 
 func main() {
-fmt.Println("hello world") // Formatting problem.
+       fmt.Println("hello world") // Formatting problem.
 }

--------------------------
Run on the symlinked project directory (/tmp/tmp.aRmyw8ndll/workdir):

$
```

</details>

<details>
<summary>After</summary>


```console
$ ./setup.sh

--------------------------
Run on the real project directory (/tmp/tmp.RhH8WxS3sf/project):

diff main.go.orig main.go
--- main.go.orig
+++ main.go
@@ -3,5 +3,5 @@
 import "fmt"
 
 func main() {
-fmt.Println("hello world") // Formatting problem.
+       fmt.Println("hello world") // Formatting problem.
 }

--------------------------
Run on the symlinked project directory (/tmp/tmp.RhH8WxS3sf/workdir):

diff main.go.orig main.go
--- main.go.orig
+++ main.go
@@ -3,5 +3,5 @@
 import "fmt"
 
 func main() {
-fmt.Println("hello world") // Formatting problem.
+       fmt.Println("hello world") // Formatting problem.
 }
$

</details>
