### PR TITLE
feat: add docnametypo linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -32,6 +32,7 @@ linters:
     - cyclop
     - decorder
     - depguard
+    - docnametypo
     - dogsled
     - dupl
     - dupword
@@ -147,6 +148,7 @@ linters:
     - cyclop
     - decorder
     - depguard
+    - docnametypo
     - dogsled
     - dupl
     - dupword
@@ -375,6 +377,33 @@ linters:
               desc: not allowed
             - pkg: "github.com/pkg/errors"
               desc: Should be replaced by standard lib errors package
+
+    # https://github.com/cce/docnametypo
+    docnametypo:
+      # Maximum Damerau-Levenshtein distance before a pair of words stops being considered a typo.
+      # Default: 1
+      maxdist: 2
+      # Check unexported functions/methods/types.
+      # Default: true
+      include-unexported: false
+      # Check exported declarations.
+      # Default: false
+      include-exported: true
+      # Extend the check to type declarations.
+      # Default: false
+      include-types: true
+      # Include files that carry the "// Code generated ... DO NOT EDIT." header.
+      # Default: false
+      include-generated: true
+      # Check interface method declarations.
+      # Default: false
+      include-interface-methods: true
+      # Comma-separated verbs treated as narrative intros (e.g. "Create", "Configure", "Tests"); matching comments are skipped.
+      # Default: "create,creates,creating,initialize,initializes,init,configure,configures,setup,setups,start,starts,read,reads,write,writes,send,sends,generate,generates,decode,decodes,encode,encodes,marshal,marshals,unmarshal,unmarshals,apply,applies,process,processes,make,makes,build,builds,test,tests"
+      allowed-leading-words: "create,configure,setup,validate,process"
+      # Comma-separated list of symbol prefixes (such as "op") that may be stripped before comparing to the doc token.
+      # Default: ""
+      allowed-prefixes: "op,ui"
 
     dogsled:
       # Checks assignments with too many blank identifiers.

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -227,6 +227,7 @@ type LintersSettings struct {
 	Cyclop                   CyclopSettings                   `mapstructure:"cyclop"`
 	Decorder                 DecorderSettings                 `mapstructure:"decorder"`
 	Depguard                 DepGuardSettings                 `mapstructure:"depguard"`
+	Docnametypo              DocnameTypoSettings              `mapstructure:"docnametypo"`
 	Dogsled                  DogsledSettings                  `mapstructure:"dogsled"`
 	Dupl                     DuplSettings                     `mapstructure:"dupl"`
 	DupWord                  DupWordSettings                  `mapstructure:"dupword"`
@@ -375,6 +376,17 @@ type DecorderSettings struct {
 	DisableVarDecNumCheck     bool     `mapstructure:"disable-var-dec-num-check"`
 	DisableDecOrderCheck      bool     `mapstructure:"disable-dec-order-check"`
 	DisableInitFuncFirstCheck bool     `mapstructure:"disable-init-func-first-check"`
+}
+
+type DocnameTypoSettings struct {
+	MaxDist                  int    `mapstructure:"maxdist"`
+	IncludeUnexported        bool   `mapstructure:"include-unexported"`
+	IncludeExported          bool   `mapstructure:"include-exported"`
+	IncludeTypes             bool   `mapstructure:"include-types"`
+	IncludeGenerated         bool   `mapstructure:"include-generated"`
+	IncludeInterfaceMethods  bool   `mapstructure:"include-interface-methods"`
+	AllowedLeadingWords      string `mapstructure:"allowed-leading-words"`
+	AllowedPrefixes          string `mapstructure:"allowed-prefixes"`
 }
 
 type DogsledSettings struct {

--- a/pkg/golinters/docnametypo/docnametypo.go
+++ b/pkg/golinters/docnametypo/docnametypo.go
@@ -1,0 +1,41 @@
+package docnametypo
+
+import (
+	"github.com/cce/docnametypo/analyzer"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New(settings *config.DocnameTypoSettings) *goanalysis.Linter {
+	a := analyzer.Analyzer
+
+	cfg := map[string]map[string]any{}
+	if settings != nil {
+		linterCfg := map[string]any{
+			"maxdist":                   settings.MaxDist,
+			"include-unexported":        settings.IncludeUnexported,
+			"include-exported":          settings.IncludeExported,
+			"include-types":             settings.IncludeTypes,
+			"include-generated":         settings.IncludeGenerated,
+			"include-interface-methods": settings.IncludeInterfaceMethods,
+		}
+
+		if settings.AllowedLeadingWords != "" {
+			linterCfg["allowed-leading-words"] = settings.AllowedLeadingWords
+		}
+
+		if settings.AllowedPrefixes != "" {
+			linterCfg["allowed-prefixes"] = settings.AllowedPrefixes
+		}
+
+		cfg[a.Name] = linterCfg
+	}
+
+	return goanalysis.NewLinter(
+		a.Name,
+		a.Doc,
+		[]*goanalysis.Analyzer{{Analyzer: a}},
+		cfg,
+	).WithLoadMode(goanalysis.LoadModeSyntax)
+}

--- a/pkg/golinters/docnametypo/docnametypo_integration_test.go
+++ b/pkg/golinters/docnametypo/docnametypo_integration_test.go
@@ -1,0 +1,11 @@
+package docnametypo
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/docnametypo/testdata/docnametypo.yml
+++ b/pkg/golinters/docnametypo/testdata/docnametypo.yml
@@ -1,0 +1,7 @@
+linters-settings:
+  docnametypo:
+    include-exported: true
+    include-types: true
+    allowed-prefixes: "op,ui"
+    allowed-leading-words: "validate,validates"
+    maxdist: 2

--- a/pkg/golinters/docnametypo/testdata/docnametypo_config.go
+++ b/pkg/golinters/docnametypo/testdata/docnametypo_config.go
@@ -1,0 +1,20 @@
+//golangcitest:args -Edocnametypo
+//golangcitest:config_path testdata/docnametypo.yml
+package testdata
+
+import "fmt"
+
+// Thing operates on things
+func opThing() {} // This should pass with allowed-prefixes
+
+// Register handles registration
+func uiRegister() {} // This should pass with allowed-prefixes
+
+// Validate checks the input (narrative with custom allowed words)
+func validateInput() {} // This should pass with custom allowed-leading-words
+
+// wrongName is wrong // want `doc comment starts with 'wrongName' but symbol is 'correctName'`
+func correctName() {}
+
+// ExportedWrong does something // want `doc comment starts with 'ExportedWrong' but symbol is 'ExportedFunc'`
+func ExportedFunc() {} // Should be flagged because include-exported is true in config

--- a/pkg/golinters/docnametypo/testdata/docnametypo_default.go
+++ b/pkg/golinters/docnametypo/testdata/docnametypo_default.go
@@ -1,0 +1,28 @@
+//golangcitest:args -Edocnametypo
+package testdata
+
+import "fmt"
+
+// confgure sets up the application // want `doc comment starts with 'confgure' but symbol is 'configure'`
+func configure() {}
+
+// ServerHTTP handles requests // want `doc comment starts with 'ServerHTTP' but symbol is 'ServeHTTP'`
+func ServeHTTP() {}
+
+// newTelemetryHook creates a hook // want `doc comment starts with 'newTelemetryHook' but symbol is 'NewTelemetryHook'`
+func NewTelemetryHook() {}
+
+// parseConfig reads configuration
+func parseManifest() {} // want `doc comment starts with 'parseConfig' but symbol is 'parseManifest'`
+
+// Creates a new HTTP client (narrative - should pass)
+func newHTTPClient() {}
+
+// Generates encryption keys (narrative - should pass)
+func generateKeys() {}
+
+// helper does something (unexported, correct name - should pass)
+func helper() {}
+
+// ExportedFunc does something (exported, but default doesn't check exported - should pass)
+func ExportedFunc() {}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/cyclop"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/decorder"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/depguard"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/docnametypo"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/dogsled"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/dupl"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/dupword"
@@ -199,6 +200,10 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		linter.NewConfig(depguard.New(&cfg.Linters.Settings.Depguard, placeholderReplacer)).
 			WithSince("v1.4.0").
 			WithURL("https://github.com/OpenPeeDeeP/depguard"),
+
+		linter.NewConfig(docnametypo.New(&cfg.Linters.Settings.Docnametypo)).
+			WithSince("v2.7.0").
+			WithURL("https://github.com/cce/docnametypo"),
 
 		linter.NewConfig(dogsled.New(&cfg.Linters.Settings.Dogsled)).
 			WithSince("v1.19.0").


### PR DESCRIPTION
This PR adds the [docnametypo](https://github.com/cce/docnametypo) linter. docnametypo detects probable typos in Go doc comments when the first word appears to reference the identifier name, but doesn't match due to typos, stale names after refactoring, or common mistakes like case mismatches.

<details>
docnametypo catches typos and stale names in documentation comments.

The linter is designed to complement existing doc comment linters like godoclint and revive. While those tools enforce that exported symbols follow strict `// FunctionName does ...` formatting, docnametypo targets a different problem: catching typos when developers do reference the symbol name, but get it wrong, especially on unexported code where they will not be caught by existing tools. Common issues it catches include:

- Typos: `// ServerHTTP handles ...` above a `ServeHTTP` function
- Stale names after renaming/refactoring: `// parseConfig reads ...` above a function now called `parseManifest`, plus word transpositions like `// newTelemetryFilteredHook makes ...` above a function called `newFilteredTelemetryHook`
- Case mismatches after changing exported vs unexported: `// NewHandler creates...` above an unexported `newHandler` function

It uses multiple detection strategies (Damerau-Levenshtein distance, CamelCase analysis, prefix handling) to understand the author's intent and flag probable mistakes while allowing flexible documentation styles.

###  Integration

I believe the linter satisfies all technical criteria on the checklist. The linter is free of init(), panic(), and os.Exit() calls. The linter uses `LoadModeSyntax` and only needs AST info.

The linter has sensible defaults that make it usable out of the box:
  - Checks unexported symbols by default (where style is typically relaxed)
  - Skips exported symbols by default (assuming other tools like godoclint or revive handle those)
  - Includes a default list of narrative verbs (Creates, Initializes, etc.) that are skipped, a source of false positives in my testing on real codebases
  - Maximum Levenshtein distance of 1 to minimize false positives

This approach aims to ensure the linter provides value immediately while staying out of the way of intentional documentation choices. These settings reduced false positives to zero for the codebases I tried it on.

### Motivation

The initial idea behind writing this linter was to catch and pre-empt this new class of typo PRs that seem to be coming in for OSS projects on Github. They may be using LLMs or private tools to detect these typos and hopefully this linter will help projects detect them quicker on their own.
</details>