### PR TITLE
dev: isolating GOCACHE for integration tests

### DIFF
--- a/test/testshared/integration/run.go
+++ b/test/testshared/integration/run.go
@@ -64,6 +64,8 @@ func testOneSource(t *testing.T, log *logutils.StderrLog, binPath, sourcePath st
 		"--max-issues-per-linter=100",
 	}
 
+	cacheDir := t.TempDir()
+
 	for _, addArg := range []string{"", "-Etypecheck"} {
 		caseArgs := slices.Clone(args)
 
@@ -73,6 +75,7 @@ func testOneSource(t *testing.T, log *logutils.StderrLog, binPath, sourcePath st
 
 		cmd := testshared.NewRunnerBuilder(t).
 			WithBinPath(binPath).
+			WithEnviron("GOCACHE=" + cacheDir).
 			WithArgs(caseArgs...).
 			WithRunContext(rc).
 			WithTargetPath(sourcePath).


### PR DESCRIPTION
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

Non-versioned dependencies are managed by the golangci-lint maintainers.

No pull requests to update a linter will be accepted unless:
you are the original author of the linter, AND there are important changes required (like a major version bump).

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->

Every integration test now runs golangci-lint with its own temporary GOCACHE, so Go drops build artifacts into a folder the test owns instead of `~/Library/Caches/go-build`. That stops the “operation not permitted” errors we were seeing in sandboxes/CI when tests tried to write into the user cache, and it doesn’t affect normal CLI usage, only the test harness changed.
