### PR TITLE
modernize: disable stringscut analyzer

### DIFF
--- a/pkg/golinters/modernize/modernize.go
+++ b/pkg/golinters/modernize/modernize.go
@@ -14,9 +14,9 @@ func New(settings *config.ModernizeSettings) *goanalysis.Linter {
 	var analyzers []*analysis.Analyzer
 
 	if settings == nil {
-		analyzers = modernize.Suite
+		analyzers = cleanSuite()
 	} else {
-		for _, analyzer := range modernize.Suite {
+		for _, analyzer := range cleanSuite() {
 			if slices.Contains(settings.Disable, analyzer.Name) {
 				continue
 			}
@@ -31,4 +31,20 @@ func New(settings *config.ModernizeSettings) *goanalysis.Linter {
 		analyzers,
 		nil).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}
+
+func cleanSuite() []*analysis.Analyzer {
+	var analyzers []*analysis.Analyzer
+
+	for _, analyzer := range modernize.Suite {
+		// Disabled because of false positives
+		// https://github.com/golang/go/issues/76687
+		if analyzer.Name == "stringscut" {
+			continue
+		}
+
+		analyzers = append(analyzers, analyzer)
+	}
+
+	return analyzers
 }


### PR DESCRIPTION
`stringscut` analyzer reports false positives.
And this is a more important problem because it applies suggested fixes that could creates bugs.

Related to https://github.com/golangci/golangci-lint/issues/6232#issuecomment-3609413970