### PR TITLE
fix(fixer): dedupe error message on conflicts from the same linter

### DIFF
--- a/pkg/result/processors/fixer.go
+++ b/pkg/result/processors/fixer.go
@@ -301,6 +301,10 @@ func diff3Conflict(path, xlabel, ylabel string, xedits, yedits []diff.Edit) erro
 		return err
 	}
 
-	return fmt.Errorf("conflicting edits from %s and %s on %s\nfirst edits:\n%s\nsecond edits:\n%s",
-		xlabel, ylabel, path, xdiff, ydiff)
+	from := xlabel
+	if from != ylabel {
+		from += " and " + ylabel
+	}
+	return fmt.Errorf("conflicting edits from %s on %s\nfirst edits:\n%s\nsecond edits:\n%s",
+		from, path, xdiff, ydiff)
 }


### PR DESCRIPTION
For example, modernize's omitzero produces this. Better to say

> conflicting edits from modernize on ...

...than:

> conflicting edits from modernize and modernize on ...

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

Non-versioned dependencies are managed by the golangci-lint maintainers.

No pull requests to update a linter will be accepted unless:
you are the original author of the linter, AND there are important changes required (like a major version bump).

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
