### PR TITLE
dev: fix attest-build-provenance subject-checksums usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
         run: docker login -u golangci -p ${{ secrets.GOLANGCI_LINT_DOCKER_TOKEN }}
 
       - name: Create release
+        id: goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
@@ -84,7 +85,7 @@ jobs:
 
       - uses: actions/attest-build-provenance@v3
         with:
-          subject-checksums: ./dist/golangci-lint-*-checksums.txt
+          subject-checksums: ./dist/golangci-lint-${{ fromJSON(steps.goreleaser.outputs.metadata).version }}-checksums.txt
           github-token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
       - uses: actions/attest-build-provenance@v3
         with:


### PR DESCRIPTION
Unlike subject-path, subject-checksums does not take a glob.

- https://github.com/actions/attest-build-provenance/blob/c6f9859ac6fd46168bba4ac441e2994fa837fc39/action.yml#L26-L30
- https://github.com/actions/attest/blob/9902fb2594e0b5bbab9995737abd2547cde67f22/src/subject.ts#L145-L151

Grab the needed version string from goreleaser metadata output instead.
Ref https://github.com/orgs/goreleaser/discussions/6295

This is untested, but I suppose it could work.
Prior art: https://github.com/search?q=fromJSON%28steps.goreleaser.outputs.metadata%29.version+subject-checksums&type=code


---

- https://github.com/goreleaser/goreleaser-action/blob/d31d51ab5501a8d6d0f08c7a080136a1d0adb7a3/action.yml#L33
- https://github.com/goreleaser/goreleaser-action/blob/d31d51ab5501a8d6d0f08c7a080136a1d0adb7a3/src/goreleaser.ts#L104-L114
