### PR TITLE
revive: add missing enable-default-rules setting

### DIFF
--- a/pkg/golinters/revive/revive.go
+++ b/pkg/golinters/revive/revive.go
@@ -208,11 +208,12 @@ func getConfig(cfg *config.ReviveSettings) (*lint.Config, error) {
 
 func createConfigMap(cfg *config.ReviveSettings) map[string]any {
 	rawRoot := map[string]any{
-		"confidence":     cfg.Confidence,
-		"severity":       cfg.Severity,
-		"errorCode":      cfg.ErrorCode,
-		"warningCode":    cfg.WarningCode,
-		"enableAllRules": cfg.EnableAllRules,
+		"confidence":         cfg.Confidence,
+		"severity":           cfg.Severity,
+		"errorCode":          cfg.ErrorCode,
+		"warningCode":        cfg.WarningCode,
+		"enableAllRules":     cfg.EnableAllRules,
+		"enableDefaultRules": cfg.EnableDefaultRules,
 
 		// Should be managed with `linters.exclusions.generated`.
 		"ignoreGeneratedHeader": false,


### PR DESCRIPTION
Given 
```yaml
version: "2"
linters:
  settings:
    revive:
      enable-default-rules: true
      rules:
        - name: unused-parameter
          disabled: true
```
Running
```console
$ GL_DEBUG=revive golangci-lint run --enable-only=revive
```
would output:
```console
DEBU [revive] Default rules (23): blank-imports, context-as-argument, context-keys-type, dot-imports, empty-block, error-naming, error-return, error-strings, errorf, exported, increment-decrement, indent-error-flow, package-comments, range, receiver-naming, redefines-builtin-id, superfluous-else, time-naming, unexported-return, unreachable-code, unused-parameter, var-declaration, var-naming. 
DEBU [revive] Enabled by config rules (0): .      
DEBU [revive] revive configuration: &lint.Config{IgnoreGeneratedHeader:false, Confidence:0.8, Severity:"warning", EnableAllRules:false, EnableDefaultRules:false, Rules:map[string]lint.RuleConfig{"unused-parameter":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:true, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}}, ErrorCode:0, WarningCode:0, Directives:map[string]lint.DirectiveConfig(nil), Exclude:[]string(nil), GoVersion:(*version.Version)(nil)} 
```

Note the `EnableDefaultRules:false` despite the config file having `enable-default-rules: true` and how no rules are configured.
This happens because the config.ReviveSettings is non-zero, but the ReviveSettings.EnableDefaultRules field is not being copied over to lint.Config.


With this fix we get:
```console
DEBU [revive] Default rules (23): blank-imports, context-as-argument, context-keys-type, dot-imports, empty-block, error-naming, error-return, error-strings, errorf, exported, increment-decrement, indent-error-flow, package-comments, range, receiver-naming, redefines-builtin-id, superfluous-else, time-naming, unexported-return, unreachable-code, unused-parameter, var-declaration, var-naming. 
DEBU [revive] Enabled by config rules (22): blank-imports, context-as-argument, context-keys-type, dot-imports, empty-block, error-naming, error-return, error-strings, errorf, exported, increment-decrement, indent-error-flow, package-comments, range, receiver-naming, redefines-builtin-id, superfluous-else, time-naming, unexported-return, unreachable-code, var-declaration, var-naming. 
DEBU [revive] revive configuration: &lint.Config{IgnoreGeneratedHeader:false, Confidence:0.8, Severity:"warning", EnableAllRules:false, EnableDefaultRules:true, Rules:map[string]lint.RuleConfig{"blank-imports":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "context-as-argument":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "context-keys-type":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "dot-imports":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "empty-block":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "error-naming":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "error-return":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "error-strings":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "errorf":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "exported":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "increment-decrement":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "indent-error-flow":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "package-comments":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "range":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "receiver-naming":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "redefines-builtin-id":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "superfluous-else":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "time-naming":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unexported-return":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unreachable-code":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "unused-parameter":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:true, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "var-declaration":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}, "var-naming":lint.RuleConfig{Arguments:[]interface {}(nil), Severity:"warning", Disabled:false, Exclude:[]string(nil), excludeFilters:[]*lint.FileFilter(nil)}}, ErrorCode:0, WarningCode:0, Directives:map[string]lint.DirectiveConfig(nil), Exclude:[]string(nil), GoVersion:(*version.Version)(nil)}
```

In particular:`EnableDefaultRules:true` and how we get the expected default rules aside from "unused-parameter".   
(Note: Disabling unused-parameter is just an arbitrary example, the behavior is the same for any combination of rules)

