### PR TITLE
docs: fix link to the swaggo/swag

### DIFF
--- a/docs/data/formatters_info.json
+++ b/docs/data/formatters_info.json
@@ -53,7 +53,7 @@
     "name": "swaggo",
     "desc": "Check if swaggo comments are formatted",
     "loadMode": 8199,
-    "originalURL": "https://github.com/swaggo/swaggo",
+    "originalURL": "https://github.com/swaggo/swag",
     "internal": false,
     "canAutoFix": true,
     "isSlow": false,

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -619,7 +619,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		linter.NewConfig(swaggo.New()).
 			WithSince("v2.2.0").
 			WithAutoFix().
-			WithURL("https://github.com/swaggo/swaggo"),
+			WithURL("https://github.com/swaggo/swag"),
 
 		linter.NewConfig(tagalign.New(&cfg.Linters.Settings.TagAlign)).
 			WithSince("v1.53.0").


### PR DESCRIPTION
Hello, awesome maintainers :wink: !

Just a small PR to update the link to the swaggo/swag formatter, as the previous one returns a 404.

Thanks, and keep up the good work!

### Additional comments

Follows the addition of the swaggo formatter in https://github.com/golangci/golangci-lint/pull/5749
