### PR TITLE
feat: do not collect VCS information when loading code

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -4740,6 +4740,10 @@ run:
   # Default: ""
   modules-download-mode: readonly
 
+  # Uses version control information during the loading of packages.
+  # Default: false (implies `-buildvcs=false`)
+  enable-build-vcs: true
+
   # Allow multiple parallel golangci-lint instances running.
   # If false, golangci-lint acquires file lock on start.
   # Default: false

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -4618,6 +4618,10 @@
           "description": "Option to pass to \"go list -mod={option}\".\nSee \"go help modules\" for more information.",
           "enum": ["mod", "readonly", "vendor"]
         },
+        "enable-build-vcs": {
+          "type": "boolean",
+          "default": false
+        },
         "allow-parallel-runners": {
           "description": "Allow multiple parallel golangci-lint instances running. If disabled, golangci-lint acquires file lock on start.",
           "type": "boolean",

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -21,6 +21,7 @@ type Run struct {
 
 	BuildTags           []string `mapstructure:"build-tags"`
 	ModulesDownloadMode string   `mapstructure:"modules-download-mode"`
+	EnableBuildVCS      bool     `mapstructure:"enable-build-vcs"`
 
 	ExitCodeIfIssuesFound int  `mapstructure:"issues-exit-code"`
 	AnalyzeTests          bool `mapstructure:"tests"`

--- a/pkg/lint/package.go
+++ b/pkg/lint/package.go
@@ -230,8 +230,10 @@ func (l *PackageLoader) makeBuildFlags() []string {
 		buildFlags = append(buildFlags, fmt.Sprintf("-mod=%s", l.cfg.Run.ModulesDownloadMode))
 	}
 
-	// disable collecting VCS information
-	buildFlags = append(buildFlags, "-buildvcs=false")
+	if !l.cfg.Run.EnableBuildVCS {
+		// disable collecting VCS information
+		buildFlags = append(buildFlags, "-buildvcs=false")
+	}
 
 	return buildFlags
 }


### PR DESCRIPTION
Fixes https://github.com/golangci/golangci-lint/issues/6348.

Explicitly disables collecting VCS information when loading packages, since it is not needed and can take a significant time.