### PR TITLE
govet: add `inline` analyzer

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1775,6 +1775,8 @@ linters:
         - httpresponse
         # Detect impossible interface-to-interface type assertions.
         - ifaceassert
+        # Find calls to functions and uses of constants marked with a "//go:fix inline" directive.
+        - inline
         # Check references to loop variables from within nested functions.
         - loopclosure
         # Check cancel func returned by context.WithCancel is called.

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1858,6 +1858,7 @@ linters:
         - httpmux
         - httpresponse
         - ifaceassert
+        - inline
         - loopclosure
         - lostcancel
         - nilfunc

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -1726,7 +1726,7 @@ linters:
       # Enable analyzers by name.
       # (In addition to default:
       #   appends, asmdecl, assign, atomic, bools, buildtag, cgocall, composites, copylocks, defers, directive, errorsas,
-      #   framepointer, httpresponse, ifaceassert, loopclosure, lostcancel, nilfunc, printf, shift, sigchanyzer, slog,
+      #   framepointer, httpresponse, ifaceassert, inline, loopclosure, lostcancel, nilfunc, printf, shift, sigchanyzer, slog,
       #   stdmethods, stringintconv, structtag, testinggoroutine, tests, timeformat, unmarshal, unreachable, unsafeptr,
       #   unusedresult
       # ).

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -574,6 +574,7 @@
         "httpmux",
         "httpresponse",
         "ifaceassert",
+        "inline",
         "loopclosure",
         "lostcancel",
         "nilfunc",

--- a/pkg/golinters/govet/govet.go
+++ b/pkg/golinters/govet/govet.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/tools/go/analysis/passes/httpmux"
 	"golang.org/x/tools/go/analysis/passes/httpresponse"
 	"golang.org/x/tools/go/analysis/passes/ifaceassert"
+	"golang.org/x/tools/go/analysis/passes/inline"
 	_ "golang.org/x/tools/go/analysis/passes/inspect" // unused internal analyzer
 	"golang.org/x/tools/go/analysis/passes/loopclosure"
 	"golang.org/x/tools/go/analysis/passes/lostcancel"
@@ -83,6 +84,7 @@ var (
 		httpmux.Analyzer,
 		httpresponse.Analyzer,
 		ifaceassert.Analyzer,
+		inline.Analyzer,
 		loopclosure.Analyzer,
 		lostcancel.Analyzer,
 		nilfunc.Analyzer,

--- a/pkg/golinters/govet/govet.go
+++ b/pkg/golinters/govet/govet.go
@@ -111,7 +111,8 @@ var (
 		waitgroup.Analyzer,
 	}
 
-	// https://github.com/golang/go/blob/go1.25.2/src/cmd/vet/main.go#L57-L91
+	// https://github.com/golang/go/blob/go1.26.1/src/cmd/vet/main.go#L63-L99
+	// https://github.com/golang/go/blob/go1.26.1/src/cmd/fix/main.go#L47-L51
 	defaultAnalyzers = []*analysis.Analyzer{
 		appends.Analyzer,
 		asmdecl.Analyzer,
@@ -129,6 +130,7 @@ var (
 		hostport.Analyzer,
 		httpresponse.Analyzer,
 		ifaceassert.Analyzer,
+		inline.Analyzer,
 		loopclosure.Analyzer,
 		lostcancel.Analyzer,
 		nilfunc.Analyzer,

--- a/pkg/golinters/govet/testdata/fix/in/govet.go
+++ b/pkg/golinters/govet/testdata/fix/in/govet.go
@@ -23,3 +23,12 @@ func nonConstantFormat(s string) {
 	fmt.Fprintf(os.Stderr, "%s", s)
 	log.Printf("%s", s)
 }
+
+func _() {
+	ReadFile("")
+}
+
+//go:fix inline
+func ReadFile(filename string) ([]byte, error) {
+	return os.ReadFile(filename)
+}

--- a/pkg/golinters/govet/testdata/fix/out/govet.go
+++ b/pkg/golinters/govet/testdata/fix/out/govet.go
@@ -23,3 +23,12 @@ func nonConstantFormat(s string) {
 	fmt.Fprintf(os.Stderr, "%s", s)
 	log.Printf("%s", s)
 }
+
+func _() {
+	os.ReadFile("")
+}
+
+//go:fix inline
+func ReadFile(filename string) ([]byte, error) {
+	return os.ReadFile(filename)
+}

--- a/pkg/golinters/govet/testdata/govet_fix.yml
+++ b/pkg/golinters/govet/testdata/govet_fix.yml
@@ -14,3 +14,4 @@ linters:
         - stringintconv
         - timeformat
         - unreachable
+        - inline


### PR DESCRIPTION
The `inline` analyzer has been available since [golang.org/x/tools@v0.38.0](https://pkg.go.dev/golang.org/x/tools@v0.38.0/go/analysis/passes/inline).

---

Checked the analyzer on golangci-lint's codebase:

```patch
diff --git a/.golangci.yml b/.golangci.yml
index 8c9f7789..e6605185 100644
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,7 @@ linters:
             - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Errorf
             - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Fatalf
       enable:
+        - inline
         - nilness
         - shadow
     errorlint:
```

```console
❯ make build
go build -o golangci-lint ./cmd/golangci-lint
❯ ./golangci-lint run --enable-only govet
pkg/goanalysis/runner_loadingpackage.go:516:7: inline: Constant reflect.Ptr should be inlined (govet)
        case reflect.Ptr:
             ^
1 issues:
* govet: 1
```