### PR TITLE
dev: cleanup

### DIFF
--- a/pkg/goanalysis/runner_checker.go
+++ b/pkg/goanalysis/runner_checker.go
@@ -427,7 +427,7 @@ func (act *action) exportPackageFact(fact analysis.Fact) {
 // NOTE(ldez) altered: add receiver to handle logs.
 func (act *action) factType(fact analysis.Fact) reflect.Type {
 	t := reflect.TypeOf(fact)
-	if t.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Pointer {
 		act.runner.log.Fatalf("invalid Fact type: got %T, want pointer", fact)
 	}
 	return t

--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -513,7 +513,7 @@ func sizeOfValueTreeBytes(v any) int {
 
 func sizeOfReflectValueTreeBytes(rv reflect.Value, visitedPtrs map[uintptr]struct{}) int {
 	switch rv.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		ptrSize := int(rv.Type().Size())
 		if rv.IsNil() {
 			return ptrSize

--- a/pkg/goanalysis/runners_cache.go
+++ b/pkg/goanalysis/runners_cache.go
@@ -25,7 +25,7 @@ func saveIssuesToCache(allPkgs []*packages.Package, pkgsFromCache map[*packages.
 		perPkgIssues[issue.Pkg] = append(perPkgIssues[issue.Pkg], issue)
 	}
 
-	var savedIssuesCount int64 = 0
+	var savedIssuesCount int64
 	lintResKey := getIssuesCacheKey(analyzers)
 
 	workerCount := runtime.GOMAXPROCS(-1)

--- a/pkg/result/processors/exclusion_rules.go
+++ b/pkg/result/processors/exclusion_rules.go
@@ -32,7 +32,7 @@ func NewExclusionRules(log logutils.Log, lines *fsutils.LineCache, cfg *config.L
 		skippedCounter: map[string]int{},
 	}
 
-	excludeRules := slices.Concat(slices.Clone(cfg.Rules), getLinterExclusionPresets(cfg.Presets))
+	excludeRules := slices.Concat(cfg.Rules, getLinterExclusionPresets(cfg.Presets))
 
 	p.rules = parseRules(excludeRules, "", newExcludeRule)
 


### PR DESCRIPTION
- `reflect.Ptr` is the old name for the [Pointer](https://pkg.go.dev/reflect#Pointer) kind.
- `slices.Concat` returns a new slice, no need for additional `slices.Clone`.