### PR TITLE
feat: add kubetyped linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2035,6 +2035,33 @@ linters:
       reject:
         - github.com\/user\/package\/v4\.Type
 
+    kubetyped:
+      # Include test files in the analysis.
+      # Default: false
+      include-test-files: false
+      # Per-check enable/disable map.
+      # Valid checks: map_literal, sprintf_yaml, unstructured_gvk, raw_gvk_string,
+      #   deprecated_api, embedded_yaml, raw_condition_status, raw_condition_type,
+      #   condition_map_literal, unstructured_status
+      # Default: all enabled
+      checks:
+        map_literal: true
+        sprintf_yaml: true
+      # Additional GVK-to-typed-struct mappings.
+      # Default: []
+      extra-known-gvks:
+        - api-version: "example.io/v1"
+          kind: "Widget"
+          typed-package: "example.io/api/v1.Widget"
+      # GVKs to suppress diagnostics for (format: "apiVersion/kind").
+      # Default: []
+      ignore-gvks:
+        - "v1/ConfigMap"
+      # GVKs to reject by policy (format: "apiVersion/kind").
+      # Default: []
+      reject-gvks:
+        - "v1/Pod"
+
     lll:
       # Max line length, lines longer will be reported.
       # '\t' is counted as 1 character by default, and can be changed with the tab-width option.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/golangci/golangci-lint/v2
 // The minimum Go version must always be latest-1.
 // This version should never be changed outside of the PR to add the support of newer Go version.
 // Only golangci-lint maintainers are allowed to change it.
-go 1.25.0
+go 1.26
 
 ignore (
 	./docs
@@ -75,6 +75,7 @@ require (
 	github.com/jgautheron/goconst v1.8.2
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jjti/go-spancheck v0.6.5
+	github.com/jplimack-ai/kubetyped v1.2.0
 	github.com/julz/importas v0.2.0
 	github.com/karamaru-alpha/copyloopvar v1.2.2
 	github.com/kisielk/errcheck v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -353,6 +353,8 @@ github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+D
 github.com/jjti/go-spancheck v0.6.5 h1:lmi7pKxa37oKYIMScialXUK6hP3iY5F1gu+mLBPgYB8=
 github.com/jjti/go-spancheck v0.6.5/go.mod h1:aEogkeatBrbYsyW6y5TgDfihCulDYciL1B7rG2vSsrU=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+github.com/jplimack-ai/kubetyped v1.2.0 h1:ZBEMpNp4Lz9Wp9GSy7o/Tvt0EUR5u6kpAUuqUy9A10s=
+github.com/jplimack-ai/kubetyped v1.2.0/go.mod h1:e8onccg1gBrGyI26QSNW4coiGjzWq4bgoErbPStaaME=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -282,6 +282,7 @@ type LintersSettings struct {
 	InterfaceBloat           InterfaceBloatSettings           `mapstructure:"interfacebloat"`
 	IotaMixing               IotaMixingSettings               `mapstructure:"iotamixing"`
 	Ireturn                  IreturnSettings                  `mapstructure:"ireturn"`
+	Kubetyped                KubetypedSettings                `mapstructure:"kubetyped"`
 	Lll                      LllSettings                      `mapstructure:"lll"`
 	LoggerCheck              LoggerCheckSettings              `mapstructure:"loggercheck"`
 	MaintIdx                 MaintIdxSettings                 `mapstructure:"maintidx"`
@@ -707,6 +708,20 @@ type IotaMixingSettings struct {
 type IreturnSettings struct {
 	Allow  []string `mapstructure:"allow"`
 	Reject []string `mapstructure:"reject"`
+}
+
+type KubetypedSettings struct {
+	IncludeTestFiles bool                `mapstructure:"include-test-files"`
+	Checks           map[string]bool     `mapstructure:"checks"`
+	ExtraKnownGVKs   []KubetypedGVKEntry `mapstructure:"extra-known-gvks"`
+	IgnoreGVKs       []string            `mapstructure:"ignore-gvks"`
+	RejectGVKs       []string            `mapstructure:"reject-gvks"`
+}
+
+type KubetypedGVKEntry struct {
+	APIVersion   string `mapstructure:"api-version"`
+	Kind         string `mapstructure:"kind"`
+	TypedPackage string `mapstructure:"typed-package"`
 }
 
 type LllSettings struct {

--- a/pkg/golinters/kubetyped/kubetyped.go
+++ b/pkg/golinters/kubetyped/kubetyped.go
@@ -1,0 +1,33 @@
+package kubetyped
+
+import (
+	"github.com/jplimack-ai/kubetyped"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New(settings *config.KubetypedSettings) *goanalysis.Linter {
+	s := kubetyped.Settings{}
+	if settings != nil {
+		s.IncludeTestFiles = settings.IncludeTestFiles
+		s.IgnoreGVKs = settings.IgnoreGVKs
+		s.RejectGVKs = settings.RejectGVKs
+		for _, g := range settings.ExtraKnownGVKs {
+			s.ExtraKnownGVKs = append(s.ExtraKnownGVKs, kubetyped.GVKEntry{
+				APIVersion:   g.APIVersion,
+				Kind:         g.Kind,
+				TypedPackage: g.TypedPackage,
+			})
+		}
+		for name, enabled := range settings.Checks {
+			if s.Checks == nil {
+				s.Checks = make(map[string]kubetyped.CheckConfig)
+			}
+			s.Checks[name] = kubetyped.CheckConfig{Enabled: &enabled}
+		}
+	}
+	return goanalysis.
+		NewLinterFromAnalyzer(kubetyped.NewAnalyzer(&s)).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/kubetyped/kubetyped_integration_test.go
+++ b/pkg/golinters/kubetyped/kubetyped_integration_test.go
@@ -1,0 +1,11 @@
+package kubetyped
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/kubetyped/testdata/kubetyped.go
+++ b/pkg/golinters/kubetyped/testdata/kubetyped.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Ekubetyped
+package testdata
+
+func example() {
+	m := map[string]any{ // want `use \*corev1\.Pod`
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata":   map[string]any{"name": "test"},
+	}
+	_ = m
+}

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -66,6 +66,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/intrange"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/iotamixing"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/ireturn"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/kubetyped"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/lll"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/loggercheck"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/maintidx"
@@ -461,6 +462,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.43.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/butuzov/ireturn"),
+
+		linter.NewConfig(kubetyped.New(&cfg.Linters.Settings.Kubetyped)).
+			WithSince("v2.11.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/jplimack-ai/kubetyped"),
 
 		linter.NewConfig(lll.New(&cfg.Linters.Settings.Lll)).
 			WithSince("v1.8.0"),


### PR DESCRIPTION
## Summary
- Add [kubetyped](https://github.com/jplimack-ai/kubetyped) as a built-in linter
- Detects untyped Kubernetes manifest construction (map literals, sprintf YAML, unstructured objects) and suggests typed Go structs
- 10 configurable checks covering map literals, sprintf YAML, unstructured GVK, raw GVK strings, deprecated APIs, embedded YAML, condition handling, and unstructured status access

## Changes
- `pkg/golinters/kubetyped/` — linter wrapper, integration test, testdata
- `pkg/config/linters_settings.go` — `KubetypedSettings` and `KubetypedGVKEntry` structs
- `pkg/lint/lintersdb/builder_linter.go` — registration
- `.golangci.next.reference.yml` — reference config documentation
