### PR TITLE
feat: add goqueryguard linter

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -66,6 +66,7 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
+    - goqueryguard
     - gosec
     - gosmopolitan
     - govet
@@ -181,6 +182,7 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
+    - goqueryguard
     - gosec
     - gosmopolitan
     - govet
@@ -1494,6 +1496,12 @@ linters:
         # Set to true to raise lint issues for packages that are loaded from a local path via replace directive.
         # Default: false
         local-replace-directives: false
+
+    goqueryguard:
+      # Optional path to a goqueryguard configuration file.
+      # If empty, default config discovery is used.
+      # Default: ""
+      config: .goqueryguard.yaml
 
     gosec:
       # To select a subset of rules to run.

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/manuelarte/funcorder v0.5.0
 	github.com/maratori/testableexamples v1.0.1
 	github.com/maratori/testpackage v1.1.2
+	github.com/mario-pinderi/goqueryguard v0.1.2
 	github.com/matoous/godox v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mgechev/revive v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -416,6 +416,8 @@ github.com/maratori/testableexamples v1.0.1 h1:HfOQXs+XgfeRBJ+Wz0XfH+FHnoY9TVqL6
 github.com/maratori/testableexamples v1.0.1/go.mod h1:XE2F/nQs7B9N08JgyRmdGjYVGqxWwClLPCGSQhXQSrQ=
 github.com/maratori/testpackage v1.1.2 h1:ffDSh+AgqluCLMXhM19f/cpvQAKygKAJXFl9aUjmbqs=
 github.com/maratori/testpackage v1.1.2/go.mod h1:8F24GdVDFW5Ew43Et02jamrVMNXLUNaOynhDssITGfc=
+github.com/mario-pinderi/goqueryguard v0.1.2 h1:KUY6bo5TSPfAbQQG9+LvNEdkVgdiRkzxxtPVYxfDtnE=
+github.com/mario-pinderi/goqueryguard v0.1.2/go.mod h1:SA4GKMO0e5yE8Y/CkM7um1mClOuNWxw8FQo7xbSa8y4=
 github.com/matoous/godox v1.1.0 h1:W5mqwbyWrwZv6OQ5Z1a/DHGMOvXYCBP3+Ht7KMoJhq4=
 github.com/matoous/godox v1.1.0/go.mod h1:jgE/3fUXiTurkdHOLT5WEkThTSuE7yxHv5iWPa80afs=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -864,6 +864,7 @@
             "gomoddirectives",
             "gomodguard",
             "goprintffuncname",
+            "goqueryguard",
             "gosec",
             "gosimple",
             "gosmopolitan",
@@ -2337,6 +2338,17 @@
                   "default": true
                 }
               }
+            }
+          }
+        },
+        "goqueryguardSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "config": {
+              "description": "Optional path to a goqueryguard configuration file.",
+              "type": "string",
+              "default": ""
             }
           }
         },
@@ -4893,6 +4905,9 @@
             },
             "gomodguard": {
               "$ref": "#/definitions/settings/definitions/gomodguardSettings"
+            },
+            "goqueryguard": {
+              "$ref": "#/definitions/settings/definitions/goqueryguardSettings"
             },
             "gosec": {
               "$ref": "#/definitions/settings/definitions/gosecSettings"

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -270,6 +270,7 @@ type LintersSettings struct {
 	Goheader                 GoHeaderSettings                 `mapstructure:"goheader"`
 	GoModDirectives          GoModDirectivesSettings          `mapstructure:"gomoddirectives"`
 	Gomodguard               GoModGuardSettings               `mapstructure:"gomodguard"`
+	Goqueryguard             GoqueryguardSettings             `mapstructure:"goqueryguard"`
 	Gosec                    GoSecSettings                    `mapstructure:"gosec"`
 	Gosmopolitan             GosmopolitanSettings             `mapstructure:"gosmopolitan"`
 	Unqueryvet               UnqueryvetSettings               `mapstructure:"unqueryvet"`
@@ -620,6 +621,10 @@ type GoModGuardModule struct {
 type GoModGuardVersion struct {
 	Version string `mapstructure:"version"`
 	Reason  string `mapstructure:"reason"`
+}
+
+type GoqueryguardSettings struct {
+	Config string `mapstructure:"config"`
 }
 
 type GoSecSettings struct {

--- a/pkg/golinters/goqueryguard/goqueryguard.go
+++ b/pkg/golinters/goqueryguard/goqueryguard.go
@@ -1,0 +1,35 @@
+package goqueryguard
+
+import (
+	publicanalyzer "github.com/mario-pinderi/goqueryguard/golangci/analyzer"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
+)
+
+const linterName = "goqueryguard"
+
+func New(settings *config.GoqueryguardSettings) *goanalysis.Linter {
+	return goanalysis.NewLinter(
+		linterName,
+		"Reports database queries executed inside loops, including indirect call chains.",
+		newAnalyzers(settings),
+		nil,
+	).WithLoadMode(goanalysis.LoadModeTypesInfo)
+}
+
+func newAnalyzers(settings *config.GoqueryguardSettings) []*analysis.Analyzer {
+	var configPath string
+	if settings != nil && settings.Config != "" {
+		configPath = settings.Config
+	}
+
+	a, err := publicanalyzer.NewAnalyzerFromConfigPath(configPath)
+	if err != nil {
+		internal.LinterLogger.Fatalf("%s: create analyzer: %v", linterName, err)
+	}
+
+	return []*analysis.Analyzer{a}
+}

--- a/pkg/golinters/goqueryguard/goqueryguard_integration_test.go
+++ b/pkg/golinters/goqueryguard/goqueryguard_integration_test.go
@@ -1,0 +1,11 @@
+package goqueryguard
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/goqueryguard/testdata/goqueryguard.go
+++ b/pkg/golinters/goqueryguard/testdata/goqueryguard.go
@@ -1,0 +1,19 @@
+//golangcitest:args -Egoqueryguard
+package testdata
+
+import "database/sql"
+
+func queryInLoop(db *sql.DB, ids []int) {
+	for range ids {
+		_, _ = db.Query("SELECT 1") // want `query-in-loop \[definite\]`
+	}
+}
+
+func rowsIterationIsNotAQuery(db *sql.DB, ids []int) {
+	rows, _ := db.Query("SELECT 1")
+	defer rows.Close()
+
+	for range ids {
+		_ = rows.Next()
+	}
+}

--- a/pkg/golinters/goqueryguard/testdata/goqueryguard_custom.go
+++ b/pkg/golinters/goqueryguard/testdata/goqueryguard_custom.go
@@ -1,0 +1,12 @@
+//golangcitest:args -Egoqueryguard
+//golangcitest:config_path testdata/goqueryguard_custom.yml
+//golangcitest:expected_exitcode 0
+package testdata
+
+import "database/sql"
+
+func queryInLoopConfigured(db *sql.DB, ids []int) {
+	for range ids {
+		_, _ = db.Query("SELECT 1")
+	}
+}

--- a/pkg/golinters/goqueryguard/testdata/goqueryguard_custom.yml
+++ b/pkg/golinters/goqueryguard/testdata/goqueryguard_custom.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    goqueryguard:
+      config: goqueryguard_custom_config.cfg

--- a/pkg/golinters/goqueryguard/testdata/goqueryguard_custom_config.cfg
+++ b/pkg/golinters/goqueryguard/testdata/goqueryguard_custom_config.cfg
@@ -1,0 +1,5 @@
+version: 1
+
+rules:
+  query-in-loop:
+    enabled: false

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -54,6 +54,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/gomoddirectives"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/gomodguard"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/goprintffuncname"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/goqueryguard"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/gosec"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/gosmopolitan"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/govet"
@@ -399,6 +400,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 		linter.NewConfig(goprintffuncname.New()).
 			WithSince("v1.23.0").
 			WithURL("https://github.com/golangci/go-printf-func-name"),
+
+		linter.NewConfig(goqueryguard.New(&cfg.Linters.Settings.Goqueryguard)).
+			WithSince("v2.11.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/mario-pinderi/goqueryguard"),
 
 		linter.NewConfig(gosec.New(&cfg.Linters.Settings.Gosec)).
 			WithSince("v1.0.0").


### PR DESCRIPTION
<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

Non-versioned dependencies are managed by the golangci-lint maintainers.

No pull requests to update a linter will be accepted unless:
you are the original author of the linter, AND there are important changes required (like a major version bump).

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->

 `goqueryguard` detects database queries executed inside loops (including indirect call chains), helping catch N+1 query patterns and similar performance issues early in CI.
https://github.com/mario-pinderi/goqueryguard