### PR TITLE
errcheck: ignore Rollback errors in std-error-handling preset

### DIFF
--- a/docs/data/exclusion_presets.json
+++ b/docs/data/exclusion_presets.json
@@ -82,7 +82,7 @@
       "linters": [
         "errcheck"
       ],
-      "text": "(?i)Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked"
+      "text": "(?i)Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv|.*Rollback). is not checked"
     }
   ]
 }

--- a/pkg/result/processors/exclusion_presets.go
+++ b/pkg/result/processors/exclusion_presets.go
@@ -55,7 +55,7 @@ var LinterExclusionPresets = map[string][]config.ExcludeRule{
 			// Almost all programs ignore errors on these functions and in most cases it's ok.
 			BaseRule: config.BaseRule{
 				Text: "(?i)Error return value of .((os\\.)?std(out|err)\\..*|.*Close" +
-					"|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked",
+					"|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv|.*Rollback). is not checked",
 				Linters:           []string{"errcheck"},
 				InternalReference: "EXC0001",
 			},


### PR DESCRIPTION
## Description

This PR updates the `std-error-handling` exclusion preset to ignore errors from `Rollback` calls.

Currently, `golangci-lint` with `errcheck` reports an error when `defer tx.Rollback()` is not checked. Since it's a common pattern to ignore the error returned by `Rollback` when deferring it (as the transaction will either be committed or rollback will just do nothing if already committed/rolled back), this update prevents false positives.

### Changes made:
* Appended `|.*Rollback` to the regex pattern in the `std-error-handling` preset defined in `pkg/result/processors/exclusion_presets.go`.
* Updated the corresponding documentation reference in `docs/data/exclusion_presets.json`.

Tests were executed locally to ensure this change causes no regressions.
