### PR TITLE
docs: fix typos and grammar errors in docs and code comments

### DIFF
--- a/docs/content/docs/configuration/file.md
+++ b/docs/content/docs/configuration/file.md
@@ -33,7 +33,7 @@ The configuration file can be validated with the JSON Schema: [golangci.jsonsche
 
 {{< cards  cols=2 >}}
 {{< card link="/docs/linters" title="Linters Overview" icon="collection" >}}
-{{< card link="/docs/linters/configuration" title="Linters  Settings" icon="adjustments" >}}
+{{< card link="/docs/linters/configuration" title="Linters Settings" icon="adjustments" >}}
 {{< /cards >}}
 
 {{% golangci/configuration-file-snippet section="linters" %}}
@@ -42,7 +42,7 @@ The configuration file can be validated with the JSON Schema: [golangci.jsonsche
 
 {{< cards  cols=2 >}}
 {{< card link="/docs/formatters" title="Formatters Overview" icon="collection" >}}
-{{< card link="/docs/formatters/configuration" title="Formatters  Settings" icon="adjustments" >}}
+{{< card link="/docs/formatters/configuration" title="Formatters Settings" icon="adjustments" >}}
 {{< /cards >}}
 
 {{% golangci/configuration-file-snippet section="formatters" %}}

--- a/docs/content/docs/contributing/architecture.md
+++ b/docs/content/docs/contributing/architecture.md
@@ -46,8 +46,8 @@ func (l *PackageLoader) Load(ctx context.Context, linters []*linter.Config) (pkg
 ```
 
 First, we find a load mode as union of load modes for all enabled linters.
-We use [go/packages](https://pkg.go.dev/golang.org/x/tools/go/packages) for packages loading and use it's enum `packages.Need*` for load modes.
-Load mode sets which data does a linter needs for execution.
+We use [go/packages](https://pkg.go.dev/golang.org/x/tools/go/packages) for packages loading and use its enum `packages.Need*` for load modes.
+Load mode sets which data a linter needs for execution.
 
 A linter that works only with AST need minimum of information: only filenames and AST.
 

--- a/docs/content/docs/contributing/faq.md
+++ b/docs/content/docs/contributing/faq.md
@@ -16,7 +16,7 @@ See [there](/docs/contributing/new-linters#how-to-add-a-private-linter-to-golang
 ## How to update an existing linter
 
 We use [Dependabot](https://github.com/golangci/golangci-lint/blob/HEAD/.github/dependabot.yml) to update dependencies, including linters.  
-The updates happen at least automatically once a week (Sunday 11am UTC).
+The updates happen automatically at least once a week (Sunday 11am UTC).
 
 No pull requests to update a linter will be accepted unless you are the author of the linter and specific changes are required.
 

--- a/docs/content/docs/contributing/new-linters.md
+++ b/docs/content/docs/contributing/new-linters.md
@@ -28,7 +28,7 @@ After that:
     - Add `WithSince("next_version")`, where `next_version` must be replaced by the next minor version. (ex: v1.2.0 if the current version is v1.1.0)
 4. Find out what options do you need to configure for the linter.
    For example, `nakedret` has only 1 option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml).
-   Choose default values to not being annoying for users of golangci-lint. Add configuration options to:
+   Choose default values to not be annoying for users of golangci-lint. Add configuration options to:
     - [.golangci.next.reference.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.next.reference.yml): the example of a configuration file.
       You can also add them to [.golangci.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.yml)
       if you think that this project needs not default values.

--- a/docs/content/docs/linters/false-positives.md
+++ b/docs/content/docs/linters/false-positives.md
@@ -34,7 +34,7 @@ linters:
 
 You can use `linters.exclusions.rules` config option for per-path or per-linter configuration.
 
-In the following example, all the reports from the linters (`linters`) that contains the text (`text`) are excluded:
+In the following example, all the reports from the linters (`linters`) that contain the text (`text`) are excluded:
 
 ```yaml
 linters:
@@ -56,7 +56,7 @@ linters:
         source: "^//go:generate "
 ```
 
-In the following example, all the reports that contains the text (`text`) in the path (`path`) are excluded:
+In the following example, all the reports that contain the text (`text`) in the path (`path`) are excluded:
 
 ```yaml
 linters:
@@ -70,7 +70,7 @@ linters:
 
 Exclude issues in path by `linters.exclusions.paths` or `linters.exclusions.rules` config options.
 
-In the following example, all the reports from the linters (`linters`) that concerns the path (`path`) are excluded:
+In the following example, all the reports from the linters (`linters`) that concern the path (`path`) are excluded:
 
 ```yaml
 linters:

--- a/docs/content/docs/plugins/go-plugins.md
+++ b/docs/content/docs/plugins/go-plugins.md
@@ -82,5 +82,5 @@ If the 'disable all' option is specified either on command line or in `.golangci
 they can be re-enabled by adding them to the `linters.enable` list,
 or providing the enabled option on the command line, `golangci-lint run -Eexample`.
 
-The configuration inside the `linters.settings` field of linter have some limitations (there are NOT related to the plugin system itself):
-we use Viper to handle the configuration, but Viper put all the keys in lowercase, and `.` cannot be used inside a key.
+The configuration inside the `linters.settings` field of linter has some limitations (these are NOT related to the plugin system itself):
+we use Viper to handle the configuration, but Viper puts all the keys in lowercase, and `.` cannot be used inside a key.

--- a/docs/content/docs/welcome/faq.md
+++ b/docs/content/docs/welcome/faq.md
@@ -12,7 +12,7 @@ The same as the Go team (the 2 latest minor versions).
 
 Basically, golangci-lint supports Go versions lower or equal to the Go version used to compile it.
 
-New versions of Go are not automatically supported because, in addition of the Go version used to build it,
+New versions of Go are not automatically supported because, in addition to the Go version used to build it,
 some linters and/or internal pieces of golangci-lint could need to be adapted to support this new Go version.
 
 ## How to use golangci-lint in CI
@@ -91,14 +91,14 @@ Also, take a look at option `--new`,
 but consider that CI scripts that generate unstaged files will make `--new` only point out issues in those files and not in the last commit.
 In that regard `--new-from-merge-base=main` or `--new-from-rev=HEAD~1` are safer.
 
-By doing this you won't create new issues in your code and can choose fix existing issues (or not).
+By doing this you won't create new issues in your code and can choose to fix existing issues (or not).
 
 ## Why `--new-from-xxx` don't seem to be working in some cases?
 
 The options `--new-from-merge-base`, `--new-from-rev`, and `--new-from-patch` work by comparing `git diff` output and issues.
 
 If an issue is not reported as the same line as the changes then the issue will be skipped.
-This is the line of the issue is not inside the lines changed.
+This is because the line of the issue is not inside the lines changed.
 
 To fix that, you have to use the option `--whole-files`.
 

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -132,7 +132,7 @@ func NewLinterBuilder() *LinterBuilder {
 }
 
 // Build loads all the "internal" linters.
-// The configuration is use for the linter settings.
+// The configuration is used for the linter settings.
 func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 	if cfg == nil {
 		return nil, nil


### PR DESCRIPTION
Fix minor grammar and typo issues I found while reading the docs.

- `it's` → `its` (architecture.md)
- subject-verb agreement: `contains` → `contain`, `have` → `has`, etc.
- missing preposition: `in addition of` → `in addition to`
- double spaces in card titles (file.md)
- typo in code comment in builder_linter.go (`is use for` → `is used for`)