### PR TITLE
feat(custom): propagate replace directives from local plugin go.mod files

### DIFF
--- a/pkg/commands/internal/builder.go
+++ b/pkg/commands/internal/builder.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode"
 
+	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/sumdb/dirhash"
 
 	"github.com/golangci/golangci-lint/v2/pkg/logutils"
@@ -157,6 +158,49 @@ func (b Builder) addReplaceDirective(ctx context.Context, plugin *Plugin) error 
 		b.log.Warnf("%s", string(output))
 
 		return fmt.Errorf("%s: %w", strings.Join(cmd.Args, " "), err)
+	}
+
+	return b.propagatePluginReplaces(ctx, plugin.Path)
+}
+
+// propagatePluginReplaces reads the plugin's go.mod and adds any replace directives it
+// contains to the golangci-lint go.mod. This is necessary because replace directives are
+// only respected in the main module; a replace directive in a dependency's go.mod is
+// ignored by Go. Without propagation, local-path dependencies of a local plugin cannot
+// be resolved during `go mod tidy`.
+func (b Builder) propagatePluginReplaces(ctx context.Context, pluginPath string) error {
+	data, err := os.ReadFile(filepath.Join(pluginPath, "go.mod"))
+	if err != nil {
+		return fmt.Errorf("read plugin go.mod: %w", err)
+	}
+
+	f, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return fmt.Errorf("parse plugin go.mod: %w", err)
+	}
+
+	for _, r := range f.Replace {
+		var newPath string
+		if r.New.Version == "" {
+			// local directory replace — resolve relative to the plugin directory
+			newPath = filepath.Join(pluginPath, filepath.FromSlash(r.New.Path))
+		} else {
+			newPath = r.New.Path + "@" + r.New.Version
+		}
+
+		replace := fmt.Sprintf("%s=%s", r.Old.Path, newPath)
+
+		cmd := exec.CommandContext(ctx, "go", "mod", "edit", "-replace", replace)
+		cmd.Dir = b.repo
+
+		b.log.Infof("propagating plugin replace: %s", replace)
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			b.log.Warnf("%s", string(output))
+
+			return fmt.Errorf("%s: %w", strings.Join(cmd.Args, " "), err)
+		}
 	}
 
 	return nil

--- a/pkg/commands/internal/builder_test.go
+++ b/pkg/commands/internal/builder_test.go
@@ -1,10 +1,109 @@
 package internal
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/golangci/golangci-lint/v2/pkg/logutils"
 )
+
+func Test_propagatePluginReplaces(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		pluginGoMod  string
+		wantReplaces []string // expected replace directives in repo go.mod after propagation
+	}{
+		{
+			desc: "local path replace is resolved relative to plugin dir",
+			pluginGoMod: `module example.com/myplugin
+
+go 1.22
+
+require example.com/mylib v0.0.0
+
+replace example.com/mylib => ../mylib
+`,
+			wantReplaces: []string{"example.com/mylib"},
+		},
+		{
+			desc: "versioned replace is passed through as-is",
+			pluginGoMod: `module example.com/myplugin
+
+go 1.22
+
+require example.com/mylib v1.2.3
+
+replace example.com/mylib v1.2.3 => example.com/myfork v1.2.4
+`,
+			wantReplaces: []string{"example.com/mylib"},
+		},
+		{
+			desc: "no replaces is a no-op",
+			pluginGoMod: `module example.com/myplugin
+
+go 1.22
+
+require example.com/mylib v1.2.3
+`,
+			wantReplaces: nil,
+		},
+		{
+			desc: "multiple replaces are all propagated",
+			pluginGoMod: `module example.com/myplugin
+
+go 1.22
+
+require (
+	example.com/liba v0.0.0
+	example.com/libb v0.0.0
+)
+
+replace (
+	example.com/liba => ../liba
+	example.com/libb => ../libb
+)
+`,
+			wantReplaces: []string{"example.com/liba", "example.com/libb"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Set up a fake repo module directory.
+			repoDir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module example.com/repo\n\ngo 1.22\n"), 0o600))
+
+			// Set up a fake plugin directory with its go.mod.
+			pluginDir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "go.mod"), []byte(tc.pluginGoMod), 0o600))
+
+			b := Builder{
+				log:  logutils.NewStderrLog("test"),
+				repo: repoDir,
+			}
+
+			err := b.propagatePluginReplaces(t.Context(), pluginDir)
+			require.NoError(t, err)
+
+			// Read the repo go.mod and check the replace directives were added.
+			data, err := os.ReadFile(filepath.Join(repoDir, "go.mod"))
+			require.NoError(t, err)
+			gomod := string(data)
+
+			for _, want := range tc.wantReplaces {
+				assert.Contains(t, gomod, want, "expected replace for %q to be present in go.mod", want)
+			}
+
+			if len(tc.wantReplaces) == 0 {
+				assert.NotContains(t, gomod, "replace", "expected no replace directives in go.mod")
+			}
+		})
+	}
+}
 
 func Test_sanitizeVersion(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Problem

When a plugin is referenced by local path in `.custom-gcl.yml`, the `golangci-lint custom` build fails if the plugin's `go.mod` contains any replace directives. This affects three common real-world scenarios:

**1. Local/unpublished dependencies**
A plugin that wraps an internal shared library that has never been published to a module proxy:

```
    replace example.com/mylib => ../mylib
```

`go mod tidy` tries to fetch `example.com/mylib` from VCS and fails with "repository not found".

**2. Forked dependencies**
A plugin depending on a patched fork of an upstream library:

```
    replace github.com/upstream/lib => github.com/myfork/lib v1.2.3
```

`go mod tidy` attempts to resolve the original module path and may fail if the version doesn't exist upstream, or silently use the wrong code.

**3. Pre-release / in-development dependencies**
A plugin being developed alongside a library that hasn't cut a release yet, using a local path to track HEAD:

```
    replace example.com/lib => /home/user/projects/lib
```

`go mod tidy` fails to resolve the module from the proxy because the required version has not been published.

The root cause is a Go modules constraint: `replace` directives are only honoured in the *main module*. When the builder clones `golangci-lint` into a temporary directory and runs `go mod tidy` there, `golangci-lint` itself becomes the main module. Any `replace` directives declared inside the plugin's own go.mod are silently ignored.

This effectively forces plugin authors to either duplicate source code inside the plugin module, or publish every dependency before  `golangci-lint custom` will work, neither of which may be acceptable for private, forked, or actively-developed modules.

## Fix

After `addReplaceDirective` registers the plugin's own path replace in the `golangci-lint` `go.mod`, it now calls the new `propagatePluginReplaces` function. This function parses the plugin's `go.mod` using `golang.org/x/mod/modfile` (already a transitive dependency) and forwards every replace directive it finds into the `golangci-lint` `go.mod` via `go mod edit -replace`, before `go mod tidy` runs.

Two cases are handled:
*  Local directory replaces (empty New.Version): the path is resolved to an absolute path relative to the plugin directory, since the relative path would be meaningless inside the cloned golangci-lint tree in /tmp.
* Versioned replaces (non-empty New.Version): forwarded verbatim, e.g. `github.com/upstream/lib=github.com/myfork/lib@v1.2.3`.

The fix is intentionally one level deep and propagates **only** the replace directives from the plugin's own `go.mod`, not recursively from transitive dependencies. Deeper dependency graphs are better served by publishing
modules.

## Testing

Four table-driven unit tests are added to builder_test.go:
- Local path replace is resolved to an absolute path relative to the plugin directory
- Versioned replace (fork) is forwarded unchanged
- Plugin with no replace directives is a no-op
- Plugin with multiple replace directives has all of them propagated