### PR TITLE
feat: decrease cache entropy

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -170,6 +171,11 @@ func (c *Cache) computePkgHash(pkg *packages.Package) (hashResults, error) {
 		h, fErr := c.fileHash(f)
 		if fErr != nil {
 			return nil, fmt.Errorf("failed to calculate file %s hash: %w", f, fErr)
+		}
+
+		// This is the current module (the project to analyze).
+		if pkg.Module != nil && pkg.Module.Version == "" {
+			f = pkg.Module.Path + strings.TrimPrefix(filepath.ToSlash(f), filepath.ToSlash(pkg.Module.Dir))
 		}
 
 		fmt.Fprintf(key, "file %s %x\n", f, h)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -155,4 +157,30 @@ func TestCache_computeHash(t *testing.T) {
 	assert.Equal(t, "8978e3d76c6f99e9663558d7147a7790f229a676804d1fde706a611898547b74", results[HashModeNeedOnlySelf])
 	assert.Equal(t, "b1aef902a0619b5cbfc2d6e2e91a73dd58dd448e58274b2d7a5ff8efd97aefa4", results[HashModeNeedDirectDeps])
 	assert.Equal(t, "9c602ef861197b6807e82c99caa7c4042eb03c1a92886303fb02893744355131", results[HashModeNeedAllDeps])
+}
+
+func TestCache_computeHash_module(t *testing.T) {
+	pkgCache := setupCache(t)
+
+	// This creates a new random directory for each test run, but the hash will stay consistent.
+	tempDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(tempDir, "foo.go"), []byte("package foo"), 0600)
+	require.NoError(t, err)
+
+	pkg := fakePackage()
+	pkg.Module = &packages.Module{
+		Dir:  tempDir,
+		Path: "github.com/golangci/example",
+	}
+	pkg.IgnoredFiles = []string{filepath.Join(tempDir, "foo.go")}
+
+	results, err := pkgCache.computePkgHash(pkg)
+	require.NoError(t, err)
+
+	require.Len(t, results, 3)
+
+	assert.Equal(t, "ac5d79f4630d6b5f1e4ac88bfa9974698ea44ea1f53760bc75001bd7c9ce9064", results[HashModeNeedOnlySelf])
+	assert.Equal(t, "73fd7ef46b20efdd1bff7eaedade26b1655ee727d83f4210b7934bf4d4a1ac1d", results[HashModeNeedDirectDeps])
+	assert.Equal(t, "063ffbaa2ea6b2a9a02724effe2a616b88672a4d8c3c4c6c8d777bfe5a49e7b4", results[HashModeNeedAllDeps])
 }

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -713,7 +713,8 @@ func computeGoModSalt() (string, error) {
 		return "", fmt.Errorf("failed to read go.mod: %w", err)
 	}
 
-	sum, err := dirhash.Hash1([]string{goModPath}, func(string) (io.ReadCloser, error) {
+	// NOTE: the filename `goModPath` is not used here to have the same hash for the same content.
+	sum, err := dirhash.Hash1([]string{"go.mod"}, func(string) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(data)), nil
 	})
 	if err != nil {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -713,7 +713,7 @@ func computeGoModSalt() (string, error) {
 		return "", fmt.Errorf("failed to read go.mod: %w", err)
 	}
 
-	// NOTE: the filename `goModPath` is not used here to have the same hash for the same content.
+	// NOTE: the variable `goModPath` is not used here to ensure getting the same hash, independently of the location, for the same content.
 	sum, err := dirhash.Hash1([]string{"go.mod"}, func(string) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(data)), nil
 	})


### PR DESCRIPTION
A project inside different locations will be able to reuse the cache.

As the entropy is decreased, parallel runs for the same project, in different locations, will never work because it will create unsafe concurrent access to the files used by the cache.

Fixes #6430

Notes:
- The cache usage can be see by using `GL_DEBUG="goanalysis/issues/cache"`
- No need to use a worktree to check the PR, you only need to copy a project in 2 different places.