### PR TITLE
docs: update link to default linters page

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -11,7 +11,7 @@ version: "2"
 linters:
   # Default set of linters.
   # The value can be:
-  # - `standard`: https://golangci-lint.run/docs/linters/#all-linters - Default
+  # - `standard`: the "Default" linters https://golangci-lint.run/docs/linters/#all-linters
   # - `all`: enables all linters by default.
   # - `none`: disables all linters by default.
   # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).

--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -11,7 +11,7 @@ version: "2"
 linters:
   # Default set of linters.
   # The value can be:
-  # - `standard`: https://golangci-lint.run/docs/linters/#all-linters - Default
+  # - `standard`: the "Default" linters https://golangci-lint.run/docs/linters/#all-linters
   # - `all`: enables all linters by default.
   # - `none`: disables all linters by default.
   # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).


### PR DESCRIPTION
The anchor `https://golangci-lint.run/docs/linters/#enabled-by-default` no longer exists. We should use https://golangci-lint.run/docs/linters/#all-linters with the "Default" filter.

<img width="670" height="463" alt="image" src="https://github.com/user-attachments/assets/eb8da8d3-0478-4c09-bd74-8681cd0dd9fe" />
