### PR TITLE
dev: improve migration suggestion for gomodguardv2

### DIFF
--- a/pkg/golinters/gomodguard/gomodguard.go
+++ b/pkg/golinters/gomodguard/gomodguard.go
@@ -90,28 +90,32 @@ func New(settings *config.GoModGuardSettings) *goanalysis.Linter {
 
 // Only used the set YAML struct tags.
 type v2YAML struct {
-	Allowed                []goModGuardv2Base    `yaml:"allowed"`
-	Blocked                []goModGuardv2Blocked `yaml:"blocked"`
-	LocalReplaceDirectives bool                  `yaml:"local-replace-directives"`
+	Allowed                []goModGuardv2Base    `yaml:"allowed,omitempty"`
+	Blocked                []goModGuardv2Blocked `yaml:"blocked,omitempty"`
+	LocalReplaceDirectives bool                  `yaml:"local-replace-directives,omitempty"`
 }
 
 // Only used the set YAML struct tags.
 type goModGuardv2Base struct {
-	Module    string `yaml:"module"`
-	Version   string `yaml:"version"`
-	MatchType string `yaml:"match-type"`
+	Module    string `yaml:"module,omitempty"`
+	Version   string `yaml:"version,omitempty"`
+	MatchType string `yaml:"match-type,omitempty"`
 }
 
 // Only used the set YAML struct tags.
 type goModGuardv2Blocked struct {
 	goModGuardv2Base
 
-	Recommendations []string `yaml:"recommendations"`
-	Reason          string   `yaml:"reason"`
+	Recommendations []string `yaml:"recommendations,omitempty"`
+	Reason          string   `yaml:"reason,omitempty"`
 }
 
 func Migration(old *config.GoModGuardSettings) any {
 	if old == nil {
+		return nil
+	}
+
+	if len(old.Allowed.Modules) == 0 && len(old.Allowed.Domains) == 0 && len(old.Blocked.Modules) == 0 && !old.Blocked.LocalReplaceDirectives {
 		return nil
 	}
 

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -189,10 +189,10 @@ func Replacement[T any](replacement string, mgr func(T) any, data T) func(*Depre
 				"enable": []string{d.Replacement},
 			}
 
-			settings := mgr(data)
+			replacementSettings := mgr(data)
 
-			if settings != nil {
-				linters["settings"] = map[string]any{d.Replacement: settings}
+			if replacementSettings != nil {
+				linters["settings"] = map[string]any{d.Replacement: replacementSettings}
 			}
 
 			suggestion := map[string]any{

--- a/pkg/lint/linter/config.go
+++ b/pkg/lint/linter/config.go
@@ -185,15 +185,18 @@ func Replacement[T any](replacement string, mgr func(T) any, data T) func(*Depre
 			encoder := yaml.NewEncoder(buf)
 			encoder.SetIndent(2)
 
+			linters := map[string]any{
+				"enable": []string{d.Replacement},
+			}
+
+			settings := mgr(data)
+
+			if settings != nil {
+				linters["settings"] = map[string]any{d.Replacement: settings}
+			}
+
 			suggestion := map[string]any{
-				"linters": map[string]any{
-					"enable": []string{
-						d.Replacement,
-					},
-					"settings": map[string]any{
-						d.Replacement: mgr(data),
-					},
-				},
+				"linters": linters,
 			}
 
 			err := encoder.Encode(suggestion)


### PR DESCRIPTION
When there is no explicit configuration, the current suggestion is:
```yml
linters:
  enable:
    - gomodguard_v2
  settings:
    gomodguard_v2:
      allowed: []
      blocked: []
      local-replace-directives: false 
```

with this PR, the suggestion is:
```yml
linters:
  enable:
    - gomodguard_v2
```

Same thing when the other fields are not explicitly set.
