### PR TITLE
paralleltest: expose checkcleanup option

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2316,6 +2316,10 @@ linters:
       # still required to have `t.Parallel`, but subtests are allowed to skip it.
       # Default: false
       ignore-missing-subtests: true
+      # Check that `defer` is not used with `t.Parallel` (use `t.Cleanup` instead 
+      # to ensure cleanup runs after parallel subtests complete).
+      # Default: false
+      check-cleanup: true
 
     perfsprint:
       # Enable/disable optimization of integer formatting.

--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -2312,12 +2312,13 @@ linters:
       # Ignore missing calls to `t.Parallel()` and only report incorrect uses of it.
       # Default: false
       ignore-missing: true
-      # Ignore missing calls to `t.Parallel()` in subtests. Top-level tests are
-      # still required to have `t.Parallel`, but subtests are allowed to skip it.
+      # Ignore missing calls to `t.Parallel()` in subtests.
+      # Top-level tests are still required to have `t.Parallel`,
+      # but subtests are allowed to skip it.
       # Default: false
       ignore-missing-subtests: true
-      # Check that `defer` is not used with `t.Parallel` (use `t.Cleanup` instead 
-      # to ensure cleanup runs after parallel subtests complete).
+      # Check that `defer` is not used with `t.Parallel`.
+      # (use `t.Cleanup` instead to ensure cleanup runs after parallel subtests complete).
       # Default: false
       check-cleanup: true
 

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -3048,6 +3048,11 @@
               "description": "Ignore missing calls to `t.Parallel()` in subtests. Top-level tests are still required to have `t.Parallel`, but subtests are allowed to skip it.",
               "type": "boolean",
               "default": false
+            },
+            "check-cleanup": {
+              "description": "Check that defer is not used with t.Parallel (use t.Cleanup instead).",
+              "type": "boolean",
+              "default": false
             }
           }
         },

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -820,6 +820,7 @@ type ParallelTestSettings struct {
 	Go                    string `mapstructure:"-"`
 	IgnoreMissing         bool   `mapstructure:"ignore-missing"`
 	IgnoreMissingSubtests bool   `mapstructure:"ignore-missing-subtests"`
+	CheckCleanup          bool   `mapstructure:"check-cleanup"`
 }
 
 type PerfSprintSettings struct {

--- a/pkg/golinters/paralleltest/paralleltest.go
+++ b/pkg/golinters/paralleltest/paralleltest.go
@@ -14,6 +14,7 @@ func New(settings *config.ParallelTestSettings) *goanalysis.Linter {
 		cfg = map[string]any{
 			"i":                     settings.IgnoreMissing,
 			"ignoremissingsubtests": settings.IgnoreMissingSubtests,
+			"checkcleanup":          settings.CheckCleanup,
 		}
 
 		if config.IsGoGreaterThanOrEqual(settings.Go, "1.22") {


### PR DESCRIPTION
Add support for the `checkcleanup` option in [paralleltest](https://github.com/kunwardeep/paralleltest).

`make build`, `./golangci-lint run -v` and `make test` all pass.