### PR TITLE
goconst: ignore strings from tests

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -719,6 +719,8 @@ linters:
       # Evaluates of constant expressions like Prefix + "suffix".
       # Default: false
       eval-const-expressions: true
+      # Ignore strings from test files.
+      ignore-tests: false
 
     gocritic:
       # Disable all checks.

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1715,6 +1715,11 @@
               "description": "Evaluates of constant expressions like Prefix + \"suffix\"",
               "type": "boolean",
               "default": false
+            },
+            "ignore-tests": {
+              "description": "Ignore strings from test files",
+              "type": "boolean",
+              "default": false
             }
           }
         },

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -528,6 +528,10 @@ type GoConstSettings struct {
 	FindDuplicates       bool     `mapstructure:"find-duplicates"`
 	EvalConstExpressions bool     `mapstructure:"eval-const-expressions"`
 
+	// This option cannot be managed with `linters.exclusions.rules`.
+	// Because the linter counts occurrences across all files in the package.
+	IgnoreTests bool `mapstructure:"ignore-tests"`
+
 	// Deprecated: use IgnoreStringValues instead.
 	IgnoreStrings string `mapstructure:"ignore-strings"`
 }

--- a/pkg/golinters/goconst/goconst.go
+++ b/pkg/golinters/goconst/goconst.go
@@ -59,9 +59,7 @@ func runGoconst(pass *analysis.Pass, settings *config.GoConstSettings) ([]*goana
 		ExcludeTypes:         map[goconstAPI.Type]bool{},
 		FindDuplicates:       settings.FindDuplicates,
 		EvalConstExpressions: settings.EvalConstExpressions,
-
-		// Should be managed with `linters.exclusions.rules`.
-		IgnoreTests: false,
+		IgnoreTests:          settings.IgnoreTests,
 	}
 
 	if settings.IgnoreCalls {


### PR DESCRIPTION
This option cannot be managed with `linters.exclusions.rules` because the linter counts occurrences across all files in the package.

<details><summary>main.go</summary>

```go
package main

import "fmt"

func main() {
	a := "needconst"
	fmt.Print(a)
	b := "needconst"
	fmt.Print(b)
	c := "needconst"
	fmt.Print(c)
	d := "needconst"
	fmt.Print(d)
}

```

</details>

<details>
<summary>main_test.go</summary>

```go
package main

import (
	"fmt"
	"testing"
)

func TestName(t *testing.T) {
	a := "needconst"
	fmt.Print(a)
	b := "needconst"
	fmt.Print(b)
	c := "needconst"
	fmt.Print(c)
}

```

</details>


#### Existing behavior

<details>
<summary>.golangci.yml</summary>

```yml
version: "2"

linters:
  default: none
  enable:
    - goconst
  exclusions:
    rules:
      - linters:
          - goconst
        path: _test\.go

```

</details>

<details>

```console
$ golangci-lint run
main.go:6:7: string `needconst` has 7 occurrences, make it a constant (goconst)
        a := "needconst"
             ^
1 issues:
* goconst: 1
```

</details>

#### New behavior

<details>
<summary>.golangci.yml</summary>

```yml
version: "2"

linters:
  default: none
  enable:
    - goconst
  settings:
    goconst:
      ignore-tests: true
```

</details>

<details>

```console
$ ./golangci-lint run 
main.go:6:7: string `needconst` has 4 occurrences, make it a constant (goconst)
        a := "needconst"
             ^
1 issues:
* goconst: 1
```

</details>