### PR TITLE
feat: add pathconcat linter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/gostaticanalysis/forcetypeassert v0.2.0
 	github.com/gostaticanalysis/nilerr v0.1.2
 	github.com/hashicorp/go-version v1.9.0
+	github.com/jakedoublev/pathconcat v0.3.0
 	github.com/jgautheron/goconst v1.10.0
 	github.com/jingyugao/rowserrcheck v1.1.1
 	github.com/jjti/go-spancheck v0.6.5

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jakedoublev/pathconcat v0.3.0 h1:LvpQAl7VaC74ZyLwn4W54gCZb0FfCdSbrRM4axOnYJM=
+github.com/jakedoublev/pathconcat v0.3.0/go.mod h1:nCiAfBSLaLjQVf9nkGJL6bSRjmz3ow37CezaIvtq6Ho=
 github.com/jgautheron/goconst v1.10.0 h1:Ptt+OoE4NaEWKhLrWrrN3IpZdGLiqaf7WLnEX/iv4Jw=
 github.com/jgautheron/goconst v1.10.0/go.mod h1:0p+wv1lFOiUr0IlNNT1nrm6+8DB8u2sU6KHGzFRXHDc=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -298,6 +298,7 @@ type LintersSettings struct {
 	NoLintLint               NoLintLintSettings               `mapstructure:"nolintlint"`
 	NoNamedReturns           NoNamedReturnsSettings           `mapstructure:"nonamedreturns"`
 	ParallelTest             ParallelTestSettings             `mapstructure:"paralleltest"`
+	PathConcat               PathConcatSettings               `mapstructure:"pathconcat"`
 	PerfSprint               PerfSprintSettings               `mapstructure:"perfsprint"`
 	Prealloc                 PreallocSettings                 `mapstructure:"prealloc"`
 	Predeclared              PredeclaredSettings              `mapstructure:"predeclared"`
@@ -826,6 +827,11 @@ type ParallelTestSettings struct {
 	IgnoreMissing         bool   `mapstructure:"ignore-missing"`
 	IgnoreMissingSubtests bool   `mapstructure:"ignore-missing-subtests"`
 	CheckCleanup          bool   `mapstructure:"check-cleanup"`
+}
+
+type PathConcatSettings struct {
+	IgnoreStrings     []string `mapstructure:"ignore-strings"`
+	CheckSchemeConcat bool     `mapstructure:"check-scheme-concat"`
 }
 
 type PerfSprintSettings struct {

--- a/pkg/golinters/pathconcat/pathconcat.go
+++ b/pkg/golinters/pathconcat/pathconcat.go
@@ -1,0 +1,19 @@
+package pathconcat
+
+import (
+	"github.com/jakedoublev/pathconcat"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
+)
+
+func New(settings *config.PathConcatSettings) *goanalysis.Linter {
+	a := pathconcat.NewAnalyzer(pathconcat.Settings{
+		IgnoreStrings:     settings.IgnoreStrings,
+		CheckSchemeConcat: settings.CheckSchemeConcat,
+	})
+
+	return goanalysis.
+		NewLinterFromAnalyzer(a).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
+}

--- a/pkg/golinters/pathconcat/pathconcat_integration_test.go
+++ b/pkg/golinters/pathconcat/pathconcat_integration_test.go
@@ -1,0 +1,11 @@
+package pathconcat
+
+import (
+	"testing"
+
+	"github.com/golangci/golangci-lint/v2/test/testshared/integration"
+)
+
+func TestFromTestdata(t *testing.T) {
+	integration.RunTestdata(t)
+}

--- a/pkg/golinters/pathconcat/testdata/pathconcat.go
+++ b/pkg/golinters/pathconcat/testdata/pathconcat.go
@@ -1,0 +1,47 @@
+//golangcitest:args -Epathconcat
+package testdata
+
+import (
+	"fmt"
+	"strings"
+)
+
+func concatWithSlash(a, b string) string {
+	return a + "/" + b // want `use path\.Join\(\) instead of string concatenation with "/"`
+}
+
+func concatMultiSegment(a, b, c string) string {
+	return a + "/" + b + "/" + c // want `use path\.Join\(\) instead of string concatenation with "/"`
+}
+
+func sprintfPath(a, b string) string {
+	return fmt.Sprintf("%s/%s", a, b) // want `use path\.Join\(\) instead of fmt\.Sprintf with path separators`
+}
+
+func stringsJoinSlash(parts []string) string {
+	return strings.Join(parts, "/") // want `use path\.Join\(\) instead of strings\.Join with "/"`
+}
+
+func schemePrefix(host string) string {
+	return "https://" + host // OK: scheme prefix
+}
+
+func regularConcat(a, b string) string {
+	return a + b // OK: no slash
+}
+
+func concatNonSep(a string) string {
+	return a + "/api" // OK: no bare "/" separator
+}
+
+func sprintfNoPathSep(a string) string {
+	return fmt.Sprintf("value: %s", a) // OK: no path separator
+}
+
+func stringsJoinComma(parts []string) string {
+	return strings.Join(parts, ",") // OK: not a slash
+}
+
+func postgresConnStr(user, pass, host, db string) string {
+	return fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", user, pass, host, db) // OK: connection string
+}

--- a/pkg/golinters/pathconcat/testdata/pathconcat_check_scheme_concat.go
+++ b/pkg/golinters/pathconcat/testdata/pathconcat_check_scheme_concat.go
@@ -1,0 +1,7 @@
+//golangcitest:args -Epathconcat
+//golangcitest:config_path pathconcat_check_scheme_concat.yml
+package testdata
+
+func schemeConcat(host string) string {
+	return "https://" + host // want `use url\.JoinPath\(\) instead of string concatenation with "/"`
+}

--- a/pkg/golinters/pathconcat/testdata/pathconcat_check_scheme_concat.yml
+++ b/pkg/golinters/pathconcat/testdata/pathconcat_check_scheme_concat.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    pathconcat:
+      check-scheme-concat: true

--- a/pkg/golinters/pathconcat/testdata/pathconcat_ignore_strings.go
+++ b/pkg/golinters/pathconcat/testdata/pathconcat_ignore_strings.go
@@ -1,0 +1,11 @@
+//golangcitest:args -Epathconcat
+//golangcitest:config_path pathconcat_ignore_strings.yml
+package testdata
+
+func fqnAttr(ns, name string) string {
+	return ns + "/attr/" + name // OK: contains ignored string
+}
+
+func fqnValue(ns, name, val string) string {
+	return ns + "/attr/" + name + "/value/" + val // OK: contains ignored string
+}

--- a/pkg/golinters/pathconcat/testdata/pathconcat_ignore_strings.yml
+++ b/pkg/golinters/pathconcat/testdata/pathconcat_ignore_strings.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  settings:
+    pathconcat:
+      ignore-strings:
+        - "/attr/"
+        - "/value/"

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -87,6 +87,7 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nonamedreturns"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/nosprintfhostport"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/paralleltest"
+	"github.com/golangci/golangci-lint/v2/pkg/golinters/pathconcat"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/perfsprint"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/prealloc"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/predeclared"
@@ -554,6 +555,11 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithSince("v1.33.0").
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/kunwardeep/paralleltest"),
+
+		linter.NewConfig(pathconcat.New(&cfg.Linters.Settings.PathConcat)).
+			WithSince("v2.12.0").
+			WithLoadForGoAnalysis().
+			WithURL("https://github.com/jakedoublev/pathconcat"),
 
 		linter.NewConfig(perfsprint.New(&cfg.Linters.Settings.PerfSprint)).
 			WithSince("v1.55.0").


### PR DESCRIPTION
## Summary

Adds [pathconcat](https://github.com/jakedoublev/pathconcat), a linter that detects string-based path/URL concatenation and suggests `path.Join`, `filepath.Join`, or `url.JoinPath` instead.

### What it catches

| Pattern | Example |
|---------|---------|
| String concat with `"/"` | `a + "/" + b` |
| `fmt.Sprintf` with path separators | `fmt.Sprintf("%s/%s", a, b)` |
| `strings.Join` with `"/"` | `strings.Join(parts, "/")` |

### Built-in suppression

- **Connection strings** — `postgres://`, `mysql://`, `redis://`, `mongodb://`, `amqp://`, `nats://`
- **Scheme prefixes** — `"https://" + host` (configurable via `check-scheme-concat`)
- **Configurable `ignore-strings`** — suppress findings containing domain-specific substrings

### Smart suggestions

Suggests the appropriate join function based on file imports:
- `url.JoinPath` if `net/url` or `net/http` is imported
- `filepath.Join` if `path/filepath` or `os` is imported
- `path.Join` otherwise

## Configuration

```yaml
linters:
  enable:
    - pathconcat
  settings:
    pathconcat:
      ignore-strings:
        - "/attr/"
        - "/value/"
      check-scheme-concat: true
```

## Changes

- `pkg/golinters/pathconcat/` — linter wrapper, integration tests, testdata
- `pkg/config/linters_settings.go` — `PathConcatSettings` struct
- `pkg/lint/lintersdb/builder_linter.go` — linter registration
- `go.mod` — add `github.com/jakedoublev/pathconcat v0.3.0`