### PR TITLE
chore: new workflow to add a linter

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/new-linter-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/new-linter-proposals.yml
@@ -1,0 +1,126 @@
+title: Add XXX linter
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Inside golangci-lint we differentiate two types of analyzers:
+        - the linters (find problems with nearly zero false positives)
+        - the detectors (detect potential problems, and so a majority of false positives)
+
+        The detectors are not allowed because of the number of false positives
+  - type: input
+    id: repo-url
+    attributes:
+      label: Repository URL
+      description: Add a link to the repository of the analyzer.
+    validations:
+      required: true
+  - type: checkboxes
+    id: analyzer-requirements
+    attributes:
+      label: Analyzer Requirements
+      options:
+        - label: The analyzer must be more than one month old.
+          required: true
+        - label: The usage of AI must be explicitly expressed inside the readme.
+          required: true
+        - label: It must use [`go/analysis`](https://golangci-lint.run/docs/contributing/new-linters/).
+          required: true
+        - label: It must not be a duplicate or too close of an existing analyzer.
+          required: true
+        - label: It must use Go version <= 1.25.0
+          required: true
+        - label: The dependencies must be minimal.
+          required: true
+        - label: It must be available as a plugin.
+          required: true
+  - type: dropdown
+    id: analyzer-goal
+    attributes:
+      label: Analyzer Goal
+      description: 'What is the goal of the analyzer?'
+      options:
+        - No goal
+        - Finds bugs
+        - Style
+    validations:
+      required: true
+  - type: textarea
+    id: analyzer-description
+    attributes:
+      label: Analyzer Description
+      description: A short one or two lines maximum.
+      placeholder: Add the description here.
+    validations:
+      required: true
+  - type: checkboxes
+    id: license
+    attributes:
+      label: Analyzer License
+      options:
+        - label: AGPL is not allowed.
+          required: true
+        - label: The file must start with `LICENSE` (capitalized)
+          required: true
+        - label: "The file must contain the required information by the license, ex: author, year, etc."
+          required: true
+  - type: checkboxes
+    id: analyzer-info
+    attributes:
+      label: Analyzer Details
+      options:
+        - label: It must have tests.
+          required: true
+        - label: It must not contain `init()`.
+          required: true
+        - label: It must not contain `panic()`.
+          required: true
+        - label: It must not contain `log.Fatal()`.
+          required: true
+        - label: It must not contain `os.Exit()`.
+          required: true
+        - label: It must not modify the AST.
+          required: true
+        - label: The configuration must not rely on external files.
+          required: true
+  - type: checkboxes
+    id: repo-info
+    attributes:
+      label: Repository Details
+      options:
+        - label: 'It must have a valid semver tag, ex: `v1.0.0`, `v0.1.0` (`0.0.x` are not valid).'
+          required: true
+        - label: A tag should never be deleted or recreated.
+          required: false
+        - label: It should have a readme.
+          required: true
+        - label: The repository must have a CI.
+          required: true
+        - label: The CI must run on PR.
+          required: true
+        - label: The CI must run on the default branch.
+          required: true
+  - type: checkboxes
+    id: repo-recommendations
+    attributes:
+      label: Repository Recommendations
+      options:
+        - label: It should have linting.
+          required: false
+        - label: It should have a `.gitignore` (IDE files, binaries, OS files, etc. should not be committed)
+          required: false
+        - label: Use `main` as the default branch name.
+          required: false
+  - type: checkboxes
+    id: pr
+    attributes:
+      label: Pull Request
+      description: You should not open a PR to add the analyzer before a maintainer approves your suggestion.
+      options:
+        - label: Yes, I will wait for the approval of a maintainer before creating a PR.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        **This checklist does not imply that we will accept the linter.**

--- a/.github/DISCUSSION_TEMPLATE/new-linter-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/new-linter-proposals.yml
@@ -3,11 +3,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Inside golangci-lint we differentiate two types of analyzers:
+        Inside `golangci-lint`, we differentiate two types of analyzers:
         - the linters (find problems with nearly zero false positives)
-        - the detectors (detect potential problems, and so a majority of false positives)
+        - the detectors (detect potential problems and thus produce a majority of false positives)
 
-        The detectors are not allowed because of the number of false positives
+        The detectors are not allowed because of the number of false positives.
   - type: input
     id: repo-url
     attributes:
@@ -26,9 +26,9 @@ body:
           required: true
         - label: It must use [`go/analysis`](https://golangci-lint.run/docs/contributing/new-linters/).
           required: true
-        - label: It must not be a duplicate or too close of an existing analyzer.
+        - label: It must not be a duplicate or too close to an existing analyzer.
           required: true
-        - label: It must use Go version <= 1.25.0
+        - label: It must have a Go version inside the `go.mod` <= 1.25.0.
           required: true
         - label: The dependencies must be minimal.
           required: true
@@ -38,18 +38,19 @@ body:
     id: analyzer-goal
     attributes:
       label: Analyzer Goal
-      description: 'What is the goal of the analyzer?'
+      description: What is the goal of the analyzer?
       options:
         - No goal
         - Finds bugs
         - Style
+        - Other
     validations:
       required: true
   - type: textarea
     id: analyzer-description
     attributes:
       label: Analyzer Description
-      description: A short one or two lines maximum.
+      description: A short description, no more than one or two lines.
       placeholder: Add the description here.
     validations:
       required: true
@@ -60,9 +61,9 @@ body:
       options:
         - label: AGPL is not allowed.
           required: true
-        - label: The file must start with `LICENSE` (capitalized)
+        - label: The file must start with `LICENSE` (capitalized).
           required: true
-        - label: "The file must contain the required information by the license, ex: author, year, etc."
+        - label: 'The file must contain the required information by the license, e.g.: author, year, etc.'
           required: true
   - type: checkboxes
     id: analyzer-info
@@ -88,11 +89,11 @@ body:
     attributes:
       label: Repository Details
       options:
-        - label: 'It must have a valid semver tag, ex: `v1.0.0`, `v0.1.0` (`0.0.x` are not valid).'
+        - label: 'It must have a [semver](https://semver.org/) tag, e.g.: `v1.0.0`, `v0.1.0` (`0.0.x` are not valid).'
           required: true
-        - label: A tag should never be deleted or recreated.
+        - label: A tag must never be deleted or recreated.
           required: false
-        - label: It should have a readme.
+        - label: It must have a readme.
           required: true
         - label: The repository must have a CI.
           required: true
@@ -107,7 +108,7 @@ body:
       options:
         - label: It should have linting.
           required: false
-        - label: It should have a `.gitignore` (IDE files, binaries, OS files, etc. should not be committed)
+        - label: It should have a `.gitignore` (IDE files, binaries, OS files, etc. should not be committed).
           required: false
         - label: Use `main` as the default branch name.
           required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,14 @@
 <!--
 
-WARNING:
+WARNING: If you don't follow the rules, the pull request will be closed.
+
+-->
+
+<!--
+Please don't use an AI to generate the PR description.
+-->
+
+<!--
 
 We use Dependabot to update dependencies (linters included).
 The updates happen at least automatically once a week (Sunday 11am UTC).
@@ -14,7 +22,14 @@ you are the original author of the linter, AND there are important changes requi
 
 <!--
 
-WARNING:
+If you want to add a new linter, you MUST open a discussion in the category "New Linter Proposals" and
+wait for a maintainer to approve it BEFORE opening a pull request.
+
+If you don't follow the previous rule, the pull request will be closed.
+
+-->
+
+<!--
 
 Pull requests from a fork inside a GitHub organization are not allowed.
 Only pull requests from personal forks are allowed. 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ WARNING: If you don't follow the rules, the pull request will be closed.
 -->
 
 <!--
-Please don't use an AI to generate the PR description.
+Please keep the description brief.
 -->
 
 <!--

--- a/docs/content/docs/contributing/new-linters.md
+++ b/docs/content/docs/contributing/new-linters.md
@@ -26,12 +26,12 @@ After that:
    list of all supported linters in [`pkg/lint/lintersdb/builder_linter.go`](https://github.com/golangci/golangci-lint/blob/HEAD/pkg/lint/lintersdb/builder_linter.go)
    to the method `LinterBuilder.Build`.
     - Add `WithSince("next_version")`, where `next_version` must be replaced by the next minor version. (ex: v1.2.0 if the current version is v1.1.0)
-4. Find out what options do you need to configure for the linter.
-   For example, `nakedret` has only 1 option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml).
+4. Find out what options you need to configure for the linter.
+   For example, `nakedret` has only one option: [`max-func-lines`](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml).
    Choose default values to not be annoying for users of golangci-lint. Add configuration options to:
     - [.golangci.next.reference.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.next.reference.yml): the example of a configuration file.
       You can also add them to [.golangci.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.yml)
-      if you think that this project needs not default values.
+      if you think that this project needs no default values.
     - [config struct](https://github.com/golangci/golangci-lint/blob/HEAD/pkg/config/config.go):
       don't forget about `mapstructure` tags for proper configuration files parsing.
 5. Take a look at the example of [pull requests with new linter support](https://github.com/golangci/golangci-lint/pulls?q=is%3Apr+is%3Amerged+label%3A%22linter%3A+new%22).
@@ -45,7 +45,7 @@ After that:
 Some people and organizations may choose to have custom-made linters run as a part of `golangci-lint`.  
 Typically, these linters can't be open-sourced or too specific.
 
-Such linters can be added through 2 plugin systems:
+Such linters can be added through two plugin systems:
 
 {{< cards cols=2 >}}
   {{< card link="/docs/plugins/module-plugins" title="Module Plugin System" icon="puzzle" tag="Recommended" >}}

--- a/docs/content/docs/contributing/workflow.md
+++ b/docs/content/docs/contributing/workflow.md
@@ -5,7 +5,7 @@ aliases:
   - /contributing/workflow/
 ---
 
-By participating in this project, you agree to abide our [code of conduct](https://github.com/golangci/golangci-lint?tab=coc-ov-file).
+By participating in this project, you agree to abide by our [code of conduct](https://github.com/golangci/golangci-lint?tab=coc-ov-file).
 
 ## Set up your machine
 
@@ -39,7 +39,15 @@ Which runs all the linters and tests.
 
 Add your new or updated parameters to [.golangci.next.reference.yml](https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.next.reference.yml) so they will be shown in the docs
 
+## Create a discussion
+
+You must create a discussion **before** opening a pull request.
+
+There is a dedicated category for new linters: [New Linter Proposals](https://github.com/golangci/golangci-lint/discussions/categories/new-linter-proposals).
+
 ## Submit a pull request
+
+Once the maintainers have approved your linter proposal in the discussion.
 
 Push your branch to your golangci-lint fork and open a pull request against the
 `main` branch.


### PR DESCRIPTION
Faced with the proliferation of low-quality analyzers generated by AI, aged of a few hours, I want to modify the workflow to integrate a new linter.

This new workflow will require opening a discussion and an approval of the linter before creating a pull request.

Creating an analyzer is inexpensive due to generative AI, but it still represents the same workload for maintainers, sometimes even more, because the AI generates unnecessarily complex code.

Therefore, I need to find a way to mitigate this.

FYI, this kind of workflow is now adopted by several notable projects.