### PR TITLE
-

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -353,7 +353,7 @@ github_release() {
   owner_repo=$1
   version=$2
   test -z "$version" && version="latest"
-  giturl="https://github.com/${owner_repo}/releases/${version}"
+  giturl="${GITHUB_URL:-https://github.com}/${owner_repo}/releases/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1
   version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
@@ -412,13 +412,14 @@ FORMAT=tar.gz
 OS=$(uname_os)
 ARCH=$(uname_arch)
 PREFIX="$OWNER/$REPO"
+GITHUB_URL=${GITHUB_URL:-https://github.com}
 
 # use in logging routines
 log_prefix() {
 	echo "$PREFIX"
 }
 PLATFORM="${OS}/${ARCH}"
-GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+GITHUB_DOWNLOAD=${GITHUB_URL}/${OWNER}/${REPO}/releases/download
 
 uname_os_check "$OS"
 uname_arch_check "$ARCH"


### PR DESCRIPTION
## Summary
Add support for a `GITHUB_URL` environment variable to override the
hardcoded `https://github.com` base URL used for release downloads and
version lookups. This enables the install script to work in airgapped
or restricted network environments where GitHub traffic must route
through a mirror or artifact proxy.