### PR TITLE
chore: improve GHA workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -10,6 +10,8 @@ jobs:
   doc:
     name: Build and deploy documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       # https://github.com/actions/setup-go#supported-version-syntax
       # ex:
@@ -20,6 +22,8 @@ jobs:
       CGO_ENABLED: 0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -39,4 +43,4 @@ jobs:
         with:
           publish_dir: docs/public
           force_orphan: true
-          github_token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/new-linter-checklist.yml
+++ b/.github/workflows/new-linter-checklist.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Add checklist
         run: |
           # Avoid adding multiple comments for the same PR.

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -11,14 +11,17 @@ env:
   # - 1.18rc1 -> 1.18.0-rc.1
   GO_VERSION: '1.26'
 
+permissions:
+  contents: read
+
 jobs:
   update-gha-assets:
     name: "Update GitHub Action assets"
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -30,7 +33,9 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: main
-          token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+          token: ${{ secrets.RELEASER_TOKEN }}
+          push-to-fork: golangci-releaser/golangci-lint
+          author: GolangCI-Lint Releaser <65486276+golangci-releaser@users.noreply.github.com>
           branch-suffix: timestamp
           title: "docs: update GitHub Action assets"
           delete-branch: true
@@ -38,10 +43,10 @@ jobs:
   update-assets:
     name: "Update documentation assets"
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -59,7 +64,9 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: main
-          token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+          token: ${{ secrets.RELEASER_TOKEN }}
+          push-to-fork: golangci-releaser/golangci-lint
+          author: GolangCI-Lint Releaser <65486276+golangci-releaser@users.noreply.github.com>
           branch-suffix: timestamp
           title: "docs: update documentation assets"
           delete-branch: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 env:
   # https://github.com/actions/setup-go#supported-version-syntax
   # ex:
@@ -18,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -27,23 +31,6 @@ jobs:
           git diff --exit-code go.mod
           git diff --exit-code go.sum
 
-  # This check is disabled because of GitHub API instability: 504 Gateway Timeout.
-  # Checks: GitHub action assets
-#  check-generated:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v6
-#        with:
-#          fetch-depth: 0
-#      - uses: actions/setup-go@v6
-#        with:
-#          go-version: ${{ env.GO_VERSION }}
-#      - name: Check generated files are up-to-date
-#        run: make fast_check_generated
-#        env:
-#          # needed for github-action-config.json generation
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   check-local-install-script:
     name: Installation script (local)
     strategy:
@@ -52,6 +39,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Check installation script
         run: cat ./install.sh | sh -s -- -d -b "./install-golangci-lint"
 
@@ -60,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -3,6 +3,8 @@ name: Check Documentation
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
 
   doc:
@@ -19,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 env:
   # https://github.com/actions/setup-go#supported-version-syntax
   # ex:
@@ -18,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -33,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           # https://github.com/actions/setup-go#supported-version-syntax
@@ -52,6 +58,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
@@ -63,6 +71,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }} # test only the latest go version to speed up CI
@@ -82,6 +92,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.golang }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - v*
 
 permissions:
+  contents: write
   # Allow the workflow to write attestations.
   id-token: write
   attestations: write
@@ -29,7 +30,7 @@ jobs:
 
       # https://github.com/marketplace/actions/free-disk-space-ubuntu
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # this might remove tools that are actually needed
           tool-cache: false
@@ -45,9 +46,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: false
 
 #      - name: Install chocolatey
 #        run: |
@@ -81,13 +84,13 @@ jobs:
           AUR_KEY: ${{ secrets.AUR_KEY }}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-          GITHUB_TOKEN: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-checksums: ./dist/golangci-lint-${{ fromJSON(steps.goreleaser.outputs.metadata).version }}-checksums.txt
-          github-token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-checksums: ./dist/digests.txt
-          github-token: ${{ secrets.GOLANGCI_LINT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The goal is to improve the GHA workflows security.

All the actions are pinned to a specific commit.

`persist-credentials` is disabled. (https://github.com/actions/checkout)

The permissions are restricted to only what is needed.

The GitHub tokens are replaced by short-lived tokens (`secrets.GITHUB_TOKEN`).

In the release workflow, the cache is disabled to avoid cache poisoning attack.

The PRs created by the post-release workflow are now created from a fork owned by the bot `golangci-releaser`.

The rights of `golangci-releaser` on the repository has been removed: this account has only access to its own repositories.
The `golangci-releaser` account is removed from the organization.
The token used by `golangci-releaser` to create the PRs is also restricted.
FYI, the access to the `golangci-releaser` account is protected by a secure MFA.

I hope the permissions are right because if it's not, I will cry during the next release, but I'm confident based on tests I did.
