### PR TITLE
Add 'golangci-lint config update' command

### DIFF
--- a/pkg/commands/config.go
+++ b/pkg/commands/config.go
@@ -68,9 +68,23 @@ func newConfigCommand(log logutils.Log, info BuildInfo) *configCommand {
 		RunE:              c.executePath,
 	}
 
+	updateCommand := &cobra.Command{
+		Use:               "update",
+		Short:             "Update configuration with commented-out options and linters.",
+		Long: "Read the current configuration file (if it exists) and add all unspecified options " +
+			"and linters as comments with descriptions. Options or linters that already exist " +
+			"(either as values or as comments) are not duplicated.",
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              c.executeUpdate,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+	}
+
 	configCmd.AddCommand(
 		pathCommand,
 		verifyCommand,
+		updateCommand,
 	)
 
 	flagSet := configCmd.PersistentFlags()

--- a/pkg/commands/config_update.go
+++ b/pkg/commands/config_update.go
@@ -1,0 +1,263 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
+	"github.com/golangci/golangci-lint/v2/pkg/lint/lintersdb"
+	"github.com/golangci/golangci-lint/v2/pkg/logutils"
+)
+
+func (c *configCommand) executeUpdate(cmd *cobra.Command, _ []string) error {
+	configFilePath := c.getUsedConfig()
+
+	var cfgNode yaml.Node
+
+	if configFilePath != "" {
+		data, err := os.ReadFile(configFilePath)
+		if err != nil {
+			return fmt.Errorf("reading config file: %w", err)
+		}
+		if err = yaml.Unmarshal(data, &cfgNode); err != nil {
+			return fmt.Errorf("parsing config file: %w", err)
+		}
+	} else {
+		configFilePath = ".golangci.yml"
+		cfgNode = newEmptyConfig()
+		c.log.Infof("No config file found, creating %s", configFilePath)
+	}
+
+	// Build linter database.
+	manager, err := lintersdb.NewManager(
+		c.log.Child(logutils.DebugKeyLintersDB),
+		config.NewDefault(),
+		lintersdb.NewLinterBuilder(),
+	)
+	if err != nil {
+		return fmt.Errorf("creating linter manager: %w", err)
+	}
+
+	update := configUpdate{}
+	update.load(manager)
+
+	// Get the root mapping node.
+	if cfgNode.Kind != yaml.DocumentNode || len(cfgNode.Content) == 0 || cfgNode.Content[0].Kind != yaml.MappingNode {
+		return fmt.Errorf("invalid YAML document structure")
+	}
+	rootMap := cfgNode.Content[0]
+
+	// Ensure the linters section exists and update it with missing linters.
+	update.addMissingLintersComments(rootMap)
+
+	// Add missing formatter names as comments.
+	update.addMissingFormatterComments(rootMap)
+
+	// Marshal and write the updated config.
+	var buf bytes.Buffer
+
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+
+	if err = encoder.Encode(&cfgNode); err != nil {
+		return fmt.Errorf("encoding YAML: %w", err)
+	}
+
+	if err = encoder.Close(); err != nil {
+		return fmt.Errorf("closing encoder: %w", err)
+	}
+
+	if err = os.WriteFile(configFilePath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	cmd.Printf("Configuration updated: %s\n", configFilePath)
+
+	return nil
+}
+
+func newEmptyConfig() yaml.Node {
+	return yaml.Node{
+		Kind: yaml.DocumentNode,
+		Content: []*yaml.Node{
+			{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Value: "version", Tag: "!!str"},
+					{Kind: yaml.ScalarNode, Value: "2", Tag: "!!str", Style: yaml.DoubleQuotedStyle},
+				},
+			},
+		},
+	}
+}
+
+type configUpdate struct {
+	supportedLinters    []string
+	supportedFormatters []string
+	descriptions        map[string]string
+}
+
+func (u *configUpdate) load(manager *lintersdb.Manager) {
+	u.descriptions = map[string]string{}
+	for _, lc := range manager.GetAllSupportedLinterConfigs() {
+		if !lc.Internal && !lc.IsDeprecated() {
+			name := lc.Name()
+			u.descriptions[name], _, _ = strings.Cut(lc.Linter.Desc(), "\n")
+			if goformatters.IsFormatter(name) {
+				u.supportedFormatters = append(u.supportedFormatters, name)
+			} else {
+				u.supportedLinters = append(u.supportedLinters, name)
+			}
+		}
+	}
+}
+
+func (u *configUpdate) addMissingLineComments(item *yaml.Node) {
+	if item.LineComment == "" {
+		item.LineComment = u.descriptions[item.Value]
+	}
+}
+
+// addMissingLintersComments adds commented-out entries for linters
+// that are not yet in the enable/disable lists.
+// The allLinters slice must already be filtered (no internal, no deprecated, no formatters).
+func (u *configUpdate) addMissingLintersComments(rootMap *yaml.Node) {
+	existingLinters := make(map[string]bool)
+
+	checkNode := rootMap
+	editNode, header, indent := rootMap, "Linter configuration.\nlinters:\n  enable:", "    "
+
+	lintersVal := findMappingValue(rootMap, "linters")
+	if lintersVal != nil && lintersVal.Kind == yaml.MappingNode {
+		checkNode = lintersVal
+		editNode, header, indent = lintersVal, "Enable specific linter.\nenable:", "  "
+
+		enableVal := findMappingValue(lintersVal, "enable")
+		if enableVal != nil && enableVal.Kind == yaml.SequenceNode {
+			editNode, header, indent = enableVal, "New linters", ""
+			for _, item := range enableVal.Content {
+				if item.Kind == yaml.ScalarNode {
+					existingLinters[item.Value] = true
+					u.addMissingLineComments(item)
+				}
+			}
+		}
+
+		disableVal := findMappingValue(lintersVal, "disable")
+		if disableVal != nil && disableVal.Kind == yaml.SequenceNode {
+			for _, item := range disableVal.Content {
+				if item.Kind == yaml.ScalarNode {
+					existingLinters[item.Value] = true
+					u.addMissingLineComments(item)
+				}
+			}
+		}
+	}
+
+	// Build list of missing linter comments.
+	commentLines := []string{header}
+	for _, name := range u.supportedLinters {
+		if !existingLinters[name] && !textInNodeComments(checkNode, name) {
+			commentLines = append(commentLines, fmt.Sprintf("%s- %s  # %s", indent, name, u.descriptions[name]))
+		}
+	}
+	if len(commentLines) > 1 {
+		appendToFootComment(editNode, strings.Join(commentLines, "\n"))
+	}
+}
+
+// addMissingFormatterComments adds commented-out entries for formatters not yet enabled.
+// The allFormatters slice must already be filtered to only contain formatter configs.
+func (u *configUpdate) addMissingFormatterComments(rootMap *yaml.Node) {
+	existingFormatters := make(map[string]bool)
+
+	checkNode := rootMap
+	editNode, header, indent := rootMap, "Formatters configuration.\nformatters:\n  enable:", "    "
+
+	formattersVal := findMappingValue(rootMap, "formatters")
+	if formattersVal != nil && formattersVal.Kind == yaml.MappingNode {
+		checkNode = formattersVal
+		editNode, header, indent = formattersVal, "Enable specific formatter.\nenable:", "  "
+
+		enableVal := findMappingValue(formattersVal, "enable")
+		if enableVal != nil && enableVal.Kind == yaml.SequenceNode {
+			editNode, header, indent = enableVal, "New formatters", ""
+
+			for _, item := range enableVal.Content {
+				if item.Kind == yaml.ScalarNode {
+					existingFormatters[item.Value] = true
+					u.addMissingLineComments(item)
+				}
+			}
+		}
+	}
+
+	commentLines := []string{header}
+	for _, name := range u.supportedFormatters {
+		if !existingFormatters[name] && !textInNodeComments(checkNode, name) {
+			commentLines = append(commentLines, fmt.Sprintf("%s- %s  # %s", indent, name, u.descriptions[name]))
+		}
+	}
+	if len(commentLines) > 1 {
+		appendToFootComment(editNode, strings.Join(commentLines, "\n"))
+	}
+}
+
+// --- YAML node helper functions ---
+
+// findMappingValue returns the value node for a given key in a mapping node.
+// Returns nil if the key is not found.
+func findMappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i < len(mapping.Content)-1; i += 2 {
+		if mapping.Content[i].Kind == yaml.ScalarNode && mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+// textInNodeComments checks recursively whether the given text appears in any comment of the node tree.s
+func textInNodeComments(node *yaml.Node, text string) bool {
+	if node == nil {
+		return false
+	}
+
+	if strings.Contains(node.HeadComment, text) ||
+		strings.Contains(node.LineComment, text) ||
+		strings.Contains(node.FootComment, text) {
+		return true
+	}
+
+	return slices.ContainsFunc(node.Content, func(child *yaml.Node) bool {
+		return textInNodeComments(child, text)
+	})
+}
+
+// appendToFootComment appends additional comment text to a node's FootComment.
+func appendToFootComment(node *yaml.Node, comment string) {
+	if node == nil {
+		return
+	}
+
+	if (node.Kind == yaml.SequenceNode || node.Kind == yaml.MappingNode) && len(node.Content) > 0 {
+		node = node.Content[len(node.Content)-1]
+	}
+
+	if node.FootComment == "" {
+		node.FootComment = comment
+	} else {
+		node.FootComment += "\n\n" + comment
+	}
+}

--- a/pkg/commands/config_update_test.go
+++ b/pkg/commands/config_update_test.go
@@ -1,0 +1,161 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/lint/lintersdb"
+	"github.com/golangci/golangci-lint/v2/pkg/logutils"
+)
+
+func testAllLinters(t *testing.T) *configUpdate {
+	t.Helper()
+
+	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
+	logutils.SetupVerboseLog(log, false)
+
+	dbManager, err := lintersdb.NewManager(log, config.NewDefault(), lintersdb.NewLinterBuilder())
+	require.NoError(t, err)
+
+	update := configUpdate{}
+	update.load(dbManager)
+
+	return &update
+}
+
+func Test_addMissingLintersComments(t *testing.T) {
+	t.Parallel()
+
+	input := `version: "2"
+linters:
+  enable:
+    - govet
+    - errcheck
+`
+
+	var doc yaml.Node
+	err := yaml.Unmarshal([]byte(input), &doc)
+	require.NoError(t, err)
+
+	rootMap := docRootMapping(&doc)
+	require.NotNil(t, rootMap)
+
+	update := testAllLinters(t)
+
+	update.addMissingLintersComments(rootMap)
+
+	output := marshalDoc(t, &doc)
+
+	// govet and errcheck should remain unchanged (uncommented).
+	assert.Contains(t, output, "- govet")
+	assert.Contains(t, output, "- errcheck")
+
+	// Other linters should appear as commented-out entries.
+	assert.Contains(t, output, "# - staticcheck")
+}
+
+func Test_addMissingLintersComments_skips_already_commented(t *testing.T) {
+	t.Parallel()
+
+	input := `version: "2"
+linters:
+  enable:
+    - govet
+    # - staticcheck  # already disabled
+`
+
+	var doc yaml.Node
+	err := yaml.Unmarshal([]byte(input), &doc)
+	require.NoError(t, err)
+
+	rootMap := docRootMapping(&doc)
+	require.NotNil(t, rootMap)
+
+	update := testAllLinters(t)
+
+	update.addMissingLintersComments(rootMap)
+
+	output := marshalDoc(t, &doc)
+
+	// staticcheck should appear only once (in the existing comment).
+	count := strings.Count(output, "staticcheck")
+	assert.Equal(t, 1, count, "staticcheck should appear exactly once (already commented)")
+}
+
+func Test_textInNodeComments(t *testing.T) {
+	t.Parallel()
+
+	input := `version: "2"
+# This is a head comment for linters.
+linters:
+  enable:
+    - govet
+    # - staticcheck  # already present
+`
+
+	var doc yaml.Node
+	err := yaml.Unmarshal([]byte(input), &doc)
+	require.NoError(t, err)
+
+	rootMap := docRootMapping(&doc)
+	require.NotNil(t, rootMap)
+
+	assert.True(t, textInNodeComments(rootMap, "staticcheck"))
+	assert.True(t, textInNodeComments(rootMap, "head comment"))
+	assert.False(t, textInNodeComments(rootMap, "nonexistent"))
+}
+
+func Test_findMappingValue(t *testing.T) {
+	t.Parallel()
+
+	input := `version: "2"
+linters:
+  enable:
+    - govet
+`
+
+	var doc yaml.Node
+	err := yaml.Unmarshal([]byte(input), &doc)
+	require.NoError(t, err)
+
+	rootMap := docRootMapping(&doc)
+	require.NotNil(t, rootMap)
+
+	assert.NotNil(t, findMappingValue(rootMap, "version"))
+	assert.NotNil(t, findMappingValue(rootMap, "linters"))
+	assert.Nil(t, findMappingValue(rootMap, "run"))
+	assert.Nil(t, findMappingValue(rootMap, "nonexistent"))
+}
+
+// --- Test helpers ---
+
+func marshalDoc(t *testing.T, doc *yaml.Node) string {
+	t.Helper()
+
+	var buf strings.Builder
+
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+
+	err := encoder.Encode(doc)
+	require.NoError(t, err)
+
+	err = encoder.Close()
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
+// docRootMapping returns the root mapping node of a YAML document.
+func docRootMapping(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 && doc.Content[0].Kind == yaml.MappingNode {
+		return doc.Content[0]
+	}
+
+	return nil
+}


### PR DESCRIPTION
The command reads the current config file (if it exists) and
adds all unspecified linters and formattes as comments with descriptions.
It skip linters which are ready enabled/disable or mentioned in comment.
For enabled/disable linters it also adds comment with their descriptions.

<details>

```yaml
version: "2"

linters:
  enable:
    - bodyclose # checks whether HTTP response body is closed successfully
    - copyloopvar # a linter detects places where loop variables are copied
    - depguard # Go linter that checks if package imports are in a list of acceptable packages
    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
    - dupl # Detects duplicate fragments of code.
    - errcheck # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases
    - errorlint # Find code that can cause problems with the error wrapping scheme introduced in Go 1.13.
    - funlen # Checks for long functions.
    - gocheckcompilerdirectives # Checks that go compiler directive comments (//go:) are valid.
    - gochecknoinits # Checks that no init functions are present in Go code
    - goconst # Finds repeated strings that could be replaced by a constant
    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
    - gocyclo # Computes and checks the cyclomatic complexity of functions
    - godox # Detects usage of FIXME, TODO and other keywords inside comments
    - mnd # An analyzer to detect magic numbers.
    - goprintffuncname # Checks that printf-like functions are named with `f` at the end.
    - gosec # Inspects source code for security problems
    - govet # Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes.
    - intrange # intrange is a linter to find places where for loops could make use of an integer range.
    - ineffassign # detects when assignments to existing variables are not used
    - lll # Reports long lines
    - misspell # Finds commonly misspelled English words
    - nakedret # Checks that functions with naked returns are not longer than a maximum size (can be zero).
    - noctx # Detects function and method with missing usage of context.Context
    - nolintlint # Reports ill-formed or insufficient nolint directives
    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
    - staticcheck # It's the set of rules from staticcheck.
    - testifylint # Checks usage of github.com/stretchr/testify.
    - unconvert # Remove unnecessary type conversions
    - unparam # Reports unused function parameters
    - unused # Checks Go code for unused constants, variables, functions and types
    - whitespace # Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
    # New linters
    # - arangolint  # opinionated best practices for arangodb client
    # - asasalint  # check for pass []any as any in variadic func(...any)
    # - asciicheck  # checks that all code identifiers does not have non-ASCII symbols in the name
    # - bidichk  # Checks for dangerous unicode character sequences
    # - canonicalheader  # canonicalheader checks whether net/http.Header uses canonical header
    # - containedctx  # containedctx is a linter that detects struct contained context.Context field
    # - contextcheck  # check whether the function uses a non-inherited context
    # - cyclop  # checks function and package cyclomatic complexity
    # - decorder  # check declaration order and count of types, constants, variables and functions
    # - dupword  # Checks for duplicate words in the source code
    # - durationcheck  # check for two durations multiplied together
    # - embeddedstructfieldcheck  # Embedded types should be at the top of the field list of a struct, and there must be an empty line separating embedded fields from regular fields.
    # - errchkjson  # Checks types passed to the json encoding functions. Reports unsupported types and reports occurrences where the check for the returned error can be omitted.
    # - errname  # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
    # - exhaustive  # check exhaustiveness of enum switch statements
    # - exhaustruct  # Checks if all structure fields are initialized
    # - exptostd  # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
    # - forbidigo  # Forbids identifiers
    # - forcetypeassert  # Find forced type assertions
    # - funcorder  # checks the order of functions, methods, and constructors
    # - fatcontext  # detects nested contexts in loops and function literals
    # - ginkgolinter  # enforces standards of using ginkgo and gomega
    # - gochecknoglobals  # Check that no global variables exist.
    # - gochecksumtype  # Run exhaustiveness checks on Go "sum types"
    # - gocognit  # Computes and checks the cognitive complexity of functions
    # - godoclint  # Checks Golang's documentation practice (godoc)
    # - godot  # Check if comments end in a period
    # - err113  # Check errors handling expressions
    # - goheader  # Check if file header matches to pattern
    # - modernize  # A suite of analyzers that suggest simplifications to Go code, using modern language and library features.
    # - gomoddirectives  # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
    # - gomodguard_v2  # Allow and blocklist linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
    # - gosmopolitan  # Report certain i18n/l10n anti-patterns in your Go codebase
    # - grouper  # Analyze expression groups.
    # - iface  # Detect the incorrect use of interfaces, helping developers avoid interface pollution.
    # - importas  # Enforces consistent import aliases
    # - inamedparam  # reports interfaces with unnamed method parameters
    # - interfacebloat  # A linter that checks the number of methods inside an interface.
    # - iotamixing  # checks if iotas are being used in const blocks with other non-iota declarations.
    # - ireturn  # Accept Interfaces, Return Concrete Types
    # - loggercheck  # Checks key value pairs for common logger libraries (kitlog,klog,logr,slog,zap).
    # - maintidx  # maintidx measures the maintainability index of each function.
    # - makezero  # Find slice declarations with non-zero initial length
    # - mirror  # reports wrong mirror patterns of bytes/strings usage
    # - musttag  # enforce field tags in (un)marshaled structs
    # - nestif  # Reports deeply nested if statements
    # - nilerr  # Find the code that returns nil even if it checks that the error is not nil.
    # - nilnesserr  # Reports constructs that checks for err != nil, but returns a different nil value error.
    # - nilnil  # Checks that there is no simultaneous return of `nil` error and an invalid value.
    # - nlreturn  # Checks for a new line before return and branch statements to increase code clarity
    # - noinlineerr  # Disallows inline error handling (`if err := ...; err != nil {`)
    # - nonamedreturns  # Reports all named returns
    # - nosprintfhostport  # Checks for misuse of Sprintf to construct a host with port in a URL.
    # - paralleltest  # Detects missing usage of t.Parallel() method in your Go test
    # - perfsprint  # Checks that fmt.Sprintf can be replaced with a faster alternative.
    # - prealloc  # Find slice declarations that could potentially be pre-allocated
    # - predeclared  # find code that shadows one of Go's predeclared identifiers
    # - promlinter  # Check Prometheus metrics naming via promlint
    # - protogetter  # Reports direct reads from proto message fields when getters should be used
    # - reassign  # Checks that package variables are not reassigned
    # - recvcheck  # checks for receiver type consistency
    # - rowserrcheck  # checks whether Rows.Err of rows is checked successfully
    # - sloglint  # ensure consistent code style when using log/slog
    # - sqlclosecheck  # Checks that sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed.
    # - spancheck  # Checks for mistakes with OpenTelemetry/Census spans.
    # - tagalign  # check that struct tags are well aligned
    # - tagliatelle  # Checks the struct tags.
    # - testableexamples  # linter checks if examples are testable (have an expected output)
    # - testpackage  # linter that makes you use a separate _test package
    # - thelper  # thelper detects tests helpers which do not start with the t.Helper() method.
    # - tparallel  # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes.
    # - unqueryvet  # detects SELECT * in SQL queries and SQL builders, preventing performance issues and encouraging explicit column selection
    # - usestdlibvars  # A linter that detect the possibility to use variables/constants from the Go standard library.
    # - usetesting  # Reports uses of functions with replacement inside the testing package.
    # - varnamelen  # checks that the length of a variable's name matches its scope
    # - wastedassign  # Finds wasted assignment statements
    # - wrapcheck  # Checks that errors returned from external packages are wrapped
    # - wsl_v5  # add or remove empty lines
    # - zerologlint  # Detects the wrong usage of `zerolog` that a user forgets to dispatch with `Send` or `Msg`

formatters:
  enable:
    - gofmt # Check if the code is formatted according to 'gofmt' command.
    - goimports # Checks if the code and import statements are formatted according to the 'goimports' command.
    # New formatters
    # - gofumpt  # Check if code and import statements are formatted, with additional rules.
    # - golines  # Checks if code is formatted, and fixes long lines
    # - swaggo  # Check if swaggo comments are formatted
```

</details>
