### PR TITLE
nolintlint: remove blank line after standalone unused directive

### DIFF
--- a/pkg/golinters/nolintlint/internal/nolintlint.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint.go
@@ -2,6 +2,8 @@
 package internal
 
 import (
+	"bytes"
+	"go/ast"
 	"go/token"
 	"regexp"
 	"strings"
@@ -34,6 +36,49 @@ var fullDirectivePattern = regexp.MustCompile(`^//\s*nolint(?::(\s*[\w-]+\s*(?:,
 type Linter struct {
 	needs           Needs // indicates which linter checks to perform
 	excludeByLinter map[string]bool
+}
+
+func expandStandaloneDirectiveRange(
+	pass *analysis.Pass,
+	comment *ast.Comment,
+	pos, end token.Position,
+) (int, int) {
+	rawPos := pass.Fset.PositionFor(comment.Pos(), false)
+	rawEnd := pass.Fset.PositionFor(comment.End(), false)
+
+	if pass.ReadFile == nil || rawPos.Line == 0 {
+		return pos.Offset, end.Offset
+	}
+
+	file := pass.Fset.File(comment.Pos())
+	if file == nil {
+		return pos.Offset, end.Offset
+	}
+
+	content, err := pass.ReadFile(file.Name())
+	if err != nil {
+		return pos.Offset, end.Offset
+	}
+
+	lineStart := file.Offset(file.LineStart(rawPos.Line))
+	lineEnd := file.Size()
+	if rawPos.Line < file.LineCount() {
+		lineEnd = file.Offset(file.LineStart(rawPos.Line + 1))
+	}
+
+	if rawPos.Offset > len(content) || rawEnd.Offset > len(content) || lineStart > len(content) || lineEnd > len(content) {
+		return pos.Offset, end.Offset
+	}
+
+	if len(bytes.TrimSpace(content[lineStart:rawPos.Offset])) != 0 {
+		return pos.Offset, end.Offset
+	}
+
+	if len(bytes.TrimSpace(content[rawEnd.Offset:lineEnd])) != 0 {
+		return pos.Offset, end.Offset
+	}
+
+	return lineStart, lineEnd
 }
 
 // NewLinter creates a linter that enforces that the provided directives fulfill the provided requirements
@@ -162,10 +207,12 @@ func (l Linter) Run(pass *analysis.Pass) ([]*goanalysis.Issue, error) {
 
 				// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
 				if (l.needs & NeedsUnused) != 0 {
+					startOffset, endOffset := expandStandaloneDirectiveRange(pass, comment, pos, end)
+
 					removeNolintCompletely := []analysis.SuggestedFix{{
 						TextEdits: []analysis.TextEdit{{
-							Pos:     token.Pos(pos.Offset),
-							End:     token.Pos(end.Offset),
+							Pos:     token.Pos(startOffset),
+							End:     token.Pos(endOffset),
 							NewText: nil,
 						}},
 					}}

--- a/pkg/golinters/nolintlint/testdata/fix/in/nolintlint.go
+++ b/pkg/golinters/nolintlint/testdata/fix/in/nolintlint.go
@@ -13,3 +13,8 @@ func nolintlint() {
 
 	fmt.Println() //nolint:alice,lll // we don't drop individual linters from lists
 }
+
+// MyTest is a great struct.
+//
+//nolint:lll // nolint should be dropped
+type MyTest struct{}

--- a/pkg/golinters/nolintlint/testdata/fix/out/nolintlint.go
+++ b/pkg/golinters/nolintlint/testdata/fix/out/nolintlint.go
@@ -13,3 +13,6 @@ func nolintlint() {
 
 	fmt.Println() //nolint:alice,lll // we don't drop individual linters from lists
 }
+
+// MyTest is a great struct.
+type MyTest struct{}


### PR DESCRIPTION
Fixes #6459

When `nolintlint --fix` removes an unused standalone directive line, it currently deletes only the comment text and leaves the now-empty source line behind. In doc comments, that separates the remaining docstring from its target.

This change expands the deletion range to the whole line when the unused directive is the only non-whitespace content on that line, which restores the expected doc comment shape.

Validation:
- `go test ./pkg/golinters/nolintlint -run 'TestFix/nolintlint.go' -count=1`\n- `go test ./pkg/golinters/nolintlint/... -count=1`\n- `go build -o ./golangci-lint ./cmd/golangci-lint`\n- local repro with `golangci-lint run --enable nolintlint --enable lll --fix test.go`