### PR TITLE
fix: strip GIT env vars from subprocesses in golangci-lint custom (#6513)

### DIFF
--- a/pkg/commands/internal/builder.go
+++ b/pkg/commands/internal/builder.go
@@ -29,6 +29,42 @@ type Builder struct {
 	repo string
 }
 
+// cleanGitEnv returns a copy of the current environment with GIT_* variables
+// removed that could interfere with subprocess git/go operations.
+//
+// When golangci-lint is invoked from a git hook (e.g. pre-commit), git sets
+// environment variables like GIT_DIR, GIT_INDEX_FILE, and GIT_WORK_TREE.
+// If these leak into subprocesses, operations like `git clone` will write to
+// the wrong index file — corrupting the original repository's git state.
+//
+// This mirrors the approach used by pre-commit (no_git_env) and is similar to
+// how git itself cleans the environment for hooks.
+func cleanGitEnv() []string {
+	keep := map[string]bool{
+		"GIT_EXEC_PATH":            true,
+		"GIT_SSH":                  true,
+		"GIT_SSH_COMMAND":          true,
+		"GIT_SSL_CAINFO":          true,
+		"GIT_SSL_NO_VERIFY":       true,
+		"GIT_CONFIG_COUNT":        true,
+		"GIT_HTTP_PROXY_AUTHMETHOD": true,
+		"GIT_ALLOW_PROTOCOL":      true,
+		"GIT_ASKPASS":             true,
+		"GIT_TERMINAL_PROMPT":     true,
+	}
+
+	var env []string
+	for _, e := range os.Environ() {
+		key, _, _ := strings.Cut(e, "=")
+		if strings.HasPrefix(key, "GIT_") && !keep[key] {
+			continue
+		}
+		env = append(env, e)
+	}
+
+	return env
+}
+
 // NewBuilder creates a new Builder.
 func NewBuilder(logger logutils.Log, cfg *Configuration, root string) *Builder {
 	return &Builder{
@@ -96,6 +132,7 @@ func (b Builder) clone(ctx context.Context) error {
 		"https://github.com/golangci/golangci-lint.git",
 	)
 	cmd.Dir = b.root
+	cmd.Env = cleanGitEnv()
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -131,6 +168,7 @@ func (b Builder) goGet(ctx context.Context, plugin *Plugin) error {
 	//nolint:gosec // the variables are user related.
 	cmd := exec.CommandContext(ctx, "go", "get", plugin.Module+"@"+plugin.Version)
 	cmd.Dir = b.repo
+	cmd.Env = cleanGitEnv()
 
 	b.log.Infof("run: %s", strings.Join(cmd.Args, " "))
 
@@ -149,6 +187,7 @@ func (b Builder) addReplaceDirective(ctx context.Context, plugin *Plugin) error 
 
 	cmd := exec.CommandContext(ctx, "go", "mod", "edit", "-replace", replace)
 	cmd.Dir = b.repo
+	cmd.Env = cleanGitEnv()
 
 	b.log.Infof("run: %s", strings.Join(cmd.Args, " "))
 
@@ -165,6 +204,7 @@ func (b Builder) addReplaceDirective(ctx context.Context, plugin *Plugin) error 
 func (b Builder) goModTidy(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "go", "mod", "tidy")
 	cmd.Dir = b.repo
+	cmd.Env = cleanGitEnv()
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -192,6 +232,7 @@ func (b Builder) goBuild(ctx context.Context, binaryName string) error {
 		"./cmd/golangci-lint",
 	)
 	cmd.Dir = b.repo
+	cmd.Env = cleanGitEnv()
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/commands/internal/builder_test.go
+++ b/pkg/commands/internal/builder_test.go
@@ -1,10 +1,42 @@
 package internal
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_cleanGitEnv(t *testing.T) {
+	// Simulate the environment set by git during pre-commit hook execution.
+	// These variables, if inherited by `git clone`, cause the clone's checkout
+	// to write its index to GIT_INDEX_FILE — corrupting the original repo.
+	t.Setenv("GIT_DIR", "/repo/.git/worktrees/my-worktree")
+	t.Setenv("GIT_INDEX_FILE", "/repo/.git/worktrees/my-worktree/index")
+	t.Setenv("GIT_WORK_TREE", "/repo/my-worktree")
+	t.Setenv("GIT_AUTHOR_NAME", "Test Author")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+
+	// These should be preserved — they configure how git finds its binaries
+	// and connects to remotes, not how it resolves repo state.
+	t.Setenv("GIT_EXEC_PATH", "/usr/lib/git-core")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=no")
+
+	// A non-GIT_ variable that should always be preserved.
+	t.Setenv("HOME", "/home/test")
+
+	env := cleanGitEnv()
+
+	assert.True(t, slices.Contains(env, "HOME=/home/test"), "non-GIT_ vars must be preserved")
+	assert.True(t, slices.Contains(env, "GIT_EXEC_PATH=/usr/lib/git-core"), "GIT_EXEC_PATH must be preserved")
+	assert.True(t, slices.Contains(env, "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no"), "GIT_SSH_COMMAND must be preserved")
+
+	assert.False(t, slices.ContainsFunc(env, func(e string) bool { return e == "GIT_DIR=/repo/.git/worktrees/my-worktree" }), "GIT_DIR must be removed")
+	assert.False(t, slices.ContainsFunc(env, func(e string) bool { return e == "GIT_INDEX_FILE=/repo/.git/worktrees/my-worktree/index" }), "GIT_INDEX_FILE must be removed")
+	assert.False(t, slices.ContainsFunc(env, func(e string) bool { return e == "GIT_WORK_TREE=/repo/my-worktree" }), "GIT_WORK_TREE must be removed")
+	assert.False(t, slices.ContainsFunc(env, func(e string) bool { return e == "GIT_AUTHOR_NAME=Test Author" }), "GIT_AUTHOR_NAME must be removed")
+	assert.False(t, slices.ContainsFunc(env, func(e string) bool { return e == "GIT_AUTHOR_EMAIL=test@example.com" }), "GIT_AUTHOR_EMAIL must be removed")
+}
 
 func Test_sanitizeVersion(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
When invoked inside a git pre-commit hook, git sets `GIT_INDEX_FILE`, `GIT_DIR`, and `GIT_WORK_TREE` as environment variables. The `git clone` in `Builder.clone()` inherits these, causing the clone's checkout to write its index to `GIT_INDEX_FILE` -- silently overwriting the original repository's git index with golangci-lint's file tree. This destroys all staged changes and corrupts the repo (`git fsck` reports missing blobs, `git diff` fails).

Filter `GIT_*` variables from the environment for all subprocesses in `builder.go` (clone, go get, go mod tidy, go build), preserving transport/auth vars like `GIT_SSH_COMMAND` and `GIT_EXEC_PATH`.


<!--

WARNING: If you don't follow the rules, the pull request will be closed.

-->

<!--
Please keep the description brief.
-->

<!--

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

Non-versioned dependencies are managed by the golangci-lint maintainers.

No pull requests to update a linter will be accepted unless:
you are the original author of the linter, AND there are important changes required (like a major version bump).

-->

<!--

If you want to add a new linter, you MUST open a discussion in the category "New Linter Proposals" and
wait for a maintainer to approve it BEFORE opening a pull request.

https://github.com/golangci/golangci-lint/discussions/new?category=new-linter-proposals

If you don't follow the previous rule, the pull request will be closed.

-->

<!--

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
