### PR TITLE
chore: remove homebrew tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,29 +97,6 @@ source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{ .Version }}-source'
 
-brews:
-  - description: Fast linters runner for Go.
-    homepage: https://golangci.com
-    skip_upload: false
-    repository:
-      owner: golangci
-      name: homebrew-tap
-    commit_author:
-      name: golangci-releaser
-      email: 65486276+golangci-releaser@users.noreply.github.com
-    directory: Formula
-    install: |
-      bin.install "golangci-lint"
-      output = Utils.popen_read("#{bin}/golangci-lint completion bash")
-      (bash_completion/"golangci-lint").write output
-      output = Utils.popen_read("#{bin}/golangci-lint completion zsh")
-      (zsh_completion/"_golangci-lint").write output
-      output = Utils.popen_read("#{bin}/golangci-lint completion fish")
-      (fish_completion/"golangci-lint.fish").write output
-      prefix.install_metafiles
-    test: |
-      system "#{bin}/golangci-lint --version"
-
 ## chocolatey is disabled because mono has been removed from GitHub Actions runners due to security and maintenance concerns.
 ## The release is done manually and locally, with goreleaser after the release of the other elements.
 ## Note(ldez): add documentation about how to do it.

--- a/docs/content/docs/welcome/install/local.md
+++ b/docs/content/docs/welcome/install/local.md
@@ -45,15 +45,7 @@ brew upgrade golangci-lint
 ```
 
 Note: Previously, we used a [Homebrew tap](https://github.com/golangci/homebrew-tap).
-We recommend using the [official formula](https://formulae.brew.sh/formula/golangci-lint) instead of the tap,
-but sometimes the most recent release isn't immediately available via Homebrew core due to manual updates that need to occur from Homebrew core maintainers.
-In this case, the tap formula, which is updated automatically,
-can be used to install the latest version of golangci-lint:
-
-```bash
-brew tap golangci/tap
-brew install golangci/tap/golangci-lint
-```
+We recommend using the [official formula](https://formulae.brew.sh/formula/golangci-lint) instead of the tap.
 
 ### MacPorts
 


### PR DESCRIPTION
We don't need to maintain the Homebrew Tap, the formula is already in the main repository.

Also, the integration inside goreleaser is [deprecated](https://goreleaser.com/blog/goreleaser-v2.10/) and replaced by Homebrew Casks.

This is also a problem with short-lived GitHub tokens (the rights are limited).