### PR TITLE
fix: install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | head -n 1 | cut -d ' ' -f 1)
+  want=$(grep "${BASENAME}$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1

--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | head -n 1 | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
---

> [!IMPORTANT] 
> If you are using the install script from the `master` branch:
> `https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh`
> This branch is not used anymore, we are using `main`.
>
> We recommend using `https://golangci-lint.run/install.sh` as URL to install golangci-lint.
> 
> https://golangci-lint.run/docs/welcome/install/local/#binaries

---

The SBOM files has been added to the checksum file.

```
6b89d77b6396f81decee882f20473486bda5ef28b160f9a13b08f24848d9003c  golangci-lint-2.12.0-linux-amd64.tar.gz
7976b1209947f3d94a851145bfb67ea4779bd431b0999a3cd8f38f4544afd0cf  golangci-lint-2.12.0-linux-amd64.tar.gz.sbom.json
```

The script uses grep to find the right line, but there are two lines that match.

```console
$ grep "golangci-lint-2.12.0-linux-amd64.tar.gz" "golangci-lint-2.12.0-checksums.txt" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1 
6b89d77b6396f81decee882f20473486bda5ef28b160f9a13b08f24848d9003c
7976b1209947f3d94a851145bfb67ea4779bd431b0999a3cd8f38f4544afd0cf
```

~~So, I added a `head -n 1`, this is only a quick fix.~~
I edited the grep matcher to use `$`.

I need to think if this is a proper solution, but for now, I need to unlock the situation.

The job `check-local-install-script` of the workflow `pr-checks.yml` validates that my fix is right.

Fixes https://github.com/golangci/golangci-lint/discussions/6537