### PR TITLE
gomodguard: fix panic with migration suggestion

### DIFF
--- a/pkg/golinters/gomodguard/gomodguard.go
+++ b/pkg/golinters/gomodguard/gomodguard.go
@@ -104,7 +104,7 @@ type goModGuardv2Base struct {
 
 // Only used the set YAML struct tags.
 type goModGuardv2Blocked struct {
-	goModGuardv2Base
+	goModGuardv2Base `yaml:",inline"`
 
 	Recommendations []string `yaml:"recommendations,omitempty"`
 	Reason          string   `yaml:"reason,omitempty"`


### PR DESCRIPTION
There is a panic with the suggested migration:

```
panic: reflect.Value.Interface: cannot return value obtained from unexported field or method [recovered, repanicked]
```

To reproduce:
```yml
version: "2"

linters:
  default: none
  enable:
    - gomodguard
  settings:
    gomodguard:
      blocked:
        modules:
          - io/ioutil:
              recommendations:
                - io
                - os
```

Related to #6541 and #6543