### PR TITLE
fix(nolintlint): remove entire line for standalone unused directives

### DIFF
--- a/pkg/golinters/nolintlint/internal/nolintlint.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint.go
@@ -57,6 +57,8 @@ var (
 //nolint:funlen,gocyclo // the function is going to be refactored in the future
 func (l Linter) Run(pass *analysis.Pass) ([]*goanalysis.Issue, error) {
 	var issues []*goanalysis.Issue
+	var fileContent []byte
+	tokenFile := pass.Fset.File(file.Pos())
 
 	for _, file := range pass.Files {
 		for _, c := range file.Comments {
@@ -162,10 +164,20 @@ func (l Linter) Run(pass *analysis.Pass) ([]*goanalysis.Issue, error) {
 
 				// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
 				if (l.needs & NeedsUnused) != 0 {
+					removeStart := pos.Offset
+					removeEnd := end.Offset
+
+					// When the nolint directive is on its own line (not inline with code), remove the entire line including the newline 
+					// to avoid leaving a blank line that would separate a doc comment from its target declaration.
+					if isCommentOnlyLine(pass, tokenFile, &fileContent, pos, end) {
+						removeStart = pos.Offset - (pos.Column - 1) // start of line
+						removeEnd = nextLineOffset(tokenFile, pos.Line, end.Offset)
+					}
+
 					removeNolintCompletely := []analysis.SuggestedFix{{
 						TextEdits: []analysis.TextEdit{{
-							Pos:     token.Pos(pos.Offset),
-							End:     token.Pos(end.Offset),
+							Pos:     token.Pos(removeStart),
+							End:     token.Pos(removeEnd),
 							NewText: nil,
 						}},
 					}}
@@ -229,4 +241,51 @@ func (l Linter) Run(pass *analysis.Pass) ([]*goanalysis.Issue, error) {
 	}
 
 	return issues, nil
+}
+
+// isCommentOnlyLine reports whether the comment at pos occupies its line alone 
+// (only optional whitespace before it, nothing after it except a newline or EOF).
+func isCommentOnlyLine(
+	pass *analysis.Pass,
+	tokenFile *token.File,
+	fileContent *[]byte,
+	pos, end token.Position,
+) bool {
+	// Lazy-load the file content once per file.
+	if len(*fileContent) == 0 {
+		filename := tokenFile.Name()
+		content, err := pass.ReadFile(filename)
+		if err != nil || len(content) == 0 {
+			return false
+		}
+		*fileContent = content
+	}
+
+	content := *fileContent
+
+	// Check that everything before the comment on the same line is whitespace.
+	lineStart := pos.Offset - (pos.Column - 1) // Column is 1-based
+	for i := lineStart; i < pos.Offset; i++ {
+		if content[i] != ' ' && content[i] != '\t' {
+			return false
+		}
+	}
+
+	// Check that nothing follows the comment on the same line (except a newline or EOF).
+	afterComment := end.Offset
+	if afterComment < len(content) && content[afterComment] != '\n' && content[afterComment] != '\r' {
+		return false
+	}
+
+	return true
+}
+
+// nextLineOffset returns the byte offset of the start of the line after lineNum.
+// If lineNum is the last line, it returns endOffset (the end of the comment).
+func nextLineOffset(tokenFile *token.File, lineNum int, endOffset int) int {
+	if lineNum < tokenFile.LineCount() {
+		return tokenFile.Offset(tokenFile.LineStart(lineNum + 1))
+	}
+
+	return endOffset
 }

--- a/pkg/golinters/nolintlint/internal/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint_test.go
@@ -236,11 +236,42 @@ func foo() {
 				SuggestedFixes: []analysis.SuggestedFix{{
 					TextEdits: []analysis.TextEdit{{
 						Pos: 13,
-						End: 32,
+						End: 33,
 					}},
 				}},
 				ExpectNoLint:         true,
 				ExpectedNoLintLinter: "somelinter",
+			}},
+		},
+		{
+			desc:  "needs unused nolint in docstring removes full line to preserve doc association",
+			needs: NeedsUnused,
+			contents: `
+			package bar
+
+			// MyTest is a great struct.
+			//
+			//nolint:lll
+			type MyTest struct{}
+			`,
+			// offset 0: "package bar\n" (12 bytes)
+			// offset 12: "\n"
+			// offset 13: "// MyTest is a great struct.\n" (29 bytes, offset 13-41)
+			// offset 42: "//\n" (3 bytes, offset 42-44)
+			// offset 45: "//nolint:lll\n" (13 bytes, offset 45-57)
+			// offset 58: "type MyTest struct{}\n"
+			expected: []*result.Issue{{
+				FromLinter: "nolintlint",
+				Text:       "directive `//nolint:lll` is unused for linter \"lll\"",
+				Pos:        token.Position{Filename: "testing.go", Offset: 45, Line: 5, Column: 1},
+				SuggestedFixes: []analysis.SuggestedFix{{
+					TextEdits: []analysis.TextEdit{{
+						Pos: 45,
+						End: 58,
+					}},
+				}},
+				ExpectNoLint:         true,
+				ExpectedNoLintLinter: "lll",
 			}},
 		},
 		{
@@ -284,6 +315,9 @@ func foo() {
 			pass := &analysis.Pass{
 				Fset:  fset,
 				Files: []*ast.File{expr},
+				ReadFile: func(string) ([]byte, error) {
+					return []byte(test.contents), nil
+				},
 			}
 
 			analysisIssues, err := linter.Run(pass)

--- a/pkg/golinters/nolintlint/testdata/fix/in/nolintlint.go
+++ b/pkg/golinters/nolintlint/testdata/fix/in/nolintlint.go
@@ -13,3 +13,11 @@ func nolintlint() {
 
 	fmt.Println() //nolint:alice,lll // we don't drop individual linters from lists
 }
+
+// docStringFunc is a great function.
+//
+//nolint:lll
+func docStringFunc() {}
+
+//nolint:lll
+func standaloneNolint() {}

--- a/pkg/golinters/nolintlint/testdata/fix/out/nolintlint.go
+++ b/pkg/golinters/nolintlint/testdata/fix/out/nolintlint.go
@@ -13,3 +13,8 @@ func nolintlint() {
 
 	fmt.Println() //nolint:alice,lll // we don't drop individual linters from lists
 }
+
+// docStringFunc is a great function.
+func docStringFunc() {}
+
+func standaloneNolint() {}


### PR DESCRIPTION
### Description
This PR fixes an issue in the `nolintlint` fixer where removing an unnecessary standalone `//nolint` directive leaves behind a blank line. 

Previously, when a docstring was immediately followed by a `//nolint` directive, removing just the comment text left a newline character. This orphaned the docstring, separating it from its target declaration and causing friction with documentation linters like `revive`.

### Fix
* Added `isCommentOnlyLine` to detect if the `//nolint` directive is the only meaningful text on its line.
* Added `nextLineOffset` to calculate the start of the next line.
* When replacing an unused standalone directive, the `TextEdit` boundaries are expanded to cover the leading whitespace and the trailing newline, effectively removing the entire line and keeping docstrings attached to their declarations.

### Related Issue
Resolves #6459 


<!--

WARNING: If you don't follow the rules, the pull request will be closed.

-->

<!--
Please keep the description brief.
-->

<!--

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

Non-versioned dependencies are managed by the golangci-lint maintainers.

No pull requests to update a linter will be accepted unless:
you are the original author of the linter, AND there are important changes required (like a major version bump).

-->

<!--

If you want to add a new linter, you MUST open a discussion in the category "New Linter Proposals" and
wait for a maintainer to approve it BEFORE opening a pull request.

https://github.com/golangci/golangci-lint/discussions/new?category=new-linter-proposals

If you don't follow the previous rule, the pull request will be closed.

-->

<!--

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
