### PR TITLE
docs: update GitHub Action assets

### DIFF
--- a/assets/github-action-config-v2.json
+++ b/assets/github-action-config-v2.json
@@ -1,7 +1,7 @@
 {
   "MinorVersionToConfig": {
     "latest": {
-      "TargetVersion": "v2.12.0"
+      "TargetVersion": "v2.12.1"
     },
     "v1.10": {
       "Error": "golangci-lint version 'v1.10' isn't supported: we support only v2.0.0 and later versions"
@@ -202,7 +202,7 @@
       "TargetVersion": "v2.11.4"
     },
     "v2.12": {
-      "TargetVersion": "v2.12.0"
+      "TargetVersion": "v2.12.1"
     },
     "v2.2": {
       "TargetVersion": "v2.2.2"


### PR DESCRIPTION
I discover why the post-release workflow are not been triggered: as we are now using short-liven token, the actor of the release process has changed.
Sadly, when using those tokens, you cannot trigger other workflows.

https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow

I don't want to come back to a PAT, so I will have to think about a different approach.