### PR TITLE
dev: workaround for post-release trigger

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,5 +1,11 @@
 name: "Post release"
 on:
+  workflow_dispatch:
+    inputs:
+      user:
+        description: Who are you?
+        required: true
+        type: string
   release:
     types:
       - published


### PR DESCRIPTION
As I explained [here](https://github.com/golangci/golangci-lint/pull/6546#issue-4368694178) the post-release workflow is not trigger anymore.

So I added `workflow_dispatch` as a workaround.
