### PR TITLE
fix: improve checksum verification logic in hash_sha256_verify function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,17 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=""
+  # Parse checksum files by fields to avoid substring/regex matches.
+  while read -r sum file _; do
+    [ -z "$sum" ] && continue
+    file=${file#\*}
+    file=$(echo "$file" | tr -d '\r')
+    if [ "$file" = "$BASENAME" ]; then
+      want="$sum"
+      break
+    fi
+  done < "$checksums"
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
When installing via `install.sh` on linux-amd64, I noticed a checksum error.  The script was finding the checksum for the sbom rather than the tarball.  This small patch seems to work for me by falling back to shell syntax instead of using grep.  I've tested it on macos and ubuntu, so I believe it covers the various shell/coreutils behaviors properly.

## Bug Listing
```
$ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 2.12.1 for v2.12.1/linux/amd64
golangci/golangci-lint err hash_sha256_verify checksum for '/tmp/tmp.QAhs33Nb6n/golangci-lint-2.12.1-linux-amd64.tar.gz' did not verify 82c7932d9aa10c34e22ef56961ac5aad71d4a14806a1a31b06931add2688b368
4a1fed90469250d59ab1d623521c3584027ed9cf94ea7aba3c2477164746e2cf vs 82c7932d9aa10c34e22ef56961ac5aad71d4a14806a1a31b06931add2688b368
```

```
$ sha256sum /tmp/tmp.QAhs33Nb6n/golangci-lint-2.12.1-linux-amd64.tar.gz
82c7932d9aa10c34e22ef56961ac5aad71d4a14806a1a31b06931add2688b368  /tmp/tmp.QAhs33Nb6n/golangci-lint-2.12.1-linux-amd64.tar.gz

$ grep linux-amd64.tar.gz /tmp/tmp.QAhs33Nb6n/golangci-lint-2.12.1-checksums.txt
82c7932d9aa10c34e22ef56961ac5aad71d4a14806a1a31b06931add2688b368  golangci-lint-2.12.1-linux-amd64.tar.gz
4a1fed90469250d59ab1d623521c3584027ed9cf94ea7aba3c2477164746e2cf  golangci-lint-2.12.1-linux-amd64.tar.gz.sbom.json
```

## Listing after patch
```
$ cat install.sh | sh
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 2.12.1 for v2.12.1/linux/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
```