### PR TITLE
fix(gomodguard_v2): squash embedded base so blocked rules decode Module field

### DIFF
--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -624,7 +624,7 @@ type GoModGuardv2Base struct {
 }
 
 type GoModGuardv2Blocked struct {
-	GoModGuardv2Base
+	GoModGuardv2Base `mapstructure:",squash"`
 
 	Recommendations []string `mapstructure:"recommendations"`
 	Reason          string   `mapstructure:"reason"`

--- a/pkg/golinters/gomodguard/testdata/gomodguard.go
+++ b/pkg/golinters/gomodguard/testdata/gomodguard.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"golang.org/x/mod/modfile"
-	"gopkg.in/yaml.v3" // want "import of package `gopkg.in/yaml.v3` is blocked because the module is not in the allowed modules list."
+	"gopkg.in/yaml.v3" // want "import of package `gopkg.in/yaml.v3` is blocked because the module is in the blocked modules list. `github.com/kylelemons/go-gypsy` is a recommended module. This is an example of a reason."
 )
 
 // Something just some struct

--- a/pkg/golinters/gomodguard/testdata/gomodguard_cgo.go
+++ b/pkg/golinters/gomodguard/testdata/gomodguard_cgo.go
@@ -17,7 +17,7 @@ import (
 	"unsafe"
 
 	"golang.org/x/mod/modfile"
-	"gopkg.in/yaml.v3" // want "import of package `gopkg.in/yaml.v3` is blocked because the module is not in the allowed modules list."
+	"gopkg.in/yaml.v3" // want "import of package `gopkg.in/yaml.v3` is blocked because the module is in the blocked modules list. `github.com/kylelemons/go-gypsy` is a recommended module. This is an example of a reason."
 )
 
 func _() {


### PR DESCRIPTION
`GoModGuardv2Blocked` embeds `GoModGuardv2Base` without a `mapstructure:",squash"` tag. mapstructure does not promote embedded fields by default, so the user's flat YAML (`module:`, `match-type:`, `version:` keys directly under each `blocked` entry) was decoding into `Module=""`, `MatchType=""`, `Version=""` — only `Reason` and `Recommendations` survived.

Every blocked rule then arrived at gomodguard with an empty `Module`, collided on the same exact-match key, and never matched any required module from `go.mod`. Imports of supposedly blocked modules silently fell through to the allowed-list check, producing the misleading "is blocked because the module is not in the allowed modules list" message instead of the intended reason and recommendation.

Add `mapstructure:",squash"` to the embedded base, matching the pattern already used for `Tagliatelle*` settings in the same file. Update the gomodguard_v2 testdata `// want` expectations, which previously asserted the buggy "not in the allowed modules list" message and now correctly assert the blocked-rule message including the reason and recommendation.

<!--

WARNING: If you don't follow the rules, the pull request will be closed.

-->

<!--
Please keep the description brief.
-->

<!--

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

Non-versioned dependencies are managed by the golangci-lint maintainers.

No pull requests to update a linter will be accepted unless:
you are the original author of the linter, AND there are important changes required (like a major version bump).

-->

<!--

If you want to add a new linter, you MUST open a discussion in the category "New Linter Proposals" and
wait for a maintainer to approve it BEFORE opening a pull request.

https://github.com/golangci/golangci-lint/discussions/new?category=new-linter-proposals

If you don't follow the previous rule, the pull request will be closed.

-->

<!--

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
