### PR TITLE
install.sh: avoid grep matching .tar.gz.sbom.json as well.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep " ${BASENAME}\$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
There already was a "$" supposed to prevent that, but it needs to be escaped as it's in double-quotes.

This hits on alpine with busybox shell, sone others possibly as well. The result is a want with two sha256sums, which of course does not match. Fix is to properly escape the "\$".