### PR TITLE
goconst: add option exclude-types

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -720,6 +720,28 @@ linters:
       # Ignore when constant is not used as function argument.
       # Default: true
       ignore-calls: false
+      # Ignore constants from specific types.
+      # Default: [Call]
+      exclude-types:
+        # Represents a string in an assignment context.
+        # (e.g., x := "foo")
+        - Assignment
+        # Represents a string in a binary expression.
+        # (e.g., x == "foo")
+        - Binary
+        # Represents a string in a case clause.
+        # (e.g., case "foo":)
+        - Case
+        # Represents a string in a return statement.
+        # (e.g., return "foo")
+        - Return
+        # Represents a string passed as an argument to a function call.
+        # (e.g., f("foo"))
+        - Call
+        # Represents a string inside a composite literal.
+        # (e.g., []string{"foo"}, map[string]string{"k": "v" }, MyStruct{Field: "foo" })
+        - CompositeLit
+
       # Exclude strings matching the given regular expression.
       # Default: ""
       ignore-string-values:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,6 +75,7 @@ linters:
     goconst:
       min-len: 2
       min-occurrences: 3
+      ignore-tests: true
     gocritic:
       enabled-tags:
         - diagnostic
@@ -237,10 +238,10 @@ linters:
       - path: pkg/golinters/gomodguard/
         linters:
           - dupl
-      # TODO(ldez): temporary fix, it will change in the future.
-      - path: internal/cache/cache.go
+      - path: pkg/golinters/goconst/goconst.go
+        text: "SA1019: settings.IgnoreCalls is deprecated: use ExcludeTypes instead."
         linters:
-          - goconst
+          - staticcheck
 
 formatters:
   enable:

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1702,6 +1702,19 @@
               "type": "integer",
               "default": 3
             },
+            "exclude-types": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "Assignment",
+                  "Binary",
+                  "Case",
+                  "Return",
+                  "Call",
+                  "CompositeLit"
+                ]
+              }
+            },
             "ignore-calls": {
               "description": "Ignore when constant is not used as function argument",
               "type": "boolean",

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -63,6 +63,7 @@ var defaultLintersSettings = LintersSettings{
 		MinOccurrencesCount: 3,
 		NumberMin:           3,
 		NumberMax:           3,
+		ExcludeTypes:        []string{"Call"},
 		IgnoreCalls:         true,
 	},
 	Gocritic: GoCriticSettings{
@@ -533,7 +534,7 @@ type GoConstSettings struct {
 	ParseNumbers         bool     `mapstructure:"numbers"`
 	NumberMin            int      `mapstructure:"min"`
 	NumberMax            int      `mapstructure:"max"`
-	IgnoreCalls          bool     `mapstructure:"ignore-calls"`
+	ExcludeTypes         []string `mapstructure:"exclude-types"`
 	FindDuplicates       bool     `mapstructure:"find-duplicates"`
 	EvalConstExpressions bool     `mapstructure:"eval-const-expressions"`
 	IgnoreFunctions      []string `mapstructure:"ignore-functions"`
@@ -541,6 +542,11 @@ type GoConstSettings struct {
 	// This option cannot be managed with `linters.exclusions.rules`.
 	// Because the linter counts occurrences across all files in the package.
 	IgnoreTests bool `mapstructure:"ignore-tests"`
+
+	// NOTE(ldez): `ignore-calls` was here to have the same options as goconst as CLI.
+	//
+	// Deprecated: use ExcludeTypes instead.
+	IgnoreCalls bool `mapstructure:"ignore-calls"`
 
 	// Deprecated: use IgnoreStringValues instead.
 	IgnoreStrings string `mapstructure:"ignore-strings"`

--- a/pkg/golinters/goconst/goconst.go
+++ b/pkg/golinters/goconst/goconst.go
@@ -2,6 +2,7 @@ package goconst
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	goconstAPI "github.com/jgautheron/goconst"
@@ -48,7 +49,7 @@ func New(settings *config.GoConstSettings) *goanalysis.Linter {
 }
 
 func runGoconst(pass *analysis.Pass, settings *config.GoConstSettings) ([]*goanalysis.Issue, error) {
-	cfg := goconstAPI.Config{
+	cfg := &goconstAPI.Config{
 		IgnoreStrings:        settings.IgnoreStringValues,
 		IgnoreTests:          settings.IgnoreTests,
 		MatchWithConstants:   settings.MatchWithConstants,
@@ -63,11 +64,24 @@ func runGoconst(pass *analysis.Pass, settings *config.GoConstSettings) ([]*goana
 		IgnoreFunctions:      settings.IgnoreFunctions,
 	}
 
-	if settings.IgnoreCalls {
-		cfg.ExcludeTypes[goconstAPI.Call] = true
+	// There is no deprecation log for `IgnoreCalls` because the default is true.
+	// As the default of `ExcludeTypes` contains `call`,
+	// setting `IgnoreCalls` to false is the only way for a user to explicitly use the value `call`.
+	// TODO(ldez): `IgnoreCalls` must be removed if the next major version.
+	if !settings.IgnoreCalls && len(settings.ExcludeTypes) == 1 && strings.EqualFold(settings.ExcludeTypes[0], "call") {
+		settings.ExcludeTypes = nil
 	}
 
-	lintIssues, err := goconstAPI.Run(pass.Files, pass.Fset, pass.TypesInfo, &cfg)
+	for _, k := range settings.ExcludeTypes {
+		typ, err := toType(k)
+		if err != nil {
+			return nil, err
+		}
+
+		cfg.ExcludeTypes[typ] = true
+	}
+
+	lintIssues, err := goconstAPI.Run(pass.Files, pass.Fset, pass.TypesInfo, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -109,4 +123,29 @@ func runGoconst(pass *analysis.Pass, settings *config.GoConstSettings) ([]*goana
 	}
 
 	return res, nil
+}
+
+func toType(v string) (goconstAPI.Type, error) {
+	switch strings.ToLower(v) {
+	case "assignment":
+		return goconstAPI.Assignment, nil
+
+	case "binary":
+		return goconstAPI.Binary, nil
+
+	case "case":
+		return goconstAPI.Case, nil
+
+	case "return":
+		return goconstAPI.Return, nil
+
+	case "call":
+		return goconstAPI.Call, nil
+
+	case "compositelit":
+		return goconstAPI.CompositeLit, nil
+
+	default:
+		return 0, fmt.Errorf("unknown type %s", v)
+	}
 }

--- a/pkg/golinters/goconst/testdata/goconst_exclude_types.go
+++ b/pkg/golinters/goconst/testdata/goconst_exclude_types.go
@@ -1,0 +1,26 @@
+//golangcitest:args -Egoconst
+//golangcitest:config_path testdata/goconst_exclude_types.yml
+package testdata
+
+import "fmt"
+
+const FooBar = "foobar"
+
+func _() {
+	a := "foobar" // want "string `foobar` has 3 occurrences, but such constant `FooBar` already exists"
+	fmt.Print(a)
+
+	_ = []string{"foobar"}
+
+	_ = map[string]string{"foobar": "value"}
+
+	b := "foobar"
+	fmt.Print(b)
+
+	c := "foobar"
+	fmt.Print(c)
+
+	fmt.Print("foobar")
+
+	fmt.Print("fdsqfdsqfezrazt")
+}

--- a/pkg/golinters/goconst/testdata/goconst_exclude_types.yml
+++ b/pkg/golinters/goconst/testdata/goconst_exclude_types.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  settings:
+    goconst:
+      exclude-types:
+        - Call
+        - CompositeLit


### PR DESCRIPTION
The current option `ignore-calls` was here to mimic the goconst CLI option.
This option is directly related to the API only configuration option `ExcludeTypes` inside goconst.

We can expose this option as a configuration option for golangci-lint.

Sadly, we cannot really deprecate the `ignore-calls` option because of some edge cases.

Closes #6571