### PR TITLE
dev: close 'blank' issues

### DIFF
--- a/.github/workflows/close-blank-issue.yml
+++ b/.github/workflows/close-blank-issue.yml
@@ -1,0 +1,21 @@
+name: No Blank Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  issues: write
+
+jobs:
+  no-blank-issue:
+    name: No Blank Issue
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Check New Issue
+        uses: ldez/no-blank-issue@800e2d0c81c9e0ca7bdb58f3e7480a74602d91e0 # v1.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Until GitHub decides to protect us from this, I created a GitHub Action to close "blank template" issues.

https://github.com/ldez/no-blank-issue

The process is straightforward: when an issue is opened without the templates, there will be no label, and an external contributor cannot add a label.

Therefore, this allows us to detect a "blank template" issue.

In this case, the issue is automatically closed with a message asking users to use the forms.

The message is:

```markdown
Hi [name of the issue author], thanks for opening an issue.

It looks like you did not use one of the provided issue forms when creating this issue.
To help us triage and respond efficiently, please open a new issue using one of the [available issue forms](https://github.com/<user/org><repo_name>/issues/new/choose).

This issue is being closed automatically.
```

This is not perfect, but it's better than nothing.
