### PR TITLE
-

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -332,14 +332,30 @@ http_download_wget() {
 }
 http_download() {
   log_debug "http_download $2"
-  if is_command curl; then
-    http_download_curl "$@"
-    return
-  elif is_command wget; then
-    http_download_wget "$@"
-    return
-  fi
-  log_crit "http_download unable to find wget or curl"
+  local retries=${HTTP_RETRY_COUNT:-3}
+  local attempt=1
+  local wait_time=1
+  while [ "$attempt" -le "$retries" ]; do
+    if is_command curl; then
+      if http_download_curl "$@"; then
+        return 0
+      fi
+    elif is_command wget; then
+      if http_download_wget "$@"; then
+        return 0
+      fi
+    else
+      log_crit "http_download unable to find wget or curl"
+      return 1
+    fi
+    if [ "$attempt" -lt "$retries" ]; then
+      log_info "http_download attempt $attempt failed, retrying in ${wait_time}s..."
+      sleep "$wait_time"
+      wait_time=$((wait_time * 2))
+    fi
+    attempt=$((attempt + 1))
+  done
+  log_err "http_download failed after $retries attempts"
   return 1
 }
 http_copy() {


### PR DESCRIPTION
## Problem

The install script's HTTP download functions have no retry logic. When GitHub returns transient errors (e.g. 504 Gateway Timeout), the installation fails immediately without any retry.

## Solution

Added exponential backoff retry logic to the `http_download` function that wraps both curl and wget backends:

- Retries up to **3 times** by default on failure
- Exponential backoff: 1s → 2s → 4s between attempts
- Configurable via `HTTP_RETRY_COUNT` environment variable
- Logs retry attempts at info level for debugging

This addresses the issue reported in #6498 where CI pipelines fail due to intermittent GitHub network issues.

## Testing

- Verified script syntax with `bash -n install.sh`
- Successfully tested download and installation: `bash install.sh -d -b /tmp/test`
- Confirmed retry behavior triggers on failure