### PR TITLE
-

### DIFF
--- a/pkg/goanalysis/linter.go
+++ b/pkg/goanalysis/linter.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"sync"
 
 	"golang.org/x/tools/go/analysis"
 
@@ -44,6 +45,35 @@ type Linter struct {
 	contextSetter           func(*linter.Context)
 	loadMode                LoadMode
 	needUseOriginalPackages bool
+}
+
+type ThreadSafeLinterBuilder struct {
+	mu     sync.Mutex
+	issues []*Issue
+}
+
+func NewThreadSafeLinterBuilder() *ThreadSafeLinterBuilder {
+	return &ThreadSafeLinterBuilder{}
+}
+
+func (b *ThreadSafeLinterBuilder) Add(issues ...*Issue) {
+	if len(issues) == 0 {
+		return
+	}
+
+	b.mu.Lock()
+	b.issues = append(b.issues, issues...)
+	b.mu.Unlock()
+}
+
+func (b *ThreadSafeLinterBuilder) Issues() []*Issue {
+	return b.issues
+}
+
+func (b *ThreadSafeLinterBuilder) Reporter() func(*linter.Context) []*Issue {
+	return func(*linter.Context) []*Issue {
+		return b.issues
+	}
 }
 
 func NewLinter(name, desc string, analyzers []*analysis.Analyzer, cfg map[string]map[string]any) *Linter {

--- a/pkg/goanalysis/linter.go
+++ b/pkg/goanalysis/linter.go
@@ -66,15 +66,12 @@ func (b *ThreadSafeLinterBuilder) Add(issues ...*Issue) {
 	b.mu.Unlock()
 }
 
-func (b *ThreadSafeLinterBuilder) Issues() []*Issue {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.issues
-}
-
+// Reporter returns a WithIssuesReporter-compatible function.
+// It must only be called after all analyzer Run callbacks have completed,
+// which is guaranteed by runner.run() waiting on actsWg before calling buildAllIssues.
 func (b *ThreadSafeLinterBuilder) Reporter() func(*linter.Context) []*Issue {
 	return func(*linter.Context) []*Issue {
-		return b.Issues()
+		return b.issues
 	}
 }
 

--- a/pkg/goanalysis/linter.go
+++ b/pkg/goanalysis/linter.go
@@ -67,12 +67,14 @@ func (b *ThreadSafeLinterBuilder) Add(issues ...*Issue) {
 }
 
 func (b *ThreadSafeLinterBuilder) Issues() []*Issue {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.issues
 }
 
 func (b *ThreadSafeLinterBuilder) Reporter() func(*linter.Context) []*Issue {
 	return func(*linter.Context) []*Issue {
-		return b.issues
+		return b.Issues()
 	}
 }
 

--- a/pkg/golinters/dupl/dupl.go
+++ b/pkg/golinters/dupl/dupl.go
@@ -3,7 +3,6 @@ package dupl
 import (
 	"fmt"
 	"go/token"
-	"sync"
 
 	duplAPI "github.com/golangci/dupl/lib"
 	"golang.org/x/tools/go/analysis"
@@ -12,15 +11,13 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/fsutils"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "dupl"
 
 func New(settings *config.DuplSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	return goanalysis.
 		NewLinterFromAnalyzer(&analysis.Analyzer{
@@ -32,20 +29,11 @@ func New(settings *config.DuplSettings) *goanalysis.Linter {
 					return nil, err
 				}
 
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(issues...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 

--- a/pkg/golinters/errcheck/errcheck.go
+++ b/pkg/golinters/errcheck/errcheck.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"fmt"
 	"regexp"
-	"sync"
 
 	"github.com/kisielk/errcheck/errcheck"
 	"golang.org/x/tools/go/analysis"
@@ -20,8 +19,7 @@ import (
 const linterName = "errcheck"
 
 func New(settings *config.ErrcheckSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	analyzer := &analysis.Analyzer{
 		Name: linterName,
@@ -37,22 +35,11 @@ func New(settings *config.ErrcheckSettings) *goanalysis.Linter {
 			checker.Tags = lintCtx.Cfg.Run.BuildTags
 
 			analyzer.Run = func(pass *analysis.Pass) (any, error) {
-				issues := runErrCheck(pass, checker, settings.Verbose)
-
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(runErrCheck(pass, checker, settings.Verbose)...)
 				return nil, nil
 			}
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 

--- a/pkg/golinters/gochecksumtype/gochecksumtype.go
+++ b/pkg/golinters/gochecksumtype/gochecksumtype.go
@@ -2,7 +2,6 @@ package gochecksumtype
 
 import (
 	"strings"
-	"sync"
 
 	gochecksumtype "github.com/alecthomas/go-check-sumtype"
 	"golang.org/x/tools/go/analysis"
@@ -10,15 +9,13 @@ import (
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "gochecksumtype"
 
 func New(settings *config.GoChecksumTypeSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	return goanalysis.
 		NewLinterFromAnalyzer(&analysis.Analyzer{
@@ -30,20 +27,11 @@ func New(settings *config.GoChecksumTypeSettings) *goanalysis.Linter {
 					return nil, err
 				}
 
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(issues...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(_ *linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 

--- a/pkg/golinters/gocognit/gocognit.go
+++ b/pkg/golinters/gocognit/gocognit.go
@@ -3,7 +3,6 @@ package gocognit
 import (
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/uudashr/gocognit"
 	"golang.org/x/tools/go/analysis"
@@ -11,37 +10,24 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "gocognit"
 
 func New(settings *config.GocognitSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	return goanalysis.
 		NewLinterFromAnalyzer(&analysis.Analyzer{
 			Name: linterName,
 			Doc:  "Computes and checks the cognitive complexity of functions",
 			Run: func(pass *analysis.Pass) (any, error) {
-				issues := runGocognit(pass, settings)
-
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(runGocognit(pass, settings)...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 

--- a/pkg/golinters/goconst/goconst.go
+++ b/pkg/golinters/goconst/goconst.go
@@ -3,7 +3,6 @@ package goconst
 import (
 	"fmt"
 	"strings"
-	"sync"
 
 	goconstAPI "github.com/jgautheron/goconst"
 	"golang.org/x/tools/go/analysis"
@@ -11,15 +10,13 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "goconst"
 
 func New(settings *config.GoConstSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	return goanalysis.
 		NewLinterFromAnalyzer(&analysis.Analyzer{
@@ -31,20 +28,11 @@ func New(settings *config.GoConstSettings) *goanalysis.Linter {
 					return nil, err
 				}
 
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(issues...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 

--- a/pkg/golinters/gocyclo/gocyclo.go
+++ b/pkg/golinters/gocyclo/gocyclo.go
@@ -2,7 +2,6 @@ package gocyclo
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/fzipp/gocyclo"
 	"golang.org/x/tools/go/analysis"
@@ -10,37 +9,24 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "gocyclo"
 
 func New(settings *config.GoCycloSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	return goanalysis.
 		NewLinterFromAnalyzer(&analysis.Analyzer{
 			Name: linterName,
 			Doc:  "Computes and checks the cyclomatic complexity of functions",
 			Run: func(pass *analysis.Pass) (any, error) {
-				issues := runGoCyclo(pass, settings)
-
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(runGoCyclo(pass, settings)...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 

--- a/pkg/golinters/gomodguard/gomodguard.go
+++ b/pkg/golinters/gomodguard/gomodguard.go
@@ -1,8 +1,6 @@
 package gomodguard
 
 import (
-	"sync"
-
 	"github.com/ryancurrah/gomodguard"
 	"golang.org/x/tools/go/analysis"
 
@@ -16,8 +14,7 @@ import (
 const linterName = "gomodguard"
 
 func New(settings *config.GoModGuardSettings) *goanalysis.Linter {
-	var issues []*goanalysis.Issue
-	var mu sync.Mutex
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	processorCfg := &gomodguard.Configuration{}
 	if settings != nil {
@@ -68,11 +65,8 @@ func New(settings *config.GoModGuardSettings) *goanalysis.Linter {
 			analyzer.Run = func(pass *analysis.Pass) (any, error) {
 				gomodguardIssues := processor.ProcessFiles(internal.GetGoFileNames(pass))
 
-				mu.Lock()
-				defer mu.Unlock()
-
 				for _, gomodguardIssue := range gomodguardIssues {
-					issues = append(issues, goanalysis.NewIssue(&result.Issue{
+					b.Add(goanalysis.NewIssue(&result.Issue{
 						FromLinter: linterName,
 						Pos:        gomodguardIssue.Position,
 						Text:       gomodguardIssue.Reason,
@@ -82,9 +76,7 @@ func New(settings *config.GoModGuardSettings) *goanalysis.Linter {
 				return nil, nil
 			}
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return issues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 

--- a/pkg/golinters/gomodguard/gomodguard_v2.go
+++ b/pkg/golinters/gomodguard/gomodguard_v2.go
@@ -1,8 +1,6 @@
 package gomodguard
 
 import (
-	"sync"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/ryancurrah/gomodguard/v2"
 	"golang.org/x/tools/go/analysis"
@@ -17,8 +15,7 @@ import (
 const linterNameV2 = "gomodguard_v2"
 
 func NewV2(settings *config.GoModGuardv2Settings) *goanalysis.Linter {
-	var issues []*goanalysis.Issue
-	var mu sync.Mutex
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	processorCfg := &gomodguard.Configuration{}
 	if settings != nil {
@@ -85,11 +82,8 @@ func NewV2(settings *config.GoModGuardv2Settings) *goanalysis.Linter {
 			analyzer.Run = func(pass *analysis.Pass) (any, error) {
 				gomodguardIssues := processor.ProcessFiles(internal.GetGoFileNames(pass))
 
-				mu.Lock()
-				defer mu.Unlock()
-
 				for _, gomodguardIssue := range gomodguardIssues {
-					issues = append(issues, goanalysis.NewIssue(&result.Issue{
+					b.Add(goanalysis.NewIssue(&result.Issue{
 						FromLinter: linterNameV2,
 						Pos:        gomodguardIssue.Position,
 						Text:       gomodguardIssue.Reason,
@@ -99,8 +93,6 @@ func NewV2(settings *config.GoModGuardv2Settings) *goanalysis.Linter {
 				return nil, nil
 			}
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return issues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/gosec/gosec.go
+++ b/pkg/golinters/gosec/gosec.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/securego/gosec/v2"
 	"github.com/securego/gosec/v2/analyzers"
@@ -25,8 +24,7 @@ import (
 const linterName = "gosec"
 
 func New(settings *config.GoSecSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	conf := gosec.NewConfig()
 
@@ -64,18 +62,11 @@ func New(settings *config.GoSecSettings) *goanalysis.Linter {
 				gosecAnalyzer.LoadRules(ruleDefinitions.RulesInfo())
 				gosecAnalyzer.LoadAnalyzers(analyzerDefinitions.AnalyzersInfo())
 
-				issues := runGoSec(lintCtx, pass, settings, gosecAnalyzer)
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(runGoSec(lintCtx, pass, settings, gosecAnalyzer)...)
 				return nil, nil
 			}
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 

--- a/pkg/golinters/govet/govet.go
+++ b/pkg/golinters/govet/govet.go
@@ -30,7 +30,6 @@ import (
 	"golang.org/x/tools/go/analysis/passes/ifaceassert"
 	"golang.org/x/tools/go/analysis/passes/inline"
 	_ "golang.org/x/tools/go/analysis/passes/inspect" // unused internal analyzer
-	"golang.org/x/tools/go/analysis/passes/loopclosure"
 	"golang.org/x/tools/go/analysis/passes/lostcancel"
 	"golang.org/x/tools/go/analysis/passes/nilfunc"
 	"golang.org/x/tools/go/analysis/passes/nilness"
@@ -85,7 +84,6 @@ var (
 		httpresponse.Analyzer,
 		ifaceassert.Analyzer,
 		inline.Analyzer,
-		loopclosure.Analyzer,
 		lostcancel.Analyzer,
 		nilfunc.Analyzer,
 		nilness.Analyzer,
@@ -131,7 +129,6 @@ var (
 		httpresponse.Analyzer,
 		ifaceassert.Analyzer,
 		inline.Analyzer,
-		loopclosure.Analyzer,
 		lostcancel.Analyzer,
 		nilfunc.Analyzer,
 		printf.Analyzer,
@@ -194,11 +191,6 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 }
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
-	// TODO(ldez) remove loopclosure when go1.24
-	if name == loopclosure.Analyzer.Name && config.IsGoGreaterThanOrEqual(cfg.Go, "1.22") {
-		return false
-	}
-
 	switch {
 	case cfg.EnableAll:
 		return !slices.Contains(cfg.Disable, name)

--- a/pkg/golinters/govet/govet.go
+++ b/pkg/golinters/govet/govet.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/tools/go/analysis/passes/ifaceassert"
 	"golang.org/x/tools/go/analysis/passes/inline"
 	_ "golang.org/x/tools/go/analysis/passes/inspect" // unused internal analyzer
+	"golang.org/x/tools/go/analysis/passes/loopclosure"
 	"golang.org/x/tools/go/analysis/passes/lostcancel"
 	"golang.org/x/tools/go/analysis/passes/nilfunc"
 	"golang.org/x/tools/go/analysis/passes/nilness"
@@ -84,6 +85,7 @@ var (
 		httpresponse.Analyzer,
 		ifaceassert.Analyzer,
 		inline.Analyzer,
+		loopclosure.Analyzer,
 		lostcancel.Analyzer,
 		nilfunc.Analyzer,
 		nilness.Analyzer,
@@ -129,6 +131,7 @@ var (
 		httpresponse.Analyzer,
 		ifaceassert.Analyzer,
 		inline.Analyzer,
+		loopclosure.Analyzer,
 		lostcancel.Analyzer,
 		nilfunc.Analyzer,
 		printf.Analyzer,
@@ -191,6 +194,11 @@ func analyzersFromConfig(settings *config.GovetSettings) []*analysis.Analyzer {
 }
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
+	// TODO(ldez) remove loopclosure when go1.24
+	if name == loopclosure.Analyzer.Name && config.IsGoGreaterThanOrEqual(cfg.Go, "1.22") {
+		return false
+	}
+
 	switch {
 	case cfg.EnableAll:
 		return !slices.Contains(cfg.Disable, name)

--- a/pkg/golinters/nolintlint/nolintlint.go
+++ b/pkg/golinters/nolintlint/nolintlint.go
@@ -2,7 +2,6 @@ package nolintlint
 
 import (
 	"fmt"
-	"sync"
 
 	"golang.org/x/tools/go/analysis"
 
@@ -10,15 +9,11 @@ import (
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 	"github.com/golangci/golangci-lint/v2/pkg/golinters/internal"
 	nolintlint "github.com/golangci/golangci-lint/v2/pkg/golinters/nolintlint/internal"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 )
 
 const LinterName = nolintlint.LinterName
 
 func New(settings *config.NoLintLintSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
-
 	var needs nolintlint.Needs
 	if settings.RequireExplanation {
 		needs |= nolintlint.NeedsExplanation
@@ -35,6 +30,8 @@ func New(settings *config.NoLintLintSettings) *goanalysis.Linter {
 		internal.LinterLogger.Fatalf("%s: create analyzer: %v", nolintlint.LinterName, err)
 	}
 
+	b := goanalysis.NewThreadSafeLinterBuilder()
+
 	return goanalysis.
 		NewLinterFromAnalyzer(&analysis.Analyzer{
 			Name: nolintlint.LinterName,
@@ -45,19 +42,10 @@ func New(settings *config.NoLintLintSettings) *goanalysis.Linter {
 					return nil, fmt.Errorf("linter failed to run: %w", err)
 				}
 
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(issues...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }

--- a/pkg/golinters/promlinter/promlinter.go
+++ b/pkg/golinters/promlinter/promlinter.go
@@ -2,22 +2,19 @@ package promlinter
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/yeya24/promlinter"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "promlinter"
 
 func New(settings *config.PromlinterSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	var promSettings promlinter.Setting
 	if settings != nil {
@@ -32,22 +29,11 @@ func New(settings *config.PromlinterSettings) *goanalysis.Linter {
 			Name: linterName,
 			Doc:  "Check Prometheus metrics naming via promlint",
 			Run: func(pass *analysis.Pass) (any, error) {
-				issues := runPromLinter(pass, promSettings)
-
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(runPromLinter(pass, promSettings)...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 

--- a/pkg/golinters/revive/revive.go
+++ b/pkg/golinters/revive/revive.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/BurntSushi/toml"
 	hcversion "github.com/hashicorp/go-version"
@@ -34,8 +33,7 @@ var (
 )
 
 func New(settings *config.ReviveSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	analyzer := &analysis.Analyzer{
 		Name: linterName,
@@ -58,20 +56,11 @@ func New(settings *config.ReviveSettings) *goanalysis.Linter {
 					return nil, err
 				}
 
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(issues...)
 				return nil, nil
 			}
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeSyntax)
 }
 

--- a/pkg/golinters/unconvert/unconvert.go
+++ b/pkg/golinters/unconvert/unconvert.go
@@ -1,22 +1,18 @@
 package unconvert
 
 import (
-	"sync"
-
 	"github.com/golangci/unconvert"
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "unconvert"
 
 func New(settings *config.UnconvertSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	unconvert.SetFastMath(settings.FastMath)
 	unconvert.SetSafe(settings.Safe)
@@ -26,22 +22,11 @@ func New(settings *config.UnconvertSettings) *goanalysis.Linter {
 			Name: linterName,
 			Doc:  "Remove unnecessary type conversions",
 			Run: func(pass *analysis.Pass) (any, error) {
-				issues := runUnconvert(pass)
-
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
+				b.Add(runUnconvert(pass)...)
 				return nil, nil
 			},
 		}).
-		WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
+		WithIssuesReporter(b.Reporter()).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 

--- a/pkg/golinters/unused/unused.go
+++ b/pkg/golinters/unused/unused.go
@@ -2,7 +2,6 @@ package unused
 
 import (
 	"fmt"
-	"sync"
 
 	"golang.org/x/tools/go/analysis"
 	"honnef.co/go/tools/analysis/facts/directives"
@@ -12,30 +11,20 @@ import (
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "unused"
 
 func New(settings *config.UnusedSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	b := goanalysis.NewThreadSafeLinterBuilder()
 
 	analyzer := &analysis.Analyzer{
 		Name:     linterName,
 		Doc:      unused.Analyzer.Analyzer.Doc,
 		Requires: unused.Analyzer.Analyzer.Requires,
 		Run: func(pass *analysis.Pass) (any, error) {
-			issues := runUnused(pass, settings)
-			if len(issues) == 0 {
-				return nil, nil
-			}
-
-			mu.Lock()
-			resIssues = append(resIssues, issues...)
-			mu.Unlock()
-
+			b.Add(runUnused(pass, settings)...)
 			return nil, nil
 		},
 	}
@@ -45,9 +34,7 @@ func New(settings *config.UnusedSettings) *goanalysis.Linter {
 		"Checks Go code for unused constants, variables, functions and types",
 		[]*analysis.Analyzer{analyzer},
 		nil,
-	).WithIssuesReporter(func(_ *linter.Context) []*goanalysis.Issue {
-		return resIssues
-	}).WithLoadMode(goanalysis.LoadModeTypesInfo)
+	).WithIssuesReporter(b.Reporter()).WithLoadMode(goanalysis.LoadModeTypesInfo)
 }
 
 func runUnused(pass *analysis.Pass, cfg *config.UnusedSettings) []*goanalysis.Issue {


### PR DESCRIPTION
## Summary

Closes #6630

Introduce `ThreadSafeLinterBuilder` in `pkg/goanalysis/linter.go` to eliminate the repetitive `sync.Mutex` + `resIssues` + `WithIssuesReporter` pattern that appears in 13 linter wrappers.

### Before (8 lines per linter)
```go
var mu sync.Mutex
var resIssues []*goanalysis.Issue
// ...
mu.Lock()
resIssues = append(resIssues, issues...)
mu.Unlock()
// ...
WithIssuesReporter(func(*linter.Context) []*goanalysis.Issue { return resIssues })
```

### After (3 lines per linter)
```go
b := goanalysis.NewThreadSafeLinterBuilder()
b.Add(issues...)
WithIssuesReporter(b.Reporter())
```

### Stats

| Metric | Count |
|--------|-------|
| Files changed | 15 |
| Insertions | +73 |
| Deletions | -210 |
| Net reduction | -137 lines |
| Build | ✅ passes |