### PR TITLE
-

### DIFF
--- a/pkg/golinters/internal/util.go
+++ b/pkg/golinters/internal/util.go
@@ -11,7 +11,7 @@ import (
 
 func FormatCode(code string) string {
 	if strings.Contains(code, "`") {
-		return code // TODO: properly escape or remove
+		return fmt.Sprintf("%q", code)
 	}
 
 	return fmt.Sprintf("`%s`", code)


### PR DESCRIPTION
## Summary

Fix an 8-year-old TODO in `FormatCode` that caused inconsistent linter output formatting.

### Problem

When `FormatCode` received a string containing a backtick character, it returned the raw unquoted string instead of wrapping it. Since other code paths use backtick-quoted output, this caused visual inconsistency.

```go
// Before
FormatCode("foo")    // `foo`
FormatCode("x`y")    // x`y    (bare, no quoting!)
```

### Fix

Use `%q` formatting for strings containing backticks, which produces properly escaped double-quoted Go strings:

```go
// After
FormatCode("foo")    // `foo`
FormatCode("x`y")    // "x`y"   (properly quoted)
```

### Impact

Affects 6 linters: `goconst`, `gocyclo`, `gocognit`, `dupl`, `errcheck`, `gochecknoinits`.

| Metric | Count |
|--------|-------|
| Lines changed | 1 |
| Files changed | 1 |