### PR TITLE
docs: update modernize documentation

### DIFF
--- a/docs/data/linters_info.json
+++ b/docs/data/linters_info.json
@@ -423,6 +423,7 @@
     "loadMode": 8767,
     "originalURL": "https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize",
     "internal": false,
+    "canAutoFix": true,
     "isSlow": true,
     "since": "v2.6.0"
   },

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -398,6 +398,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 
 		linter.NewConfig(modernize.New(&cfg.Linters.Settings.Modernize)).
 			WithSince("v2.6.0").
+			WithAutoFix().
 			WithLoadForGoAnalysis().
 			WithURL("https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize"),
 


### PR DESCRIPTION
Add missing "auto-fix" info inside the documentation of modernize.