### PR TITLE
feat: Add enable setting to modernize linter

### DIFF
--- a/.golangci.reference.yml
+++ b/.golangci.reference.yml
@@ -2263,6 +2263,51 @@ linters:
         - unsafefuncs
         # Replace wg.Add(1)/go/wg.Done() with wg.Go.
         - waitgroup
+      # List of analyzers to enable.
+      # When set, only the listed analyzers are enabled.
+      # 'disable' takes precedence over 'enable'.
+      # Default: all analyzers are enabled (except those in 'disable').
+      enable:
+        # Replace interface{} with any.
+        - any
+        # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        - fmtappendf
+        # Remove redundant re-declaration of loop variables.
+        - forvar
+        # Replace explicit loops over maps with calls to maps package.
+        - mapsloop
+        # Replace if/else statements with calls to min or max.
+        - minmax
+        # Simplify code by using go1.26's new(expr).
+        - newexpr
+        # Suggest replacing omitempty with omitzero for struct fields.
+        - omitzero
+        # Remove obsolete //+build comments.
+        - plusbuild
+        # Replace 3-clause for loops with for-range over integers.
+        - rangeint
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        - reflecttypefor
+        # Replace loops with slices.Contains or slices.ContainsFunc.
+        - slicescontains
+        # Replace sort.Slice with slices.Sort for basic types.
+        - slicessort
+        # Use iterators instead of Len/At-style APIs.
+        - stditerators
+        # Replace strings.Index etc. with strings.Cut.
+        - stringscut
+        # Replace HasPrefix/TrimPrefix with CutPrefix.
+        - stringscutprefix
+        # Replace ranging over Split/Fields with SplitSeq/FieldsSeq.
+        - stringsseq
+        # Replace += with strings.Builder.
+        - stringsbuilder
+        # Replace context.WithCancel with t.Context in tests.
+        - testingcontext
+        # Replace unsafe pointer arithmetic with function calls.
+        - unsafefuncs
+        # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        - waitgroup
 
     musttag:
       # A set of custom functions to check in addition to the builtin ones.

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -3101,6 +3101,13 @@
               "items": {
                 "$ref": "#/definitions/modernize-analyzers"
               }
+            },
+            "enable": {
+              "description": "List of analyzers to enable. When set, only the listed analyzers run ('disable' still takes precedence).",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/modernize-analyzers"
+              }
             }
           }
         },

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -847,6 +847,7 @@ type MndSettings struct {
 
 type ModernizeSettings struct {
 	Disable []string `mapstructure:"disable"`
+	Enable  []string `mapstructure:"enable"`
 }
 
 type NoLintLintSettings struct {

--- a/pkg/golinters/modernize/modernize.go
+++ b/pkg/golinters/modernize/modernize.go
@@ -17,7 +17,7 @@ func New(settings *config.ModernizeSettings) *goanalysis.Linter {
 	if settings == nil {
 		analyzers = modernize.Suite
 	} else {
-		for _, name := range settings.Disable {
+		for _, name := range slices.Concat(settings.Disable, settings.Enable) {
 			switch name {
 			case "fmtappendf":
 				internal.LinterLogger.Warnf("%s has been removed from the modernize suite", name)
@@ -28,6 +28,9 @@ func New(settings *config.ModernizeSettings) *goanalysis.Linter {
 
 		for _, analyzer := range modernize.Suite {
 			if slices.Contains(settings.Disable, analyzer.Name) {
+				continue
+			}
+			if len(settings.Enable) != 0 && !slices.Contains(settings.Enable, analyzer.Name) {
 				continue
 			}
 


### PR DESCRIPTION
Adds an `enable` setting to the `modernize` linter to allow keeping a set list of enabled analyzers.