### PR TITLE
Improve goanalysis issue cache reuse

### DIFF
--- a/pkg/goanalysis/runner.go
+++ b/pkg/goanalysis/runner.go
@@ -55,6 +55,7 @@ type runner struct {
 	passToPkg      map[*analysis.Pass]*packages.Package
 	passToPkgGuard sync.Mutex
 	sw             *timeutils.Stopwatch
+	loadStats      *loadingStats
 }
 
 func newRunner(prefix string, logger logutils.Log, pkgCache *cache.Cache, loadGuard *load.Guard,
@@ -68,6 +69,7 @@ func newRunner(prefix string, logger logutils.Log, pkgCache *cache.Cache, loadGu
 		loadMode:  loadMode,
 		passToPkg: map[*analysis.Pass]*packages.Package{},
 		sw:        sw,
+		loadStats: &loadingStats{},
 	}
 }
 
@@ -83,6 +85,7 @@ func (r *runner) run(analyzers []*analysis.Analyzer, initialPackages []*packages
 	debugf("Analyzing %d packages on load mode %s", len(initialPackages), r.loadMode)
 
 	roots := r.analyze(initialPackages, analyzers)
+	r.loadStats.log(r.log)
 
 	diags, errs := extractDiagnostics(roots)
 
@@ -248,6 +251,7 @@ func (r *runner) analyze(pkgs []*packages.Package, analyzers []*analysis.Analyze
 			log:        r.log,
 			actions:    actionPerPkg[pkg],
 			loadGuard:  r.loadGuard,
+			loadStats:  r.loadStats,
 			dependents: 1, // self dependent
 		}
 	}

--- a/pkg/goanalysis/runner_loading_stats.go
+++ b/pkg/goanalysis/runner_loading_stats.go
@@ -1,0 +1,27 @@
+package goanalysis
+
+import (
+	"sync/atomic"
+
+	"github.com/golangci/golangci-lint/v2/pkg/logutils"
+)
+
+type loadingStats struct {
+	alreadyLoadedPackages atomic.Int64
+	sourceLoads           atomic.Int64
+	exportLoads           atomic.Int64
+	exportLoadFallbacks   atomic.Int64
+	factCacheHits         atomic.Int64
+	factCacheMisses       atomic.Int64
+}
+
+func (s *loadingStats) log(log logutils.Log) {
+	log.Infof("Goanalysis package loading stats: already_loaded=%d, from_source=%d, from_export=%d, "+
+		"export_fallbacks=%d, fact_cache_hits=%d, fact_cache_misses=%d",
+		s.alreadyLoadedPackages.Load(),
+		s.sourceLoads.Load(),
+		s.exportLoads.Load(),
+		s.exportLoadFallbacks.Load(),
+		s.factCacheHits.Load(),
+		s.factCacheMisses.Load())
+}

--- a/pkg/goanalysis/runner_loadingpackage.go
+++ b/pkg/goanalysis/runner_loadingpackage.go
@@ -36,6 +36,7 @@ type loadingPackage struct {
 	log         logutils.Log
 	actions     []*action // all actions with this package
 	loadGuard   *load.Guard
+	loadStats   *loadingStats
 	dependents  int32 // number of depending on it packages
 	analyzeOnce sync.Once
 	decUseMutex sync.Mutex
@@ -117,6 +118,8 @@ func (lp *loadingPackage) analyze(ctx context.Context, cancel context.CancelFunc
 }
 
 func (lp *loadingPackage) loadFromSource(loadMode LoadMode) error {
+	lp.loadStats.sourceLoads.Add(1)
+
 	pkg := lp.pkg
 
 	// Many packages have few files, much fewer than there
@@ -222,6 +225,8 @@ func (lp *loadingPackage) loadFromSource(loadMode LoadMode) error {
 }
 
 func (lp *loadingPackage) loadFromExportData() error {
+	lp.loadStats.exportLoads.Add(1)
+
 	pkg := lp.pkg
 
 	// Call NewPackage directly with explicit name.
@@ -292,11 +297,16 @@ func (lp *loadingPackage) loadWithFacts(loadMode LoadMode) error {
 	}
 
 	if pkg.TypesInfo != nil {
+		lp.loadStats.alreadyLoadedPackages.Add(1)
+
 		// Already loaded package, e.g. because another not go/analysis linter required types for deps.
 		// Try load cached facts for it.
 
 		for _, act := range lp.actions {
-			if !act.loadCachedFacts() {
+			if act.loadCachedFacts() {
+				lp.loadStats.factCacheHits.Add(1)
+			} else {
+				lp.loadStats.factCacheMisses.Add(1)
 				// Cached facts loading failed: analyze later the action from source.
 				act.needAnalyzeSource = true
 				factsCacheDebugf("Loading of facts for already loaded %s failed, analyze it from source later", act)
@@ -321,6 +331,8 @@ func (lp *loadingPackage) loadImportedPackageWithFacts(loadMode LoadMode) error 
 	// Load package from export data
 	if loadMode >= LoadModeTypesInfo {
 		if err := lp.loadFromExportData(); err != nil {
+			lp.loadStats.exportLoadFallbacks.Add(1)
+
 			// We asked Go to give us up-to-date export data, yet
 			// we can't load it. There must be something wrong.
 			//
@@ -350,8 +362,11 @@ func (lp *loadingPackage) loadImportedPackageWithFacts(loadMode LoadMode) error 
 	needLoadFromSource := false
 	for _, act := range lp.actions {
 		if act.loadCachedFacts() {
+			lp.loadStats.factCacheHits.Add(1)
 			continue
 		}
+
+		lp.loadStats.factCacheMisses.Add(1)
 
 		// Cached facts loading failed: analyze later the action from source.
 		factsCacheDebugf("Loading of facts for %s failed, analyze it from source later", act)

--- a/pkg/goanalysis/runners.go
+++ b/pkg/goanalysis/runners.go
@@ -1,6 +1,7 @@
 package goanalysis
 
 import (
+	"errors"
 	"fmt"
 	"go/token"
 	"slices"
@@ -9,6 +10,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/packages"
 
+	"github.com/golangci/golangci-lint/v2/internal/cache"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis/pkgerrors"
 	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
 	"github.com/golangci/golangci-lint/v2/pkg/logutils"
@@ -39,7 +41,8 @@ func runAnalyzers(cfg runAnalyzersConfig, lintCtx *linter.Context) ([]*result.Is
 		pkgs = lintCtx.OriginalPackages
 	}
 
-	issues, pkgsFromCache := loadIssuesFromCache(pkgs, lintCtx, cfg.getAnalyzers())
+	cacheHashMode := issuesCacheHashMode(cfg.getLoadMode())
+	issues, pkgsFromCache := loadIssuesFromCache(pkgs, lintCtx, cfg.getAnalyzers(), cacheHashMode)
 	var pkgsToAnalyze []*packages.Package
 	for _, pkg := range pkgs {
 		if !pkgsFromCache[pkg] {
@@ -50,10 +53,15 @@ func runAnalyzers(cfg runAnalyzersConfig, lintCtx *linter.Context) ([]*result.Is
 	diags, errs, passToPkg := runner.run(cfg.getAnalyzers(), pkgsToAnalyze)
 
 	defer func() {
-		if len(errs) == 0 {
-			// If we try to save to cache even if we have compilation errors
-			// we won't see them on repeated runs.
-			saveIssuesToCache(pkgs, pkgsFromCache, issues, lintCtx, cfg.getAnalyzers())
+		pkgsToSave, ok := packagesToSaveIssuesFor(pkgs, errs)
+		if ok {
+			// Cache packages that were analyzed successfully. Keep ill-typed packages out
+			// of the cache so their typechecking errors stay visible on repeated runs.
+			if len(pkgsToSave) != len(pkgs) {
+				lintCtx.Log.Infof("Skipping goanalysis issue cache save for %d ill-typed packages", len(pkgs)-len(pkgsToSave))
+			}
+
+			saveIssuesToCache(pkgsToSave, pkgsFromCache, issues, lintCtx, cfg.getAnalyzers(), cacheHashMode)
 		}
 	}()
 
@@ -81,6 +89,38 @@ func runAnalyzers(cfg runAnalyzersConfig, lintCtx *linter.Context) ([]*result.Is
 	issues = append(issues, buildAllIssues()...)
 
 	return issues, nil
+}
+
+func issuesCacheHashMode(loadMode LoadMode) cache.HashMode {
+	if loadMode <= LoadModeSyntax {
+		return cache.HashModeNeedOnlySelf
+	}
+
+	return cache.HashModeNeedAllDeps
+}
+
+func packagesToSaveIssuesFor(pkgs []*packages.Package, errs []error) ([]*packages.Package, bool) {
+	if len(errs) == 0 {
+		return pkgs, true
+	}
+
+	for _, err := range errs {
+		var ill *pkgerrors.IllTypedError
+		if !errors.As(err, &ill) {
+			return nil, false
+		}
+	}
+
+	pkgsToSave := make([]*packages.Package, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if pkg.IllTyped {
+			continue
+		}
+
+		pkgsToSave = append(pkgsToSave, pkg)
+	}
+
+	return pkgsToSave, true
 }
 
 func buildIssues(diags []*Diagnostic, linterNameBuilder func(diag *Diagnostic) string) []*result.Issue {

--- a/pkg/goanalysis/runners_cache.go
+++ b/pkg/goanalysis/runners_cache.go
@@ -17,7 +17,7 @@ import (
 )
 
 func saveIssuesToCache(allPkgs []*packages.Package, pkgsFromCache map[*packages.Package]bool,
-	issues []*result.Issue, lintCtx *linter.Context, analyzers []*analysis.Analyzer,
+	issues []*result.Issue, lintCtx *linter.Context, analyzers []*analysis.Analyzer, hashMode cache.HashMode,
 ) {
 	startedAt := time.Now()
 	perPkgIssues := map[*packages.Package][]*result.Issue{}
@@ -26,6 +26,7 @@ func saveIssuesToCache(allPkgs []*packages.Package, pkgsFromCache map[*packages.
 	}
 
 	var savedIssuesCount int64
+	var savedPackagesCount int64
 	lintResKey := getIssuesCacheKey(analyzers)
 
 	workerCount := runtime.GOMAXPROCS(-1)
@@ -51,9 +52,10 @@ func saveIssuesToCache(allPkgs []*packages.Package, pkgsFromCache map[*packages.
 				}
 
 				atomic.AddInt64(&savedIssuesCount, int64(len(encodedIssues)))
-				if err := lintCtx.PkgCache.Put(pkg, cache.HashModeNeedAllDeps, lintResKey, encodedIssues); err != nil {
+				if err := lintCtx.PkgCache.Put(pkg, hashMode, lintResKey, encodedIssues); err != nil {
 					lintCtx.Log.Infof("Failed to save package %s issues (%d) to cache: %s", pkg, len(pkgIssues), err)
 				} else {
+					atomic.AddInt64(&savedPackagesCount, 1)
 					issuesCacheDebugf("Saved package %s issues (%d) to cache", pkg, len(pkgIssues))
 				}
 			}
@@ -72,11 +74,13 @@ func saveIssuesToCache(allPkgs []*packages.Package, pkgsFromCache map[*packages.
 
 	lintCtx.PkgCache.Close()
 
+	lintCtx.Log.Infof("Saved goanalysis issues to cache: %d/%d packages, %d issues in %s",
+		savedPackagesCount, len(allPkgs), savedIssuesCount, time.Since(startedAt))
 	issuesCacheDebugf("Saved %d issues from %d packages to cache in %s", savedIssuesCount, len(allPkgs), time.Since(startedAt))
 }
 
 func loadIssuesFromCache(pkgs []*packages.Package, lintCtx *linter.Context,
-	analyzers []*analysis.Analyzer,
+	analyzers []*analysis.Analyzer, hashMode cache.HashMode,
 ) (issuesFromCache []*result.Issue, pkgsFromCache map[*packages.Package]bool) {
 	startedAt := time.Now()
 
@@ -98,7 +102,7 @@ func loadIssuesFromCache(pkgs []*packages.Package, lintCtx *linter.Context,
 		wg.Go(func() {
 			for pkg := range pkgCh {
 				var pkgIssues []*EncodingIssue
-				err := lintCtx.PkgCache.Get(pkg, cache.HashModeNeedAllDeps, lintResKey, &pkgIssues)
+				err := lintCtx.PkgCache.Get(pkg, hashMode, lintResKey, &pkgIssues)
 				cacheRes := pkgToCacheRes[pkg]
 				cacheRes.loadErr = err
 				if err != nil {
@@ -145,6 +149,9 @@ func loadIssuesFromCache(pkgs []*packages.Package, lintCtx *linter.Context,
 			issuesCacheDebugf("Didn't load package %s issues from cache: %s", pkg, cacheRes.loadErr)
 		}
 	}
+
+	lintCtx.Log.Infof("Loaded goanalysis issues from cache: %d/%d packages, %d issues in %s",
+		len(pkgsFromCache), len(pkgs), loadedIssuesCount, time.Since(startedAt))
 	issuesCacheDebugf("Loaded %d issues from cache in %s, analyzing %d/%d packages",
 		loadedIssuesCount, time.Since(startedAt), len(pkgs)-len(pkgsFromCache), len(pkgs))
 	return issuesFromCache, pkgsFromCache

--- a/pkg/goanalysis/runners_test.go
+++ b/pkg/goanalysis/runners_test.go
@@ -1,0 +1,87 @@
+package goanalysis
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+
+	"github.com/golangci/golangci-lint/v2/internal/cache"
+	"github.com/golangci/golangci-lint/v2/pkg/goanalysis/pkgerrors"
+)
+
+func TestIssuesCacheHashMode(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		loadMode LoadMode
+		want     cache.HashMode
+	}{
+		{
+			desc:     "none uses only self",
+			loadMode: LoadModeNone,
+			want:     cache.HashModeNeedOnlySelf,
+		},
+		{
+			desc:     "syntax uses only self",
+			loadMode: LoadModeSyntax,
+			want:     cache.HashModeNeedOnlySelf,
+		},
+		{
+			desc:     "types info uses all dependencies",
+			loadMode: LoadModeTypesInfo,
+			want:     cache.HashModeNeedAllDeps,
+		},
+		{
+			desc:     "whole program uses all dependencies",
+			loadMode: LoadModeWholeProgram,
+			want:     cache.HashModeNeedAllDeps,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.Equal(t, tc.want, issuesCacheHashMode(tc.loadMode))
+		})
+	}
+}
+
+func TestPackagesToSaveIssuesFor(t *testing.T) {
+	good := &packages.Package{Name: "good"}
+	bad := &packages.Package{Name: "bad", IllTyped: true}
+	pkgs := []*packages.Package{good, bad}
+
+	testCases := []struct {
+		desc   string
+		errs   []error
+		want   []*packages.Package
+		wantOk bool
+	}{
+		{
+			desc:   "no errors saves all packages",
+			want:   pkgs,
+			wantOk: true,
+		},
+		{
+			desc:   "ill typed errors save only well typed packages",
+			errs:   []error{fmt.Errorf("analyzer: %w", &pkgerrors.IllTypedError{Pkg: bad})},
+			want:   []*packages.Package{good},
+			wantOk: true,
+		},
+		{
+			desc:   "non typecheck errors skip saving",
+			errs:   []error{errors.New("analyzer failed")},
+			wantOk: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, gotOk := packagesToSaveIssuesFor(pkgs, tc.errs)
+
+			require.Equal(t, tc.wantOk, gotOk)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/lint/package.go
+++ b/pkg/lint/package.go
@@ -87,6 +87,7 @@ func (l *PackageLoader) loadPackages(ctx context.Context, loadMode packages.Load
 	if err != nil {
 		return nil, fmt.Errorf("failed to load with go/packages: %w", err)
 	}
+	l.logLoadedPackagesStats(pkgs)
 
 	if loadMode&packages.NeedSyntax == 0 {
 		// Needed e.g. for go/analysis loading.
@@ -104,6 +105,38 @@ func (l *PackageLoader) loadPackages(ctx context.Context, loadMode packages.Load
 	}
 
 	return l.filterTestMainPackages(pkgs), nil
+}
+
+func (l *PackageLoader) logLoadedPackagesStats(initialPkgs []*packages.Package) {
+	type stats struct {
+		total           int
+		withErrors      int
+		illTyped        int
+		withExportFile  int
+		compiledGoFiles int
+		goFiles         int
+	}
+
+	var s stats
+	packages.Visit(initialPkgs, nil, func(pkg *packages.Package) {
+		s.total++
+		if len(pkg.Errors) != 0 {
+			s.withErrors++
+		}
+		if pkg.IllTyped {
+			s.illTyped++
+		}
+		if pkg.ExportFile != "" {
+			s.withExportFile++
+		}
+
+		s.compiledGoFiles += len(pkg.CompiledGoFiles)
+		s.goFiles += len(pkg.GoFiles)
+	})
+
+	l.log.Infof("Go packages loaded: initial=%d, total=%d, with_errors=%d, ill_typed=%d, "+
+		"with_export_file=%d, go_files=%d, compiled_go_files=%d",
+		len(initialPkgs), s.total, s.withErrors, s.illTyped, s.withExportFile, s.goFiles, s.compiledGoFiles)
 }
 
 func (*PackageLoader) parseLoadedPackagesErrors(pkgs []*packages.Package) error {


### PR DESCRIPTION
<!--

WARNING: If you don't follow the rules, the pull request will be closed.

-->

<!--
Please keep the description brief.
-->

<!--

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

Non-versioned dependencies are managed by the golangci-lint maintainers.

No pull requests to update a linter will be accepted unless:
you are the original author of the linter, AND there are important changes required (like a major version bump).

-->

<!--

If you want to add a new linter, you MUST open a discussion in the category "New Linter Proposals" and
wait for a maintainer to approve it BEFORE opening a pull request.

https://github.com/golangci/golangci-lint/discussions/new?category=new-linter-proposals

If you don't follow the previous rule, the pull request will be closed.

-->

<!--

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->


## Summary

This PR improves goanalysis issue-cache reuse when a lint run contains typechecking errors in only some packages.

Before this change, goanalysis issue-cache saves were skipped for the entire run when the run had typechecking / ill-typed package errors. That meant packages that were successfully analyzed could not be reused by a later run.

This PR changes the cache save path to keep cacheable results for successfully analyzed packages while continuing to skip packages that had typechecking or analysis errors. It also adds `--verbose` stats so cache reuse and package-loading behavior are visible when diagnosing slow runs.

## Changes

- Add verbose goanalysis issue-cache load/save stats.
- Save goanalysis issue-cache entries for successfully analyzed packages even when other packages in the same run have typechecking errors.
- Continue to skip cache saves for packages with errors.
- Narrow issue-cache invalidation for syntax-only load modes so dependency changes do not invalidate caches unnecessarily when dependency information is not part of the loaded package data.
- Add verbose package-loading stats to make source/export loading behavior visible.

## Rationale

Large repositories can have a small number of packages with typechecking errors while most packages are still analyzed successfully. Skipping all issue-cache saves in that situation forces subsequent runs to repeat goanalysis work for packages that completed successfully.

Saving only well-typed / successfully analyzed packages preserves correctness while allowing later runs to reuse completed work.

The added verbose stats make the behavior observable, for example:

```text
Loaded goanalysis issues from cache: <loaded>/<total> packages, <issues> issues in <duration>
Saved goanalysis issues to cache: <saved>/<total> packages, <issues> issues in <duration>
Skipping goanalysis issue cache save for <n> ill-typed packages
Go packages loaded: initial=<n>, total=<n>, with_errors=<n>, ill_typed=<n>, with_export_file=<n>, go_files=<n>, compiled_go_files=<n>
```

## Correctness notes

- Packages with typechecking or analysis errors are still excluded from issue-cache saves.
- The change does not cache failed package analysis results.
- The syntax-only invalidation narrowing is limited to load modes that do not include dependency information.
- Type-aware modes remain dependency-sensitive.

## Validation

Passed locally on Windows:

```text
go test ./pkg/goanalysis ./pkg/lint
make build
./golangci-lint run -v
git diff --check origin/main...HEAD
```

Also attempted the full workflow test command:

```text
make test
```

It passed the initial build/lint step and many packages, but failed in the existing Windows cgo integration tests with:

```text
TestCgoOk: typechecking error: build constraints exclude all Go files in .../test/testdata/cgo
TestCgoWithIssues: typechecking error: build constraints exclude all Go files in .../test/testdata/cgo_with_issues
```

I did not change the cgo testdata or the integration test runner. I can rerun `make test` in a Linux environment if needed.

## Follow-up

This PR intentionally does not change goanalysis fact-cache hash modes. Fact caches can affect downstream analyzer results and need separate evidence before changing dependency sensitivity.

Remaining branch-switch slowness can be investigated separately with fact-cache and source-propagation instrumentation, but that is intentionally left out of this first PR to keep the behavior change reviewable.
