### PR TITLE
fix: cache package facts size

### DIFF
--- a/pkg/goanalysis/runner_action_cache.go
+++ b/pkg/goanalysis/runner_action_cache.go
@@ -30,35 +30,74 @@ func (act *action) loadCachedFacts() bool {
 			return true // no need to load facts
 		}
 
-		return act.loadPersistedFacts()
+		if !act.loadPersistedFacts() {
+			return false
+		}
+
+		// The cache only stores the facts a package produces about its own objects.
+		// The facts a package re-exports from its dependencies (see exportedFrom) are not persisted,
+		// to avoid duplicating them in every cache entry (which grows quadratically with the import graph).
+		// Instead, we rebuild them in memory here by inheriting from the dependencies,
+		// exactly like analyze() does for packages analyzed from source.
+		// This is safe because every dependency is fully analyzed (from cache or source)  before this package is loaded,
+		// so their facts are already available.
+		act.inheritFactsFromDeps()
+
+		return true
 	}()
+
 	act.loadCachedFactsDone = true
 	act.loadCachedFactsOk = res
+
 	return res
+}
+
+// inheritFactsFromDeps rebuilds, in memory,
+// the facts re-exported from this action's dependencies (vertical edges: same analyzer, different package),
+// mirroring the inheritance performed by analyze() for packages analyzed from source.
+func (act *action) inheritFactsFromDeps() {
+	for _, dep := range act.Deps {
+		if dep.Package == act.Package || dep.Analyzer != act.Analyzer {
+			continue
+		}
+
+		inheritFacts(act, dep)
+	}
 }
 
 func (act *action) persistFactsToCache() error {
 	analyzer := act.Analyzer
+
 	if len(analyzer.FactTypes) == 0 {
 		return nil
 	}
 
-	// Merge new facts into the package and persist them.
+	// Persist only the facts this package produces about its own objects.
+	//
+	// Facts about objects from other packages (inherited through this package's export data) are intentionally NOT persisted:
+	// doing so duplicates them in every cache entry along the import graph and makes the cache grow quadratically.
+	// When a package is restored from the cache,
+	// those re-exported facts are rebuilt in memory by inheriting from its dependencies (see inheritFactsFromDeps).
+
 	var facts []Fact
+
 	for key, fact := range act.packageFacts {
 		if key.pkg != act.Package.Types {
-			// The fact is from inherited facts from another package
+			// The fact is inherited from another package.
 			continue
 		}
+
 		facts = append(facts, Fact{
 			Path: "",
 			Fact: fact,
 		})
 	}
+
 	for key, fact := range act.objectFacts {
 		obj := key.obj
+
 		if obj.Pkg() != act.Package.Types {
-			// The fact is from inherited facts from another package
+			// The fact is inherited from another package.
 			continue
 		}
 
@@ -89,6 +128,7 @@ func (act *action) loadPersistedFacts() bool {
 		}
 
 		factsCacheDebugf("No cached facts for package %q and analyzer %s", act.Package.Name, act.Analyzer.Name)
+
 		return false
 	}
 
@@ -100,6 +140,7 @@ func (act *action) loadPersistedFacts() bool {
 			act.packageFacts[key] = f.Fact
 			continue
 		}
+
 		obj, err := objectpath.Object(act.Package.Types, objectpath.Path(f.Path))
 		if err != nil {
 			// Be lenient about these errors.

--- a/pkg/goanalysis/runner_action_cache.go
+++ b/pkg/goanalysis/runner_action_cache.go
@@ -3,7 +3,6 @@ package goanalysis
 import (
 	"errors"
 	"fmt"
-	"go/types"
 	"io"
 
 	"golang.org/x/tools/go/analysis"
@@ -13,13 +12,8 @@ import (
 )
 
 type Fact struct {
-	// PkgPath is the import path of the package owning the fact's object (object facts)
-	// or the package the fact is about (package facts).
-	// It is empty when the fact belongs to the package being cached,
-	// which keeps backward compatibility with the previous cache format.
-	PkgPath string
-	Path    string // non-empty only for object facts
-	Fact    analysis.Fact
+	Path string // non-empty only for object facts
+	Fact analysis.Fact
 }
 
 func (act *action) loadCachedFacts() bool {
@@ -38,50 +32,33 @@ func (act *action) loadCachedFacts() bool {
 
 		return act.loadPersistedFacts()
 	}()
-
 	act.loadCachedFactsDone = true
 	act.loadCachedFactsOk = res
-
 	return res
 }
 
 func (act *action) persistFactsToCache() error {
 	analyzer := act.Analyzer
-
 	if len(analyzer.FactTypes) == 0 {
 		return nil
 	}
 
 	// Merge new facts into the package and persist them.
-	//
-	// We must persist not only the facts about this package's own objects,
-	// but also the facts about objects from other packages that are reachable through this package's export data (see exportedFrom).
-	// When a package is later restored from the cache instead of being analyzed from source,
-	// it re-exports these inherited facts to its own dependents.
-	// Dropping them here makes linters using facts silently miss issues for downstream packages analyzed from source.
-	// e.g. it makes nolintlint report the related `nolint` directives as unused.
-
 	var facts []Fact
-
 	for key, fact := range act.packageFacts {
-		pkgPath := ""
 		if key.pkg != act.Package.Types {
-			pkgPath = key.pkg.Path()
+			// The fact is from inherited facts from another package
+			continue
 		}
-
 		facts = append(facts, Fact{
-			PkgPath: pkgPath,
-			Path:    "",
-			Fact:    fact,
+			Path: "",
+			Fact: fact,
 		})
 	}
-
 	for key, fact := range act.objectFacts {
 		obj := key.obj
-
-		// Keep facts about objects reachable downstream through the export data,
-		// mirroring the filter used by inheritFacts.
-		if !exportedFrom(obj, act.Package.Types) {
+		if obj.Pkg() != act.Package.Types {
+			// The fact is from inherited facts from another package
 			continue
 		}
 
@@ -91,15 +68,9 @@ func (act *action) persistFactsToCache() error {
 			continue
 		}
 
-		pkgPath := ""
-		if obj.Pkg() != nil && obj.Pkg() != act.Package.Types {
-			pkgPath = obj.Pkg().Path()
-		}
-
 		facts = append(facts, Fact{
-			PkgPath: pkgPath,
-			Path:    string(path),
-			Fact:    fact,
+			Path: string(path),
+			Fact: fact,
 		})
 	}
 
@@ -118,42 +89,18 @@ func (act *action) loadPersistedFacts() bool {
 		}
 
 		factsCacheDebugf("No cached facts for package %q and analyzer %s", act.Package.Name, act.Analyzer.Name)
-
 		return false
 	}
 
 	factsCacheDebugf("Loaded %d cached facts for package %q and analyzer %s", len(facts), act.Package.Name, act.Analyzer.Name)
 
-	var importsByPath map[string]*types.Package
-
-	// Lazily built lookup of the package owning each fact (by import path),
-	// resolved through this package's transitive imports.
-	resolvePkg := func(pkgPath string) *types.Package {
-		if pkgPath == "" {
-			return act.Package.Types
-		}
-
-		if importsByPath == nil {
-			importsByPath = collectImports(act.Package.Types)
-		}
-
-		return importsByPath[pkgPath]
-	}
-
 	for _, f := range facts {
-		pkg := resolvePkg(f.PkgPath)
-		if pkg == nil {
-			// The owning package is not reachable from this package anymore.
-			continue
-		}
-
 		if f.Path == "" { // this is a package fact
-			key := packageFactKey{pkg: pkg, typ: act.factType(f.Fact)}
+			key := packageFactKey{pkg: act.Package.Types, typ: act.factType(f.Fact)}
 			act.packageFacts[key] = f.Fact
 			continue
 		}
-
-		obj, err := objectpath.Object(pkg, objectpath.Path(f.Path))
+		obj, err := objectpath.Object(act.Package.Types, objectpath.Path(f.Path))
 		if err != nil {
 			// Be lenient about these errors.
 			// For example, when analyzing io/ioutil from source,
@@ -167,36 +114,11 @@ func (act *action) loadPersistedFacts() bool {
 			// then (part of) the unexported type will become part of the type information and our path will resolve again.
 			continue
 		}
-
 		factKey := objectFactKey{obj, act.factType(f.Fact)}
-
 		act.objectFacts[factKey] = f.Fact
 	}
 
 	return true
-}
-
-// collectImports returns a map of every package transitively imported by pkg (including pkg itself), keyed by import path.
-// It is used to resolve facts about objects that belong to a dependency reachable through the export data.
-func collectImports(pkg *types.Package) map[string]*types.Package {
-	result := map[string]*types.Package{pkg.Path(): pkg}
-
-	var visit func(p *types.Package)
-
-	visit = func(p *types.Package) {
-		for _, imp := range p.Imports() {
-			if _, ok := result[imp.Path()]; ok {
-				continue
-			}
-
-			result[imp.Path()] = imp
-			visit(imp)
-		}
-	}
-
-	visit(pkg)
-
-	return result
 }
 
 func factCacheKey(a *analysis.Analyzer) string {


### PR DESCRIPTION
I reverted #6649 and implemented the fix to not increase the cache size.

There is no performance changes, but note that technically the memory consumption is increased when using the cache (but based on my benchmarks, this is not significant)

<details>
<summary>before</summary>

```console
$ golangci-lint cache clean 
$ golangci-lint run        
0 issues.
$ golangci-lint cache status
Dir: /home/ldez/.cache/golangci-lint
Size: 2.4MiB

$ ./golangci-lint run                     
0 issues.
$ golangci-lint cache status                                 
Dir: /home/ldez/.cache/golangci-lint
Size: 52.2MiB
```

</details>

<details>
<summary>After</summary>

```console
$ golangci-lint cache clean 
$ golangci-lint run        
0 issues.
$ golangci-lint cache status
Dir: /home/ldez/.cache/golangci-lint
Size: 2.4MiB

$ ./golangci-lint run                     
0 issues.
$ golangci-lint cache status                                 
Dir: /home/ldez/.cache/golangci-lint
Size: 2.4MiB
```

</details>

Related to #6649
Related to #3228
Related to #5979