### PR TITLE
fix: apply suggested fixes spread across several files

### DIFF
--- a/pkg/goanalysis/issue.go
+++ b/pkg/goanalysis/issue.go
@@ -26,7 +26,7 @@ type EncodingIssue struct {
 	Severity             string
 	Pos                  token.Position
 	LineRange            *result.Range
-	SuggestedFixes       []analysis.SuggestedFix
+	SuggestedFixes       []result.SuggestedFix
 	ExpectNoLint         bool
 	ExpectedNoLintLinter string
 }

--- a/pkg/goanalysis/runners.go
+++ b/pkg/goanalysis/runners.go
@@ -2,7 +2,6 @@ package goanalysis
 
 import (
 	"fmt"
-	"go/token"
 	"slices"
 	"strings"
 
@@ -96,7 +95,7 @@ func buildIssues(diags []*Diagnostic, linterNameBuilder func(diag *Diagnostic) s
 			text = fmt.Sprintf("%s: %s", diag.Analyzer.Name, diag.Message)
 		}
 
-		var suggestedFixes []analysis.SuggestedFix
+		var suggestedFixes []result.SuggestedFix
 
 		for _, sf := range diag.SuggestedFixes {
 			// Skip suggested fixes on cgo files.
@@ -106,7 +105,11 @@ func buildIssues(diags []*Diagnostic, linterNameBuilder func(diag *Diagnostic) s
 				continue
 			}
 
-			nsf := analysis.SuggestedFix{Message: sf.Message}
+			nsf := result.SuggestedFix{Message: sf.Message}
+
+			// The edits of a suggested fix can be spread over several files of the package
+			// (e.g. modernize/atomictype), so each edit must be resolved against its own file.
+			valid := true
 
 			for _, edit := range sf.TextEdits {
 				end := edit.End
@@ -115,16 +118,27 @@ func buildIssues(diags []*Diagnostic, linterNameBuilder func(diag *Diagnostic) s
 					end = edit.Pos
 				}
 
+				file := diag.Pkg.Fset.File(edit.Pos)
+				if file == nil || diag.Pkg.Fset.File(end) != file {
+					// A suggested fix must be applied as a whole:
+					// an edit that cannot be resolved to a single file invalidates the whole fix.
+					valid = false
+					break
+				}
+
 				// To be applied the positions need to be "adjusted" based on the file.
 				// This is the difference between the "displayed" positions and "effective" positions.
-				nsf.TextEdits = append(nsf.TextEdits, analysis.TextEdit{
-					Pos:     token.Pos(diag.File.Offset(edit.Pos)),
-					End:     token.Pos(diag.File.Offset(end)),
-					NewText: edit.NewText,
+				nsf.TextEdits = append(nsf.TextEdits, result.TextEdit{
+					Filename: file.Name(),
+					Pos:      file.Offset(edit.Pos),
+					End:      file.Offset(end),
+					NewText:  edit.NewText,
 				})
 			}
 
-			suggestedFixes = append(suggestedFixes, nsf)
+			if valid {
+				suggestedFixes = append(suggestedFixes, nsf)
+			}
 		}
 
 		issues = append(issues, &result.Issue{

--- a/pkg/goanalysis/runners_test.go
+++ b/pkg/goanalysis/runners_test.go
@@ -1,0 +1,145 @@
+package goanalysis
+
+import (
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/packages"
+)
+
+func buildTestDiagnostic(t *testing.T, aSize, bSize int) (*token.FileSet, *token.File, *token.File, *Diagnostic) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+
+	fileA := fset.AddFile("pkg/a.go", -1, aSize)
+	fileB := fset.AddFile("pkg/b.go", -1, bSize)
+
+	pkg := &packages.Package{PkgPath: "pkg", Fset: fset}
+
+	diag := &Diagnostic{
+		Diagnostic: analysis.Diagnostic{
+			Pos:     fileA.Pos(0),
+			Message: "issue on a.go",
+		},
+		Analyzer: &analysis.Analyzer{Name: "test"},
+		Position: fset.Position(fileA.Pos(0)),
+		Pkg:      pkg,
+		File:     fileA,
+	}
+
+	return fset, fileA, fileB, diag
+}
+
+func linterNameBuilder(*Diagnostic) string { return "test" }
+
+func Test_buildIssues_suggestedFixes(t *testing.T) {
+	t.Run("edits spread over several files keep their own file", func(t *testing.T) {
+		// a.go: 50 bytes, b.go: 60 bytes.
+		_, fileA, fileB, diag := buildTestDiagnostic(t, 50, 60)
+
+		diag.SuggestedFixes = []analysis.SuggestedFix{{
+			TextEdits: []analysis.TextEdit{
+				{Pos: fileA.Pos(10), End: fileA.Pos(15), NewText: []byte("aaa")},
+				{Pos: fileB.Pos(20), End: fileB.Pos(25), NewText: []byte("bbb")},
+			},
+		}}
+
+		issues := buildIssues([]*Diagnostic{diag}, linterNameBuilder)
+		require.Len(t, issues, 1)
+		require.Len(t, issues[0].SuggestedFixes, 1)
+
+		edits := issues[0].SuggestedFixes[0].TextEdits
+		require.Len(t, edits, 2)
+
+		assert.Equal(t, "pkg/a.go", edits[0].Filename)
+		assert.Equal(t, 10, edits[0].Pos)
+		assert.Equal(t, 15, edits[0].End)
+		assert.Equal(t, []byte("aaa"), edits[0].NewText)
+
+		assert.Equal(t, "pkg/b.go", edits[1].Filename)
+		assert.Equal(t, 20, edits[1].Pos)
+		assert.Equal(t, 25, edits[1].End)
+		assert.Equal(t, []byte("bbb"), edits[1].NewText)
+	})
+
+	t.Run("edit without end is an insertion", func(t *testing.T) {
+		_, fileA, _, diag := buildTestDiagnostic(t, 50, 60)
+
+		diag.SuggestedFixes = []analysis.SuggestedFix{{
+			TextEdits: []analysis.TextEdit{
+				{Pos: fileA.Pos(10), NewText: []byte("inserted")},
+			},
+		}}
+
+		issues := buildIssues([]*Diagnostic{diag}, linterNameBuilder)
+		require.Len(t, issues, 1)
+		require.Len(t, issues[0].SuggestedFixes, 1)
+		require.Len(t, issues[0].SuggestedFixes[0].TextEdits, 1)
+
+		edit := issues[0].SuggestedFixes[0].TextEdits[0]
+		assert.Equal(t, "pkg/a.go", edit.Filename)
+		assert.Equal(t, 10, edit.Pos)
+		assert.Equal(t, 10, edit.End)
+	})
+
+	t.Run("fix with an edit spanning two files is dropped as a whole", func(t *testing.T) {
+		_, fileA, fileB, diag := buildTestDiagnostic(t, 50, 60)
+
+		diag.SuggestedFixes = []analysis.SuggestedFix{{
+			TextEdits: []analysis.TextEdit{
+				{Pos: fileA.Pos(10), End: fileA.Pos(15), NewText: []byte("aaa")},
+				{Pos: fileA.Pos(20), End: fileB.Pos(5), NewText: []byte("span")},
+			},
+		}}
+
+		issues := buildIssues([]*Diagnostic{diag}, linterNameBuilder)
+		require.Len(t, issues, 1)
+		assert.Empty(t, issues[0].SuggestedFixes)
+	})
+
+	t.Run("fix with an edit out of the package fileset is dropped as a whole", func(t *testing.T) {
+		_, fileA, _, diag := buildTestDiagnostic(t, 50, 60)
+
+		diag.SuggestedFixes = []analysis.SuggestedFix{{
+			TextEdits: []analysis.TextEdit{
+				{Pos: fileA.Pos(10), End: fileA.Pos(15), NewText: []byte("aaa")},
+				// Positions from another package are not part of the package fileset.
+				{Pos: token.Pos(10000), End: token.Pos(10005), NewText: []byte("foreign")},
+			},
+		}}
+
+		issues := buildIssues([]*Diagnostic{diag}, linterNameBuilder)
+		require.Len(t, issues, 1)
+		assert.Empty(t, issues[0].SuggestedFixes)
+	})
+
+	t.Run("suggested fixes on cgo files are skipped", func(t *testing.T) {
+		fset := token.NewFileSet()
+
+		cgoFile := fset.AddFile("pkg/a.cgo1", -1, 50)
+
+		diag := &Diagnostic{
+			Diagnostic: analysis.Diagnostic{
+				Pos:     cgoFile.Pos(0),
+				Message: "issue on cgo file",
+				SuggestedFixes: []analysis.SuggestedFix{{
+					TextEdits: []analysis.TextEdit{
+						{Pos: cgoFile.Pos(10), End: cgoFile.Pos(15), NewText: []byte("aaa")},
+					},
+				}},
+			},
+			Analyzer: &analysis.Analyzer{Name: "test"},
+			Position: fset.Position(cgoFile.Pos(0)),
+			Pkg:      &packages.Package{PkgPath: "pkg", Fset: fset},
+			File:     cgoFile,
+		}
+
+		issues := buildIssues([]*Diagnostic{diag}, linterNameBuilder)
+		require.Len(t, issues, 1)
+		assert.Empty(t, issues[0].SuggestedFixes)
+	})
+}

--- a/pkg/golinters/nolintlint/internal/nolintlint.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint.go
@@ -2,7 +2,6 @@
 package internal
 
 import (
-	"go/token"
 	"regexp"
 	"strings"
 
@@ -86,11 +85,12 @@ func (l Linter) Run(pass *analysis.Pass) ([]*goanalysis.Issue, error) {
 
 				// check for, report and eliminate leading spaces, so we can check for other issues
 				if leadingSpace != "" {
-					removeWhitespace := []analysis.SuggestedFix{{
-						TextEdits: []analysis.TextEdit{{
-							Pos:     token.Pos(pos.Offset),
-							End:     token.Pos(pos.Offset + len(commentMark) + len(leadingSpace)),
-							NewText: []byte(commentMark),
+					removeWhitespace := []result.SuggestedFix{{
+						TextEdits: []result.TextEdit{{
+							Filename: pos.Filename,
+							Pos:      pos.Offset,
+							End:      pos.Offset + len(commentMark) + len(leadingSpace),
+							NewText:  []byte(commentMark),
 						}},
 					}}
 
@@ -162,11 +162,12 @@ func (l Linter) Run(pass *analysis.Pass) ([]*goanalysis.Issue, error) {
 
 				// when detecting unused directives, we send all the directives through and filter them out in the nolint processor
 				if (l.needs & NeedsUnused) != 0 {
-					removeNolintCompletely := []analysis.SuggestedFix{{
-						TextEdits: []analysis.TextEdit{{
-							Pos:     token.Pos(pos.Offset),
-							End:     token.Pos(end.Offset),
-							NewText: nil,
+					removeNolintCompletely := []result.SuggestedFix{{
+						TextEdits: []result.TextEdit{{
+							Filename: pos.Filename,
+							Pos:      pos.Offset,
+							End:      end.Offset,
+							NewText:  nil,
 						}},
 					}}
 

--- a/pkg/golinters/nolintlint/internal/nolintlint_test.go
+++ b/pkg/golinters/nolintlint/internal/nolintlint_test.go
@@ -125,11 +125,12 @@ func foo() {
 					FromLinter: "nolintlint",
 					Text:       "directive `// nolint` should be written without leading space as `//nolint`",
 					Pos:        token.Position{Filename: "testing.go", Offset: 34, Line: 4, Column: 9},
-					SuggestedFixes: []analysis.SuggestedFix{{
-						TextEdits: []analysis.TextEdit{{
-							Pos:     34,
-							End:     37,
-							NewText: []byte(commentMark),
+					SuggestedFixes: []result.SuggestedFix{{
+						TextEdits: []result.TextEdit{{
+							Filename: "testing.go",
+							Pos:      34,
+							End:      37,
+							NewText:  []byte(commentMark),
 						}},
 					}},
 				},
@@ -137,11 +138,12 @@ func foo() {
 					FromLinter: "nolintlint",
 					Text:       "directive `//   nolint` should be written without leading space as `//nolint`",
 					Pos:        token.Position{Filename: "testing.go", Offset: 52, Line: 5, Column: 9},
-					SuggestedFixes: []analysis.SuggestedFix{{
-						TextEdits: []analysis.TextEdit{{
-							Pos:     52,
-							End:     57,
-							NewText: []byte(commentMark),
+					SuggestedFixes: []result.SuggestedFix{{
+						TextEdits: []result.TextEdit{{
+							Filename: "testing.go",
+							Pos:      52,
+							End:      57,
+							NewText:  []byte(commentMark),
 						}},
 					}},
 				},
@@ -187,10 +189,11 @@ func foo() {
 				FromLinter: "nolintlint",
 				Text:       "directive `//nolint` is unused",
 				Pos:        token.Position{Filename: "testing.go", Offset: 34, Line: 4, Column: 9},
-				SuggestedFixes: []analysis.SuggestedFix{{
-					TextEdits: []analysis.TextEdit{{
-						Pos: 34,
-						End: 42,
+				SuggestedFixes: []result.SuggestedFix{{
+					TextEdits: []result.TextEdit{{
+						Filename: "testing.go",
+						Pos:      34,
+						End:      42,
 					}},
 				}},
 				ExpectNoLint: true,
@@ -209,10 +212,11 @@ func foo() {
 				FromLinter: "nolintlint",
 				Text:       "directive `//nolint:somelinter` is unused for linter \"somelinter\"",
 				Pos:        token.Position{Filename: "testing.go", Offset: 34, Line: 4, Column: 9},
-				SuggestedFixes: []analysis.SuggestedFix{{
-					TextEdits: []analysis.TextEdit{{
-						Pos: 34,
-						End: 53,
+				SuggestedFixes: []result.SuggestedFix{{
+					TextEdits: []result.TextEdit{{
+						Filename: "testing.go",
+						Pos:      34,
+						End:      53,
 					}},
 				}},
 				ExpectNoLint:         true,
@@ -233,10 +237,11 @@ func foo() {
 				FromLinter: "nolintlint",
 				Text:       "directive `//nolint:somelinter` is unused for linter \"somelinter\"",
 				Pos:        token.Position{Filename: "testing.go", Offset: 13, Line: 3, Column: 1},
-				SuggestedFixes: []analysis.SuggestedFix{{
-					TextEdits: []analysis.TextEdit{{
-						Pos: 13,
-						End: 32,
+				SuggestedFixes: []result.SuggestedFix{{
+					TextEdits: []result.TextEdit{{
+						Filename: "testing.go",
+						Pos:      13,
+						End:      32,
 					}},
 				}},
 				ExpectNoLint:         true,

--- a/pkg/golinters/revive/revive.go
+++ b/pkg/golinters/revive/revive.go
@@ -153,10 +153,20 @@ func (w *wrapper) toIssue(pass *analysis.Pass, failure *lint.Failure) *goanalysi
 
 		// Skip cgo files because the positions are wrong.
 		if failure.Filename() == f.Name() {
-			issue.SuggestedFixes = []analysis.SuggestedFix{{
-				TextEdits: []analysis.TextEdit{{
-					Pos: f.LineStart(failure.Position.Start.Line),
-					End: goanalysis.EndOfLinePos(f, failure.Position.End.Line),
+			// EndOfLinePos points at the newline character ending the line
+			// (or at the end of the file when there is no trailing newline).
+			// The newline must be part of the replaced segment because the
+			// replacement is a full line (ReplacementLine includes the indentation).
+			end := goanalysis.EndOfLinePos(f, failure.Position.End.Line)
+			if failure.Position.End.Line < f.LineCount() {
+				end++
+			}
+
+			issue.SuggestedFixes = []result.SuggestedFix{{
+				TextEdits: []result.TextEdit{{
+					Filename: f.Name(),
+					Pos:      f.Offset(f.LineStart(failure.Position.Start.Line)),
+					End:      f.Offset(end),
 					// ReplacementLine doesn't contain the full line (missing newline), so we have to add a newline.
 					// Also `failure.Position.End.Offset` is at the end of the node but not the line.
 					NewText: []byte(failure.ReplacementLine + "\n"),

--- a/pkg/result/issue.go
+++ b/pkg/result/issue.go
@@ -5,12 +5,30 @@ import (
 	"fmt"
 	"go/token"
 
-	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/packages"
 )
 
 type Range struct {
 	From, To int
+}
+
+// TextEdit is a replacement of a portion of a file.
+// Pos and End are byte offsets inside Filename.
+type TextEdit struct {
+	// Filename is the path of the file the edit applies to.
+	// It is internal data (e.g. used by the fixer) and is not part of the JSON output.
+	Filename string `json:"-"`
+
+	Pos     int
+	End     int
+	NewText []byte
+}
+
+// A SuggestedFix is a code change associated with an Issue that a user
+// can choose to apply to their code.
+type SuggestedFix struct {
+	Message   string
+	TextEdits []TextEdit
 }
 
 type Issue struct {
@@ -33,7 +51,7 @@ type Issue struct {
 	HunkPos int `json:",omitempty"`
 
 	// If we know how to fix the issue, we can provide replacement lines
-	SuggestedFixes []analysis.SuggestedFix `json:",omitempty"`
+	SuggestedFixes []SuggestedFix `json:",omitempty"`
 
 	// If we are expecting a nolint (because this is from nolintlint), record the expected linter
 	ExpectNoLint         bool

--- a/pkg/result/processors/fixer.go
+++ b/pkg/result/processors/fixer.go
@@ -101,23 +101,28 @@ func (p Fixer) process(issues []*result.Issue) ([]*result.Issue, error) {
 
 		for _, sf := range issue.SuggestedFixes {
 			for _, edit := range sf.TextEdits {
-				start, end := edit.Pos, edit.End
-				if start > end {
+				if edit.Pos > edit.End {
 					return nil, fmt.Errorf("%q suggests invalid fix: pos (%v) > end (%v)",
 						issue.FromLinter, edit.Pos, edit.End)
 				}
 
-				edit := diff.Edit{
-					Start: int(start),
-					End:   int(end),
+				// The edits of a suggested fix can be spread over several files.
+				// Fallback on the issue file for suggested fixes built without file information
+				// (e.g. by custom/external linters).
+				path := edit.Filename
+				if path == "" {
+					path = issue.FilePath()
+				}
+
+				if _, ok := editsByLinter[path]; !ok {
+					editsByLinter[path] = make(map[string][]diff.Edit)
+				}
+
+				editsByLinter[path][issue.FromLinter] = append(editsByLinter[path][issue.FromLinter], diff.Edit{
+					Start: edit.Pos,
+					End:   edit.End,
 					New:   string(edit.NewText),
-				}
-
-				if _, ok := editsByLinter[issue.FilePath()]; !ok {
-					editsByLinter[issue.FilePath()] = make(map[string][]diff.Edit)
-				}
-
-				editsByLinter[issue.FilePath()][issue.FromLinter] = append(editsByLinter[issue.FilePath()][issue.FromLinter], edit)
+				})
 			}
 		}
 	}

--- a/pkg/result/processors/fixer_test.go
+++ b/pkg/result/processors/fixer_test.go
@@ -1,0 +1,140 @@
+package processors
+
+import (
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/golangci/golangci-lint/v2/pkg/config"
+	"github.com/golangci/golangci-lint/v2/pkg/fsutils"
+	"github.com/golangci/golangci-lint/v2/pkg/goformatters"
+	"github.com/golangci/golangci-lint/v2/pkg/logutils"
+	"github.com/golangci/golangci-lint/v2/pkg/result"
+)
+
+func newFixer(t *testing.T) *Fixer {
+	t.Helper()
+
+	cfg := &config.Config{}
+	cfg.Issues.NeedFix = true
+
+	log := logutils.NewStderrLog(logutils.DebugKeyEmpty)
+
+	formatter, err := goformatters.NewMetaFormatter(log, &config.Formatters{}, &config.Run{})
+	require.NoError(t, err)
+
+	return NewFixer(cfg, log, fsutils.NewFileCache(), formatter)
+}
+
+// replaceEdit builds an edit replacing the first occurrence of old by new inside content.
+func replaceEdit(t *testing.T, filename, content, old, new string) result.TextEdit {
+	t.Helper()
+
+	start := strings.Index(content, old)
+	require.NotEqual(t, -1, start, "substring %q not found", old)
+
+	return result.TextEdit{
+		Filename: filename,
+		Pos:      start,
+		End:      start + len(old),
+		NewText:  []byte(new),
+	}
+}
+
+// The edits of a suggested fix can be spread over several files of a package
+// (e.g. modernize/atomictype from golang.org/x/tools).
+// Each edit must be applied to its own file.
+// https://github.com/golangci/golangci-lint/issues/6671
+func TestFixer_Process_editsSpreadOverSeveralFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	aContent := "package test\n\ntype a struct {\n\tx int64\n}\n"
+	bContent := "package test\n\nimport \"sync/atomic\"\n\nfunc b() int64 {\n\tvar a a\n\treturn atomic.LoadInt64(&a.x)\n}\n"
+
+	aPath := filepath.Join(dir, "a.go")
+	bPath := filepath.Join(dir, "b.go")
+
+	require.NoError(t, os.WriteFile(aPath, []byte(aContent), 0o644))
+	require.NoError(t, os.WriteFile(bPath, []byte(bContent), 0o644))
+
+	issue := &result.Issue{
+		FromLinter: "modernize",
+		Text:       "int64 should be atomic.Int64",
+		Pos:        token.Position{Filename: aPath, Line: 4, Column: 5},
+		SuggestedFixes: []result.SuggestedFix{{
+			TextEdits: []result.TextEdit{
+				replaceEdit(t, aPath, aContent, "int64", "atomic.Int64"),
+				replaceEdit(t, bPath, bContent, "atomic.LoadInt64(&a.x)", "a.x.Load()"),
+			},
+		}},
+	}
+
+	out := process(t, newFixer(t), issue)
+	assert.Empty(t, out)
+
+	aFixed, err := os.ReadFile(aPath)
+	require.NoError(t, err)
+	assert.Equal(t, "package test\n\ntype a struct {\n\tx atomic.Int64\n}\n", string(aFixed))
+
+	bFixed, err := os.ReadFile(bPath)
+	require.NoError(t, err)
+	assert.Equal(t, "package test\n\nimport \"sync/atomic\"\n\nfunc b() int64 {\n\tvar a a\n\treturn a.x.Load()\n}\n", string(bFixed))
+}
+
+// Suggested fixes built without file information (e.g. by custom/external linters)
+// must still be applied to the issue file, as before.
+func TestFixer_Process_fallbackOnIssueFile(t *testing.T) {
+	dir := t.TempDir()
+
+	content := "package test\n\nfunc a() int {\n\treturn 1 // langauge\n}\n"
+
+	path := filepath.Join(dir, "a.go")
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	edit := replaceEdit(t, "", content, "langauge", "language")
+	edit.Filename = ""
+
+	issue := &result.Issue{
+		FromLinter: "misspell",
+		Text:       "`langauge` is a misspelling of `language`",
+		Pos:        token.Position{Filename: path, Line: 4, Column: 13},
+		SuggestedFixes: []result.SuggestedFix{{
+			TextEdits: []result.TextEdit{edit},
+		}},
+	}
+
+	out := process(t, newFixer(t), issue)
+	assert.Empty(t, out)
+
+	fixed, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "package test\n\nfunc a() int {\n\treturn 1 // language\n}\n", string(fixed))
+}
+
+func TestFixer_Process_noFixes(t *testing.T) {
+	dir := t.TempDir()
+
+	content := "package test\n"
+
+	path := filepath.Join(dir, "a.go")
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	issue := &result.Issue{
+		FromLinter: "modernize",
+		Text:       "unfixable",
+		Pos:        token.Position{Filename: path, Line: 1, Column: 1},
+	}
+
+	processAssertSame(t, newFixer(t), issue)
+
+	fixed, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(fixed))
+}


### PR DESCRIPTION
## Problem

Analyzers built on `go/analysis` (e.g. `modernize` from x/tools) may emit a single `SuggestedFix` whose `TextEdits` span multiple files of the same package. golangci-lint flattens all those edits onto the issue's file path: `buildIssues()` computes every edit's offset against the file the diagnostic was reported in, and the fixer later applies all of them to that one file. The result is corruption — edits intended for `b.go` land in `a.go` at wrong offsets and the rewritten sources no longer compile.

Fixes #6671

## Fix

Carry per-edit file identity through the pipeline instead of dropping it:

- `pkg/result`: own `SuggestedFix`/`TextEdit` types with a `Filename` field (`json:"-"` so the public JSON output stays byte-identical; the gob-encoded cache keeps the filename).
- `pkg/goanalysis/runners.go` (`buildIssues`): resolve each edit to its own file via the diagnostic's `FileSet`, compute offsets against that file, and drop a fix atomically if an edit is outside the fileset or spans files within one edit.
- `pkg/result/processors/fixer.go`: group edits by their resolved file, falling back to the issue path for external linters without file info.
- Direct `result.Issue` producers (`nolintlint`, `revive`) migrated to the new types; revive's token.Pos→offset conversion now goes through `File.Offset`, removing FileSet-base drift.

## Tests

New focused tests cover multi-file fixes (edits land in the right files), insertions, atomic drop of spanning/foreign edits, cgo-skip, and the fallback path. At head 676d774: `go build ./...` clean; `go test ./pkg/goanalysis ./pkg/result/processors ./pkg/golinters/nolintlint ./pkg/golinters/revive ./pkg/printers` all pass; `gofmt -l` clean on touched files; e2e `golangci-lint run --fix` on a two-file modernize/atomictypes repro corrupts `a.go` without this patch and lands all four upstream edits in their own files at this head.

