### PR TITLE
chore: remove chart of stargazers over time

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,3 @@ This project exists thanks to all the people who contribute. [How to contribute]
     </picture>
   </a>
 </p>
-
-## Stargazers over time
-
-[![Stargazers over time](https://starchart.cc/golangci/golangci-lint.svg?variant=adaptive)](https://starchart.cc/golangci/golangci-lint)


### PR DESCRIPTION
The star chart we've been using (`starchart.cc`) have been experiencing issues lately with no valid tokens and therefor a lot of rate limiting from GitHub's APIs. This is also active as of filing this PR. See https://github.com/caarlos0/starcharts/issues/260

As linked in that issue thread, this is further related to a change in GitHub's public API where they restrict access to stargazer information. See https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/

Because of this, I didn't bother to look for alternatives (for now). `star-history.com` also [wrote about this](https://www.star-history.com/blog/github-stargazer-api-restriction) and supports providing your own token but I don't think it's worth spreading tokens for a chart like this.