### PR TITLE
dev: disable cooldown to get the linter's updates as soon as possible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     cooldown:
-      default-days: 1
+      # Disable cooldown to get the linter's updates as soon as possible.
+      # Note: I don't know if the value 0 works:
+      # - There is no documentation about disabling the cooldown.
+      # - The JSONSchema says that 0 is not valid, but this schema is community maintained and not by GitHub.
+      default-days: 0
     schedule:
       interval: weekly
       day: "sunday"

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -3,4 +3,4 @@ rules:
     disable: true
   dependabot-cooldown:
     ignore:
-      - dependabot.yml:6:7
+      - dependabot.yml:10:7


### PR DESCRIPTION
Disable cooldown to get the linter's updates as soon as possible.

I don't know if the value `0` works:
- There is no documentation about disabling the cooldown.
- The JSONSchema says that `0` is not valid, but this schema is maintained by the community and not by GitHub.

But the fact to change the configuration will at least force dependabot to run.