### PR TITLE
build(deps): bump github.com/lasiar/canonicalheader from v1.1.2 to a fork

### DIFF
--- a/.golangci.next.reference.yml
+++ b/.golangci.next.reference.yml
@@ -288,6 +288,16 @@ linters:
       # Default: false
       check-consumption: true
 
+    canonicalheader:
+      # Use default excluded header names
+      # Default: true
+      use-default-exclusions: false
+      # List of excluded header names.
+      # Default: []
+      exclusions:
+        - Foo
+        - Bar
+
     copyloopvar:
       # Check all assigning the loop variable to another variable.
       # Default: false

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/godoc-lint/godoc-lint v0.11.2
 	github.com/gofrs/flock v0.13.0
 	github.com/golangci/asciicheck v0.5.0
+	github.com/golangci/canonicalheader v0.0.0-20260827115959-a25c71c521f6
 	github.com/golangci/dupl v0.0.0-20260401084720-c99c5cf5c202
 	github.com/golangci/go-printf-func-name v0.1.1
 	github.com/golangci/gofmt v0.0.0-20260820135601-e84e05053792
@@ -85,7 +86,6 @@ require (
 	github.com/kkHAIKE/contextcheck v1.1.6
 	github.com/kulti/thelper v0.7.1
 	github.com/kunwardeep/paralleltest v1.0.15
-	github.com/lasiar/canonicalheader v1.1.2
 	github.com/ldez/exptostd v0.4.5
 	github.com/ldez/gomoddirectives v0.9.0
 	github.com/ldez/grignotin v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golangci/asciicheck v0.5.0 h1:jczN/BorERZwK8oiFBOGvlGPknhvq0bjnysTj4nUfo0=
 github.com/golangci/asciicheck v0.5.0/go.mod h1:5RMNAInbNFw2krqN6ibBxN/zfRFa9S6tA1nPdM0l8qQ=
+github.com/golangci/canonicalheader v0.0.0-20260827115959-a25c71c521f6 h1:fVLolA3dG6s0brGetsiDAtcnpMSwVa2LqXJEw/9RJG4=
+github.com/golangci/canonicalheader v0.0.0-20260827115959-a25c71c521f6/go.mod h1:1xo+NFW5S+bEf2DKXhaxuzvcDN5AR6o/KMwvqC5Mkpo=
 github.com/golangci/dupl v0.0.0-20260401084720-c99c5cf5c202 h1:CbTB8KpqnViI6lIXxp03Oclc4VFHi3K4BWC1TacsZ+A=
 github.com/golangci/dupl v0.0.0-20260401084720-c99c5cf5c202/go.mod h1:NUw9Zr2Sy7+HxzdjIULge71wI6yEg1lWQr7Evcu8K0E=
 github.com/golangci/go-printf-func-name v0.1.1 h1:hIYTFJqAGp1iwoIfsNTpoq1xZAarogrvjO9AfiW3B4U=
@@ -397,8 +399,6 @@ github.com/kulti/thelper v0.7.1 h1:fI8QITAoFVLx+y+vSyuLBP+rcVIB8jKooNSCT2EiI98=
 github.com/kulti/thelper v0.7.1/go.mod h1:NsMjfQEy6sd+9Kfw8kCP61W1I0nerGSYSFnGaxQkcbs=
 github.com/kunwardeep/paralleltest v1.0.15 h1:ZMk4Qt306tHIgKISHWFJAO1IDQJLc6uDyJMLyncOb6w=
 github.com/kunwardeep/paralleltest v1.0.15/go.mod h1:di4moFqtfz3ToSKxhNjhOZL+696QtJGCFe132CbBLGk=
-github.com/lasiar/canonicalheader v1.1.2 h1:vZ5uqwvDbyJCnMhmFYimgMZnJMjwljN5VGY0VKbMXb4=
-github.com/lasiar/canonicalheader v1.1.2/go.mod h1:qJCeLFS0G/QlLQ506T+Fk/fWMa2VmBUiEI2cuMK4djI=
 github.com/ldez/exptostd v0.4.5 h1:kv2ZGUVI6VwRfp/+bcQ6Nbx0ghFWcGIKInkG/oFn1aQ=
 github.com/ldez/exptostd v0.4.5/go.mod h1:QRjHRMXJrCTIm9WxVNH6VW7oN7KrGSht69bIRwvdFsM=
 github.com/ldez/gomoddirectives v0.9.0 h1:2YV/EX7nVlWL4jySusYTzBKHuE3D2fgcRsQuMa3yIoo=

--- a/jsonschema/golangci.next.jsonschema.json
+++ b/jsonschema/golangci.next.jsonschema.json
@@ -1087,6 +1087,23 @@
             }
           }
         },
+        "canonicalheaderSettings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "use-default-exclusions": {
+              "type": "boolean",
+               "default": true
+            },
+            "exclusions": {
+              "additionalProperties": false,
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "cyclopSettings": {
           "type": "object",
           "additionalProperties": false,
@@ -5084,6 +5101,9 @@
             },
             "bodyclose": {
               "$ref": "#/definitions/settings/definitions/bodycloseSettings"
+            },
+            "canonicalheader": {
+              "$ref": "#/definitions/settings/definitions/canonicalheaderSettings"
             },
             "cyclop": {
               "$ref": "#/definitions/settings/definitions/cyclopSettings"

--- a/pkg/config/linters_settings.go
+++ b/pkg/config/linters_settings.go
@@ -12,6 +12,9 @@ var defaultLintersSettings = LintersSettings{
 	Asasalint: AsasalintSettings{
 		UseBuiltinExclusions: true,
 	},
+	CanonicalHeader: CanonicalHeaderSettings{
+		UseDefaultExclusions: true,
+	},
 	Decorder: DecorderSettings{
 		DecOrder:                  []string{"type", "const", "var", "func"},
 		DisableDecNumCheck:        true,
@@ -252,6 +255,7 @@ type LintersSettings struct {
 	Asasalint                AsasalintSettings                `mapstructure:"asasalint"`
 	BiDiChk                  BiDiChkSettings                  `mapstructure:"bidichk"`
 	BodyClose                BodyCloseSettings                `mapstructure:"bodyclose"`
+	CanonicalHeader          CanonicalHeaderSettings          `mapstructure:"canonicalheader"`
 	CopyLoopVar              CopyLoopVarSettings              `mapstructure:"copyloopvar"`
 	Cyclop                   CyclopSettings                   `mapstructure:"cyclop"`
 	Decorder                 DecorderSettings                 `mapstructure:"decorder"`
@@ -374,6 +378,11 @@ type BiDiChkSettings struct {
 
 type BodyCloseSettings struct {
 	CheckConsumption bool `mapstructure:"check-consumption"`
+}
+
+type CanonicalHeaderSettings struct {
+	Exclusions           []string `mapstructure:"exclusions"`
+	UseDefaultExclusions bool     `mapstructure:"use-default-exclusions"`
 }
 
 type CopyLoopVarSettings struct {

--- a/pkg/golinters/canonicalheader/canonicalheader.go
+++ b/pkg/golinters/canonicalheader/canonicalheader.go
@@ -1,13 +1,29 @@
 package canonicalheader
 
 import (
+	"strings"
+
 	"github.com/golangci/canonicalheader"
 
+	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )
 
-func New() *goanalysis.Linter {
+func New(settings *config.CanonicalHeaderSettings) *goanalysis.Linter {
+	var cfg map[string]any
+
+	if settings != nil {
+		cfg = map[string]any{
+			"useDefaultExclusion": settings.UseDefaultExclusions,
+		}
+
+		if len(settings.Exclusions) > 0 {
+			cfg["exclusions"] = strings.Join(settings.Exclusions, ",")
+		}
+	}
+
 	return goanalysis.
-		NewLinterFromAnalyzer(canonicalheader.Analyzer).
+		NewLinterFromAnalyzer(canonicalheader.New()).
+		WithConfig(cfg).
 		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }

--- a/pkg/golinters/canonicalheader/canonicalheader.go
+++ b/pkg/golinters/canonicalheader/canonicalheader.go
@@ -1,7 +1,7 @@
 package canonicalheader
 
 import (
-	"github.com/lasiar/canonicalheader"
+	"github.com/golangci/canonicalheader"
 
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
 )

--- a/pkg/golinters/canonicalheader/testdata/canonicalheader.go
+++ b/pkg/golinters/canonicalheader/testdata/canonicalheader.go
@@ -6,11 +6,11 @@ import "net/http"
 func canonicalheader() {
 	v := http.Header{}
 
-	v.Get("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Set("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Add("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Del("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Values("Test-HEader")       // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Get("Test-HEader")          // want `use "Test-Header" instead of "Test-HEader"`
+	v.Set("Test-HEader", "value") // want `use "Test-Header" instead of "Test-HEader"`
+	v.Add("Test-HEader", "value") // want `use "Test-Header" instead of "Test-HEader"`
+	v.Del("Test-HEader")          // want `use "Test-Header" instead of "Test-HEader"`
+	v.Values("Test-HEader")       // want `use "Test-Header" instead of "Test-HEader"`
 
 	v.Values("Sec-WebSocket-Accept")
 

--- a/pkg/golinters/canonicalheader/testdata/canonicalheader_cgo.go
+++ b/pkg/golinters/canonicalheader/testdata/canonicalheader_cgo.go
@@ -25,11 +25,11 @@ func _() {
 func canonicalheader() {
 	v := http.Header{}
 
-	v.Get("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Set("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Add("Test-HEader", "value") // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Del("Test-HEader")          // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
-	v.Values("Test-HEader")       // want `non-canonical header "Test-HEader", instead use: "Test-Header"`
+	v.Get("Test-HEader")          // want `use "Test-Header" instead of "Test-HEader"`
+	v.Set("Test-HEader", "value") // want `use "Test-Header" instead of "Test-HEader"`
+	v.Add("Test-HEader", "value") // want `use "Test-Header" instead of "Test-HEader"`
+	v.Del("Test-HEader")          // want `use "Test-Header" instead of "Test-HEader"`
+	v.Values("Test-HEader")       // want `use "Test-Header" instead of "Test-HEader"`
 
 	v.Values("Sec-WebSocket-Accept")
 

--- a/pkg/golinters/canonicalheader/testdata/canonicalheader_custom.go
+++ b/pkg/golinters/canonicalheader/testdata/canonicalheader_custom.go
@@ -1,0 +1,13 @@
+//golangcitest:args -Ecanonicalheader
+//golangcitest:config_path testdata/canonicalheader_custom.yml
+package testdata
+
+import "net/http"
+
+func _() {
+	v := http.Header{}
+
+	v.Get("Test-HEader")      // want `use "Test-Header" instead of "Test-HEader"`
+	v.Get("WWW-Authenticate") // want `Www-Authenticate" instead of "WWW-Authenticate"`
+	v.Get("XXX-XXX")
+}

--- a/pkg/golinters/canonicalheader/testdata/canonicalheader_custom.yml
+++ b/pkg/golinters/canonicalheader/testdata/canonicalheader_custom.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+linters:
+  settings:
+    canonicalheader:
+      use-default-exclusions: false
+      exclusions:
+        - XXX-XXX

--- a/pkg/lint/lintersdb/builder_linter.go
+++ b/pkg/lint/lintersdb/builder_linter.go
@@ -167,7 +167,7 @@ func (LinterBuilder) Build(cfg *config.Config) ([]*linter.Config, error) {
 			WithLoadForGoAnalysis().
 			WithURL("https://github.com/timakin/bodyclose"),
 
-		linter.NewConfig(canonicalheader.New()).
+		linter.NewConfig(canonicalheader.New(&cfg.Linters.Settings.CanonicalHeader)).
 			WithSince("v1.58.0").
 			WithLoadForGoAnalysis().
 			WithAutoFix().


### PR DESCRIPTION
I opened a PR against the original repository with the fix.

https://github.com/lasiar/canonicalheader/pull/89

In the meantime, to fix the bug, we will use a fork.

**This is a special case; there is no rule about forking when a linter author is not responsive.**
**The default rule stays the same: no forks.**

The fork is inside the golangci org: https://github.com/golangci/canonicalheader

Fixes #6753