### PR TITLE
build(deps): bump mvdan.cc/gofumpt from v0.11.1 to 28272d18f832

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/tools v0.49.0
 	honnef.co/go/tools v0.8.1
-	mvdan.cc/gofumpt v0.11.0
+	mvdan.cc/gofumpt v0.11.1-0.20260823225713-28272d18f832
 	mvdan.cc/unparam v0.0.0-20260823230713-2fa3d841b0c8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -992,8 +992,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.8.1 h1:+JKf3xJ1ni4CwrhVg4/pqsfPGP6vNAXcKbMXJodYx3w=
 honnef.co/go/tools v0.8.1/go.mod h1:XA+OnlRA9EDh/ukGvXMNSZNKGwFQJ+5dER0ioUkOxks=
-mvdan.cc/gofumpt v0.11.0 h1:0H01XB95PnN2QgCSR9ELdZyTlJqNZ7181B0BTMh5VZc=
-mvdan.cc/gofumpt v0.11.0/go.mod h1:BeT5wCsOJt6J9zT2MZIOGszjUHzFkn1/l9g6xAzqsXo=
+mvdan.cc/gofumpt v0.11.1-0.20260823225713-28272d18f832 h1:ps6fBbBh3lwoAxETS3GofZZw7twDf+j7mEpRPi9i7MM=
+mvdan.cc/gofumpt v0.11.1-0.20260823225713-28272d18f832/go.mod h1:AMz3nD/PjYImSqJyAX/1OPKmcI2RT4D4eOS1M4qSCZM=
 mvdan.cc/unparam v0.0.0-20260823230713-2fa3d841b0c8 h1:Re1NRyLpiAt9kB+ImaaoapwWiQXrKwER4tY8fLOkDew=
 mvdan.cc/unparam v0.0.0-20260823230713-2fa3d841b0c8/go.mod h1:MrS/+zJ1M2xvGXhKktiHbNQeQPyg3Qel+KkzT+f7/i4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
https://github.com/mvdan/gofumpt/compare/v0.11.0...28272d18f832

**This update is done by hand because dependabot is not able to update non-SemVer dependencies.**

While waiting for an official gofumpt release, we can use a pseudo version.

I will follow the releases of gofumpt and set the future tag when the release will be done.

Fixes #6764 
