### PR TITLE
build(deps): bump github.com/alecthomas/go-check-sumtype from 0.3.1 to ae6904d28606

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/MirrexOne/unqueryvet v1.5.4
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1
 	github.com/alecthomas/chroma/v2 v2.27.0
-	github.com/alecthomas/go-check-sumtype v0.3.1
+	github.com/alecthomas/go-check-sumtype v0.5.1-0.20260828200218-ae6904d28606
 	github.com/alexkohler/nakedret/v2 v2.0.6
 	github.com/alexkohler/prealloc v1.1.0
 	github.com/alingse/asasalint v0.0.11

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8v
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r5BXYZs=
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
-github.com/alecthomas/go-check-sumtype v0.3.1 h1:u9aUvbGINJxLVXiFvHUlPEaD7VDULsrxJb4Aq31NLkU=
-github.com/alecthomas/go-check-sumtype v0.3.1/go.mod h1:A8TSiN3UPRw3laIgWEUOHHLPa6/r9MtoigdlP5h3K/E=
+github.com/alecthomas/go-check-sumtype v0.5.1-0.20260828200218-ae6904d28606 h1:dXPJ+uOJLWb8rjlAuLX7JPiRJtZKw/53Ol+WxdDJ1Eo=
+github.com/alecthomas/go-check-sumtype v0.5.1-0.20260828200218-ae6904d28606/go.mod h1:ZH31IJyNpxpStxP2ayCcPQz+3T2G/OnxIQqe4LWvSDw=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/golinters/gochecksumtype/gochecksumtype.go
+++ b/pkg/golinters/gochecksumtype/gochecksumtype.go
@@ -1,82 +1,28 @@
 package gochecksumtype
 
 import (
-	"strings"
-	"sync"
-
 	gochecksumtype "github.com/alecthomas/go-check-sumtype"
-	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/packages"
 
 	"github.com/golangci/golangci-lint/v2/pkg/config"
 	"github.com/golangci/golangci-lint/v2/pkg/goanalysis"
-	"github.com/golangci/golangci-lint/v2/pkg/lint/linter"
-	"github.com/golangci/golangci-lint/v2/pkg/result"
 )
 
 const linterName = "gochecksumtype"
 
 func New(settings *config.GoChecksumTypeSettings) *goanalysis.Linter {
-	var mu sync.Mutex
-	var resIssues []*goanalysis.Issue
+	analyzer := gochecksumtype.Analyzer
+	analyzer.Name = linterName
 
-	return goanalysis.
-		NewLinterFromAnalyzer(&analysis.Analyzer{
-			Name: linterName,
-			Doc:  `Run exhaustiveness checks on Go "sum types"`,
-			Run: func(pass *analysis.Pass) (any, error) {
-				issues, err := runGoCheckSumType(pass, settings)
-				if err != nil {
-					return nil, err
-				}
+	var cfg map[string]any
 
-				if len(issues) == 0 {
-					return nil, nil
-				}
-
-				mu.Lock()
-				resIssues = append(resIssues, issues...)
-				mu.Unlock()
-
-				return nil, nil
-			},
-		}).
-		WithIssuesReporter(func(_ *linter.Context) []*goanalysis.Issue {
-			return resIssues
-		}).
-		WithLoadMode(goanalysis.LoadModeTypesInfo)
-}
-
-func runGoCheckSumType(pass *analysis.Pass, settings *config.GoChecksumTypeSettings) ([]*goanalysis.Issue, error) {
-	var resIssues []*goanalysis.Issue
-
-	pkg := &packages.Package{
-		Fset:      pass.Fset,
-		Syntax:    pass.Files,
-		Types:     pass.Pkg,
-		TypesInfo: pass.TypesInfo,
-	}
-
-	cfg := gochecksumtype.Config{
-		DefaultSignifiesExhaustive: settings.DefaultSignifiesExhaustive,
-		IncludeSharedInterfaces:    settings.IncludeSharedInterfaces,
-	}
-
-	var unknownError error
-	errors := gochecksumtype.Run([]*packages.Package{pkg}, cfg)
-	for _, err := range errors {
-		err, ok := err.(gochecksumtype.Error)
-		if !ok {
-			unknownError = err
-			continue
+	if settings != nil {
+		cfg = map[string]any{
+			"default-signifies-exhaustive": settings.DefaultSignifiesExhaustive,
+			"include-shared-interfaces":    settings.IncludeSharedInterfaces,
 		}
-
-		resIssues = append(resIssues, goanalysis.NewIssue(&result.Issue{
-			FromLinter: linterName,
-			Text:       strings.TrimPrefix(err.Error(), err.Pos().String()+": "),
-			Pos:        err.Pos(),
-		}, pass))
 	}
 
-	return resIssues, unknownError
+	return goanalysis.NewLinterFromAnalyzer(analyzer).
+		WithConfig(cfg).
+		WithLoadMode(goanalysis.LoadModeTypesInfo)
 }


### PR DESCRIPTION
[I asked for a new tag](https://github.com/alecthomas/go-check-sumtype/pull/24#issuecomment-5457383611), but I have no answer, so as the only changed between the latest release (v0.5.0) and the hash is the min Go version, this is safe to update the dependencies.
I follow the repository, so when the new tag will be created I will "resync" the dependabot.

https://github.com/alecthomas/go-check-sumtype/compare/v0.3.1...ae6904d28606

Related to #6769

Fixes #4158